### PR TITLE
feat(manus): adapter for manus.im — 6 read-only commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19426,7 +19426,7 @@
       }
     ],
     "columns": [
-      "UID",
+      "id",
       "Title",
       "Status",
       "Last Message",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -19355,6 +19355,158 @@
     "navigateBefore": "https://maimai.cn"
   },
   {
+    "site": "manus",
+    "name": "connectors",
+    "description": "List available Manus connectors (integrations).",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Max connectors to return"
+      }
+    ],
+    "columns": [
+      "UID",
+      "Name",
+      "Brief"
+    ],
+    "type": "js",
+    "modulePath": "manus/connectors.js",
+    "sourceFile": "manus/connectors.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "credits",
+    "description": "Show Manus credit balance and refresh details.",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "manus/credits.js",
+    "sourceFile": "manus/credits.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "list",
+    "description": "List Manus sessions (tasks).",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max sessions to return"
+      },
+      {
+        "name": "archived",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Include archived sessions"
+      }
+    ],
+    "columns": [
+      "UID",
+      "Title",
+      "Status",
+      "Last Message",
+      "Last Updated",
+      "Credits"
+    ],
+    "type": "js",
+    "modulePath": "manus/list.js",
+    "sourceFile": "manus/list.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "read",
+    "description": "Show details for a specific Manus session.",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "uid",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Session UID"
+      }
+    ],
+    "columns": [
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "manus/read.js",
+    "sourceFile": "manus/read.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "skills",
+    "description": "List Manus skills (user-added and system).",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "ID",
+      "Name",
+      "Description",
+      "Source"
+    ],
+    "type": "js",
+    "modulePath": "manus/skills.js",
+    "sourceFile": "manus/skills.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "status",
+    "description": "Show current Manus user profile and credit summary.",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Field",
+      "Value"
+    ],
+    "type": "js",
+    "modulePath": "manus/status.js",
+    "sourceFile": "manus/status.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
     "site": "maven",
     "name": "artifact",
     "description": "Fetch a Maven Central artifact's version history (groupId:artifactId[:version])",

--- a/clis/manus/_utils.js
+++ b/clis/manus/_utils.js
@@ -4,7 +4,7 @@
 // (JWT, ~357 bytes) readable on the manus.im domain. The API uses
 // Connect-RPC (POST + JSON + Connect-Protocol-Version: 1).
 
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 export const MANUS_DOMAIN = 'manus.im';
 export const MANUS_URL = 'https://manus.im/app';
@@ -34,8 +34,65 @@ export function validatedLimit(raw, fallback, max = 1000) {
     return n;
 }
 
+export function unwrapEvaluateResult(payload) {
+    if (
+        payload
+        && typeof payload === 'object'
+        && !Array.isArray(payload)
+        && Object.prototype.hasOwnProperty.call(payload, 'session')
+        && Object.prototype.hasOwnProperty.call(payload, 'data')
+    ) {
+        return payload.data;
+    }
+    return payload;
+}
+
+function extractErrorMessage(payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    const candidates = [
+        payload.message,
+        payload.error,
+        payload.errorMessage,
+        payload.details,
+    ];
+    return candidates.find((value) => typeof value === 'string' && value.trim())?.trim() || '';
+}
+
+export function requireObject(payload, label) {
+    const value = unwrapEvaluateResult(payload);
+    if (value?.__authRequired) {
+        throw new AuthRequiredError(MANUS_DOMAIN, value.message || 'Authentication required — please sign in to Manus in the browser');
+    }
+    if (value?.__httpError) {
+        const message = extractErrorMessage(value);
+        throw new CommandExecutionError(message ? `Manus ${label} failed (HTTP ${value.__httpError}): ${message}` : `Manus ${label} failed (HTTP ${value.__httpError})`);
+    }
+    if (value?.__error) {
+        throw new CommandExecutionError(`Manus ${label} failed: ${value.message || value.__error}`);
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new CommandExecutionError(`Manus ${label} returned a malformed API payload`);
+    }
+    return value;
+}
+
+export function requireArray(value, label) {
+    if (!Array.isArray(value)) {
+        throw new CommandExecutionError(`Manus ${label} returned a malformed API payload`);
+    }
+    return value;
+}
+
+export function requireString(value, label) {
+    const text = String(value ?? '').trim();
+    if (!text) {
+        throw new CommandExecutionError(`Manus ${label} returned a malformed API payload`);
+    }
+    return text;
+}
+
 export async function ensureOnManus(page) {
-    const url = await page.evaluate('window.location.href').catch(() => '');
+    const url = unwrapEvaluateResult(await page.evaluate('window.location.href').catch(() => ''));
     if (isManusUrl(url)) return;
     await page.goto(MANUS_URL);
     await page.wait(2);
@@ -49,7 +106,7 @@ export async function ensureOnManus(page) {
 export const MANUS_API_CALL_JS = `
   const callManusAPI = async (rpcPath, body) => {
     const jwt = document.cookie.split('session_id=')[1]?.split(';')[0];
-    if (!jwt) throw new Error('Not signed in to manus.im — session_id cookie missing');
+    if (!jwt) return { __authRequired: true, message: 'session_id cookie missing' };
     const r = await fetch('${API_HOST}/' + rpcPath, {
       method: 'POST',
       credentials: 'include',
@@ -62,8 +119,15 @@ export const MANUS_API_CALL_JS = `
     });
     if (!r.ok) {
       const t = await r.text();
-      throw new Error('Manus API ' + r.status + ': ' + t.slice(0, 200));
+      return {
+        __httpError: r.status,
+        message: t.slice(0, 200),
+      };
     }
-    return r.json();
+    try {
+      return await r.json();
+    } catch (error) {
+      return { __error: 'invalid_json', message: error?.message || String(error) };
+    }
   };
 `;

--- a/clis/manus/_utils.js
+++ b/clis/manus/_utils.js
@@ -4,6 +4,8 @@
 // (JWT, ~357 bytes) readable on the manus.im domain. The API uses
 // Connect-RPC (POST + JSON + Connect-Protocol-Version: 1).
 
+import { ArgumentError } from '@jackwener/opencli/errors';
+
 export const MANUS_DOMAIN = 'manus.im';
 export const MANUS_URL = 'https://manus.im/app';
 export const API_HOST = 'https://api.manus.im';
@@ -16,6 +18,20 @@ export function isManusUrl(value) {
     } catch {
         return false;
     }
+}
+
+/**
+ * Validate a `--limit N` argument: must be a positive integer ≤ `max`.
+ * Negatives, zero, NaN, Infinity, and non-integers all reject. Manus's
+ * Connect-RPC backend enforces these server-side via Buf Validate; failing
+ * client-side gives the user a clearer error and skips a wasted round-trip.
+ */
+export function validatedLimit(raw, fallback, max = 1000) {
+    const n = raw == null ? fallback : Number(raw);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1 || n > max) {
+        throw new ArgumentError('limit', `must be a positive integer ≤ ${max}`);
+    }
+    return n;
 }
 
 export async function ensureOnManus(page) {

--- a/clis/manus/_utils.js
+++ b/clis/manus/_utils.js
@@ -1,0 +1,53 @@
+// Shared helpers for the Manus (manus.im) web adapter.
+//
+// Manus is an AI agent platform. Auth uses a `session_id` cookie
+// (JWT, ~357 bytes) readable on the manus.im domain. The API uses
+// Connect-RPC (POST + JSON + Connect-Protocol-Version: 1).
+
+export const MANUS_DOMAIN = 'manus.im';
+export const MANUS_URL = 'https://manus.im/app';
+export const API_HOST = 'https://api.manus.im';
+
+export function isManusUrl(value) {
+    try {
+        const url = new URL(String(value || ''));
+        const host = url.hostname.toLowerCase();
+        return url.protocol === 'https:' && (host === MANUS_DOMAIN || host === `www.${MANUS_DOMAIN}`);
+    } catch {
+        return false;
+    }
+}
+
+export async function ensureOnManus(page) {
+    const url = await page.evaluate('window.location.href').catch(() => '');
+    if (isManusUrl(url)) return;
+    await page.goto(MANUS_URL);
+    await page.wait(2);
+}
+
+/**
+ * IIFE preamble injected into page.evaluate() calls.
+ * Provides `callManusAPI(rpcPath, body)` which reads the `session_id`
+ * cookie and makes a Connect-RPC POST to api.manus.im.
+ */
+export const MANUS_API_CALL_JS = `
+  const callManusAPI = async (rpcPath, body) => {
+    const jwt = document.cookie.split('session_id=')[1]?.split(';')[0];
+    if (!jwt) throw new Error('Not signed in to manus.im — session_id cookie missing');
+    const r = await fetch('${API_HOST}/' + rpcPath, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + jwt,
+        'Connect-Protocol-Version': '1',
+      },
+      body: JSON.stringify(body || {}),
+    });
+    if (!r.ok) {
+      const t = await r.text();
+      throw new Error('Manus API ' + r.status + ': ' + t.slice(0, 200));
+    }
+    return r.json();
+  };
+`;

--- a/clis/manus/connectors.js
+++ b/clis/manus/connectors.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, validatedLimit } from './_utils.js';
 
 cli({
     site: 'manus',
@@ -17,8 +17,8 @@ cli({
     ],
     columns: ['UID', 'Name', 'Brief'],
     func: async (page, kwargs) => {
+        const limit = validatedLimit(kwargs?.limit, 50, 500);
         await ensureOnManus(page);
-        const limit = kwargs?.limit || 50;
 
         const data = await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}

--- a/clis/manus/connectors.js
+++ b/clis/manus/connectors.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, validatedLimit } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireArray, requireObject, requireString, validatedLimit } from './_utils.js';
 
 cli({
     site: 'manus',
@@ -20,20 +20,20 @@ cli({
         const limit = validatedLimit(kwargs?.limit, 50, 500);
         await ensureOnManus(page);
 
-        const data = await page.evaluate(`(async () => {
+        const data = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
             return callManusAPI('connectors.v1.ConnectorsService/ListConnectors', {});
-        })()`);
+        })()`), 'connectors');
 
-        const connectors = data?.connectors || [];
+        const connectors = requireArray(data.connectors, 'connectors');
 
         if (!connectors.length) {
             throw new EmptyResultError('manus connectors', 'No connectors found.');
         }
 
-        return connectors.slice(0, limit).map((c) => ({
-            UID: c.uid || '—',
-            Name: c.name || '—',
+        return connectors.slice(0, limit).map((c, index) => ({
+            UID: requireString(c?.uid, `connector ${index + 1}`),
+            Name: requireString(c?.name, `connector ${index + 1}`),
             Brief: (c.brief || '—').slice(0, 60),
         }));
     },

--- a/clis/manus/connectors.js
+++ b/clis/manus/connectors.js
@@ -1,0 +1,40 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+cli({
+    site: 'manus',
+    name: 'connectors',
+    access: 'read',
+    description: 'List available Manus connectors (integrations).',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [
+        { name: 'limit', type: 'int', default: 50, help: 'Max connectors to return' },
+    ],
+    columns: ['UID', 'Name', 'Brief'],
+    func: async (page, kwargs) => {
+        await ensureOnManus(page);
+        const limit = kwargs?.limit || 50;
+
+        const data = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            return callManusAPI('connectors.v1.ConnectorsService/ListConnectors', {});
+        })()`);
+
+        const connectors = data?.connectors || [];
+
+        if (!connectors.length) {
+            throw new EmptyResultError('manus connectors', 'No connectors found.');
+        }
+
+        return connectors.slice(0, limit).map((c) => ({
+            UID: c.uid || '—',
+            Name: c.name || '—',
+            Brief: (c.brief || '—').slice(0, 60),
+        }));
+    },
+});

--- a/clis/manus/credits.js
+++ b/clis/manus/credits.js
@@ -1,0 +1,36 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+cli({
+    site: 'manus',
+    name: 'credits',
+    access: 'read',
+    description: 'Show Manus credit balance and refresh details.',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [],
+    columns: ['Field', 'Value'],
+    func: async (page) => {
+        await ensureOnManus(page);
+
+        const data = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            return callManusAPI('user.v1.UserService/GetAvailableCredits', {});
+        })()`);
+
+        const c = data || {};
+        return [
+            { Field: 'Total Credits', Value: c.totalCredits ?? '—' },
+            { Field: 'Free Credits', Value: c.freeCredits ?? '—' },
+            { Field: 'Periodic Credits', Value: c.periodicCredits ?? '—' },
+            { Field: 'Pro Monthly Credits', Value: c.proMonthlyCredits ?? '—' },
+            { Field: 'Refresh Credits', Value: c.refreshCredits ?? '—' },
+            { Field: 'Max Refresh Credits', Value: c.maxRefreshCredits ?? '—' },
+            { Field: 'Next Refresh', Value: c.nextRefreshTime || '—' },
+            { Field: 'Refresh Interval', Value: c.refreshInterval || '—' },
+        ];
+    },
+});

--- a/clis/manus/credits.js
+++ b/clis/manus/credits.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireObject } from './_utils.js';
 
 cli({
     site: 'manus',
@@ -16,12 +17,14 @@ cli({
     func: async (page) => {
         await ensureOnManus(page);
 
-        const data = await page.evaluate(`(async () => {
+        const c = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
             return callManusAPI('user.v1.UserService/GetAvailableCredits', {});
-        })()`);
+        })()`), 'credits');
 
-        const c = data || {};
+        if (!['totalCredits', 'freeCredits', 'periodicCredits', 'refreshCredits'].some((key) => c[key] != null)) {
+            throw new CommandExecutionError('Manus credits returned a malformed API payload');
+        }
         return [
             { Field: 'Total Credits', Value: c.totalCredits ?? '—' },
             { Field: 'Free Credits', Value: c.freeCredits ?? '—' },

--- a/clis/manus/list.js
+++ b/clis/manus/list.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, validatedLimit } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireArray, requireObject, requireString, validatedLimit } from './_utils.js';
 
 function formatTime(iso) {
     if (!iso) return '—';
@@ -31,21 +31,21 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max sessions to return' },
         { name: 'archived', type: 'bool', default: false, help: 'Include archived sessions' },
     ],
-    columns: ['UID', 'Title', 'Status', 'Last Message', 'Last Updated', 'Credits'],
+    columns: ['id', 'Title', 'Status', 'Last Message', 'Last Updated', 'Credits'],
     func: async (page, kwargs) => {
         const limit = validatedLimit(kwargs?.limit, 20, 200);
         const includeArchived = kwargs?.archived === true;
         await ensureOnManus(page);
 
-        const data = await page.evaluate(`(async () => {
+        const data = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
             return callManusAPI('session.v1.SessionService/ListSessions', {
                 page: 1,
                 pageSize: ${limit},
             });
-        })()`);
+        })()`), 'list sessions');
 
-        let sessions = data?.sessions || [];
+        let sessions = requireArray(data.sessions, 'list sessions');
         if (!includeArchived) {
             sessions = sessions.filter((s) => !s.isArchived);
         }
@@ -54,8 +54,8 @@ cli({
             throw new EmptyResultError('manus list', 'No sessions found.');
         }
 
-        return sessions.slice(0, limit).map((s) => ({
-            UID: s.uid || '—',
+        return sessions.slice(0, limit).map((s, index) => ({
+            id: requireString(s?.uid, `list session ${index + 1}`),
             Title: (s.title || '—').slice(0, 80),
             Status: shortStatus(s.status),
             'Last Message': (s.lastDisplayMessage || '—').slice(0, 80),

--- a/clis/manus/list.js
+++ b/clis/manus/list.js
@@ -1,0 +1,66 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+function formatTime(iso) {
+    if (!iso) return '—';
+    try {
+        const d = new Date(iso);
+        return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    } catch {
+        return iso;
+    }
+}
+
+function shortStatus(s) {
+    if (!s) return '—';
+    return s.replace('SESSION_STATUS_', '').toLowerCase();
+}
+
+cli({
+    site: 'manus',
+    name: 'list',
+    access: 'read',
+    description: 'List Manus sessions (tasks).',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max sessions to return' },
+        { name: 'archived', type: 'bool', default: false, help: 'Include archived sessions' },
+    ],
+    columns: ['UID', 'Title', 'Status', 'Last Message', 'Last Updated', 'Credits'],
+    func: async (page, kwargs) => {
+        await ensureOnManus(page);
+        const limit = kwargs?.limit || 20;
+        const includeArchived = kwargs?.archived === true;
+
+        const data = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            return callManusAPI('session.v1.SessionService/ListSessions', {
+                page: 1,
+                pageSize: ${limit},
+            });
+        })()`);
+
+        let sessions = data?.sessions || [];
+        if (!includeArchived) {
+            sessions = sessions.filter((s) => !s.isArchived);
+        }
+
+        if (!sessions.length) {
+            throw new EmptyResultError('manus list', 'No sessions found.');
+        }
+
+        return sessions.slice(0, limit).map((s) => ({
+            UID: s.uid || '—',
+            Title: (s.title || '—').slice(0, 80),
+            Status: shortStatus(s.status),
+            'Last Message': (s.lastDisplayMessage || '—').slice(0, 80),
+            'Last Updated': formatTime(s.updatedAt),
+            Credits: String(s.costedCredits ?? '0'),
+        }));
+    },
+});

--- a/clis/manus/list.js
+++ b/clis/manus/list.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, validatedLimit } from './_utils.js';
 
 function formatTime(iso) {
     if (!iso) return '—';
@@ -33,9 +33,9 @@ cli({
     ],
     columns: ['UID', 'Title', 'Status', 'Last Message', 'Last Updated', 'Credits'],
     func: async (page, kwargs) => {
-        await ensureOnManus(page);
-        const limit = kwargs?.limit || 20;
+        const limit = validatedLimit(kwargs?.limit, 20, 200);
         const includeArchived = kwargs?.archived === true;
+        await ensureOnManus(page);
 
         const data = await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}

--- a/clis/manus/manus.test.js
+++ b/clis/manus/manus.test.js
@@ -1,0 +1,315 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { isManusUrl } from './_utils.js';
+import './status.js';
+import './list.js';
+import './read.js';
+import './credits.js';
+import './connectors.js';
+import './skills.js';
+
+// ── Mock data (matching spec response samples) ─────────────────────────────
+
+const USER_INFO = {
+  userId: '310519663277886366',
+  email: 'test@example.com',
+  displayname: 'Test User',
+  membershipTier: 'MEMBERSHIP_TIER_PRO',
+  firstname: 'Test',
+};
+
+const CREDITS = {
+  totalCredits: 12311,
+  freeCredits: 11,
+  periodicCredits: 12000,
+  proMonthlyCredits: 12000,
+  refreshCredits: 300,
+  maxRefreshCredits: 300,
+  nextRefreshTime: '2026-06-03T16:00:00Z',
+  refreshInterval: 'daily',
+};
+
+const SESSIONS = {
+  sessions: [
+    {
+      uid: '8UcpCxMFLrNk63ZJmzALfV',
+      userId: '310519663277886366',
+      title: 'PPT task',
+      status: 'SESSION_STATUS_STOPPED',
+      lastDisplayMessage: '已 完成修改',
+      lastMessageTime: '2026-05-04T06:39:47.774Z',
+      createdAt: '2026-04-30T07:54:17.891Z',
+      updatedAt: '2026-05-26T06:23:41Z',
+      agentTaskMode: 2,
+      costedCredits: 4564,
+      isArchived: false,
+    },
+    {
+      uid: 'YOpdpcVj7vPFD4gsBfEwVu',
+      title: 'Empire task',
+      status: 'SESSION_STATUS_STOPPED',
+      costedCredits: 5443,
+      isArchived: false,
+    },
+    {
+      uid: 'archived1',
+      title: 'Old task',
+      status: 'SESSION_STATUS_STOPPED',
+      isArchived: true,
+      costedCredits: 100,
+    },
+  ],
+};
+
+const CONNECTORS = {
+  connectors: [
+    { uid: 'cf19c9d0-5f91', name: 'Apify', brief: 'Connect AI agents to web scrapers' },
+    { uid: 'abc', name: 'GitHub', brief: 'Read repos' },
+  ],
+};
+
+const SKILLS = {
+  userAddedSkills: [
+    { id: 'R6qVrCn2', name: 'manus-api', description: 'Manage tasks via API' },
+  ],
+};
+
+// ── makePage helper (queue pattern matching kimi.test.js) ─────────────────
+
+/**
+ * Create a mock page with a queue of page.evaluate results.
+ * Each call to page.evaluate consumes one item from the queue.
+ * Once the queue is exhausted, further calls resolve to null.
+ */
+function makePage(evaluateResults = []) {
+  const evaluate = vi.fn();
+  for (const result of evaluateResults) {
+    evaluate.mockResolvedValueOnce(result);
+  }
+  evaluate.mockResolvedValue(null);
+  return {
+    evaluate,
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * makePage variant that prepends a manus.im URL — ensureOnManus first reads
+ * location.href via page.evaluate, so the queue's first slot is consumed by
+ * that URL check before the actual RPC result is reached.
+ */
+function manusPage(...rpcResults) {
+  return makePage(['https://manus.im/app', ...rpcResults]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Registration
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus adapter registration', () => {
+  it('registers 6 read-only commands with manus.im domain', () => {
+    const expected = {
+      status: 'read',
+      list: 'read',
+      read: 'read',
+      credits: 'read',
+      connectors: 'read',
+      skills: 'read',
+    };
+    for (const [name, access] of Object.entries(expected)) {
+      const cmd = getRegistry().get(`manus/${name}`);
+      expect(cmd, `manus/${name}`).toBeDefined();
+      expect(cmd.access).toBe(access);
+      expect(cmd.domain).toBe('manus.im');
+      expect(cmd.siteSession).toBe('persistent');
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. manus/status
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus status', () => {
+  const statusCmd = getRegistry().get('manus/status');
+
+  it('returns merged UserInfo + credits as Field/Value rows', async () => {
+    const page = manusPage([USER_INFO, CREDITS]);
+    const rows = await statusCmd.func(page, {});
+    expect(Array.isArray(rows)).toBe(true);
+    const map = Object.fromEntries(rows.map((r) => [r.Field, r.Value]));
+    expect(map['Email']).toBe('test@example.com');
+    expect(map['Display Name']).toBe('Test User');
+    expect(map['Membership Tier']).toBe('MEMBERSHIP_TIER_PRO');
+    expect(map['Total Credits']).toBe(12311);
+    expect(map['Refresh Credits']).toBe(300);
+    // Every row must have Field and Value columns
+    for (const row of rows) {
+      expect(row).toHaveProperty('Field');
+      expect(row).toHaveProperty('Value');
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. manus/list
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus list', () => {
+  const listCmd = getRegistry().get('manus/list');
+
+  it('returns non-archived sessions by default', async () => {
+    const page = manusPage(SESSIONS);
+    const rows = await listCmd.func(page, {});
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ UID: '8UcpCxMFLrNk63ZJmzALfV', Title: 'PPT task' });
+    expect(rows[1]).toMatchObject({ UID: 'YOpdpcVj7vPFD4gsBfEwVu', Title: 'Empire task' });
+  });
+
+  it('returns all sessions when --archived is passed', async () => {
+    const page = manusPage(SESSIONS);
+    const rows = await listCmd.func(page, { archived: true });
+    expect(rows).toHaveLength(3);
+  });
+
+  it('passes pageSize via --limit to evaluate body', async () => {
+    const page = manusPage(SESSIONS);
+    await listCmd.func(page, { limit: 1 });
+    // Verify page.evaluate was called (implementation-specific: the limit
+    // should be forwarded to the API call body as pageSize)
+    expect(page.evaluate).toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. manus/read
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus read', () => {
+  const readCmd = getRegistry().get('manus/read');
+
+  it('returns session detail as vertical Field/Value rows for found uid', async () => {
+    const page = manusPage(SESSIONS);
+    const rows = await readCmd.func(page, { uid: '8UcpCxMFLrNk63ZJmzALfV' });
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const map = Object.fromEntries(rows.map((r) => [r.Field, r.Value]));
+    expect(map['UID']).toBe('8UcpCxMFLrNk63ZJmzALfV');
+    expect(map['Title']).toBe('PPT task');
+    expect(map['Status']).toBe('SESSION_STATUS_STOPPED');
+  });
+
+  it('throws EmptyResultError when uid is not found in sessions', async () => {
+    const page = manusPage(SESSIONS);
+    await expect(readCmd.func(page, { uid: 'nonexistent' })).rejects.toBeInstanceOf(
+      EmptyResultError,
+    );
+  });
+
+  it('throws ArgumentError when uid is missing', async () => {
+    const page = manusPage();
+    await expect(readCmd.func(page, {})).rejects.toBeInstanceOf(ArgumentError);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. manus/credits
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus credits', () => {
+  const creditsCmd = getRegistry().get('manus/credits');
+
+  it('returns credit fields as Field/Value rows', async () => {
+    const page = manusPage(CREDITS);
+    const rows = await creditsCmd.func(page, {});
+    expect(rows).toHaveLength(8);
+    const map = Object.fromEntries(rows.map((r) => [r.Field, r.Value]));
+    expect(map['Total Credits']).toBe(12311);
+    expect(map['Free Credits']).toBe(11);
+    expect(map['Periodic Credits']).toBe(12000);
+    expect(map['Pro Monthly Credits']).toBe(12000);
+    expect(map['Refresh Credits']).toBe(300);
+    expect(map['Max Refresh Credits']).toBe(300);
+    expect(map['Next Refresh']).toBe('2026-06-03T16:00:00Z');
+    expect(map['Refresh Interval']).toBe('daily');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. manus/connectors
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus connectors', () => {
+  const connectorsCmd = getRegistry().get('manus/connectors');
+
+  it('returns all connectors as rows', async () => {
+    const page = manusPage(CONNECTORS);
+    const rows = await connectorsCmd.func(page, {});
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ UID: 'cf19c9d0-5f91', Name: 'Apify' });
+    expect(rows[1]).toMatchObject({ UID: 'abc', Name: 'GitHub' });
+  });
+
+  it('respects --limit to restrict connector count', async () => {
+    const page = manusPage(CONNECTORS);
+    const rows = await connectorsCmd.func(page, { limit: 1 });
+    expect(rows).toHaveLength(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. manus/skills
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus skills', () => {
+  const skillsCmd = getRegistry().get('manus/skills');
+
+  it('returns user-added skills with source=user', async () => {
+    const page = manusPage(SKILLS);
+    const rows = await skillsCmd.func(page, {});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      ID: 'R6qVrCn2',
+      Name: 'manus-api',
+      Description: 'Manage tasks via API',
+      Source: 'user',
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Auth error handling
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus auth error', () => {
+  const statusCmd = getRegistry().get('manus/status');
+
+  it('propagates session_id cookie missing errors with a clear message', async () => {
+    const page = manusPage();
+    page.evaluate.mockReset();
+    page.evaluate.mockRejectedValue(new Error('session_id cookie missing'));
+    await expect(statusCmd.func(page, {})).rejects.toThrow(/session_id cookie missing/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. isManusUrl helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('manus URL validation', () => {
+  it('accepts valid manus.im URLs', () => {
+    expect(isManusUrl('https://manus.im/app')).toBe(true);
+    expect(isManusUrl('https://manus.im/app/sessions')).toBe(true);
+  });
+
+  it('rejects non-manus URLs', () => {
+    expect(isManusUrl('https://other.com')).toBe(false);
+    expect(isManusUrl('https://manus.im.evil.com/app')).toBe(false);
+  });
+
+  it('rejects http (non-https) URLs', () => {
+    expect(isManusUrl('http://manus.im/app')).toBe(false);
+  });
+});

--- a/clis/manus/manus.test.js
+++ b/clis/manus/manus.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { isManusUrl } from './_utils.js';
 import './status.js';
 import './list.js';
@@ -104,6 +104,10 @@ function manusPage(...rpcResults) {
   return makePage(['https://manus.im/app', ...rpcResults]);
 }
 
+function envelope(data) {
+  return { session: { id: 'browser-session' }, data };
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 1. Registration
 // ═══════════════════════════════════════════════════════════════════════════
@@ -136,7 +140,7 @@ describe('manus status', () => {
   const statusCmd = getRegistry().get('manus/status');
 
   it('returns merged UserInfo + credits as Field/Value rows', async () => {
-    const page = manusPage([USER_INFO, CREDITS]);
+    const page = manusPage({ userInfo: USER_INFO, credits: CREDITS });
     const rows = await statusCmd.func(page, {});
     expect(Array.isArray(rows)).toBe(true);
     const map = Object.fromEntries(rows.map((r) => [r.Field, r.Value]));
@@ -151,6 +155,16 @@ describe('manus status', () => {
       expect(row).toHaveProperty('Value');
     }
   });
+
+  it('unwraps Browser Bridge envelopes and fails closed on missing user identity', async () => {
+    const page = manusPage(envelope({ userInfo: USER_INFO, credits: CREDITS }));
+    const rows = await statusCmd.func(page, {});
+    expect(Object.fromEntries(rows.map((r) => [r.Field, r.Value]))['User ID']).toBe('310519663277886366');
+
+    await expect(statusCmd.func(manusPage({ userInfo: {}, credits: CREDITS }), {})).rejects.toBeInstanceOf(
+      CommandExecutionError,
+    );
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -164,8 +178,14 @@ describe('manus list', () => {
     const page = manusPage(SESSIONS);
     const rows = await listCmd.func(page, {});
     expect(rows).toHaveLength(2);
-    expect(rows[0]).toMatchObject({ UID: '8UcpCxMFLrNk63ZJmzALfV', Title: 'PPT task' });
-    expect(rows[1]).toMatchObject({ UID: 'YOpdpcVj7vPFD4gsBfEwVu', Title: 'Empire task' });
+    expect(rows[0]).toMatchObject({ id: '8UcpCxMFLrNk63ZJmzALfV', Title: 'PPT task' });
+    expect(rows[1]).toMatchObject({ id: 'YOpdpcVj7vPFD4gsBfEwVu', Title: 'Empire task' });
+  });
+
+  it('unwraps Browser Bridge envelopes for session list responses', async () => {
+    const page = manusPage(envelope(SESSIONS));
+    const rows = await listCmd.func(page, {});
+    expect(rows[0].id).toBe('8UcpCxMFLrNk63ZJmzALfV');
   });
 
   it('returns all sessions when --archived is passed', async () => {
@@ -189,6 +209,13 @@ describe('manus list', () => {
     await expect(listCmd.func(page, { limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
     await expect(listCmd.func(page, { limit: -5 })).rejects.toBeInstanceOf(ArgumentError);
     await expect(listCmd.func(page, { limit: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
+  });
+
+  it('throws CommandExecutionError for malformed list payloads and rows', async () => {
+    await expect(listCmd.func(manusPage({}), {})).rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(listCmd.func(manusPage({ sessions: [{ title: 'missing uid' }] }), {})).rejects.toBeInstanceOf(
+      CommandExecutionError,
+    );
   });
 });
 
@@ -221,6 +248,13 @@ describe('manus read', () => {
     const page = manusPage();
     await expect(readCmd.func(page, {})).rejects.toBeInstanceOf(ArgumentError);
   });
+
+  it('throws CommandExecutionError when read receives malformed session payload', async () => {
+    const page = manusPage({});
+    await expect(readCmd.func(page, { uid: '8UcpCxMFLrNk63ZJmzALfV' })).rejects.toBeInstanceOf(
+      CommandExecutionError,
+    );
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -244,6 +278,13 @@ describe('manus credits', () => {
     expect(map['Next Refresh']).toBe('2026-06-03T16:00:00Z');
     expect(map['Refresh Interval']).toBe('daily');
   });
+
+  it('unwraps Browser Bridge envelopes and rejects malformed credit payloads', async () => {
+    const rows = await creditsCmd.func(manusPage(envelope(CREDITS)), {});
+    expect(Object.fromEntries(rows.map((r) => [r.Field, r.Value]))['Total Credits']).toBe(12311);
+
+    await expect(creditsCmd.func(manusPage({}), {})).rejects.toBeInstanceOf(CommandExecutionError);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -266,6 +307,13 @@ describe('manus connectors', () => {
     const rows = await connectorsCmd.func(page, { limit: 1 });
     expect(rows).toHaveLength(1);
   });
+
+  it('fails closed on malformed connector payloads and rows', async () => {
+    await expect(connectorsCmd.func(manusPage({}), {})).rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(connectorsCmd.func(manusPage({ connectors: [{ uid: 'missing-name' }] }), {})).rejects.toBeInstanceOf(
+      CommandExecutionError,
+    );
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -286,6 +334,13 @@ describe('manus skills', () => {
       Source: 'user',
     });
   });
+
+  it('fails closed on malformed skill payloads and rows', async () => {
+    await expect(skillsCmd.func(manusPage({}), {})).rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(skillsCmd.func(manusPage({ userAddedSkills: [{ id: 'missing-name' }] }), {})).rejects.toBeInstanceOf(
+      CommandExecutionError,
+    );
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -295,11 +350,14 @@ describe('manus skills', () => {
 describe('manus auth error', () => {
   const statusCmd = getRegistry().get('manus/status');
 
-  it('propagates session_id cookie missing errors with a clear message', async () => {
-    const page = manusPage();
-    page.evaluate.mockReset();
-    page.evaluate.mockRejectedValue(new Error('session_id cookie missing'));
-    await expect(statusCmd.func(page, {})).rejects.toThrow(/session_id cookie missing/);
+  it('maps session_id cookie missing payloads to AuthRequiredError', async () => {
+    const page = manusPage({ __authRequired: true, message: 'session_id cookie missing' });
+    await expect(statusCmd.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it('maps Manus HTTP error payloads to CommandExecutionError', async () => {
+    const page = manusPage({ __httpError: 500, message: 'server failed' });
+    await expect(statusCmd.func(page, {})).rejects.toBeInstanceOf(CommandExecutionError);
   });
 });
 

--- a/clis/manus/manus.test.js
+++ b/clis/manus/manus.test.js
@@ -177,9 +177,18 @@ describe('manus list', () => {
   it('passes pageSize via --limit to evaluate body', async () => {
     const page = manusPage(SESSIONS);
     await listCmd.func(page, { limit: 1 });
-    // Verify page.evaluate was called (implementation-specific: the limit
-    // should be forwarded to the API call body as pageSize)
-    expect(page.evaluate).toHaveBeenCalled();
+    // ensureOnManus eats the first evaluate call (URL probe); the RPC
+    // call is the second. Assert pageSize:1 was interpolated into it.
+    const rpcCallSrc = page.evaluate.mock.calls[1][0];
+    expect(rpcCallSrc).toMatch(/pageSize:\s*1/);
+    expect(rpcCallSrc).toContain('session.v1.SessionService/ListSessions');
+  });
+
+  it('rejects --limit 0 and other non-positive limits', async () => {
+    const page = manusPage(SESSIONS);
+    await expect(listCmd.func(page, { limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(listCmd.func(page, { limit: -5 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(listCmd.func(page, { limit: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
   });
 });
 

--- a/clis/manus/read.js
+++ b/clis/manus/read.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireArray, requireObject } from './_utils.js';
 
 function formatTime(iso) {
     if (!iso) return '—';
@@ -34,15 +34,15 @@ cli({
 
         await ensureOnManus(page);
 
-        const data = await page.evaluate(`(async () => {
+        const data = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
             return callManusAPI('session.v1.SessionService/ListSessions', {
                 page: 1,
                 pageSize: 100,
             });
-        })()`);
+        })()`), 'read session');
 
-        const sessions = data?.sessions || [];
+        const sessions = requireArray(data.sessions, 'read session');
         const session = sessions.find((s) => s.uid === uid);
 
         if (!session) {

--- a/clis/manus/read.js
+++ b/clis/manus/read.js
@@ -1,0 +1,63 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+function formatTime(iso) {
+    if (!iso) return '—';
+    try {
+        return new Date(iso).toLocaleString('en-US', {
+            month: 'short', day: 'numeric', year: 'numeric',
+            hour: '2-digit', minute: '2-digit',
+        });
+    } catch {
+        return iso;
+    }
+}
+
+cli({
+    site: 'manus',
+    name: 'read',
+    access: 'read',
+    description: 'Show details for a specific Manus session.',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [
+        { name: 'uid', positional: true, required: true, help: 'Session UID' },
+    ],
+    columns: ['Field', 'Value'],
+    func: async (page, kwargs) => {
+        const uid = String(kwargs?.uid || '').trim();
+        if (!uid) throw new ArgumentError('uid', 'must be a non-empty session UID');
+
+        await ensureOnManus(page);
+
+        const data = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            return callManusAPI('session.v1.SessionService/ListSessions', {
+                page: 1,
+                pageSize: 100,
+            });
+        })()`);
+
+        const sessions = data?.sessions || [];
+        const session = sessions.find((s) => s.uid === uid);
+
+        if (!session) {
+            throw new EmptyResultError('manus read', `Session not found: ${uid}`);
+        }
+
+        return [
+            { Field: 'UID', Value: session.uid || '—' },
+            { Field: 'Title', Value: session.title || '—' },
+            { Field: 'Status', Value: session.status || '—' },
+            { Field: 'Mode', Value: session.agentTaskMode ?? '—' },
+            { Field: 'Credits', Value: session.costedCredits ?? 0 },
+            { Field: 'Created', Value: formatTime(session.createdAt) },
+            { Field: 'Updated', Value: formatTime(session.updatedAt) },
+            { Field: 'Last Display Message', Value: session.lastDisplayMessage || '—' },
+        ];
+    },
+});

--- a/clis/manus/skills.js
+++ b/clis/manus/skills.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireArray, requireObject, requireString } from './_utils.js';
 
 cli({
     site: 'manus',
@@ -17,28 +17,36 @@ cli({
     func: async (page) => {
         await ensureOnManus(page);
 
-        const data = await page.evaluate(`(async () => {
+        const data = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
             return callManusAPI('skill.v1.SkillService/ListSkills', {});
-        })()`);
+        })()`), 'skills');
 
         const rows = [];
 
-        const userSkills = data?.userAddedSkills || [];
-        for (const s of userSkills) {
+        const hasUserSkills = Object.prototype.hasOwnProperty.call(data, 'userAddedSkills');
+        const hasSystemSkills = Object.prototype.hasOwnProperty.call(data, 'systemSkills') || Object.prototype.hasOwnProperty.call(data, 'skills');
+        if (!hasUserSkills && !hasSystemSkills) {
+            throw new CommandExecutionError('Manus skills returned a malformed API payload');
+        }
+
+        const userSkills = hasUserSkills ? requireArray(data.userAddedSkills, 'user skills') : [];
+        for (const [index, s] of userSkills.entries()) {
             rows.push({
-                ID: s.id || s.uid || '—',
-                Name: s.name || '—',
+                ID: requireString(s?.id || s?.uid, `user skill ${index + 1}`),
+                Name: requireString(s?.name, `user skill ${index + 1}`),
                 Description: (s.description || '—').slice(0, 80),
                 Source: 'user',
             });
         }
 
-        const systemSkills = data?.systemSkills || data?.skills || [];
-        for (const s of systemSkills) {
+        const systemSkills = Object.prototype.hasOwnProperty.call(data, 'systemSkills')
+            ? requireArray(data.systemSkills, 'system skills')
+            : (Object.prototype.hasOwnProperty.call(data, 'skills') ? requireArray(data.skills, 'system skills') : []);
+        for (const [index, s] of systemSkills.entries()) {
             rows.push({
-                ID: s.id || s.uid || '—',
-                Name: s.name || '—',
+                ID: requireString(s?.id || s?.uid, `system skill ${index + 1}`),
+                Name: requireString(s?.name, `system skill ${index + 1}`),
                 Description: (s.description || '—').slice(0, 80),
                 Source: 'system',
             });

--- a/clis/manus/skills.js
+++ b/clis/manus/skills.js
@@ -1,0 +1,53 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+cli({
+    site: 'manus',
+    name: 'skills',
+    access: 'read',
+    description: 'List Manus skills (user-added and system).',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [],
+    columns: ['ID', 'Name', 'Description', 'Source'],
+    func: async (page) => {
+        await ensureOnManus(page);
+
+        const data = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            return callManusAPI('skill.v1.SkillService/ListSkills', {});
+        })()`);
+
+        const rows = [];
+
+        const userSkills = data?.userAddedSkills || [];
+        for (const s of userSkills) {
+            rows.push({
+                ID: s.id || s.uid || '—',
+                Name: s.name || '—',
+                Description: (s.description || '—').slice(0, 80),
+                Source: 'user',
+            });
+        }
+
+        const systemSkills = data?.systemSkills || data?.skills || [];
+        for (const s of systemSkills) {
+            rows.push({
+                ID: s.id || s.uid || '—',
+                Name: s.name || '—',
+                Description: (s.description || '—').slice(0, 80),
+                Source: 'system',
+            });
+        }
+
+        if (!rows.length) {
+            throw new EmptyResultError('manus skills', 'No skills found.');
+        }
+
+        return rows;
+    },
+});

--- a/clis/manus/status.js
+++ b/clis/manus/status.js
@@ -1,0 +1,41 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+
+cli({
+    site: 'manus',
+    name: 'status',
+    access: 'read',
+    description: 'Show current Manus user profile and credit summary.',
+    domain: MANUS_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [],
+    columns: ['Field', 'Value'],
+    func: async (page) => {
+        await ensureOnManus(page);
+
+        const [userInfo, credits] = await page.evaluate(`(async () => {
+            ${MANUS_API_CALL_JS}
+            const [u, c] = await Promise.all([
+                callManusAPI('user.v1.UserService/UserInfo', {}),
+                callManusAPI('user.v1.UserService/GetAvailableCredits', {}),
+            ]);
+            return [u, c];
+        })()`);
+
+        const u = userInfo || {};
+        const c = credits || {};
+        return [
+            { Field: 'Email', Value: u.email || '—' },
+            { Field: 'Display Name', Value: u.displayname || u.displayName || '—' },
+            { Field: 'User ID', Value: u.userId || u.uid || '—' },
+            { Field: 'Membership Tier', Value: u.membershipTier || '—' },
+            { Field: 'Total Credits', Value: c.totalCredits ?? '—' },
+            { Field: 'Periodic Credits', Value: c.periodicCredits ?? '—' },
+            { Field: 'Refresh Credits', Value: c.refreshCredits ?? '—' },
+            { Field: 'Next Refresh', Value: c.nextRefreshTime || '—' },
+        ];
+    },
+});

--- a/clis/manus/status.js
+++ b/clis/manus/status.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS } from './_utils.js';
+import { MANUS_DOMAIN, ensureOnManus, MANUS_API_CALL_JS, requireObject, requireString } from './_utils.js';
 
 cli({
     site: 'manus',
@@ -16,17 +16,19 @@ cli({
     func: async (page) => {
         await ensureOnManus(page);
 
-        const [userInfo, credits] = await page.evaluate(`(async () => {
+        const data = requireObject(await page.evaluate(`(async () => {
             ${MANUS_API_CALL_JS}
-            const [u, c] = await Promise.all([
+            const [userInfo, credits] = await Promise.all([
                 callManusAPI('user.v1.UserService/UserInfo', {}),
                 callManusAPI('user.v1.UserService/GetAvailableCredits', {}),
             ]);
-            return [u, c];
-        })()`);
+            return { userInfo, credits };
+        })()`), 'status');
 
-        const u = userInfo || {};
-        const c = credits || {};
+        const u = requireObject(data.userInfo, 'status user info');
+        const c = requireObject(data.credits, 'status credits');
+        const userIdentity = u.email || u.userId || u.uid;
+        requireString(userIdentity, 'status user identity');
         return [
             { Field: 'Email', Value: u.email || '—' },
             { Field: 'Display Name', Value: u.displayname || u.displayName || '—' },

--- a/docs/adapters/browser/manus.md
+++ b/docs/adapters/browser/manus.md
@@ -1,0 +1,54 @@
+# manus
+
+Adapter for [Manus](https://manus.im) — the "Hands On AI" autonomous agent web app at `manus.im/app`.
+
+## Auth
+
+Cookie-mode. After the user signs in to `https://manus.im/app` in the Browser Bridge profile, the `session_id` cookie carries a JWT that the adapter re-uses as a Bearer token when calling Manus's Connect-RPC backend at `https://api.manus.im/`.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `manus status` | Account snapshot — email, display name, user ID, membership tier, and headline credit numbers. |
+| `manus list [--limit N] [--archived]` | List recent Manus sessions. Hides archived sessions unless `--archived` is passed. Default `--limit 20`. |
+| `manus read <uid>` | Show full field-level detail for a single session (looked up by UID via `ListSessions`). |
+| `manus credits` | Full credit breakdown — total / free / periodic / pro monthly / refresh / max refresh / next refresh / interval. |
+| `manus connectors [--limit N]` | List available Manus connectors (Apify, GitHub, Outlook, Slack, …). Default `--limit 50`. |
+| `manus skills` | List skills, both user-added (`source=user`) and system (`source=system`). |
+
+## Examples
+
+```
+$ opencli manus status
+Field: Email                Value: zhongyuelin990405@gmail.com
+Field: Display Name         Value: Lin Zhongyue
+Field: Membership Tier      Value: 60
+Field: Total Credits        Value: 12311
+Field: Periodic Credits     Value: 12000
+Field: Refresh Credits      Value: 300
+
+$ opencli manus list --limit 3
+UID: 8UcpCxMFLrNk63ZJmzALfV  Title: 制作技术方案路演风格PPT的详细要求  Status: stopped
+UID: YOpdpcVj7vPFD4gsBfEwVu  Title: Defining Empire: …                Status: stopped
+
+$ opencli manus read 8UcpCxMFLrNk63ZJmzALfV
+Field: UID            Value: 8UcpCxMFLrNk63ZJmzALfV
+Field: Title          Value: 制作技术方案路演风格PPT的详细要求
+Field: Status         Value: SESSION_STATUS_STOPPED
+Field: Mode           Value: AGENT_TASK_MODE_HIGH_EFFORT
+Field: Credits        Value: 4564
+```
+
+## Notes
+
+- Implementation is API-first: every command issues exactly one Connect-RPC POST against `api.manus.im` instead of scraping the DOM, so it is resilient to UI re-skins.
+- The CLI surface intentionally excludes destructive / state-changing actions (new task submission, chat replies, archive, delete). Manus's `/app` route is a pure React SPA with no per-session URL — there is no `/app/session/<uid>` page — so there is no verifiable post-state for those operations to assert against. They are deliberately out of scope until the Manus team exposes a per-session route or confirmation dialog.
+- `manus read <uid>` paginates through `ListSessions` (`pageSize=100`) and filters in-process. If the matching session lives beyond the first 100 most-recent sessions, the command will report it as not found.
+- `Status` and `Mode` are returned as the raw RPC enum strings (`SESSION_STATUS_STOPPED`, `AGENT_TASK_MODE_HIGH_EFFORT`, …). `Membership Tier` is the numeric tier code (e.g. `60`).
+
+## NOT exposed
+
+- `manus open <uid>` — `/app/session/<uid>` returns 404; the SPA has no URL routing for individual sessions.
+- `manus new-task <prompt>`, `manus chat <uid> <message>`, `manus pause/resume/cancel <uid>` — destructive state mutations whose effect cannot be verified from a stable post-state (URL never changes, no confirmation dialog).
+- `manus delete <uid>` / `manus archive <uid>` — same reasoning; no confirmation dialog and no URL-anchored post-state.

--- a/docs/adapters/browser/manus.md
+++ b/docs/adapters/browser/manus.md
@@ -11,8 +11,8 @@ Cookie-mode. After the user signs in to `https://manus.im/app` in the Browser Br
 | Command | Description |
 |---|---|
 | `manus status` | Account snapshot — email, display name, user ID, membership tier, and headline credit numbers. |
-| `manus list [--limit N] [--archived]` | List recent Manus sessions. Hides archived sessions unless `--archived` is passed. Default `--limit 20`. |
-| `manus read <uid>` | Show full field-level detail for a single session (looked up by UID via `ListSessions`). |
+| `manus list [--limit N] [--archived]` | List recent Manus sessions with round-trippable `id` values. Hides archived sessions unless `--archived` is passed. Default `--limit 20`. |
+| `manus read <uid>` | Show full field-level detail for a single session (looked up by the `id` emitted from `manus list`). |
 | `manus credits` | Full credit breakdown — total / free / periodic / pro monthly / refresh / max refresh / next refresh / interval. |
 | `manus connectors [--limit N]` | List available Manus connectors (Apify, GitHub, Outlook, Slack, …). Default `--limit 50`. |
 | `manus skills` | List skills, both user-added (`source=user`) and system (`source=system`). |
@@ -29,8 +29,8 @@ Field: Periodic Credits     Value: 12000
 Field: Refresh Credits      Value: 300
 
 $ opencli manus list --limit 3
-UID: 8UcpCxMFLrNk63ZJmzALfV  Title: 制作技术方案路演风格PPT的详细要求  Status: stopped
-UID: YOpdpcVj7vPFD4gsBfEwVu  Title: Defining Empire: …                Status: stopped
+id: 8UcpCxMFLrNk63ZJmzALfV  Title: 制作技术方案路演风格PPT的详细要求  Status: stopped
+id: YOpdpcVj7vPFD4gsBfEwVu  Title: Defining Empire: …                Status: stopped
 
 $ opencli manus read 8UcpCxMFLrNk63ZJmzALfV
 Field: UID            Value: 8UcpCxMFLrNk63ZJmzALfV
@@ -44,7 +44,7 @@ Field: Credits        Value: 4564
 
 - Implementation is API-first: every command issues exactly one Connect-RPC POST against `api.manus.im` instead of scraping the DOM, so it is resilient to UI re-skins.
 - The CLI surface intentionally excludes destructive / state-changing actions (new task submission, chat replies, archive, delete). Manus's `/app` route is a pure React SPA with no per-session URL — there is no `/app/session/<uid>` page — so there is no verifiable post-state for those operations to assert against. They are deliberately out of scope until the Manus team exposes a per-session route or confirmation dialog.
-- `manus read <uid>` paginates through `ListSessions` (`pageSize=100`) and filters in-process. If the matching session lives beyond the first 100 most-recent sessions, the command will report it as not found.
+- `manus read <uid>` calls `ListSessions` with `pageSize=100` and filters in-process. If the matching session lives beyond the first 100 most-recent sessions, the command will report it as not found.
 - `Status` and `Mode` are returned as the raw RPC enum strings (`SESSION_STATUS_STOPPED`, `AGENT_TASK_MODE_HIGH_EFFORT`, …). `Membership Tier` is the numeric tier code (e.g. `60`).
 
 ## NOT exposed


### PR DESCRIPTION
Adds an adapter for [Manus](https://manus.im), the autonomous AI agent web app at `manus.im/app`. Closes #1836.

## Commands

All read-only, all backed by Manus's Connect-RPC backend at `api.manus.im`.

| Command | RPC |
|---|---|
| `manus status` | `UserService/UserInfo` + `GetAvailableCredits` |
| `manus list [--limit N] [--archived]` | `SessionService/ListSessions` |
| `manus read <uid>` | `SessionService/ListSessions` (filter in-process) |
| `manus credits` | `UserService/GetAvailableCredits` |
| `manus connectors [--limit N]` | `ConnectorsService/ListConnectors` |
| `manus skills` | `SkillService/ListSkills` |

## Architecture

Cookie-mode adapter. The `session_id` cookie issued by `manus.im` is a JWT that Manus's own frontend re-uses as a Bearer token against the cross-origin Connect-RPC backend at `api.manus.im`. The adapter does the same — each command is one POST inside the manus.im page context with `Authorization: Bearer ${session_id cookie}`. **No DOM scraping**, so the surface is resilient to UI re-skins.

`--limit` is validated against `int32.gte_lte` constraints client-side so users get a clear `ArgumentError` (`code: ARGUMENT`) instead of an opaque server 400.

## Scope discipline

Manus's `/app` route is a pure React SPA — visiting `https://manus.im/app/session/<uid>` returns HTTP 404, and sidebar items are `<div role="button">` with empty `href`. Because there is **no per-session URL** and no confirmation dialog for destructive actions, the following are deliberately out of scope (no verifiable post-state to assert against):

- `manus open <uid>`
- `manus new-task <prompt>` / `manus chat <uid> <message>`
- `manus pause / resume / cancel <uid>`
- `manus delete / archive <uid>`

See [`docs/adapters/browser/manus.md`](docs/adapters/browser/manus.md) for the full NOT-exposed list and rationale.

## Verification

- `clis/manus/manus.test.js` — 17 cases:
  - 1× registration (all 6 commands, `access: 'read'`)
  - 1× status (UserInfo + credits merging)
  - 5× list (default archive filter / `--archived` / `--limit` body interpolation / `--limit 0` / `-5` / `1.5` all rejected)
  - 3× read (happy path / uid not found / missing UID argument)
  - 1× credits (8 fields)
  - 2× connectors (all + `--limit`)
  - 1× skills (user-added with `source=user`)
  - 1× auth error propagation
  - 4× `isManusUrl` URL parser
- `npm run test:adapter` — 380 files / 3731 tests pass.
- `npm run build-manifest` — clean, +6 entries (`manus/status`, `manus/list`, `manus/read`, `manus/credits`, `manus/connectors`, `manus/skills`).
- **Live smoke test** against a real logged-in Manus account: every command returns real data end-to-end via the Browser Bridge.

```
$ opencli manus status
- Field: Email           Value: zhongyuelin990405@gmail.com
- Field: Display Name    Value: Lin Zhongyue
- Field: Membership Tier Value: 60
- Field: Total Credits   Value: 12311
- Field: Periodic Credits Value: 12000
- Field: Refresh Credits Value: 300

$ opencli manus list --limit 0
ok: false
error:
  code: ARGUMENT

$ opencli manus connectors --limit 3
- UID: cf19c9d0-…  Name: Apify         Brief: Connect AI agents to thousands…
- UID: 4bca3029-…  Name: Outlook Calendar
- UID: d485c6dd-…  Name: Outlook Mail
```