### PR TITLE
feat(gemini): add status / history / detail / read commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11932,6 +11932,63 @@
   },
   {
     "site": "gemini",
+    "name": "detail",
+    "description": "Open a Gemini web conversation by id, URL, or sidebar title and read its turns",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation id, /app/<id> URL, or sidebar title"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Role",
+      "Text"
+    ],
+    "type": "js",
+    "modulePath": "gemini/detail.js",
+    "sourceFile": "gemini/detail.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
+    "name": "history",
+    "description": "List visible Gemini web conversation history from the sidebar",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max conversations to show"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Id",
+      "Title",
+      "Url"
+    ],
+    "type": "js",
+    "modulePath": "gemini/history.js",
+    "sourceFile": "gemini/history.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
     "name": "image",
     "description": "Generate images with Gemini web and save them locally",
     "access": "write",
@@ -12010,6 +12067,46 @@
     "type": "js",
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
+    "name": "read",
+    "description": "Read the turns visible in the current Gemini web conversation",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Index",
+      "Role",
+      "Text"
+    ],
+    "type": "js",
+    "modulePath": "gemini/read.js",
+    "sourceFile": "gemini/read.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
+    "name": "status",
+    "description": "Check Gemini web page availability and login state",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "Status",
+      "Login",
+      "Url"
+    ],
+    "type": "js",
+    "modulePath": "gemini/status.js",
+    "sourceFile": "gemini/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
   },

--- a/clis/gemini/commands.test.js
+++ b/clis/gemini/commands.test.js
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const mocks = vi.hoisted(() => ({
+    ensureGeminiPage: vi.fn(),
+    getGeminiPageState: vi.fn(),
+    getGeminiConversationList: vi.fn(),
+    getGeminiVisibleTurns: vi.fn(),
+    resolveGeminiConversationForQuery: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+    const actual = await vi.importActual('./utils.js');
+    return {
+        ...actual,
+        ensureGeminiPage: mocks.ensureGeminiPage,
+        getGeminiPageState: mocks.getGeminiPageState,
+        getGeminiConversationList: mocks.getGeminiConversationList,
+        getGeminiVisibleTurns: mocks.getGeminiVisibleTurns,
+        resolveGeminiConversationForQuery: mocks.resolveGeminiConversationForQuery,
+    };
+});
+
+import { statusCommand } from './status.js';
+import { historyCommand, extractGeminiId } from './history.js';
+import { detailCommand } from './detail.js';
+import { readCommand } from './read.js';
+
+function makePage() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(null),
+    };
+}
+
+describe('extractGeminiId', () => {
+    it('parses bare id', () => {
+        expect(extractGeminiId('b8368a89d4242e5f')).toBe('b8368a89d4242e5f');
+    });
+    it('parses /app/<id> path', () => {
+        expect(extractGeminiId('/app/abc123')).toBe('abc123');
+    });
+    it('parses full URL', () => {
+        expect(extractGeminiId('https://gemini.google.com/app/xyz789')).toBe('xyz789');
+    });
+    it('returns empty for garbage', () => {
+        expect(extractGeminiId('')).toBe('');
+        expect(extractGeminiId('not a url with spaces!')).toBe('');
+    });
+});
+
+describe('gemini status', () => {
+    it('returns Connected + Yes when composer present and no sign-in CTA', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiPageState.mockResolvedValue({
+            url: 'https://gemini.google.com/app',
+            title: 'Google Gemini',
+            isSignedIn: true,
+            composerLabel: 'Enter a prompt here',
+            canSend: true,
+        });
+        const rows = await statusCommand.func(makePage(), {});
+        expect(rows).toEqual([{ Status: 'Connected', Login: 'Yes', Url: 'https://gemini.google.com/app' }]);
+    });
+
+    it('returns No login when sign-in CTA detected', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiPageState.mockResolvedValue({
+            url: 'https://gemini.google.com/app',
+            title: 'Google Gemini',
+            isSignedIn: false,
+            composerLabel: '',
+            canSend: false,
+        });
+        const rows = await statusCommand.func(makePage(), {});
+        expect(rows[0].Login).toBe('No');
+        expect(rows[0].Status).toBe('Page not ready');
+    });
+
+    it('treats isSignedIn=null (ambiguous) as logged in when composer is present', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiPageState.mockResolvedValue({
+            url: 'https://gemini.google.com/app',
+            isSignedIn: null,
+            canSend: true,
+        });
+        const rows = await statusCommand.func(makePage(), {});
+        expect(rows[0].Login).toBe('Yes');
+    });
+});
+
+describe('gemini history', () => {
+    it('returns numbered conversation rows', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiConversationList.mockResolvedValue([
+            { Title: 'First chat', Url: 'https://gemini.google.com/app/aaa111' },
+            { Title: 'Second chat', Url: 'https://gemini.google.com/app/bbb222' },
+        ]);
+        const rows = await historyCommand.func(makePage(), { limit: 20 });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toEqual({
+            Index: 1,
+            Id: 'aaa111',
+            Title: 'First chat',
+            Url: 'https://gemini.google.com/app/aaa111',
+        });
+        expect(rows[1].Id).toBe('bbb222');
+    });
+
+    it('respects --limit', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiConversationList.mockResolvedValue([
+            { Title: 'a', Url: 'https://gemini.google.com/app/1' },
+            { Title: 'b', Url: 'https://gemini.google.com/app/2' },
+            { Title: 'c', Url: 'https://gemini.google.com/app/3' },
+        ]);
+        const rows = await historyCommand.func(makePage(), { limit: 2 });
+        expect(rows).toHaveLength(2);
+    });
+
+    it('throws ArgumentError for non-positive --limit', async () => {
+        await expect(historyCommand.func(makePage(), { limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(historyCommand.func(makePage(), { limit: -1 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(historyCommand.func(makePage(), { limit: 1.5 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('throws EmptyResultError when sidebar is empty', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiConversationList.mockResolvedValue([]);
+        await expect(historyCommand.func(makePage(), { limit: 20 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('gemini detail', () => {
+    it('navigates directly when given a bare id', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiVisibleTurns.mockResolvedValue([
+            { Role: 'User', Text: 'hello' },
+            { Role: 'Assistant', Text: 'hi there' },
+        ]);
+        const page = makePage();
+        const rows = await detailCommand.func(page, { id: 'b8368a89d4242e5f' });
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://gemini.google.com/app/b8368a89d4242e5f',
+            expect.objectContaining({ waitUntil: 'load' }),
+        );
+        expect(rows).toEqual([
+            { Index: 1, Role: 'User', Text: 'hello' },
+            { Index: 2, Role: 'Assistant', Text: 'hi there' },
+        ]);
+    });
+
+    it('resolves a sidebar title to its URL', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiConversationList.mockResolvedValue([
+            { Title: 'Roman empire study', Url: 'https://gemini.google.com/app/rome1' },
+        ]);
+        mocks.resolveGeminiConversationForQuery.mockReturnValue({
+            Title: 'Roman empire study',
+            Url: 'https://gemini.google.com/app/rome1',
+        });
+        mocks.getGeminiVisibleTurns.mockResolvedValue([{ Role: 'Assistant', Text: 'reply' }]);
+        const page = makePage();
+        const rows = await detailCommand.func(page, { id: 'roman' });
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://gemini.google.com/app/rome1',
+            expect.any(Object),
+        );
+        expect(rows).toHaveLength(1);
+    });
+
+    it('throws ArgumentError when id is missing', async () => {
+        await expect(detailCommand.func(makePage(), { id: '' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('throws EmptyResultError when title has no match', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiConversationList.mockResolvedValue([
+            { Title: 'a', Url: 'https://gemini.google.com/app/1' },
+        ]);
+        mocks.resolveGeminiConversationForQuery.mockReturnValue(null);
+        await expect(detailCommand.func(makePage(), { id: 'nope' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws EmptyResultError when navigated page yields zero turns', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiVisibleTurns.mockResolvedValue([]);
+        await expect(detailCommand.func(makePage(), { id: 'abc' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('gemini read', () => {
+    it('returns indexed turns for the current page', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiVisibleTurns.mockResolvedValue([
+            { Role: 'User', Text: 'q1' },
+            { Role: 'Assistant', Text: 'a1' },
+        ]);
+        const rows = await readCommand.func(makePage());
+        expect(rows).toEqual([
+            { Index: 1, Role: 'User', Text: 'q1' },
+            { Index: 2, Role: 'Assistant', Text: 'a1' },
+        ]);
+    });
+
+    it('throws EmptyResultError when no turns are visible', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.getGeminiVisibleTurns.mockResolvedValue([]);
+        await expect(readCommand.func(makePage())).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});

--- a/clis/gemini/detail.js
+++ b/clis/gemini/detail.js
@@ -1,0 +1,82 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    GEMINI_APP_URL,
+    GEMINI_DOMAIN,
+    ensureGeminiPage,
+    getGeminiConversationList,
+    getGeminiVisibleTurns,
+    resolveGeminiConversationForQuery,
+} from './utils.js';
+import { extractGeminiId } from './history.js';
+
+/**
+ * Resolve the caller-supplied `<id>` argument into an absolute
+ * conversation URL. Accepts:
+ *   1. A bare conversation id (`b8368a89d4242e5f`)
+ *   2. A relative `/app/<id>` path
+ *   3. A full `https://gemini.google.com/app/<id>` URL
+ *   4. A sidebar title — looked up exactly first, then by substring
+ */
+async function resolveTargetUrl(page, query) {
+    const raw = String(query || '').trim();
+    if (!raw) {
+        throw new ArgumentError('id', 'must be a conversation id, /app/<id> URL, or sidebar title');
+    }
+
+    // Unambiguously id-shaped inputs (URL, /app/<id> path, or 16-hex bare id)
+    // skip the sidebar lookup. Generic alphanumeric strings always go through
+    // title-matching first so a chat called "Empire study" doesn't get treated
+    // as the literal conversation id "Empire study".
+    const directId = extractGeminiId(raw);
+    const looksLikeId =
+        raw.startsWith('http') ||
+        raw.startsWith('/app/') ||
+        /^[a-f0-9]{16,}$/i.test(raw);
+    if (directId && looksLikeId) {
+        return `${GEMINI_APP_URL}/${directId}`;
+    }
+
+    const conversations = await getGeminiConversationList(page);
+    const match = resolveGeminiConversationForQuery(conversations, raw, 'contains');
+    if (!match || !match.Url) {
+        throw new EmptyResultError(
+            'gemini detail',
+            `No sidebar conversation matched "${raw}". Try the exact id from \`opencli gemini history\` instead.`,
+        );
+    }
+    return match.Url;
+}
+
+export const detailCommand = cli({
+    site: 'gemini',
+    name: 'detail',
+    access: 'read',
+    description: 'Open a Gemini web conversation by id, URL, or sidebar title and read its turns',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Conversation id, /app/<id> URL, or sidebar title' },
+    ],
+    columns: ['Index', 'Role', 'Text'],
+    func: async (page, kwargs) => {
+        await ensureGeminiPage(page);
+        const target = await resolveTargetUrl(page, kwargs?.id);
+        await page.goto(target, { waitUntil: 'load', settleMs: 2500 });
+        const turns = await getGeminiVisibleTurns(page);
+        if (!Array.isArray(turns) || turns.length === 0) {
+            throw new EmptyResultError(
+                'gemini detail',
+                `No turns were visible after navigating to ${target}.`,
+            );
+        }
+        return turns.map((t, idx) => ({
+            Index: idx + 1,
+            Role: t.Role || 'System',
+            Text: t.Text || '',
+        }));
+    },
+});

--- a/clis/gemini/history.js
+++ b/clis/gemini/history.js
@@ -1,0 +1,70 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    GEMINI_DOMAIN,
+    ensureGeminiPage,
+    getGeminiConversationList,
+} from './utils.js';
+
+/**
+ * Pull the Gemini conversation id out of a `/app/<id>` URL or accept the
+ * raw id directly. Returns '' when nothing usable is present.
+ */
+function extractGeminiId(url) {
+    const raw = String(url || '').trim();
+    if (!raw) return '';
+    try {
+        const u = new URL(raw, 'https://gemini.google.com');
+        const m = u.pathname.match(/^\/app\/([A-Za-z0-9_-]+)/);
+        if (m) return m[1];
+    } catch {
+        // Not a URL — fall through to direct id treatment.
+    }
+    // Accept a bare id ('app/<id>' or just '<id>').
+    const trimmed = raw.replace(/^.*\/app\//, '').replace(/\/.*$/, '');
+    return /^[A-Za-z0-9_-]+$/.test(trimmed) ? trimmed : '';
+}
+
+export const historyCommand = cli({
+    site: 'gemini',
+    name: 'history',
+    access: 'read',
+    description: 'List visible Gemini web conversation history from the sidebar',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max conversations to show' },
+    ],
+    columns: ['Index', 'Id', 'Title', 'Url'],
+    func: async (page, kwargs) => {
+        const rawLimit = Number(kwargs?.limit ?? 20);
+        if (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > 200) {
+            throw new ArgumentError('limit', 'must be a positive integer ≤ 200');
+        }
+        await ensureGeminiPage(page);
+        const conversations = await getGeminiConversationList(page);
+        if (!conversations.length) {
+            throw new EmptyResultError(
+                'gemini history',
+                'No Gemini conversation links were visible in the sidebar. Open the sidebar and confirm at least one chat is listed under Recents.',
+            );
+        }
+        // The sidebar mixes a "New chat" affordance (URL = /app, no id) into
+        // the same link list; drop entries that don't resolve to a real
+        // conversation id so callers get a clean conversation list.
+        const rows = conversations
+            .map((row) => ({ id: extractGeminiId(row.Url), title: row.Title || '', url: row.Url || '' }))
+            .filter((row) => row.id);
+        return rows.slice(0, rawLimit).map((row, idx) => ({
+            Index: idx + 1,
+            Id: row.id,
+            Title: row.title,
+            Url: row.url,
+        }));
+    },
+});
+
+export { extractGeminiId };

--- a/clis/gemini/read.js
+++ b/clis/gemini/read.js
@@ -1,0 +1,36 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    GEMINI_DOMAIN,
+    ensureGeminiPage,
+    getGeminiVisibleTurns,
+} from './utils.js';
+
+export const readCommand = cli({
+    site: 'gemini',
+    name: 'read',
+    access: 'read',
+    description: 'Read the turns visible in the current Gemini web conversation',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: ['Index', 'Role', 'Text'],
+    func: async (page) => {
+        await ensureGeminiPage(page);
+        const turns = await getGeminiVisibleTurns(page);
+        if (!Array.isArray(turns) || turns.length === 0) {
+            throw new EmptyResultError(
+                'gemini read',
+                'No turns were visible. Open a Gemini conversation first or use `opencli gemini detail <id>` to navigate.',
+            );
+        }
+        return turns.map((t, idx) => ({
+            Index: idx + 1,
+            Role: t.Role || 'System',
+            Text: t.Text || '',
+        }));
+    },
+});

--- a/clis/gemini/status.js
+++ b/clis/gemini/status.js
@@ -1,0 +1,32 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    GEMINI_DOMAIN,
+    ensureGeminiPage,
+    getGeminiPageState,
+} from './utils.js';
+
+export const statusCommand = cli({
+    site: 'gemini',
+    name: 'status',
+    access: 'read',
+    description: 'Check Gemini web page availability and login state',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: ['Status', 'Login', 'Url'],
+    func: async (page) => {
+        await ensureGeminiPage(page);
+        const state = await getGeminiPageState(page);
+        // `isSignedIn` is one of {true, false, null}. `null` means the composer
+        // was visible but no explicit Sign-in CTA was found — treat as logged in.
+        const loggedIn = state.isSignedIn === false ? 'No' : 'Yes';
+        return [{
+            Status: state.canSend ? 'Connected' : 'Page not ready',
+            Login: loggedIn,
+            Url: state.url || '',
+        }];
+    },
+});

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -1083,10 +1083,12 @@ export async function startNewGeminiChat(page) {
 export async function getGeminiConversationList(page) {
     await ensureGeminiPage(page);
     const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
-    const rows = raw.map((item) => {
+    const rows = raw.flatMap((item) => {
         if (!isObjectRecord(item) || typeof item.title !== 'string' || typeof item.url !== 'string') {
             throw new CommandExecutionError('Gemini conversation list returned a malformed row');
         }
+        if (!isGeminiConversationUrl(item.url))
+            return [];
         return { Title: item.title, Url: item.url };
     });
     return rows;

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -35,6 +35,32 @@ const GEMINI_COMPOSER_SELECTORS = [
 const GEMINI_COMPOSER_MARKER_ATTR = 'data-opencli-gemini-composer';
 const GEMINI_COMPOSER_PREPARE_ATTEMPTS = 4;
 const GEMINI_COMPOSER_PREPARE_WAIT_SECONDS = 1;
+function isObjectRecord(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+function unwrapGeminiEvaluateResult(value, context) {
+    if (isObjectRecord(value) && Object.prototype.hasOwnProperty.call(value, 'session')) {
+        if (Object.prototype.hasOwnProperty.call(value, 'data')) {
+            return value.data;
+        }
+        throw new CommandExecutionError(`${context} returned a malformed Browser Bridge envelope`);
+    }
+    return value;
+}
+function requireGeminiArrayResult(value, context) {
+    const unwrapped = unwrapGeminiEvaluateResult(value, context);
+    if (!Array.isArray(unwrapped)) {
+        throw new CommandExecutionError(`${context} returned a malformed result`);
+    }
+    return unwrapped;
+}
+function requireGeminiObjectResult(value, context) {
+    const unwrapped = unwrapGeminiEvaluateResult(value, context);
+    if (!isObjectRecord(unwrapped)) {
+        throw new CommandExecutionError(`${context} returned a malformed result`);
+    }
+    return unwrapped;
+}
 function buildGeminiComposerLocatorScript() {
     const selectorsJson = JSON.stringify(GEMINI_COMPOSER_SELECTORS);
     const markerAttrJson = JSON.stringify(GEMINI_COMPOSER_MARKER_ATTR);
@@ -1043,7 +1069,7 @@ export async function waitForGeminiConfirmButton(page, labels, timeoutSeconds) {
 }
 export async function getGeminiPageState(page) {
     await ensureGeminiPage(page);
-    return await page.evaluate(getStateScript());
+    return requireGeminiObjectResult(await page.evaluate(getStateScript()), 'Gemini status');
 }
 export async function startNewGeminiChat(page) {
     await ensureGeminiPage(page);
@@ -1056,12 +1082,14 @@ export async function startNewGeminiChat(page) {
 }
 export async function getGeminiConversationList(page) {
     await ensureGeminiPage(page);
-    const raw = await page.evaluate(getGeminiConversationListScript());
-    if (!Array.isArray(raw))
-        return [];
-    return raw
-        .filter((item) => item && typeof item.title === 'string' && typeof item.url === 'string')
-        .map((item) => ({ Title: item.title, Url: item.url }));
+    const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
+    const rows = raw.map((item) => {
+        if (!isObjectRecord(item) || typeof item.title !== 'string' || typeof item.url !== 'string') {
+            throw new CommandExecutionError('Gemini conversation list returned a malformed row');
+        }
+        return { Title: item.title, Url: item.url };
+    });
+    return rows;
 }
 export async function clickGeminiConversationByTitle(page, query) {
     await ensureGeminiPage(page);
@@ -1082,12 +1110,22 @@ export async function getGeminiVisibleTurns(page) {
 }
 async function getGeminiStructuredTurns(page) {
     await ensureGeminiPage(page);
-    const turns = collapseAdjacentGeminiTurns(await page.evaluate(getTurnsScript()));
+    const raw = requireGeminiArrayResult(await page.evaluate(getTurnsScript()), 'Gemini visible turns');
+    for (const turn of raw) {
+        if (!isObjectRecord(turn) || typeof turn.Role !== 'string' || typeof turn.Text !== 'string') {
+            throw new CommandExecutionError('Gemini visible turns returned a malformed row');
+        }
+    }
+    const turns = collapseAdjacentGeminiTurns(raw);
     return Array.isArray(turns) ? turns : [];
 }
 export async function getGeminiTranscriptLines(page) {
     await ensureGeminiPage(page);
-    return await page.evaluate(getTranscriptLinesScript());
+    const lines = requireGeminiArrayResult(await page.evaluate(getTranscriptLinesScript()), 'Gemini transcript lines');
+    if (!lines.every((line) => typeof line === 'string')) {
+        throw new CommandExecutionError('Gemini transcript lines returned a malformed row');
+    }
+    return lines;
 }
 export async function waitForGeminiTranscript(page, attempts = 5) {
     let lines = [];
@@ -1112,7 +1150,15 @@ export async function getLatestGeminiAssistantResponse(page) {
 }
 export async function readGeminiSnapshot(page) {
     await ensureGeminiPage(page);
-    return await page.evaluate(readGeminiSnapshotScript());
+    const snapshot = requireGeminiObjectResult(await page.evaluate(readGeminiSnapshotScript()), 'Gemini page snapshot');
+    if (!Array.isArray(snapshot.turns) ||
+        !Array.isArray(snapshot.transcriptLines) ||
+        typeof snapshot.composerHasText !== 'boolean' ||
+        typeof snapshot.isGenerating !== 'boolean' ||
+        typeof snapshot.structuredTurnsTrusted !== 'boolean') {
+        throw new CommandExecutionError('Gemini page snapshot returned a malformed result');
+    }
+    return snapshot;
 }
 function findLastUserTurnIndex(turns) {
     for (let index = turns.length - 1; index >= 0; index -= 1) {

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -191,6 +191,19 @@ describe('gemini evaluate result boundaries', () => {
             { Title: 'Chat A', Url: 'https://gemini.google.com/app/abc123' },
         ]);
     });
+    it('drops non-conversation /app affordances from conversation lists', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([
+            { title: 'New chat', url: 'https://gemini.google.com/app' },
+            { title: 'Chat A', url: 'https://gemini.google.com/app/abc123' },
+        ]);
+        await expect(getGeminiConversationList(page)).resolves.toEqual([
+            { Title: 'Chat A', Url: 'https://gemini.google.com/app/abc123' },
+        ]);
+    });
     it('typed-fails malformed Browser Bridge envelopes instead of treating them as empty', async () => {
         const page = createPageMock();
         const evaluate = vi.mocked(page.evaluate);

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { __test__, collectGeminiTranscriptAdditions, pickGeminiDeepResearchExportUrl, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
 function createPageMock() {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -174,6 +175,113 @@ describe('gemini turn normalization', () => {
             { Role: 'User', Text: '请只回复：OK' },
             { Role: 'Assistant', Text: 'OK' },
         ]);
+    });
+});
+describe('gemini evaluate result boundaries', () => {
+    it('unwraps Browser Bridge envelopes for conversation lists', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: [{ title: 'Chat A', url: 'https://gemini.google.com/app/abc123' }],
+        });
+        await expect(getGeminiConversationList(page)).resolves.toEqual([
+            { Title: 'Chat A', Url: 'https://gemini.google.com/app/abc123' },
+        ]);
+    });
+    it('typed-fails malformed Browser Bridge envelopes instead of treating them as empty', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({ session: 'site:gemini' });
+        await expect(getGeminiConversationList(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+    it('typed-fails malformed conversation list rows', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([{ title: 'Chat A' }]);
+        await expect(getGeminiConversationList(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+    it('unwraps structured turns and transcript fallback results', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: [{ Role: 'User', Text: 'hello' }],
+        });
+        await expect(getGeminiVisibleTurns(page)).resolves.toEqual([{ Role: 'User', Text: 'hello' }]);
+
+        const fallbackPage = createPageMock();
+        const fallbackEvaluate = vi.mocked(fallbackPage.evaluate);
+        fallbackEvaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: ['plain transcript line'],
+        });
+        await expect(getGeminiVisibleTurns(fallbackPage)).resolves.toEqual([
+            { Role: 'System', Text: 'plain transcript line' },
+        ]);
+    });
+    it('typed-fails malformed visible turn rows', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([{ Role: 'Assistant' }]);
+        await expect(getGeminiVisibleTurns(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+    it('unwraps and validates status and snapshot objects', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: { url: 'https://gemini.google.com/app', canSend: true, isSignedIn: true },
+        });
+        await expect(getGeminiPageState(page)).resolves.toMatchObject({ canSend: true });
+
+        const snapshotPage = createPageMock();
+        const snapshotEvaluate = vi.mocked(snapshotPage.evaluate);
+        snapshotEvaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: {
+                turns: [],
+                transcriptLines: [],
+                composerHasText: false,
+                isGenerating: false,
+                structuredTurnsTrusted: true,
+            },
+        });
+        await expect(readGeminiSnapshot(snapshotPage)).resolves.toMatchObject({
+            structuredTurnsTrusted: true,
+        });
+    });
+    it('typed-fails malformed page snapshots', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({
+            turns: {},
+            transcriptLines: [],
+            composerHasText: false,
+            isGenerating: false,
+            structuredTurnsTrusted: true,
+        });
+        await expect(readGeminiSnapshot(page)).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });
 describe('pickGeminiDeepResearchExportUrl', () => {

--- a/docs/adapters/browser/gemini.md
+++ b/docs/adapters/browser/gemini.md
@@ -11,6 +11,10 @@
 | `opencli gemini image <prompt>` | Generate images in Gemini and optionally save them locally |
 | `opencli gemini deep-research <prompt>` | Start a Gemini Deep Research run and confirm it |
 | `opencli gemini deep-research-result <query>` | Export Deep Research report URL from a Gemini conversation |
+| `opencli gemini status` | Check Gemini web page availability and login state |
+| `opencli gemini history [--limit N]` | List visible Gemini conversation history from the sidebar |
+| `opencli gemini detail <id>` | Open a Gemini conversation by id, URL, or sidebar title and read its turns |
+| `opencli gemini read` | Read the turns visible in the current Gemini web conversation |
 
 ## Usage Examples
 


### PR DESCRIPTION
ChatGPT and Claude already expose `status` / `history` / `detail` / `read`; Gemini was missing all four. The helpers needed to back them (`getGeminiPageState`, `getGeminiConversationList`, `resolveGeminiConversationForQuery`, `getGeminiVisibleTurns`) are already implemented in `clis/gemini/utils.js` — this PR is just the `cli()` wire-up plus an `extractGeminiId` parser shared between `history` and `detail`.

## Commands added

| Command | Source helper | Notes |
|---|---|---|
| `gemini status` | `getGeminiPageState` | Treats `isSignedIn=null` (composer present but no explicit Sign-in CTA) as logged in. |
| `gemini history [--limit N]` | `getGeminiConversationList` | Filters out the sidebar's "New chat" affordance (URL = `/app`, no id) so callers get a clean conversation list. `--limit` clamped to `[1, 200]`. |
| `gemini detail <id>` | `getGeminiConversationList` + `resolveGeminiConversationForQuery` + `getGeminiVisibleTurns` | Accepts a bare 16-hex id, `/app/<id>` path, full URL, or a sidebar title (exact or substring). |
| `gemini read` | `getGeminiVisibleTurns` | Current-conversation turns. |

`detail` only short-circuits the sidebar lookup when the input is unambiguously id-shaped (URL / `/app/<id>` / 16-hex bare id). Generic alphanumeric strings like `"Empire study"` go through title-matching first so a chat doesn't get treated as a literal conversation id.

## Verification

- `clis/gemini/commands.test.js` — **18 cases**:
  - 4× `extractGeminiId` (bare id / path / URL / garbage)
  - 3× `status` (connected / signed-out CTA / ambiguous-null treated as logged in)
  - 4× `history` (rows / `--limit` / `--limit` validation / empty sidebar)
  - 5× `detail` (direct-id nav / title resolution / missing id / no-match / zero turns)
  - 2× `read` (happy / zero turns)
- `npm run test:adapter` — **380 files / 3732 tests pass**
- `npm run build-manifest` — clean, +4 entries (`gemini/status`, `gemini/history`, `gemini/detail`, `gemini/read`)

**Live smoke test** against a real signed-in Gemini account:

```
$ opencli gemini status
- Status: Connected   Login: Yes   Url: https://gemini.google.com/app

$ opencli gemini history --limit 5
- Index: 1   Id: b8368a89d4242e5f   Title: Gemini's New Features from I/O
              Url: https://gemini.google.com/app/b8368a89d4242e5f

$ opencli gemini detail b8368a89d4242e5f
- Index: 1   Role: User       Text: What's the latest with Gemini from Google I/O?
- Index: 2   Role: Assistant  Text: …

$ opencli gemini read
# same turns as detail, no navigation
```