### PR TITLE
fix(douban): inline normalizeText into splitDoubanTitle for page eval

### DIFF
--- a/clis/douban/utils.js
+++ b/clis/douban/utils.js
@@ -68,6 +68,10 @@ function extractDoubanPublishYear(value) {
     return match?.[0] || '';
 }
 function splitDoubanTitle(fullTitle) {
+    // Inline normalizeText so the toString-injected copy inside
+    // loadDoubanMovieSubject's page.evaluate runs without a closure reference
+    // to the module-level helper (which does not survive Function.toString()).
+    const normalizeText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
     const normalized = normalizeText(fullTitle);
     if (!normalized)
         return { title: '', originalTitle: '' };

--- a/clis/douban/utils.test.js
+++ b/clis/douban/utils.test.js
@@ -78,6 +78,18 @@ function runMovieHotEvaluate(script, items) {
     return vm.runInNewContext(script, { document, URL });
 }
 
+function runMovieSubjectEvaluate(script, elementMap) {
+    const document = {
+        querySelector(selector) {
+            return elementMap[selector] || null;
+        },
+        querySelectorAll() {
+            return [];
+        },
+    };
+    return vm.runInNewContext(script, { document, URL });
+}
+
 async function runSearchEvaluate(script, rawItems, domItems) {
     const document = {
         querySelector(selector) {
@@ -319,6 +331,32 @@ ISBN: 9787544270871
         };
 
         await expect(loadDoubanMovieHot(page, 20)).rejects.toThrow('douban movie-hot returned no data');
+    });
+
+    it('loads a movie subject without ReferenceError when splitDoubanTitle is toString-injected (regression for #1851)', async () => {
+        const elementMap = {
+            'span[property="v:itemreviewed"]': createFakeNode('海贼王：黄金大冒险 One Piece Gold'),
+            '.year': createFakeNode('(2016)'),
+            'strong[property="v:average"]': createFakeNode('7.5'),
+            'span[property="v:votes"]': createFakeNode('1234'),
+            '#info': createFakeNode('制片国家/地区: 日本\n类型: 动画'),
+            'span[property="v:runtime"]': createFakeNode('120分钟'),
+            'span[property="v:summary"]': createFakeNode('summary text'),
+        };
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ blocked: false, title: '海贼王 (豆瓣)', href: 'https://movie.douban.com/subject/37116446/' })
+                .mockImplementationOnce((script) => runMovieSubjectEvaluate(script, elementMap)),
+        };
+
+        const detail = await loadDoubanSubjectDetail(page, '37116446', 'movie');
+
+        expect(detail.id).toBe('37116446');
+        expect(detail.type).toBe('movie');
+        expect(detail.title).toBe('海贼王：黄金大冒险');
+        expect(detail.originalTitle).toBe('One Piece Gold');
     });
 
     it('loads book subject details from book.douban.com when type=book', async () => {


### PR DESCRIPTION
## Description

`opencli douban subject <id>` fails with `ReferenceError: normalizeText is not defined` thrown at `splitDoubanTitle (<anonymous>:5:24)`, matching the symptom reported in #1851. `loadDoubanMovieSubject` in `clis/douban/utils.js:217` builds its `page.evaluate` script by inlining `splitDoubanTitle.toString()` directly into the expression at line 227. `Function.prototype.toString()` returns only the source of the function body, never its closure, so when the page eval runs in the browser scope it sees a fresh `splitDoubanTitle` whose body references the module-level helper `normalizeText` (defined at `clis/douban/utils.js:11`) that does not exist in that scope. The same eval block already declares a local `normalize` helper at line 226, but the name does not match what `splitDoubanTitle` reaches for.

The minimal fix is to make `splitDoubanTitle` self-contained: inline a `normalizeText` const at the top of the function so the toString-injected copy carries its own helper. The three existing `normalizeText(...)` call sites inside the function continue to work, behavior is unchanged, no other caller exists (the function is only invoked in this one page.evaluate, never directly in Node), and the daemon protocol surface is untouched.

Audit of every other `*.toString()`-injected helper in `clis/` confirms none has the same closure-leak shape: `resolveDoubanPhotoAssetUrl` (`clis/douban/utils.js:143`) uses only `String` / `URL` / regex literals; `inferDoubanSearchResultType` (`clis/douban/utils.js:556`) uses only `String` / `Array.isArray` / regex literals; `looksAuthWallText` (`clis/reuters/utils.js:94`) uses only `String` / regex; `collectCodexProjectsFromDocument` (`clis/codex/sidebar.js:56`) and `extractSearchRows` (`clis/gov-policy/search.js:28`) and `extractRecentRows` (`clis/gov-policy/recent.js:28`) all define their helpers inside their own function body. `splitDoubanTitle` was the only outlier; the codebase idiom is that injected helpers must be self-contained, and this PR brings `splitDoubanTitle` back into that idiom.

Related issue: fixes #1851.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Pre-fix live repro on upstream main `944ca3a1`:

```
$ node dist/src/main.js douban subject 37116446
ok: false
error:
  code: UNKNOWN
  message: |-
    ReferenceError: normalizeText is not defined
        at splitDoubanTitle (<anonymous>:5:24)
        at <anonymous>:16:3
        at <anonymous>:57:7
```

Post-fix live verify on this branch with the same subject id from the issue:

```
$ node dist/src/main.js douban subject 37116446
- id: '37116446'
  type: movie
  title: 给阿嬷的情书
  originalTitle: ''
  year: '2026'
  rating: 9.2
  ratingCount: 783406
  directors: 蓝鸿春
  casts:
    - 李思潼
    - 王彦桐
    - 吴少卿
    - 郑润奇
    - 王晓慧
  country:
    - 中国大陆
  duration: 118
  genres: 剧情,家庭
  url: https://movie.douban.com/subject/37116446/
```

A new regression test under `describe('douban utils')` in `clis/douban/utils.test.js` exercises `loadDoubanSubjectDetail(page, '37116446', 'movie')` end-to-end by routing the second `page.evaluate(...)` call through `vm.runInNewContext(script, { document, URL })`, the same harness `runMovieHotEvaluate` already uses at `clis/douban/utils.test.js:71`. The new `runMovieSubjectEvaluate(script, elementMap)` helper sits next to it at module scope so the two share the same shape and discoverability. Without this PR's fix the test fails with the exact `ReferenceError: normalizeText is not defined`; with the fix the test asserts `title === '海贼王：黄金大冒险'` and `originalTitle === 'One Piece Gold'`. Full douban suite continues to pass: 24/24. `cli-manifest.json` untouched, no source other than `clis/douban/utils.js` is touched.
