### PR TITLE
fix(xiaohongshu): prioritize visible title input over hidden scaffolding

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -34,14 +34,18 @@ const DRAFT_METHOD_NAMES = ['_onSave', '_onSaveDraft', '_onDraft'];
 /** Selectors for the title field, ordered by priority across current UI variants. */
 const TITLE_SELECTORS = [
     // Some creator-center variants expose the title as contenteditable,
-    // others use a normal <input> with the same placeholder.
+    // others use a normal <input> with the same placeholder. Visible
+    // user-facing variants always carry a Chinese placeholder; class-based
+    // variants also match a pair of 4 px wide hidden scaffolding inputs
+    // (same `class*="title"`, empty placeholder, no v-model commit on save)
+    // so placeholder-based selectors take precedence to avoid filling those.
     '[contenteditable="true"][placeholder*="标题"]',
     '[contenteditable="true"][placeholder*="赞"]',
+    'input[placeholder*="标题"]',
+    'input[placeholder*="title" i]',
     '[contenteditable="true"][class*="title"]',
     'input[maxlength="20"]',
     'input[class*="title"]',
-    'input[placeholder*="标题"]',
-    'input[placeholder*="title" i]',
     '.title-input input',
     '.note-title input',
     'input[maxlength]',

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -96,6 +96,12 @@ describe('xiaohongshu publish', () => {
         });
         expect(insertText).toHaveBeenNthCalledWith(1, '标题走原生输入');
         expect(insertText).toHaveBeenNthCalledWith(2, '正文也走原生输入');
+        const titleLocateCall = page.evaluate.mock.calls
+            .map(([code]) => String(code))
+            .find((code) => code.includes('__opencli_xhs_fill_phase') && code.includes('"locate"') && code.includes('input[placeholder*='));
+        expect(titleLocateCall).toBeDefined();
+        expect(titleLocateCall.indexOf('input[placeholder*=')).toBeLessThan(titleLocateCall.indexOf('input[maxlength='));
+        expect(titleLocateCall.indexOf('input[placeholder*=')).toBeLessThan(titleLocateCall.indexOf('input[class*='));
         expect(result).toEqual([
             {
                 status: '✅ 发布成功',


### PR DESCRIPTION
## Description

`opencli xiaohongshu publish --title <text>` saves the draft with an empty title even though the command reports `status: ✅ 暂存成功` with the title echoed in `detail`. `opencli xiaohongshu drafts` shows the just-saved entry as `(untitled)`, and the raw `image-draft` IndexedDB row has `content.draftStore.title === ""`. Same symptom as #1840.

The cause is selector priority in `TITLE_SELECTORS` at `clis/xiaohongshu/publish.js:34`, not the typing mechanism. On the current creator-center DOM, `document.querySelectorAll('input[class*="title"]')` matches three visible inputs: two 4 px wide hidden scaffolding inputs (empty placeholder, register a Vue 3 IME composition handler set `[onChange, onCompositionstart, onCompositionend, onInput]` but never commit on save) plus the real user-facing title input (`placeholder="填写标题会有更多赞哦"`, 499 px wide, simple `[onChange, onInput, onFocus, onBlur]` handler set, Vue 3 v-model). The previous order listed `input[class*="title"]` before the placeholder-based variants, so `fillField` typed into the first hidden 4 px input, its DOM `.value` updated, the verify phase read the same hidden input back and the command reported a false positive. The real Vue-bound input never received a keystroke, so the draft persisted with an empty title.

Move `input[placeholder*="标题"]` and `input[placeholder*="title" i]` ahead of the class-based variants in `TITLE_SELECTORS`. The placeholder-based selectors uniquely target the real user-facing title input across the variants currently shipped by xiaohongshu. The class-based selectors stay as fallbacks for any future variant that drops the Chinese placeholder. No typing path, locator helper, or save flow is touched.

Related issue: fixes #1840.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Live verified on a logged-in `creator.xiaohongshu.com` session with opencli 1.8.2 + Browser Bridge v1.0.17 on macOS 26.5. The verification compares the draft `content.draftStore.title` written to the `image-draft` IndexedDB store before and after this patch:

| publish.js variant | drafts list title | raw IDB `draftStore.title` |
|---|---|---|
| upstream/main | `(untitled)` | `""` (BODY persisted correctly) |
| patched | `TITLE_REAL1780481801` | `"TITLE_REAL1780481801"` (BODY persisted correctly) |

DOM probe at `fillField` resolve time:

```
[
  { sel: 'input[class*="title"]', visible: true, rect_w: 4,   value: '', placeholder: '',                  vei_keys: [onChange, onCompositionstart, onCompositionend, onInput] },
  { sel: 'input[class*="title"]', visible: true, rect_w: 4,   value: '', placeholder: '',                  vei_keys: [onChange, onCompositionstart, onCompositionend, onInput] },
  { sel: 'input[placeholder*="标题"]', visible: true, rect_w: 500, value: '', placeholder: '填写标题会有更多赞哦', vei_keys: [onChange, onInput, onFocus, onBlur] }
]
```

The class-based selectors return the two 4 px hidden scaffolding inputs first; the placeholder-based selector returns the real visible input. All test drafts created during verification were deleted via `opencli xiaohongshu draft-delete <id> --execute true` after the run.

No code under test outside `clis/xiaohongshu/publish.js` was touched. `cli-manifest.json` is untouched (selectors are static array literals).
