### PR TITLE
feat(browser): add paste-files command for clipboard-paste file uploads

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -392,6 +392,48 @@ async function insertText(tabId, text) {
   await ensureAttached(tabId);
   await sendDebuggerCommand({ tabId }, "Input.insertText", { text });
 }
+async function pasteClipboardFiles(tabId, files, selector) {
+  await ensureAttached(tabId);
+  const targetExpr = selector ? `document.querySelector(${JSON.stringify(selector)})` : "document.activeElement && document.activeElement !== document.body ? document.activeElement : document.body";
+  const expression = `
+    (() => {
+      const target = ${targetExpr};
+      if (!target) return { ok: false };
+      const files = ${JSON.stringify(files)};
+      const dt = new DataTransfer();
+      for (const f of files) {
+        const binary = atob(f.base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+        const blob = new Blob([bytes], { type: f.mimeType });
+        dt.items.add(new File([blob], f.name, { type: f.mimeType }));
+      }
+      const event = new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      // dispatchEvent returns false when a listener cancelled the event — for
+      // a file paste that cancellation is the only signal an app-level handler
+      // consumed the files (the browser default does nothing with them).
+      const delivered = !target.dispatchEvent(event);
+      return { ok: true, count: files.length, delivered };
+    })()
+  `;
+  const result = await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
+    expression,
+    returnByValue: true
+  });
+  if (result.exceptionDetails) {
+    const description = result.exceptionDetails.exception?.description ?? result.exceptionDetails.text ?? "Unknown error";
+    throw new Error(`paste-files evaluate failed: ${description}`);
+  }
+  const value = result.result?.value;
+  if (!value?.ok) {
+    throw new Error(selector ? `No element found matching selector: ${selector}` : "Page has no document.body to receive the paste event");
+  }
+  return { count: value.count ?? files.length, delivered: value.delivered === true };
+}
 function registerFrameTracking() {
   registerFrameTargetCleanup();
   chrome.debugger.onEvent.addListener((source, method, params) => {
@@ -1705,6 +1747,8 @@ async function handleCommand(cmd) {
         return await handleSetFileInput(cmd, leaseKey);
       case "insert-text":
         return await handleInsertText(cmd, leaseKey);
+      case "paste-files":
+        return await handlePasteFiles(cmd, leaseKey);
       case "bind":
         return await handleBind(cmd, leaseKey);
       case "network-capture-start":
@@ -2271,6 +2315,20 @@ async function handleInsertText(cmd, leaseKey) {
   try {
     await insertText(tabId, cmd.text);
     return pageScopedResult(cmd.id, tabId, { inserted: true });
+  } catch (err) {
+    return errorResult(cmd.id, err);
+  }
+}
+async function handlePasteFiles(cmd, leaseKey) {
+  const files = cmd.clipboardFiles;
+  if (!Array.isArray(files) || files.length === 0) {
+    return { id: cmd.id, ok: false, error: "Missing or empty clipboardFiles array" };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, leaseKey);
+  try {
+    const { count, delivered } = await pasteClipboardFiles(tabId, files, cmd.selector);
+    return pageScopedResult(cmd.id, tabId, { count, delivered });
   } catch (err) {
     return errorResult(cmd.id, err);
   }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1337,6 +1337,8 @@ async function handleCommand(cmd: Command): Promise<Result> {
         return await handleSetFileInput(cmd, leaseKey);
       case 'insert-text':
         return await handleInsertText(cmd, leaseKey);
+      case 'paste-files':
+        return await handlePasteFiles(cmd, leaseKey);
       case 'bind':
         return await handleBind(cmd, leaseKey);
       case 'network-capture-start':
@@ -2031,6 +2033,21 @@ async function handleInsertText(cmd: Command, leaseKey: string): Promise<Result>
   try {
     await executor.insertText(tabId, cmd.text);
     return pageScopedResult(cmd.id, tabId, { inserted: true });
+  } catch (err) {
+    return errorResult(cmd.id, err);
+  }
+}
+
+async function handlePasteFiles(cmd: Command, leaseKey: string): Promise<Result> {
+  const files = cmd.clipboardFiles;
+  if (!Array.isArray(files) || files.length === 0) {
+    return { id: cmd.id, ok: false, error: 'Missing or empty clipboardFiles array' };
+  }
+  const cmdTabId = await resolveCommandTabId(cmd);
+  const tabId = await resolveTabId(cmdTabId, leaseKey);
+  try {
+    const { count, delivered } = await executor.pasteClipboardFiles(tabId, files, cmd.selector);
+    return pageScopedResult(cmd.id, tabId, { count, delivered });
   } catch (err) {
     return errorResult(cmd.id, err);
   }

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -609,6 +609,70 @@ export async function insertText(
   await sendDebuggerCommand({ tabId }, 'Input.insertText', { text });
 }
 
+/**
+ * Dispatch a synthesized ClipboardEvent('paste') with a DataTransfer payload
+ * built from the supplied files on the currently focused element, or on the
+ * element matched by `selector` when provided. Targets web apps whose upload
+ * flow only listens to clipboard paste events.
+ *
+ * @param tabId - Target tab ID
+ * @param files - Array of file entries (name, mimeType, base64 content)
+ * @param selector - Optional CSS selector for the paste target; defaults to document.activeElement
+ */
+export async function pasteClipboardFiles(
+  tabId: number,
+  files: Array<{ name: string; mimeType: string; base64: string }>,
+  selector?: string,
+): Promise<{ count: number; delivered: boolean }> {
+  await ensureAttached(tabId);
+  const targetExpr = selector
+    ? `document.querySelector(${JSON.stringify(selector)})`
+    : 'document.activeElement && document.activeElement !== document.body ? document.activeElement : document.body';
+  const expression = `
+    (() => {
+      const target = ${targetExpr};
+      if (!target) return { ok: false };
+      const files = ${JSON.stringify(files)};
+      const dt = new DataTransfer();
+      for (const f of files) {
+        const binary = atob(f.base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+        const blob = new Blob([bytes], { type: f.mimeType });
+        dt.items.add(new File([blob], f.name, { type: f.mimeType }));
+      }
+      const event = new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      // dispatchEvent returns false when a listener cancelled the event — for
+      // a file paste that cancellation is the only signal an app-level handler
+      // consumed the files (the browser default does nothing with them).
+      const delivered = !target.dispatchEvent(event);
+      return { ok: true, count: files.length, delivered };
+    })()
+  `;
+  const result = await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+  }) as {
+    result?: { value?: { ok?: boolean; count?: number; delivered?: boolean } };
+    exceptionDetails?: { exception?: { description?: string }; text?: string };
+  };
+  if (result.exceptionDetails) {
+    const description = result.exceptionDetails.exception?.description ?? result.exceptionDetails.text ?? 'Unknown error';
+    throw new Error(`paste-files evaluate failed: ${description}`);
+  }
+  const value = result.result?.value;
+  if (!value?.ok) {
+    throw new Error(selector
+      ? `No element found matching selector: ${selector}`
+      : 'Page has no document.body to receive the paste event');
+  }
+  return { count: value.count ?? files.length, delivered: value.delivered === true };
+}
+
 export function registerFrameTracking(): void {
   registerFrameTargetCleanup();
   chrome.debugger.onEvent.addListener((source, method, params: any) => {

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -15,6 +15,7 @@ export type Action =
   | 'sessions'
   | 'set-file-input'
   | 'insert-text'
+  | 'paste-files'
   | 'bind'
   | 'network-capture-start'
   | 'network-capture-read'
@@ -61,6 +62,8 @@ export interface Command {
   selector?: string;
   /** Raw text payload for insert-text action */
   text?: string;
+  /** Base64-encoded files for paste-files action (name, mimeType, base64 content per entry) */
+  clipboardFiles?: Array<{ name: string; mimeType: string; base64: string }>;
   /** URL substring filter pattern for network capture actions */
   pattern?: string;
   /** Download wait timeout in milliseconds */

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -201,7 +201,7 @@ function isPreConnectFetchError(err: unknown): boolean {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames' | 'lease-release';
+  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'paste-files' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames' | 'lease-release';
   /** Target page identity (targetId). Cross-layer contract with the extension. */
   page?: string;
   code?: string;
@@ -227,6 +227,8 @@ export interface DaemonCommand {
   selector?: string;
   /** Raw text payload for insert-text action */
   text?: string;
+  /** Base64-encoded files for paste-files action (name, mimeType, base64 content per entry) */
+  clipboardFiles?: Array<{ name: string; mimeType: string; base64: string }>;
   /** URL substring filter pattern for network capture */
   pattern?: string;
   /** Download wait timeout in milliseconds */

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { sendCommandMock, sendCommandFullMock } = vi.hoisted(() => ({
@@ -19,6 +22,7 @@ vi.mock('../logger.js', () => ({
 }));
 
 import { Page } from './page.js';
+import { ArgumentError } from '../errors.js';
 
 describe('Page.getCurrentUrl', () => {
   beforeEach(() => {
@@ -505,5 +509,78 @@ describe('Page.screenshot', () => {
     expect(args.width).toBeUndefined();
     expect(args.height).toBeUndefined();
     expect(args.fullPage).toBeUndefined();
+  });
+});
+
+describe('Page.pasteFiles', () => {
+  beforeEach(() => {
+    sendCommandMock.mockReset();
+    sendCommandFullMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it('base64-encodes provided files and forwards them as clipboardFiles', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const filePath = path.join(dir, 'note.png');
+    fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    try {
+      sendCommandMock.mockResolvedValueOnce({ count: 1, delivered: true });
+
+      const page = new Page('default');
+      await expect(page.pasteFiles([filePath], '#composer')).resolves.toEqual({ count: 1, delivered: true });
+
+      const call = sendCommandMock.mock.calls.at(-1);
+      expect(call?.[0]).toBe('paste-files');
+      const args = call?.[1] as Record<string, unknown>;
+      expect(args.selector).toBe('#composer');
+      expect(args.clipboardFiles).toEqual([
+        { name: 'note.png', mimeType: 'image/png', base64: 'iVBORw==' },
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports delivered:false when no page listener consumed the paste', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const filePath = path.join(dir, 'note.txt');
+    fs.writeFileSync(filePath, 'hi');
+
+    try {
+      sendCommandMock.mockResolvedValueOnce({ count: 1, delivered: false });
+      const page = new Page('default');
+      await expect(page.pasteFiles([filePath])).resolves.toEqual({ count: 1, delivered: false });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a payload over the daemon body cap before reaching the daemon', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const filePath = path.join(dir, 'big.bin');
+    fs.writeFileSync(filePath, Buffer.alloc(1024 * 1024));
+
+    try {
+      const page = new Page('default');
+      await expect(page.pasteFiles([filePath])).rejects.toBeInstanceOf(ArgumentError);
+      expect(sendCommandMock).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when the extension returns no count (unsupported action)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const filePath = path.join(dir, 'note.txt');
+    fs.writeFileSync(filePath, 'hi');
+
+    try {
+      sendCommandMock.mockResolvedValueOnce({});
+      const page = new Page('default');
+      await expect(page.pasteFiles([filePath])).rejects.toThrow(/no count/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -9,6 +9,8 @@
  * page-scoped operations target the correct page without guessing.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { BrowserCookie, BrowserDownloadWaitResult, BrowserEvaluateFunction, ScreenshotOptions } from '../types.js';
 import { sendCommand, sendCommandFull } from './daemon-client.js';
 import { buildEvaluateExpression } from './utils.js';
@@ -17,7 +19,41 @@ import { generateStealthJs } from './stealth.js';
 import { waitForDomStableJs } from './dom-helpers.js';
 import { BasePage } from './base-page.js';
 import { classifyBrowserError } from './errors.js';
+import { ArgumentError } from '../errors.js';
 import { log } from '../logger.js';
+
+/**
+ * File-extension to MIME-type lookup used by `pasteFiles` to populate
+ * DataTransfer item types. Unknown extensions fall back to
+ * `application/octet-stream`, which browser paste handlers usually still
+ * accept because they sniff content themselves. Audio/video extensions are
+ * omitted on purpose: typical media files exceed the payload ceiling below.
+ */
+const CLIPBOARD_MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.json': 'application/json',
+  '.csv': 'text/csv',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+};
+
+/**
+ * Ceiling for the summed base64 size of a `pasteFiles` payload. The daemon
+ * destroys request bodies over 1 MB before parsing (MAX_BODY in daemon.ts),
+ * which surfaces client-side as an opaque socket error — so oversized files
+ * are rejected upfront with the real reason. Kept slightly under the cap to
+ * leave room for the rest of the JSON command body.
+ */
+const CLIPBOARD_FILES_MAX_BASE64_BYTES = 1000 * 1024;
 
 function isUnsupportedNetworkCaptureError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
@@ -325,6 +361,35 @@ export class Page extends BasePage {
     if (!result?.inserted) {
       throw new Error('insertText returned no inserted flag — command may not be supported by the extension');
     }
+  }
+
+  async pasteFiles(files: string[], selector?: string): Promise<{ count: number; delivered: boolean }> {
+    const clipboardFiles = files.map((filePath) => {
+      const absPath = path.resolve(filePath);
+      const buffer = fs.readFileSync(absPath);
+      const ext = path.extname(absPath).toLowerCase();
+      return {
+        name: path.basename(absPath),
+        mimeType: CLIPBOARD_MIME_BY_EXT[ext] ?? 'application/octet-stream',
+        base64: buffer.toString('base64'),
+      };
+    });
+    const payloadBytes = clipboardFiles.reduce((sum, file) => sum + file.base64.length, 0);
+    if (payloadBytes > CLIPBOARD_FILES_MAX_BASE64_BYTES) {
+      throw new ArgumentError(
+        `pasteFiles payload is ${Math.ceil(payloadBytes / 1024)} KB base64-encoded; the daemon rejects command bodies over 1 MB`,
+        'Use browser upload for large files — CDP reads them from the local filesystem.',
+      );
+    }
+    const result = await sendCommand('paste-files', {
+      clipboardFiles,
+      selector,
+      ...this._cmdOpts(),
+    }) as { count?: number; delivered?: boolean };
+    if (!result?.count) {
+      throw new Error('pasteFiles returned no count — command may not be supported by the extension');
+    }
+    return { count: result.count, delivered: result.delivered === true };
   }
 
   async frames(): Promise<Array<{ index: number; frameId: string; url: string; name: string }>> {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2782,6 +2782,7 @@ describe('browser click/type commands', () => {
       match_level: 'exact',
       multiple: false,
     }),
+    pasteFiles: vi.fn().mockResolvedValue({ count: 1, delivered: true }),
     drag: vi.fn().mockResolvedValue({
       dragged: true,
       source: '#card',
@@ -3157,6 +3158,62 @@ describe('browser click/type commands', () => {
 
     expect(lastJsonLog().error.code).toBe('file_not_found');
     expect(browserState.page!.uploadFiles).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('paste-files: validates local files and delegates to page.pasteFiles with the optional --target selector', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const file = path.join(dir, 'screenshot.png');
+    fs.writeFileSync(file, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    (browserState.page!.pasteFiles as any).mockResolvedValueOnce({ count: 1, delivered: true });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'paste-files', file, '--target', '#composer']);
+
+    expect(browserState.page!.pasteFiles).toHaveBeenCalledWith([file], '#composer');
+    expect(lastJsonLog()).toEqual({
+      pasted: true,
+      delivered: true,
+      count: 1,
+      file_names: ['screenshot.png'],
+      target: '#composer',
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('paste-files: omits --target and reports the focused-element default in the envelope', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const file = path.join(dir, 'screenshot.png');
+    fs.writeFileSync(file, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    (browserState.page!.pasteFiles as any).mockResolvedValueOnce({ count: 1, delivered: true });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'paste-files', file]);
+
+    expect(browserState.page!.pasteFiles).toHaveBeenCalledWith([file], undefined);
+    expect(lastJsonLog().target).toBe('focused');
+  });
+
+  it('paste-files: sets a non-zero exit code when no listener consumed the paste', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-paste-'));
+    const file = path.join(dir, 'screenshot.png');
+    fs.writeFileSync(file, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    (browserState.page!.pasteFiles as any).mockResolvedValueOnce({ count: 1, delivered: false });
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'paste-files', file]);
+
+    expect(lastJsonLog()).toMatchObject({ pasted: true, delivered: false });
+    expect(process.exitCode).toBeDefined();
+  });
+
+  it('paste-files: rejects missing files before touching the page', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync(['node', 'opencli', 'browser', '--session', 'test', 'paste-files', '/tmp/opencli-missing-paste-file']);
+
+    expect(lastJsonLog().error.code).toBe('file_not_found');
+    expect(browserState.page!.pasteFiles).not.toHaveBeenCalled();
     expect(process.exitCode).toBeDefined();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2146,6 +2146,29 @@ Examples:
       console.log(JSON.stringify(result, null, 2));
     }));
 
+  addBrowserTabOption(browser.command('paste-files'))
+    .argument('<files...>', 'Local file path(s) to paste as clipboard content')
+    .option('--target <selector>', 'CSS selector for the paste target; defaults to the currently focused element')
+    .description('Paste local files into the focused or targeted element via a synthesized clipboard paste event — JSON envelope {pasted, delivered, count, file_names, target}')
+    .action(browserAction(async (page, files, opts) => {
+      if (typeof page.pasteFiles !== 'function') throw new Error('browser paste-files is not supported by this browser backend');
+      const resolvedFiles = resolveUploadFilePaths(files);
+      if ('error' in resolvedFiles) {
+        console.log(JSON.stringify({ error: resolvedFiles.error }, null, 2));
+        process.exitCode = EXIT_CODES.USAGE_ERROR;
+        return;
+      }
+      const result = await page.pasteFiles(resolvedFiles.files, opts?.target);
+      if (!result.delivered) process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      console.log(JSON.stringify({
+        pasted: true,
+        delivered: result.delivered,
+        count: result.count,
+        file_names: resolvedFiles.files.map((p) => path.basename(p)),
+        target: opts?.target ?? 'focused',
+      }, null, 2));
+    }));
+
   addBrowserTabOption(
     addPrefixedSemanticLocatorOptions(
       addPrefixedSemanticLocatorOptions(browser.command('drag'), 'from'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,14 @@ export interface IPage {
    * Useful for rich editors that ignore synthetic DOM value/text mutations.
    */
   insertText?(text: string): Promise<void>;
+  /**
+   * Paste local files into the focused element (or the optional `selector`)
+   * by dispatching a synthesized ClipboardEvent('paste') with a DataTransfer
+   * payload built from the file contents. Use for web apps whose upload flow
+   * only listens to clipboard paste. `delivered` is true when a page listener
+   * cancelled the event, i.e. actually consumed the pasted files.
+   */
+  pasteFiles?(files: string[], selector?: string): Promise<{ count: number; delivered: boolean }>;
   closeWindow?(): Promise<void>;
   /** Returns the current page URL, or null if unavailable. */
   getCurrentUrl?(): Promise<string | null>;


### PR DESCRIPTION
## Description

Adds one browser primitive: `IPage.pasteFiles(files, selector?)` synthesizes a `ClipboardEvent('paste')` whose `DataTransfer` carries local files, with a `browser paste-files <files...> [--target <selector>]` verb driving it. It serves web apps whose upload flow listens only to clipboard paste, not to hidden file inputs or `DOM.setFileInputFiles`. Fifteen adapter files hand-roll this dispatch today; none are migrated here, so each later migration stays small and bisectable.

The implementation mirrors `setFileInput` across the same layers: types, `Page`, daemon action, extension protocol and handler, CLI verb. The extension routes its `Runtime.evaluate` through the #2067 deadline wrapper, and the envelope reports a `delivered` postcondition, true only when a page listener consumed the paste by cancelling it, so an agent can tell a dispatched-but-ignored paste from a consumed one. Payloads over the daemon's 1 MB body cap fail upfront as `ArgumentError` pointing at `browser upload`. `--target` takes a CSS selector; adopting the write-verb locator contract instead is left open for review.

Related issue: Closes #1843

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

`opencli browser <session> paste-files img.png --target "#composer"` returns:

```json
{
  "pasted": true,
  "delivered": true,
  "count": 1,
  "file_names": ["img.png"],
  "target": "#composer"
}
```

Without `--target` the event goes to `document.activeElement`, falling back to `document.body`, and `delivered: false` marks a paste no listener consumed.

Rebased onto current main across the #2070 transport rewrite; `extension/dist/background.js` is rebuilt from source and its diff against main is exactly the paste-files addition. Unit suites over `src/browser` and `src/cli.test.ts` 577 / 577 with the new tests mutation-checked; extension suite 96 / 96; typecheck, both lint gates and doc coverage pass; `cli-manifest.json` unchanged, since it registers only adapter commands.
