### PR TITLE
docs(sitemap): seed xiaohongshu phase 2 with login schema dogfood

### DIFF
--- a/sitemaps/xiaohongshu/SITE.md
+++ b/sitemaps/xiaohongshu/SITE.md
@@ -1,0 +1,63 @@
+---
+schema_version: 1.1
+site: xiaohongshu.com
+last_verified: 2026-06-04
+source: global
+login_required: true
+auth_strategy: COOKIE_API
+login:
+  # pending: login command MVP (codex task #276) — 命令 ship 后去掉本注释
+  login_url: https://www.xiaohongshu.com/login
+  verify:
+    - kind: adapter_probe
+      command: [xiaohongshu, whoami]
+      strength: strong
+    - kind: read_probe
+      command: [xiaohongshu, feed, "--limit", "1"]
+      strength: medium
+      notes: feed 走 SSR Pinia store，未登录会 redirect /login 或 store 缺 `feed.feeds`
+    - kind: cookie_probe
+      cookies: [web_session]
+      domain: .xiaohongshu.com
+      strength: weak
+      notes: web_session 在但 server revoke 会假阳性；只做 precheck
+    - kind: dom_probe
+      url: https://www.xiaohongshu.com/explore
+      signal: 未出现"登录后查看搜索结果"/"请登录"文案 且 `.user-avatar` 存在
+      strength: weakest
+      notes: 最后兜底，DOM rebrand 易腐
+---
+
+## Overview
+
+小红书 (`xiaohongshu.com`，前身 redbook / 简称 xhs / 海外品牌 rednote)。图文笔记 + 短视频 social feed，agent 主要任务是搜笔记 / 发笔记 / 读笔记内容 + 评论 / 看 creator 数据。**大多数读写都需要登录态**（`web_session` cookie）；未登录只能访问极少量 public surface（个别 note URL，且 search / explore / user profile 都触发 login wall）。
+
+**Creator center 是独立 host `creator.xiaohongshu.com`**：发笔记 / 草稿 / creator stats 走这个域；feed / search / note detail 走主站 `www.xiaohongshu.com`。两 host 共享 SSO（同 cookie），但路由结构 / DOM 完全不同。
+
+## Top-level routes
+
+- `/` `/explore` → pages/explore.md（首页 feed / explore feed，未登录有 login wall）
+- `/search_result/?keyword=...` → pages/explore.md（搜索结果，同 explore 复用）
+- `/user/profile/<id>` → pages/profile.md（用户 profile）
+- `/explore/<note_id>?xsec_token=...` → pages/note.md（笔记详情，需 signed URL）
+- `creator.xiaohongshu.com/publish/publish?from=menu_left&target=image` → pages/compose.md（图文发布，creator center）
+- `/notifications` → 直接用 adapter `opencli xiaohongshu notifications`，无 workflow
+- `creator.xiaohongshu.com/creator/notes` → 直接用 adapter `opencli xiaohongshu creator-notes`，无 workflow
+
+## Common goals
+
+- search notes by keyword → workflows/search.md
+- publish an image note → workflows/publish.md
+- comment on a note → workflows/comment.md
+- read a note's full content + comments → 直接用 adapter `opencli xiaohongshu note <url>` + `opencli xiaohongshu comments <url>`
+- read user's notes → 直接用 adapter `opencli xiaohongshu user <id>`
+
+## Site-wide pitfalls
+
+详见 pitfalls.md。最容易踩的：
+
+- 大多数 route 未登录会 login wall（搜索 / explore / profile / notifications 全中）
+- 主站 `www.xiaohongshu.com` 与 creator center `creator.xiaohongshu.com` 是两套 DOM，发笔记必须走 creator host
+- note URL 必须带 `xsec_token` query 参数才能 drill-down（feed/search 出来的 URL 自带，但手拼裸 `/explore/<note_id>` 会 403）
+- search API 已 broken，现行 search adapter 走 DOM scrape（见 `pitfall:search_api_returns_empty`）
+- creator center 的 publish button 是 closed shadow DOM 自定义元素，host-level `.click()` 不触发；adapter 内已用 instance method invocation 兜底，task agent 不要手 click

--- a/sitemaps/xiaohongshu/apis.md
+++ b/sitemaps/xiaohongshu/apis.md
@@ -1,0 +1,57 @@
+---
+schema_version: 1.1
+last_verified: 2026-06-04
+source: global
+---
+
+## Endpoint index
+
+> 引用规则（schema §2.4）：`endpoint_id` 必须存在于 `~/.opencli/sites/xiaohongshu/endpoints.json`。本文件只放 endpoint_id + 触发关系 + contract_strength，URL/method/params/response 是 endpoints.json 单一来源。
+
+### endpoint:HomeFeed_HydratedStore
+
+- triggers_on_pages: [home, explore]
+- triggered_by_actions: [load_home_feed]
+- contract_strength: internal-unstable
+- notes: 不是 XHR endpoint，是 SSR 直出 `window.__INITIAL_STATE__.feed.feeds`。adapter `feed.js` 直接读 Pinia store；走 next-page XHR `/homefeed` 的 items 无 `xsec_token`，drill-down 用不了。
+
+### endpoint:NoteDetail_PiniaStore
+
+- triggers_on_pages: [note]
+- triggered_by_actions: [open_note_detail]
+- contract_strength: internal-unstable
+- notes: 同样是 SSR 直出 `window.__INITIAL_STATE__.note`。adapter `note.js` 当前走 DOM extraction (`.interact-container` scoped selectors)，store 路径是备选。
+
+### endpoint:UserNotes_PiniaStore
+
+- triggers_on_pages: [profile]
+- triggered_by_actions: [load_user_notes]
+- contract_strength: internal-unstable
+- notes: SSR `window.__INITIAL_STATE__.user.notes` + `user.userPageData`，adapter `user.js` 已实现 `assertReadableUserSnapshot` validator。
+
+---
+
+## v1 gap（intentional）
+
+xhs adapter family (`clis/xiaohongshu/*.js`) 引用的 endpoint 大多是 **SSR Pinia store snapshot** 而非可独立调用的 XHR：
+
+- **search**：早期走 `/api/sns/web/v1/search/notes` 已 `data:{items:[]}` 空，现行 adapter 改 DOM scrape（issue #10 / pitfall:search_api_returns_empty）
+- **publish**：creator center 走 form upload + CDP `DOM.setFileInputFiles` + shadow-DOM instance method invocation，不是 REST endpoint
+- **comments / notifications**：走站内 XHR (`/api/sns/web/v2/comment/page` / `/api/sns/web/v1/you/...`)，可独立 fetch，但 endpoints.json 当前未回填
+
+行动建议（不在本 PoC scope，留给 adapter-author follow-up）：
+
+- 跑 `opencli browser network` 抓 xhs session 拿到当前 XHR endpoint set，回填 `~/.opencli/sites/xiaohongshu/endpoints.json`
+- comments / notifications / creator-stats 这几条 XHR 形 endpoint 优先补，可见 contract 加强
+
+---
+
+## contract_strength 分布预期
+
+| 强度 | endpoint 类型 | xhs 实际 |
+|---|---|---|
+| stable | 公开签名 API | 无（无官方开放 API） |
+| visible-ui | 公开可见 HTML | 个别 `/explore/<note_id>` 公开 metadata，但需 `xsec_token` 才能完整 drill-down |
+| internal-unstable | SSR Pinia store / 站内 XHR | 几乎全部 endpoint 都在此档 |
+
+xhs 实战上 **全 endpoint 都是 internal-unstable** —— 同 twitter，意味着 agent 路径决策默认是 "能走 adapter 走 adapter，adapter broken 时 fallback DOM"（`workflows/*.md` 的 Fallback path），而不是手解 store 路径 / signed URL params。

--- a/sitemaps/xiaohongshu/pages/_note_card.md
+++ b/sitemaps/xiaohongshu/pages/_note_card.md
@@ -1,0 +1,47 @@
+---
+schema_version: 1.1
+page_id: _note_card
+url_patterns: []
+purpose: partial — actions on any note card (used by explore / search_result / profile / feed)
+last_verified: 2026-06-04
+source: global
+---
+
+> Partial：`_` 前缀 + 空 `url_patterns` = 跨页通用 UI。其他 page 通过 `action:<id> in pages/_note_card.md` 引用。
+
+## Visual anchors
+
+- pattern: `section.note-item` 或 `section:has(a[href*="/explore/"])` / `section:has(a[href*="/search_result/"])`（class 漂兜底）
+- selector_pattern: card 内 `a[href*="/explore/"]` 是 note permalink（自带 `xsec_token` query）
+- text: card 底部 like 计数 `.like-wrapper .count` / 标题 `.title` (search) / 用户名 `.author .name`
+
+## Card scope rule（全 action 共享）
+
+所有 selector 必须 scoped 到 card root `section.note-item, section:has(a[href*="/explore/"])`，**不能** 用 page-level first match，否则点到 grid 首张非 target card。
+
+## Actions
+
+```yaml
+### action:open_note
+pre: card visible in viewport
+do: click section a[href*="/explore/"] (scoped to this card) || evaluate href then goto
+post: URL -> /explore/<note_id>?xsec_token=...; pages/note.md loaded
+fail: stays on listing | modal not nav | 403 / security_block
+recover: 直接 evaluate href 拿完整带 `xsec_token` URL 后 goto；href 不含 xsec_token -> pitfall:note_url_requires_xsec_token，跳过该 card
+evidence: opencli browser click + state
+```
+
+```yaml
+### action:read_card_meta
+pre: card visible
+do: evaluate("(c => ({title:c.querySelector('.title')?.innerText, like:c.querySelector('.like-wrapper .count')?.innerText, href:c.querySelector('a[href*=\"/explore/\"]')?.href}))(arguments[0])")
+post: 返 {title, like, href}；href 自带 xsec_token
+fail: 空对象 / title undef
+recover: card 漂版，回 explore.md Page pitfalls 看 selector 变体；fallback workflow 走 adapter `feed` / `search` 直接拿结构化数据
+evidence: opencli browser evaluate
+```
+
+## Pitfalls inherited
+
+- 不要从 card 拿到 note_id 后手拼 `/explore/<note_id>`，必须用 card 原始 href — `pitfall:note_url_requires_xsec_token`
+- 不要 page-level `document.querySelector('.title')` 拿"当前 card" — 全 grid 首张匹配

--- a/sitemaps/xiaohongshu/pages/compose.md
+++ b/sitemaps/xiaohongshu/pages/compose.md
@@ -1,0 +1,79 @@
+---
+schema_version: 1.1
+page_id: compose
+url_patterns:
+  - https://creator.xiaohongshu.com/publish/publish?from=*&target=image
+  - https://creator.xiaohongshu.com/publish/publish?from=*&target=video
+purpose: creator center publish form — image / video note authoring (DIFFERENT host from main site)
+last_verified: 2026-06-04
+source: global
+---
+
+> **host 警告**：本 page **不在** `www.xiaohongshu.com`，而是 `creator.xiaohongshu.com`。两 host 共享 SSO（同 `web_session` cookie），但 DOM / 路由 / shadow DOM 完全不同 — `pitfall:creator_center_is_different_host`
+
+## Visual anchors
+
+- a11y: 无统一 role；form 区块按 visible text 分
+- pattern: file input `input[type="file"][accept*="image"]`；标题 `input[placeholder*="请输入标题"][offsetWidth>50]`（visible filter 排 4px hidden decoy）；正文 contenteditable `[contenteditable="true"]`；topic input 触发 visible text `#话题`；publish button `<xhs-publish-btn>` 自定义元素
+- testid: 无
+- selector_pattern: title input 有 visible / hidden 两套同 class，**必须** filter `offsetWidth > 50` — `pitfall:title_input_has_hidden_decoy`
+- text: publish button visible text `发布`；save draft `存草稿`；image upload 区 `点击上传`
+
+## Actions
+
+```yaml
+### action:upload_images
+pre: on /publish/publish?target=image, logged_in, image files local paths ready
+do: opencli xiaohongshu publish --title "..." "..." --images /path/a.jpg,/path/b.jpg ... (走 CDP DOM.setFileInputFiles)
+post: image preview 区出现缩略图，3s 内 upload settle
+fail: file input 找不到 | upload 卡住 | "上传失败" toast
+recover: 检查图片格式 (jpg/png/webp <10MB)；最多 9 张 (MAX_IMAGES)；adapter 内置 base64 fallback；都 fail -> adapter_health suspect
+evidence: opencli xiaohongshu publish
+```
+
+```yaml
+### action:fill_text
+pre: images uploaded, title input + body contenteditable visible
+do: type "<title>" into title input (visible filter) + type "<body>" into body contenteditable
+post: 标题 + 正文 v-model 同步，submit button 候选 enable
+fail: 输入到 hidden decoy input (v-model 不 commit) | character limit 超 (title >20 / body >1000)
+recover: 标题截到 20 字符内；body 截到 1000 内；fallback selector 加 `offsetWidth > 50` filter
+evidence: opencli xiaohongshu publish
+```
+
+```yaml
+### action:add_topics
+pre: title + body filled, topic 输入位置 visible
+do: opencli xiaohongshu publish --topics 生活,旅行 (adapter 内部处理 #话题 trigger + 选项 click)
+post: 正文末尾出现 #话题 inline 链接
+fail: 话题 popup 不弹 | 选项 click 不响应
+recover: 跳过 topics 重试 publish（非必需）；persistent fail adapter_health suspect
+evidence: opencli xiaohongshu publish
+```
+
+```yaml
+### action:submit_publish
+pre: title / images / body 都 ready
+do: opencli xiaohongshu publish ... (adapter 内部走 shadow DOM instance method invocation: `_onPublish` / `onPublish` / `_onSubmit` / `_handlePublish`)
+post: redirect 到 /creator/notes 或 toast "发布成功"
+fail: shadow DOM method invocation 全 miss | "发布失败" toast | 安全验证 modal 弹
+recover: 安全验证 modal -> 停手报 user；其他 fail -> adapter_health suspect 然后看 fallback (但 shadow DOM publish 没有 task-agent-能跑的 fallback，必须 adapter)
+evidence: opencli xiaohongshu publish; opencli xiaohongshu creator-notes (verify new note)
+```
+
+```yaml
+### action:save_draft
+pre: 至少 title 或 images 之一存在
+do: opencli xiaohongshu publish --draft ... (adapter 内部走 `_onSave` / `_onSaveDraft` / `_onDraft`)
+post: redirect /creator/notes/drafts 或 toast "已保存草稿"；可通过 opencli xiaohongshu drafts 列出
+fail: 同 submit_publish
+recover: 同 submit_publish
+evidence: opencli xiaohongshu publish --draft; opencli xiaohongshu drafts
+```
+
+## Page pitfalls
+
+- 走 creator host，不要在 main site `www.xiaohongshu.com` 找发布入口 — `pitfall:creator_center_is_different_host`
+- title input visible filter **必须** 加，否则输入丢到 4px hidden decoy — `pitfall:title_input_has_hidden_decoy`
+- publish button 是 closed shadow DOM，host `.click()` 不触发，必须 instance method invocation — `pitfall:publish_button_shadow_dom`
+- 安全验证 modal 是 human-only 红线（CAPTCHA / 滑块 / 短信 2FA），停手报 user

--- a/sitemaps/xiaohongshu/pages/explore.md
+++ b/sitemaps/xiaohongshu/pages/explore.md
@@ -1,0 +1,55 @@
+---
+schema_version: 1.1
+page_id: explore
+url_patterns:
+  - https://www.xiaohongshu.com/
+  - https://www.xiaohongshu.com/explore
+  - https://www.xiaohongshu.com/search_result/?keyword=*
+purpose: home feed / explore feed / search results — same DOM shape, same note-card grid
+last_verified: 2026-06-04
+source: global
+---
+
+## Visual anchors
+
+- a11y: `role=main` 内 note grid（无明确 role region 名，靠 selector）
+- pattern: note items `section.note-item` 或 `section:has(a[href*="/search_result/"])` / `section:has(a[href*="/explore/"])`（#1507 兜底，class 漂时用 `<section>` 结构 + href substring）
+- testid: 站内基本无 `data-testid`，靠 class + href substring 锚定
+- text: search input placeholder `搜索小红书`；搜索按钮 visible text `搜索`；login wall 文案 `登录后查看搜索结果` / `请登录`
+- selector_pattern: search submit URL pattern `/search_result/?keyword=<encoded>`
+
+## Actions
+
+```yaml
+### action:run_search
+pre: on /, logged_in
+do: opencli xiaohongshu search "<keyword>" || (focus input[placeholder*="搜索小红书"] + type + Enter)
+post: URL -> /search_result/?keyword=<encoded>; note grid rendered
+fail: stays on / | "登录后查看搜索结果" overlay | empty results panel
+recover: adapter_health_update: opencli xiaohongshu search -> suspect; check whoami; persistent empty -> workflows/search.md Fallback
+evidence: opencli xiaohongshu search
+```
+
+```yaml
+### action:scroll_feed
+pre: on / OR /explore OR /search_result/, feed loaded
+do: evaluate("window.scrollBy(0, window.innerHeight * 2)")
+post: 更多 section.note-item 追加 DOM
+fail: 2s 无新 entry | 安全限制 toast | URL 切到 /login
+recover: wait 2s retry; 持续无新 entry -> 已到尾 OR 触发 security_block，停手
+evidence: opencli browser evaluate
+```
+
+## Note card actions
+
+每张 note card 上的 open / 提取 link 是跨页通用，定义在 [`pages/_note_card.md`](./_note_card.md)。
+
+- use `action:open_note in pages/_note_card.md`
+- use `action:read_card_meta in pages/_note_card.md`
+
+## Page pitfalls
+
+- `/` 与 `/explore` 是同一 feed，不同 url 不同 referer 行为但 DOM 一致
+- `/search_result/?keyword=<encoded>` 关键词必须 URL-encode（含中文 / 空格）
+- 未登录访问 `/explore` 或 `/search_result/` 大概率 redirect `/login` 或叠 login wall overlay — `pitfall:login_wall_on_most_routes`
+- search API 已 broken，adapter 走 DOM scrape — `pitfall:search_api_returns_empty`

--- a/sitemaps/xiaohongshu/pages/note.md
+++ b/sitemaps/xiaohongshu/pages/note.md
@@ -1,0 +1,57 @@
+---
+schema_version: 1.1
+page_id: note
+url_patterns:
+  - https://www.xiaohongshu.com/explore/*?xsec_token=*
+  - https://www.xiaohongshu.com/discovery/item/*?xsec_token=*
+purpose: note detail page — title / body / author / tags / interaction counts + comments section
+last_verified: 2026-06-04
+source: global
+---
+
+## Visual anchors
+
+- a11y: 无明显 role；靠 selector / scoped container
+- pattern: title `#detail-title, .title`；body `#detail-desc, .desc, .note-text`；author `.username, .author-wrapper .name`
+- testid: 无
+- selector_pattern: 互动计数必须 scoped 到 `.interact-container`（page-level `.like-wrapper .count` 会命中评论区第一条评论的 like 数，不是 post 自己）
+- text: login wall `登录后查看` / `请登录`；page 404 `页面不见了` / `笔记不存在` / `无法浏览`；security `安全限制` / `访问链接异常`
+
+## Actions
+
+```yaml
+### action:read_note_content
+pre: on /explore/<note_id>?xsec_token=..., logged_in
+do: opencli xiaohongshu note <url> --max-content 0
+post: 输出 {title, body, author, like_count, collect_count, comment_count, tags}
+fail: AuthRequiredError | EmptyResultError | CommandExecutionError | security_block
+recover: AuthRequired -> opencli xiaohongshu login（# pending: codex task #276）；Empty -> note 已删除/私密 跳过；CommandExecution -> adapter_health suspect 走 Fallback
+evidence: opencli xiaohongshu note
+```
+
+```yaml
+### action:read_comments
+pre: on /explore/<note_id>?xsec_token=..., logged_in
+do: opencli xiaohongshu comments <url>
+post: 输出评论列表 + 子评论
+fail: AuthRequired | Empty (无评论或全删) | CommandExecution
+recover: 同 read_note_content；Empty 是合法状态（笔记没评论）
+evidence: opencli xiaohongshu comments
+```
+
+```yaml
+### action:post_comment
+pre: on /explore/<note_id>?xsec_token=..., logged_in, 评论框 visible (.comment-input || textarea[placeholder*="评论"])
+do: focus 评论 textarea + type "<text>" + click "发布" button
+post: 评论区顶部出现自己 username + 内容 within 3s
+fail: textarea 不 focus | submit button 不 enable | 安全验证 modal 弹
+recover: 触发安全验证 modal 时停手报 user（"human authenticates"），不要尝试解滑块；session 失效 -> AuthRequired
+evidence: opencli browser click + opencli xiaohongshu comments (verify new comment)
+```
+
+## Page pitfalls
+
+- URL 不带 `xsec_token` 必 403 — `pitfall:note_url_requires_xsec_token`
+- 互动计数 selector **必须 scoped 到 `.interact-container`**，否则拿到评论的计数（adapter 已 scoped，DOM fallback 写时务必注意）
+- 高频访问同 URL 触发 `pitfall:security_block_on_repeated_access`
+- `--max-content N` 是 opt-in 截断（default 0 = 不截断），不要假定默认截断

--- a/sitemaps/xiaohongshu/pages/profile.md
+++ b/sitemaps/xiaohongshu/pages/profile.md
@@ -1,0 +1,50 @@
+---
+schema_version: 1.1
+page_id: profile
+url_patterns:
+  - https://www.xiaohongshu.com/user/profile/*
+purpose: user profile — bio, follower / following counts, user's published notes grid
+last_verified: 2026-06-04
+source: global
+---
+
+## Visual anchors
+
+- a11y: 无明显 role
+- pattern: bio container `.user-info` / `.user-page`；user notes grid 同 explore 复用 `section.note-item`
+- selector_pattern: SSR Pinia store `window.__INITIAL_STATE__.user.notes` + `window.__INITIAL_STATE__.user.userPageData`
+- text: follower / following 数字旁文案 `粉丝` / `关注`；login wall `请登录`
+
+## Actions
+
+```yaml
+### action:read_user_notes
+pre: on /user/profile/<id>, logged_in
+do: opencli xiaohongshu user <id>
+post: 输出用户 metadata + 笔记列表（href 自带 xsec_token，可 drill-down 到 note.md）
+fail: AuthRequired | Empty (用户无笔记 / 私密 / 已注销) | CommandExecution (Pinia store 漂)
+recover: AuthRequired -> opencli xiaohongshu login（# pending: codex task #276）；CommandExecution -> adapter_health suspect；Empty 视为合法
+evidence: opencli xiaohongshu user
+```
+
+```yaml
+### action:scroll_user_notes
+pre: on /user/profile/<id>, notes grid loaded
+do: evaluate("window.scrollBy(0, window.innerHeight * 2)")
+post: 更多 section.note-item 追加，Pinia store 同步刷新
+fail: 2s 无新 entry | 触发 security_block
+recover: 已到尾 OR security_block；前者正常停手，后者 pitfall:security_block_on_repeated_access
+evidence: opencli browser evaluate
+```
+
+## Note card actions
+
+profile 页的 note grid 复用 `pages/_note_card.md`：
+
+- use `action:open_note in pages/_note_card.md`
+
+## Page pitfalls
+
+- user_id 不是 short handle，是 24-hex MongoDB ObjectId 形式（e.g. `5be4c0710000000001003c10`）
+- user 的 note 列表通过 SSR 一次性 hydrate 首屏，scroll 才触发更多 — 不要假定 first call 拿到全部
+- 私密账号 / 已注销账号 store 仍 hydrate 但 notes 为空，adapter 抛 Empty 是合法

--- a/sitemaps/xiaohongshu/pitfalls.md
+++ b/sitemaps/xiaohongshu/pitfalls.md
@@ -1,0 +1,65 @@
+---
+schema_version: 1.1
+last_verified: 2026-06-04
+source: global
+---
+
+> **Scope**：本文件只列 **task-executing agent** 跑 sitemap workflow 时会撞的坑。adapter-author 实现层的坑（Pinia store SSR vs XHR 形状差异 / creator-center shadow-DOM publish button / `xsec_token` signed URL 起源）放在 `~/.opencli/sites/xiaohongshu/notes.md`，与本文件互补。
+
+## Site-specific pitfalls
+
+### pitfall:login_wall_on_most_routes
+
+- trigger: 未登录访问 `/` `/explore` `/search_result/...` `/user/profile/<id>` `/notifications` 等几乎全部 route
+- symptom: 页面文案 `登录后查看搜索结果` / `请登录` / redirect 到 `/login`，或 search adapter 抛 `AuthRequiredError`
+- workaround: 跑 workflow / adapter 前先 `opencli xiaohongshu whoami` 验登录态（# pending: login command MVP, codex task #276）；未登录 → `opencli xiaohongshu login`；不要尝试自动填用户名密码（CAPTCHA / 短信 2FA / 滑块 全踩，"human authenticates, machine verifies"）
+- verified_at: 2026-06-04
+
+### pitfall:note_url_requires_xsec_token
+
+- trigger: agent 手拼 `/explore/<note_id>` 裸路径，没带 `xsec_token` query
+- symptom: 页面 403 / `error_code=300017` / `error_code=300031` / `website-login/error` redirect
+- workaround: note URL 必须来自 feed / search / user adapter 输出，那些 adapter 已经把 signed URL 完整带出；不要自己从 note_id 重建 URL；如果只有 note_id，先跑 `opencli xiaohongshu search` / `feed` 拿到 signed URL 再 drill down
+- verified_at: 2026-06-04
+
+### pitfall:search_api_returns_empty
+
+- trigger: 走 workflow Best path `opencli xiaohongshu search`，adapter 返 0 行或 EmptyResultError
+- symptom: 关键词在网页搜得到结果但 adapter 输出空，或抛 typed error
+- workaround: 把 workflow `adapter_health` 标 `suspect`，走 Fallback (browser DOM scrape on `/search_result/?keyword=...`)。根因是 `/api/sns/web/v1/search/notes` 返 `items:[]`（issue #10），adapter 已切 DOM scrape，但 DOM 也可能因 `section.note-item` class 漂动产生（PR #1507 兜底过一层）；task agent 不需要解 API 漂移，只需切 DOM Fallback
+- verified_at: 2026-06-04
+
+### pitfall:creator_center_is_different_host
+
+- trigger: agent 想发笔记，停留在 `www.xiaohongshu.com` 上找发布入口
+- symptom: 主站没有完整的发布入口（顶 nav 的"发布"按钮跳到 `creator.xiaohongshu.com/publish/publish?from=menu_left&target=image`），手 click 容易撞 popup / iframe / sso refresh 链
+- workaround: 发笔记直接 `opencli xiaohongshu publish ...`，adapter 内部走 creator host；如果 fallback 需手操，先 `goto creator.xiaohongshu.com/publish/publish?from=menu_left&target=image` 再操作
+- verified_at: 2026-06-04
+
+### pitfall:publish_button_shadow_dom
+
+- trigger: agent fallback 手 click creator center 的"发布"按钮 `<xhs-publish-btn>`
+- symptom: 看似 click 成功但表单不提交，dev tools 看 host element `.click()` 没触发内部 handler
+- workaround: 不要手 click；`opencli xiaohongshu publish` adapter 已用 instance method invocation (`_onPublish` / `onPublish` / `_onSubmit` / `_handlePublish`) 兜底（#1606）；如果 adapter broken 必须手动，用 `opencli browser evaluate` 调实例方法而不是 click
+- verified_at: 2026-06-04
+
+### pitfall:security_block_on_repeated_access
+
+- trigger: 短时间高频访问同一 note URL / 高频 search
+- symptom: 页面文案 `安全限制` / `访问链接异常`，URL 含 `website-login/error` 或 `error_code=300017|300031`
+- workaround: 触发后 60s 内不重试同 URL；workflow 内用 1-2s wait 隔开连续请求；如果 sticky，换 session（清 cookie 重 login → 但这种已经超出 task agent 范围，应停手报给 user）
+- verified_at: 2026-06-04
+
+### pitfall:title_input_has_hidden_decoy
+
+- trigger: publish workflow fallback 用 visible text selector 找 title 输入框
+- symptom: 输入到一对 4px 宽的隐藏 scaffolding input，submit 时 v-model 不 commit，标题永远为空
+- workaround: 优先用 `opencli xiaohongshu publish` adapter（已 prioritize visible title input）；fallback 时按 placeholder text `请输入标题` 加 visible filter (`offsetWidth > 50`) 选可见 input；不要按 nth-child / first match
+- verified_at: 2026-06-04
+
+### pitfall:home_feed_xhr_lacks_xsec_token
+
+- trigger: agent 想拿 home feed 下一页，调内部 `/homefeed` XHR 取 items
+- symptom: items 拿到但每条 `xsec_token` 缺，drill-down 到 note 详情时所有 URL 403
+- workaround: 不要 fetch `/homefeed`；走 SSR Pinia store snapshot (`feed.js` adapter 已是这套)；first-screen 的 items 才有 `xsecToken`；如果一定要翻页，scroll + 重读 store
+- verified_at: 2026-06-04

--- a/sitemaps/xiaohongshu/workflows/comment.md
+++ b/sitemaps/xiaohongshu/workflows/comment.md
@@ -1,0 +1,86 @@
+---
+schema_version: 1.1
+workflow_id: comment
+intent: post a comment on a xiaohongshu note
+last_verified: 2026-06-04
+source: global
+---
+
+## Goal
+
+在指定 note 下发一条 **文本评论**（无图片 / 无 @ 用户 / 无 emoji panel）。
+
+- 回复别人的评论（reply to comment）**不在** v1 PoC scope（属于子评论 nested workflow）
+- 评论带图 / @ 用户 / 表情 panel **不在** v1 PoC scope
+
+## State signature
+
+- entry: 任意 page，logged_in，note URL (含 `xsec_token`) ready，评论文本 ready
+- success: 评论区顶部 / 自己 username 下出现刚发的文本，且 `opencli xiaohongshu comments <url>` 输出含该条
+
+## Best path
+
+xhs 现阶段 **没有 cookie-API 形 `opencli xiaohongshu comment` adapter**（comments adapter 只读不写）。直接走 browser DOM workflow：
+
+```yaml
+preconditions:
+  - logged_in
+  - note URL with valid xsec_token
+  - comment text ready (<= 1000 chars, no special markup)
+estimated_turns: 4
+```
+
+```yaml
+flow:
+  - goto <note_url>  # 必须含 xsec_token，否则 pitfall:note_url_requires_xsec_token
+  - wait for action:read_comments precondition (评论区 rendered)
+  - action:post_comment in pages/note.md
+  - verify: opencli xiaohongshu comments <url> --limit 5 看顶部是否是新评论
+```
+
+> **Adapter follow-up candidate**：cookie-API 形 `opencli xiaohongshu comment <url> "<text>"` 是合理的下一发，发完 v1 sitemap 后开 issue 给 adapter-author。
+
+## Fallback path
+
+Best path 已经是 DOM-only。Fallback 主要处理 AuthRequired / security_block：
+
+```yaml
+on_action_fail:
+  - if URL 含 /login OR overlay "请登录":
+    - recovery: opencli xiaohongshu login  # pending: codex task #276
+    - 登录后从 Best path step 1 重跑
+  - if 安全验证 modal visible (CAPTCHA / 滑块 / 短信):
+    - 停手报 user，不要尝试自动过验证
+  - if 评论 textarea 找不到 (selector 漂):
+    - 标记 page action `action:post_comment` stale，停手报 user
+  - if submit button click 后评论未出现 > 5s:
+    - 等 10s 后 cross-verify opencli xiaohongshu comments，可能是 server lag
+    - 仍未出现 -> 评论被过滤（敏感词 / spam 检测），停手报 user 让其改文案
+estimated_turns: +2
+```
+
+## Avoid
+
+- 不要在不带 `xsec_token` 的 URL 上跑（403）— `pitfall:note_url_requires_xsec_token`
+- 不要循环 retry 评论（spam 检测 / 触发 security_block）
+- 不要尝试 click 表情 panel / @ 用户 / 上传图片 — out of scope
+- 不要 click "发布" 后立刻关 page，server commit 有 1-3s lag，必须 cross-verify 后再退出
+
+## Re-entry checkpoints
+
+agent 中断后醒来按 `opencli browser state` URL + comments 比对判断：
+
+- 非 `/explore/<note_id>?xsec_token=...` URL → 重新 goto
+- on note page, textarea visible 但未输入 → step 3 起
+- on note page, 评论已 submit 但未 cross-verify → cross-verify 一次
+- on `/login` 或 login wall → 走 Recovery
+
+## State validation
+
+- `opencli xiaohongshu comments <url> --limit 5` 输出顶部 row 的 `author` 是 self（whoami 对比） 且 `content` 匹配（normalize whitespace + emoji NFC）
+- 评论时间显示 `刚刚` / `1秒前` / `1分钟前`
+
+## Stale markers
+
+- 评论 textarea selector 漂（`.comment-input` / `textarea[placeholder*="评论"]` 都 miss） → action:post_comment 需更新
+- xhs 引入 cookie-API `comment` adapter 后，Best path 切 adapter，本 workflow 改 Fallback

--- a/sitemaps/xiaohongshu/workflows/publish.md
+++ b/sitemaps/xiaohongshu/workflows/publish.md
@@ -1,0 +1,87 @@
+---
+schema_version: 1.1
+workflow_id: publish
+intent: publish an image note (title + body + 1-9 images, optional topics)
+last_verified: 2026-06-04
+source: global
+---
+
+## Goal
+
+发一篇 **图文笔记**：标题（≤20 字）+ 正文 + 1-9 张本地图片，可选 topic 话题。
+
+- 视频笔记 / 长文 / 私密 / 定时发布 / @用户 / 位置 **不在** v1 PoC scope
+- 草稿保存走同 page action:save_draft，走 `--draft` flag，不算 publish 完成
+
+## State signature
+
+- entry: 任意 page，logged_in，本地图片路径 ready，标题 / 正文 string ready
+- success: `opencli xiaohongshu creator-notes` 列表里出现新笔记（title 匹配），或 publish toast `发布成功`
+
+## Best path
+
+```yaml
+adapter: opencli xiaohongshu publish
+adapter_health: healthy
+preconditions:
+  - logged_in (creator.xiaohongshu.com 同 cookie 共享)
+  - title <= 20 chars
+  - 1-9 local image paths (jpg/png/webp, <10MB each)
+  - body text ready
+estimated_turns: 1
+```
+
+直接 `opencli xiaohongshu publish --title "<title>" "<body>" --images /path/a.jpg,/path/b.jpg [--topics 生活,旅行]`。adapter 内部 navigate creator host + CDP file upload + shadow DOM submit。
+
+## Fallback path
+
+当 adapter 抛 typed error（AuthRequiredError / CommandExecutionError）或卡死 > 60s：
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli xiaohongshu publish -> suspect
+  - if AuthRequiredError:
+    - recovery: opencli xiaohongshu login  # pending: codex task #276
+    - 登录后 retry adapter 一次
+  - opencli browser state (verify host + URL)
+  - if host != creator.xiaohongshu.com: goto https://creator.xiaohongshu.com/publish/publish?from=menu_left&target=image
+  - action:upload_images in pages/compose.md (CDP DOM.setFileInputFiles)
+  - wait 3s for upload settle
+  - action:fill_text in pages/compose.md (title visible filter + body contenteditable)
+  - 如果 topics 非空: action:add_topics in pages/compose.md
+  - action:submit_publish in pages/compose.md
+  - **注意**: publish button 是 closed shadow DOM, host-level click 不响应 -> 必须 evaluate 实例方法 `_onPublish` / `onPublish` / `_onSubmit` / `_handlePublish`
+  - verify URL redirect 到 /creator/notes 或 toast "发布成功"
+  - cross-verify: opencli xiaohongshu creator-notes --limit 1 看顶部是否是新发的
+estimated_turns: 8
+```
+
+## Avoid
+
+- 不要在 `www.xiaohongshu.com` 找发布入口 — `pitfall:creator_center_is_different_host`
+- 不要 host-level `.click()` `<xhs-publish-btn>` — `pitfall:publish_button_shadow_dom`
+- 不要 page-level selector 找 title input — `pitfall:title_input_has_hidden_decoy`，要加 visible filter (`offsetWidth > 50`)
+- 安全验证 modal（CAPTCHA / 滑块 / 短信 2FA）弹出停手报 user，不要尝试自动解
+- 不要 publish 失败后立刻 retry 5 次 — 触发 security_block 概率高
+- 不要把 `--draft` 当 fallback — 草稿 != 已发布，不算 workflow 成功
+
+## Re-entry checkpoints
+
+agent 中断后醒来按 `opencli browser state` URL + creator-notes 比对判断：
+
+- on 非 creator host → 重新走 Best path
+- on `creator.xiaohongshu.com/publish/publish?...`, 图片已上传但 title/body 未填 → Fallback step "fill_text" 起
+- on `/creator/notes` 或 toast `发布成功` 已显示 → 已完成，cross-verify `creator-notes` 顶部
+- 安全验证 modal visible → 停手报 user
+
+## State validation
+
+- `opencli xiaohongshu creator-notes --limit 5` 顶部出现 title 匹配新 row，或
+- `creator.xiaohongshu.com/creator/notes` URL 上看到新笔记 card（visible text 匹配）
+- publish toast `发布成功` 出现过
+
+## Stale markers
+
+- shadow DOM publish button instance method 名变化（`_onPublish` family） → adapter 内部 fallback 链全 miss，task agent 在 Fallback step 卡住，标 adapter_health suspect
+- title input class 漂 / hidden decoy 结构换 → visible filter 阈值需调整
+- creator center URL `from=` `target=` query 变化 → goto URL 需更新

--- a/sitemaps/xiaohongshu/workflows/search.md
+++ b/sitemaps/xiaohongshu/workflows/search.md
@@ -1,0 +1,78 @@
+---
+schema_version: 1.1
+workflow_id: search
+intent: search xiaohongshu for notes matching a keyword
+last_verified: 2026-06-04
+source: global
+---
+
+## Goal
+
+按 keyword 搜小红书笔记列表，每条带 title / author / like_count / signed note URL（可 drill-down 到 note detail）。
+
+- 高级 filter（sort by hot / newest / image-only / video-only / date range）**不在** v1 PoC scope，task agent 现阶段只能拿 default mixed feed
+- 拿到 list 后 drill-down 单 note 走 `opencli xiaohongshu note <url>`，不属于本 workflow
+
+## State signature
+
+- entry: 任意 page on xiaohongshu.com, logged_in (cookie `web_session` 有效)
+- success: 输出至少 1 条结构化 note row（title / author / note_url / like_count），或合法的 0 行（关键词无结果）
+
+## Best path
+
+```yaml
+adapter: opencli xiaohongshu search
+adapter_health: degraded  # API broken，已切 DOM scrape (issue #10)，仍标 healthy 不准
+preconditions:
+  - logged_in
+  - keyword ready (中文需 UTF-8 直传，adapter 内部 encode)
+estimated_turns: 1
+```
+
+直接 `opencli xiaohongshu search "<keyword>" --limit 20`。adapter 内部 navigate `/search_result/?keyword=<encoded>` + DOM scrape `section.note-item`。
+
+## Fallback path
+
+当 adapter 抛 typed error（AuthRequiredError / EmptyResultError / CommandExecutionError）或返回 unexpected empty 时：
+
+```yaml
+on_adapter_fail:
+  - adapter_health_update: opencli xiaohongshu search -> suspect
+  - if AuthRequiredError:
+    - recovery: opencli xiaohongshu login  # pending: codex task #276 实现该子命令
+    - 登录后 retry adapter 一次
+  - opencli browser state (verify current URL/login wall)
+  - goto https://www.xiaohongshu.com/search_result/?keyword=<URL-encoded keyword>
+  - wait for section.note-item OR text "登录后查看搜索结果"
+    - login wall 命中 -> 同 AuthRequired 路径
+    - 6s 后仍无 note-item -> EmptyResultError
+  - 用 action:read_card_meta in pages/_note_card.md 逐 card 抽取 {title, author, note_url, like_count}
+  - 输出结构化 list
+estimated_turns: 5
+```
+
+## Avoid
+
+- 不要走 `/api/sns/web/v1/search/notes` XHR — `pitfall:search_api_returns_empty`，已 broken
+- 不要自己从 note title 重建 URL 拼 `/explore/<note_id>` — `pitfall:note_url_requires_xsec_token`
+- 关键词含特殊字符（空格 / 中英混排 / `&` / `#`）记得 URL-encode 或交给 adapter 处理
+- 触发 `安全限制` toast 时停手 60s，不要循环 retry — `pitfall:security_block_on_repeated_access`
+
+## Re-entry checkpoints
+
+agent 中断后醒来按 `opencli browser state` URL 判断：
+
+- on `/`，未搜过 → 重新跑 Best path
+- on `/search_result/?keyword=<X>` 且 note-item 已渲染 → 从 Fallback step "read_card_meta" 起
+- on `/login` 或命中 login wall overlay → 走 Recovery path：`opencli xiaohongshu login`（# pending: codex task #276），login 后回 Best path 重跑
+
+## State validation
+
+- 至少 1 条 row 输出 OR 合法的 0 行（page 显式 "暂无结果" 文案）
+- 每 row 的 `note_url` **必含 `xsec_token` query**（否则 drill-down 必 403）
+- like_count 是 string（小红书显示 `1.2万` 类压缩格式，不要假定 int）
+
+## Stale markers
+
+- adapter `opencli xiaohongshu search` 30 天内 fix PR 增多（DOM class 漂） → adapter_health audit 标 suspect
+- `section.note-item` class 名换 / `登录后查看搜索结果` 文案换 → 视觉 anchor 需更新（PR #1507 已加 fallback selector，再换需第二层 fallback）


### PR DESCRIPTION
## Summary

Phase 2 sitemap seed for `xiaohongshu` — 11 files / 909 lines under `sitemaps/xiaohongshu/`. Dogfoods the new `login:` block schema agreed in #OpenCLI:7bbdfcd2 (login + whoami design pin) **before** codex's command MVP ships, so the schema gets a real second use case beyond twitter / hackernews PoC.

## Files

- `SITE.md` — frontmatter with new `login:` block (4-tier verify: adapter probe > read probe > cookie probe > DOM probe). `login_url: https://www.xiaohongshu.com/login`, cookie key `web_session`.
- `apis.md` — Pinia SSR store snapshot endpoints (`HomeFeed_HydratedStore` / `NoteDetail_PiniaStore` / `UserNotes_PiniaStore`).
- `pitfalls.md` — 8 site-specific gotchas (login wall / xsec_token / search API broken / creator host split / shadow DOM publish / security_block / hidden title decoy / homefeed XHR missing xsec_token).
- `pages/` — `_note_card` (partial) + `explore` + `note` + `profile` + `compose` (creator host).
- `workflows/` — `search` + `publish` + `comment` (last is DOM-only, no cookie-API adapter today).

## Login schema dogfood

Workflow `Recovery` sections reference `opencli xiaohongshu login` with `# pending: codex task #276` annotation. Once codex's command MVP ships, drop the `# pending` comments — no other change needed.

This is the new schema's second author-side instance (twitter / hackernews PoC was first). Surfaces:
- Is `verify` array (strong→weak 4 entries) ergonomic for authors? ✅ wrote it from scratch in one pass.
- Does `# pending` lint clean? Each pending site references the future command three places (SITE.md `verify.command`, pitfalls.md `pitfall:login_wall_on_most_routes` workaround, each workflow `Recovery`). Grep-able.

## Cohesion bias on three files

`pitfalls.md` (4.7KB) / `pages/compose.md` (4.3KB) / `workflows/publish.md` (4.0KB) over the 800-token soft cap. Kept as single files per #1824 audit-flag-explanation loop:

- `pitfalls.md`: 8 xhs-specific gotchas, cross-referenced from every workflow + page. Splitting forces multi-file resolution per pitfall lookup.
- `pages/compose.md`: 5 actions on creator center publish form (upload / fill / topics / submit / save_draft). All operate on same page DOM, sharing visual anchors + scope rule. Splitting would duplicate anchors.
- `workflows/publish.md`: Single user-intent (image note publish), 8-step Fallback chain references creator host pitfalls. Splitting workflow by step breaks State signature continuity.

## Test plan

- [ ] schema validator (when 质量官's audit lands) — frontmatter `schema_version: 1.1` / `auth_strategy: COOKIE_API` / `source: global` consistent across all 11 files
- [ ] grep `# pending: codex task #276` returns 3 hits per relevant file (SITE.md verify / pitfalls.md login_wall / workflows/{search,publish,comment,note}.md Recovery) — verify all references are grep-able when codex ships login MVP and we strip annotations
- [ ] cross-reference check: every `pages/_note_card.md action` reference resolves; every `pitfalls.md` ID referenced by workflow / page exists
- [ ] live verify against xhs after codex's login command MVP merges (`opencli xiaohongshu whoami` + run each workflow once)

Cc @opencli-质量官 @codex-coder @WAWQAQ — schema dogfood feedback welcome before login MVP lands.