### PR TITLE
fix(test): bump runCli maxBuffer to fit growing manifest

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -25,14 +25,20 @@ export interface CliResult {
  */
 export async function runCli(
   args: string[],
-  opts: { timeout?: number; env?: Record<string, string> } = {},
+  opts: { timeout?: number; env?: Record<string, string>; maxBuffer?: number } = {},
 ): Promise<CliResult> {
   const timeout = opts.timeout ?? 30_000;
+  // `opencli list -f json` already weighs ~1 MB at 1030 entries on v1.8.2 and
+  // grows with every new adapter. The execFile default maxBuffer is 1 MB; past
+  // it stdout overflows and the helper returns code
+  // 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' instead of the actual exit code.
+  const maxBuffer = opts.maxBuffer ?? 16 * 1024 * 1024;
   try {
     const runtime = process.env.OPENCLI_TEST_RUNTIME || 'node';
     const { stdout, stderr } = await exec(runtime, [MAIN, ...args], {
       cwd: ROOT,
       timeout,
+      maxBuffer,
       env: {
         ...process.env,
         // Prevent chalk colors from polluting test assertions

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -13,6 +13,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
 const MAIN = path.join(ROOT, 'dist', 'src', 'main.js');
 
+/**
+ * Default stdout cap for `runCli`. `opencli list -f json` already weighs
+ * ~1 MB at 1030 entries on v1.8.2 and grows with every new adapter. The
+ * execFile default maxBuffer is 1 MB; past it stdout overflows and the
+ * helper returns code 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' instead of the
+ * actual exit code.
+ */
+const DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+
 export interface CliResult {
   stdout: string;
   stderr: string;
@@ -28,11 +37,7 @@ export async function runCli(
   opts: { timeout?: number; env?: Record<string, string>; maxBuffer?: number } = {},
 ): Promise<CliResult> {
   const timeout = opts.timeout ?? 30_000;
-  // `opencli list -f json` already weighs ~1 MB at 1030 entries on v1.8.2 and
-  // grows with every new adapter. The execFile default maxBuffer is 1 MB; past
-  // it stdout overflows and the helper returns code
-  // 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' instead of the actual exit code.
-  const maxBuffer = opts.maxBuffer ?? 16 * 1024 * 1024;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER_BYTES;
   try {
     const runtime = process.env.OPENCLI_TEST_RUNTIME || 'node';
     const { stdout, stderr } = await exec(runtime, [MAIN, ...args], {


### PR DESCRIPTION
## Description

`tests/e2e/helpers.ts` uses `promisify(execFile)` without passing `maxBuffer`, so it inherits Node's 1 MB default. On v1.8.2 `node dist/src/main.js list -f json | wc -c` measures 1,067,516 bytes, which is just past the default. `execFile` rejects with `code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'`, the catch block returns that string as the result `code`, and the E2E assertions `expect(code).toBe(0)` fail with the literal `'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'`. The failure repros on both ubuntu and macos in the `E2E Headed Chrome` workflow on `ec3eddec chore(release): 1.8.2 (#1830)`, and affects `tests/e2e/management.test.ts > list shows all registered commands` plus `tests/e2e/output-formats.test.ts > list -f json produces valid output`. yaml / csv / md formats stayed under 1 MB so they passed, but the underlying helper has no headroom for any future adapter additions in any format.

Pass an explicit `maxBuffer` of 16 MB to `execFile`, with an optional `opts.maxBuffer` override for callers that need a different bound. 16 MB gives roughly 15x headroom over the current manifest size and matches the order-of-magnitude that other Node CLIs default to when wrapping their own subprocesses. The default behavior of every existing `runCli` caller is preserved; only the silent overflow ceiling moves.

Related issue: closes #1841.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Pre-fix repro on `upstream/main` v1.8.2:

```
$ node dist/src/main.js list -f json | wc -c
 1067516

$ npx vitest run tests/e2e/management.test.ts -t "list shows all registered commands"
× tests/e2e/management.test.ts > list shows all registered commands
   AssertionError: expected 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' to be +0
```

Post-fix on this branch:

```
$ npx vitest run tests/e2e/management.test.ts tests/e2e/output-formats.test.ts
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

Full local check: `npx tsc --noEmit` clean. `tests/e2e/management.test.ts` + `tests/e2e/output-formats.test.ts` 16/16. `cli-manifest.json` untouched.