### PR TITLE
feat(browser): expose cookies command for HttpOnly-aware reads

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2338,6 +2338,60 @@ describe('browser console command', () => {
   });
 });
 
+describe('browser cookies command', () => {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    consoleLogSpy.mockClear();
+    mockBrowserConnect.mockClear();
+    mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    browserState.page = {
+      session: 'test',
+      setActivePage: vi.fn(),
+      getActivePage: vi.fn().mockReturnValue('tab-1'),
+      tabs: vi.fn().mockResolvedValue([{ page: 'tab-1', active: true }]),
+      getCookies: vi.fn().mockResolvedValue([
+        { name: 'session', value: 'abc', domain: 'example.com', path: '/', secure: true, httpOnly: true },
+        { name: 'theme', value: 'dark', domain: 'example.com', path: '/', secure: false, httpOnly: false },
+      ]),
+    } as unknown as IPage;
+  });
+
+  function lastJsonLog(): any {
+    const calls = consoleLogSpy.mock.calls;
+    if (calls.length === 0) throw new Error('Expected at least one console.log call');
+    const last = calls[calls.length - 1][0];
+    if (typeof last !== 'string') throw new Error(`Expected string arg to console.log, got ${typeof last}`);
+    return JSON.parse(last);
+  }
+
+  it('returns cookies including HttpOnly entries for a scoped domain read', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'cookies', '--domain', 'example.com']);
+
+    expect(browserState.page!.getCookies).toHaveBeenCalledWith({ domain: 'example.com', url: undefined });
+    const out = lastJsonLog();
+    expect(out.count).toBe(2);
+    expect(out.cookies).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'session', httpOnly: true }),
+      expect.objectContaining({ name: 'theme', httpOnly: false }),
+    ]));
+  });
+
+  it('errors with missing_scope when neither --domain nor --url is provided', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'cookies']);
+
+    expect(browserState.page!.getCookies).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+    const out = lastJsonLog();
+    expect(out.error.code).toBe('missing_scope');
+  });
+});
+
 describe('browser get html command', () => {
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2371,13 +2371,36 @@ describe('browser cookies command', () => {
 
     await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'cookies', '--domain', 'example.com']);
 
-    expect(browserState.page!.getCookies).toHaveBeenCalledWith({ domain: 'example.com', url: undefined });
+    expect(browserState.page!.getCookies).toHaveBeenCalledWith({ domain: 'example.com' });
     const out = lastJsonLog();
-    expect(out.count).toBe(2);
+    expect(out).toMatchObject({
+      session: 'test',
+      count: 2,
+      captured_at: expect.any(String),
+    });
     expect(out.cookies).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'session', httpOnly: true }),
       expect.objectContaining({ name: 'theme', httpOnly: false }),
     ]));
+  });
+
+  it('passes --url through to getCookies without sending an unset --domain', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'cookies', '--url', 'https://example.com/login']);
+
+    expect(browserState.page!.getCookies).toHaveBeenCalledWith({ url: 'https://example.com/login' });
+  });
+
+  it('emits an empty cookies envelope with count 0 when the scope matches nothing', async () => {
+    (browserState.page!.getCookies as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'cookies', '--domain', 'nothing.example']);
+
+    const out = lastJsonLog();
+    expect(out.count).toBe(0);
+    expect(out.cookies).toEqual([]);
   });
 
   it('errors with missing_scope when neither --domain nor --url is provided', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1320,7 +1320,7 @@ Examples:
 
   addBrowserTabOption(browser.command('cookies'))
     .option('--domain <domain>', 'Cookie domain scope (e.g. example.com)')
-    .option('--url <url>', 'URL scope (use domain or url, not both)')
+    .option('--url <url>', 'URL scope (may be combined with --domain to narrow)')
     .description('Read scoped cookies (includes HttpOnly)')
     .action(browserAction(async (page, opts) => {
       if (!opts.domain && !opts.url) {
@@ -1328,7 +1328,10 @@ Examples:
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const cookies = await page.getCookies({ domain: opts.domain, url: opts.url });
+      const cookies = await page.getCookies({
+        ...(opts.domain ? { domain: opts.domain } : {}),
+        ...(opts.url ? { url: opts.url } : {}),
+      });
       console.log(JSON.stringify({
         session: getPageSession(page),
         captured_at: new Date().toISOString(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1318,6 +1318,25 @@ Examples:
       }, null, 2));
     }));
 
+  addBrowserTabOption(browser.command('cookies'))
+    .option('--domain <domain>', 'Cookie domain scope (e.g. example.com)')
+    .option('--url <url>', 'URL scope (use domain or url, not both)')
+    .description('Read scoped cookies (includes HttpOnly)')
+    .action(browserAction(async (page, opts) => {
+      if (!opts.domain && !opts.url) {
+        console.log(JSON.stringify({ error: { code: 'missing_scope', message: 'Provide --domain or --url to scope the cookie read' } }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const cookies = await page.getCookies({ domain: opts.domain, url: opts.url });
+      console.log(JSON.stringify({
+        session: getPageSession(page),
+        captured_at: new Date().toISOString(),
+        count: cookies.length,
+        cookies,
+      }, null, 2));
+    }));
+
   // ── Analyze (site recon, agent-native) ──
   //
   // Mechanizes the `site-recon.md` decision tree into one CLI call. The agent


### PR DESCRIPTION
## Description

`IPage.getCookies()` already exists end-to-end on main: the daemon action `'cookies'` is registered in `src/browser/daemon-client.ts`, the extension's `handleCookies` returns `chrome.cookies.getAll(details)` results with each cookie's `httpOnly` flag, and internal callers (`browser analyze`, the yt-dlp cookie export in `src/pipeline/steps/download.ts`) already rely on it. The capability has no user-facing verb, so agents cannot read the HttpOnly cookies that `document.cookie` and `browser eval` cannot reach.

Add `opencli browser cookies --domain <d> | --url <u>` as a thin wrapper over `page.getCookies({ domain, url })`, mirroring the read-only JSON envelope `browser console` uses. Scope is required: with neither flag the command emits a `missing_scope` error envelope and exits `USAGE_ERROR`, matching the extension's own guard and keeping the verb from being a blanket cookie dump.

Related issue: refs #1472, its HttpOnly-cookies use case; persistent request interception and top-level await in `browser eval` stay out of scope.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

`opencli browser <session> cookies --domain example.com` returns the existing extension envelope unchanged, with `httpOnly` preserved per cookie. Sample shape:

```json
{
  "session": "test",
  "captured_at": "2026-06-03T07:06:35.000Z",
  "count": 2,
  "cookies": [
    { "name": "session", "value": "abc", "domain": "example.com", "path": "/", "secure": true, "httpOnly": true },
    { "name": "theme", "value": "dark", "domain": "example.com", "path": "/", "secure": false, "httpOnly": false }
  ]
}
```

`opencli browser <session> cookies` (no scope) emits a `missing_scope` error envelope and sets a non-zero exit code, matching the existing extension-side guard.

Four cases under `describe('browser cookies command', ...)` in `src/cli.test.ts` cover the domain read, the url passthrough, the empty-scope envelope, and the missing-scope guard against a mocked `IPage.getCookies`. Full `src/cli.test.ts` 164 / 164; full unit sweep 1159 passed / 1 skipped; `npx tsc --noEmit` and `npm run build` clean; `cli-manifest.json` untouched.
