### PR TITLE
feat(grok): add stream command capturing full SSE response

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13164,6 +13164,52 @@
   },
   {
     "site": "grok",
+    "name": "stream",
+    "description": "Send a message to Grok and capture the full streamed response (final text, thinking, model, conversationId, generated image URLs)",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Prompt to send to Grok"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 180,
+        "required": false,
+        "help": "Max seconds to wait for the stream to complete (default: 180)"
+      },
+      {
+        "name": "new",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Start a new chat before sending (default: false)"
+      }
+    ],
+    "columns": [
+      "response",
+      "thinking",
+      "model",
+      "conversationId",
+      "responseId",
+      "title",
+      "images"
+    ],
+    "type": "js",
+    "modulePath": "grok/stream.js",
+    "sourceFile": "grok/stream.js",
+    "navigateBefore": "https://grok.com",
+    "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
     "name": "unpin",
     "description": "Unpin a Grok conversation by ID",
     "access": "write",

--- a/clis/grok/stream.js
+++ b/clis/grok/stream.js
@@ -1,0 +1,235 @@
+/**
+ * Grok streaming ask — captures the full SSE response from
+ * `POST /rest/app-chat/conversations/new`, surfacing the model's final answer,
+ * thinking trace, model id, conversation id, and any generated image URLs.
+ *
+ * The existing `grok ask` command polls visible message bubbles in the DOM and
+ * stabilises on the last assistant turn. That is robust but lossy — the
+ * thinking trace, server-assigned conversationId/responseId, model hash, and
+ * generated image URLs never reach the agent. `stream` plugs a fetch
+ * interceptor in front of grok.com's own client SDK so the entire SSE body
+ * lands here verbatim and we hand back a single structured row.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import {
+    authRequired,
+    ensureOnGrok,
+    isLoggedIn,
+    normalizeBooleanFlag,
+    sendMessage,
+    startNewChat,
+} from './utils.js';
+
+const CHAT_ENDPOINT_PATH = '/rest/app-chat/conversations/new';
+const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
+
+/**
+ * Page-side interceptor: patches `window.fetch` once, drains the response body
+ * via the stream reader (so SSE chunks are captured even while grok.com is
+ * also reading from the original response), and pushes the resulting envelope
+ * into `window.__opencliGrokStream`.
+ */
+const INSTALL_STREAM_INTERCEPTOR_JS = `
+(() => {
+    if (window.__opencliGrokStreamPatched) return { installed: false };
+    window.__opencliGrokStreamPatched = true;
+    window.__opencliGrokStream = [];
+    const ENDPOINT_HINT = ${JSON.stringify(CHAT_ENDPOINT_PATH)};
+    const origFetch = window.fetch.bind(window);
+    window.fetch = async function (input, init) {
+        const url = typeof input === 'string' ? input : (input && input.url) || '';
+        const method = (init && init.method)
+            || (typeof input !== 'string' && input && input.method)
+            || 'GET';
+        const response = await origFetch(input, init);
+        if (url && url.indexOf(ENDPOINT_HINT) !== -1) {
+            const status = response.status;
+            (async () => {
+                try {
+                    const reader = response.clone().body.getReader();
+                    const chunks = [];
+                    while (true) {
+                        const r = await reader.read();
+                        if (r.done) break;
+                        chunks.push(r.value);
+                    }
+                    let total = 0;
+                    for (const c of chunks) total += c.length;
+                    const merged = new Uint8Array(total);
+                    let off = 0;
+                    for (const c of chunks) { merged.set(c, off); off += c.length; }
+                    window.__opencliGrokStream.push({
+                        url,
+                        method,
+                        status,
+                        body: new TextDecoder('utf-8').decode(merged),
+                        capturedAt: Date.now(),
+                    });
+                } catch (err) {
+                    window.__opencliGrokStream.push({
+                        url,
+                        method,
+                        status,
+                        error: err && err.message ? err.message : String(err),
+                        capturedAt: Date.now(),
+                    });
+                }
+            })();
+        }
+        return response;
+    };
+    return { installed: true };
+})()
+`;
+
+/**
+ * Iterate the newline-delimited JSON frames Grok streams back. Malformed
+ * lines are skipped — the upstream stream occasionally interleaves keep-alive
+ * blanks and we don't want one bad line to drop the whole response.
+ */
+export function* iterFrames(rawBody) {
+    if (!rawBody) return;
+    for (const line of rawBody.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+            yield JSON.parse(trimmed);
+        } catch {
+            // Skip malformed frame; partial chunks at the seam of the network
+            // buffer can leave a half-written JSON tail.
+        }
+    }
+}
+
+/**
+ * Reduce the SSE frame sequence into a tabular row: final answer, thinking
+ * trace, model id, conversation id, response id, title, and any generated
+ * image URLs. The final `modelResponse` frame, when present, wins over the
+ * accumulated token stream — Grok occasionally rewrites short answers in the
+ * trailing frame.
+ */
+export function summarizeResponse(rawBody) {
+    let conversationId = '';
+    let responseId = '';
+    let title = '';
+    let model = '';
+    let thinking = '';
+    let final = '';
+    const images = [];
+
+    for (const frame of iterFrames(rawBody)) {
+        const r = frame && frame.result;
+        if (!r) continue;
+        if (r.conversation && r.conversation.conversationId) {
+            conversationId = r.conversation.conversationId;
+        }
+        if (r.title && r.title.newTitle) {
+            title = r.title.newTitle;
+        }
+        const resp = r.response;
+        if (!resp) continue;
+        if (typeof resp.token === 'string') {
+            if (resp.isThinking) thinking += resp.token;
+            else final += resp.token;
+        }
+        if (resp.modelResponse) {
+            responseId = resp.modelResponse.responseId || responseId;
+            model = resp.modelResponse.model || model;
+            if (typeof resp.modelResponse.message === 'string' && resp.modelResponse.message) {
+                final = resp.modelResponse.message;
+            }
+            for (const u of resp.modelResponse.generatedImageUrls || []) {
+                if (typeof u === 'string') images.push(u);
+            }
+        }
+    }
+    return {
+        response: final.trim(),
+        thinking: thinking.trim(),
+        model,
+        conversationId,
+        responseId,
+        title,
+        images: images.join('\n'),
+    };
+}
+
+async function pollForCapture(page, timeoutMs) {
+    const POLL_INTERVAL_S = 0.4;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const captures = await page.evaluate(`(window.__opencliGrokStream || []).slice()`);
+        if (Array.isArray(captures) && captures.length > 0) return captures[0];
+        await page.wait(POLL_INTERVAL_S);
+    }
+    return null;
+}
+
+export const streamCommand = cli({
+    site: 'grok',
+    name: 'stream',
+    access: 'write',
+    description: 'Send a message to Grok and capture the full streamed response (final text, thinking, model, conversationId, generated image URLs)',
+    domain: 'grok.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    args: [
+        { name: 'prompt', positional: true, type: 'string', required: true, help: 'Prompt to send to Grok' },
+        { name: 'timeout', type: 'int', default: 180, help: 'Max seconds to wait for the stream to complete (default: 180)' },
+        { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending (default: false)' },
+    ],
+    columns: ['response', 'thinking', 'model', 'conversationId', 'responseId', 'title', 'images'],
+    func: async (page, kwargs) => {
+        const prompt = kwargs.prompt;
+        const timeoutSeconds = kwargs.timeout || 180;
+        const newChat = normalizeBooleanFlag(kwargs.new);
+
+        if (newChat) {
+            await startNewChat(page);
+        } else {
+            await ensureOnGrok(page);
+        }
+
+        if (!(await isLoggedIn(page))) {
+            throw authRequired();
+        }
+
+        // Install the interceptor BEFORE submitting so it catches the very
+        // first chat-endpoint fetch. Idempotent via window guard.
+        await page.evaluate(INSTALL_STREAM_INTERCEPTOR_JS);
+
+        const sendResult = await sendMessage(page, prompt);
+        if (!sendResult || !sendResult.ok) {
+            const reason = sendResult?.reason || 'Unable to send the prompt to Grok.';
+            const detail = sendResult?.detail ? ` ${sendResult.detail}` : '';
+            throw new CommandExecutionError(`${reason}${detail}`, SESSION_HINT);
+        }
+
+        const capture = await pollForCapture(page, timeoutSeconds * 1000);
+        if (!capture) {
+            throw new TimeoutError('grok stream response', timeoutSeconds);
+        }
+        if (capture.error) {
+            throw new CommandExecutionError(
+                `Grok stream capture failed: ${capture.error}`,
+                SESSION_HINT,
+            );
+        }
+        if (capture.status >= 400) {
+            const preview = (capture.body || '').slice(0, 200);
+            throw new CommandExecutionError(
+                `Grok responded HTTP ${capture.status}: ${preview}`,
+                SESSION_HINT,
+            );
+        }
+        return [summarizeResponse(capture.body || '')];
+    },
+});
+
+export const __test__ = {
+    iterFrames,
+    summarizeResponse,
+    INSTALL_STREAM_INTERCEPTOR_JS,
+};

--- a/clis/grok/stream.test.js
+++ b/clis/grok/stream.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './stream.js';
+
+const { iterFrames, summarizeResponse } = __test__;
+
+// Hand-crafted body mirroring the shape sniffed from grok.com's
+// `POST /rest/app-chat/conversations/new` SSE response — see the adjacent
+// `stream.js` doc comment for the live capture flow.
+const SAMPLE_BODY = [
+    '{"result":{"conversation":{"conversationId":"00000000-1111-2222-3333-444444444444","title":"New conversation","createTime":"2026-05-26T17:34:13.212874Z"}}}',
+    '{"result":{"response":{"userResponse":{"responseId":"u1","message":"hi"}}}}',
+    '{"result":{"response":{"llmInfo":{"modelHash":"abc"},"responseId":"r1"}}}',
+    '{"result":{"response":{"token":"Thinking","isThinking":true,"messageTag":"header","responseId":"r1"}}}',
+    '{"result":{"response":{"token":" about ","isThinking":true,"responseId":"r1"}}}',
+    '{"result":{"response":{"token":"your request","isThinking":true,"responseId":"r1"}}}',
+    '{"result":{"response":{"token":"po","isThinking":false,"messageTag":"final","responseId":"r1"}}}',
+    '{"result":{"response":{"token":"ng","isThinking":false,"responseId":"r1"}}}',
+    '{"result":{"response":{"modelResponse":{"responseId":"r1","model":"grok-3","message":"pong","generatedImageUrls":[]}}}}',
+    '{"result":{"title":{"newTitle":"Pong"}}}',
+].join('\n');
+
+describe('grok stream parser', () => {
+    describe('iterFrames', () => {
+        it('yields one parsed object per non-empty line and skips malformed lines', () => {
+            const body = '{"a":1}\n\n   \nnot json\n{"b":2}\n';
+            expect(Array.from(iterFrames(body))).toEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        it('returns nothing for empty input', () => {
+            expect(Array.from(iterFrames(''))).toEqual([]);
+            expect(Array.from(iterFrames(undefined))).toEqual([]);
+        });
+    });
+
+    describe('summarizeResponse', () => {
+        const row = summarizeResponse(SAMPLE_BODY);
+
+        it('extracts the final assistant text, preferring modelResponse over the token stream', () => {
+            expect(row.response).toBe('pong');
+        });
+
+        it('joins the thinking-tagged tokens into the thinking field', () => {
+            expect(row.thinking).toBe('Thinking about your request');
+        });
+
+        it('surfaces the conversationId, responseId, model, and title for the agent', () => {
+            expect(row.conversationId).toBe('00000000-1111-2222-3333-444444444444');
+            expect(row.responseId).toBe('r1');
+            expect(row.model).toBe('grok-3');
+            expect(row.title).toBe('Pong');
+        });
+
+        it('returns generated image URLs as a newline-joined string', () => {
+            const bodyWithImages = SAMPLE_BODY.replace(
+                '"generatedImageUrls":[]',
+                '"generatedImageUrls":["https://assets.grok.com/a.jpg","https://assets.grok.com/b.jpg"]',
+            );
+            expect(summarizeResponse(bodyWithImages).images)
+                .toBe('https://assets.grok.com/a.jpg\nhttps://assets.grok.com/b.jpg');
+        });
+
+        it('falls back to the streamed token concatenation when modelResponse is absent', () => {
+            const partial = SAMPLE_BODY.split('\n').slice(0, -2).join('\n');
+            expect(summarizeResponse(partial).response).toBe('pong');
+        });
+
+        it('handles an empty body without throwing', () => {
+            const empty = summarizeResponse('');
+            expect(empty.response).toBe('');
+            expect(empty.thinking).toBe('');
+            expect(empty.model).toBe('');
+            expect(empty.images).toBe('');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds `grok stream` — captures grok.com's `POST /rest/app-chat/conversations/new` SSE response in full and emits one row with `response`, `thinking`, `model`, `conversationId`, `responseId`, `title`, and newline-joined `images`. Companion / motivation: #1847.

`grok ask` stays untouched. The new command sits next to it for callers who want the assistant's reasoning trace, server IDs, model id, and generated-image URLs without an extra round-trip through the DOM.

## How it works

1. Installs `INSTALL_STREAM_INTERCEPTOR_JS` once per tab (idempotent via `window.__opencliGrokStreamPatched`).
2. The interceptor wraps `window.fetch`; for any request hitting `/rest/app-chat/conversations/new` it `response.clone().body.getReader()`-drains the SSE chunks into a buffer, then pushes a `{url, method, status, body, capturedAt}` envelope onto `window.__opencliGrokStream`.
3. The Node side reuses the existing `ensureOnGrok` / `isLoggedIn` / `startNewChat` / `sendMessage` helpers from `clis/grok/utils.js` to drive the composer, then polls the queue until the envelope shows up (or `--timeout` seconds elapse).
4. `summarizeResponse` walks the newline-delimited JSON frames and reduces them: thinking-tagged tokens → `thinking`, untagged tokens → `response`, terminal `modelResponse` wins over the streamed concatenation, `modelResponse.generatedImageUrls` → `images`.

Not using `Strategy.INTERCEPT` / `page.installInterceptor()` here because the upstream interceptor calls `await response.clone().json()`, which silently drops Grok's newline-delimited JSON. The fetch hook for `stream` keeps the raw body string and parses per site — same approach we'll need for chatgpt/claude/gemini/deepseek SSE shapes in the follow-up PRs.

## Test plan

- [x] `npx vitest run clis/grok/stream.test.js` — 8 unit tests on `iterFrames` + `summarizeResponse` against a hand-crafted SSE body (final text, thinking trace, IDs, title, image URL list, malformed-line skipping, empty-body safety)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:adapter` — 380 files / 3722 tests pass with the new file added
- [x] `npm run build` — manifest regenerates, dist/src/main.js exposes `opencli grok stream`
- [x] Live E2E against grok.com:
  ```
  $ node dist/src/main.js grok stream "say only pong" -f json
  [
    {
      "response": "pong",
      "thinking": "Thinking about your request",
      "model": "grok-3",
      "conversationId": "00c9df44-9f05-4002-8914-fb708d9bacd2",
      "responseId": "dde78767-3bef-4e06-864e-7ae44a566cda",
      "title": "pong",
      "images": ""
    }
  ]
  ```

## Follow-ups

If this lands cleanly I'll open separate PRs for `chatgpt stream`, `claude stream`, `gemini stream`, `deepseek stream` — each parser shape differs enough to deserve its own diff. Detail of each shape is in the issue.
