### PR TITLE
feat(cnki): add detail extraction and advanced search

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6458,26 +6458,113 @@
   },
   {
     "site": "cnki",
-    "name": "search",
-    "description": "中国知网论文搜索（海外版）",
+    "name": "detail",
+    "description": "CNKI paper detail metadata and abstract extraction",
     "access": "read",
-    "domain": "oversea.cnki.net",
+    "domain": "kns.cnki.net",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "CNKI detail page URL"
+      }
+    ],
+    "columns": [
+      "title",
+      "authors",
+      "journal",
+      "source",
+      "date",
+      "year",
+      "volume",
+      "issue",
+      "pages",
+      "startPage",
+      "endPage",
+      "doi",
+      "classification",
+      "album",
+      "subject",
+      "fund",
+      "onlinePublishedAt",
+      "cnkiId",
+      "abstract",
+      "keywords",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cnki/detail.js",
+    "sourceFile": "cnki/detail.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "cnki",
+    "name": "search",
+    "description": "CNKI paper search",
+    "access": "read",
+    "domain": "kns.cnki.net",
     "strategy": "cookie",
     "browser": true,
     "args": [
       {
         "name": "query",
         "type": "str",
-        "required": true,
+        "required": false,
         "positional": true,
-        "help": "搜索关键词"
+        "help": "Search query"
       },
       {
         "name": "limit",
         "type": "int",
         "default": 10,
         "required": false,
-        "help": "返回结果数量 (max 20)"
+        "help": "Max results; 0 means all pages OpenCLI can reach"
+      },
+      {
+        "name": "with-abstract",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Open each detail page and extract abstracts"
+      },
+      {
+        "name": "expr",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "CNKI professional search expression, for example: TI=rutting and KY=pavement"
+      },
+      {
+        "name": "field",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "CNKI field for query when --expr is not used: SU,TKA,KY,TI,FT,AU,FI,RP,AF,FU,AB,CO,RF,CLC,LY,DOI,CF"
+      },
+      {
+        "name": "from",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Publish date start, YYYY-MM-DD"
+      },
+      {
+        "name": "to",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Publish date end, YYYY-MM-DD"
+      },
+      {
+        "name": "types",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "help": "Comma-separated document types: journal,dissertation,conference,newspaper,book,patent,standard,achievement,yearbook"
       }
     ],
     "columns": [
@@ -6486,6 +6573,14 @@
       "authors",
       "journal",
       "date",
+      "year",
+      "volume",
+      "issue",
+      "pages",
+      "doi",
+      "classification",
+      "abstract",
+      "keywords",
       "url"
     ],
     "type": "js",

--- a/clis/cnki/detail.js
+++ b/clis/cnki/detail.js
@@ -1,0 +1,26 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { extractCnkiDetail, normalizeCnkiUrl } from './shared.js';
+
+cli({
+  site: 'cnki',
+  name: 'detail',
+  description: 'CNKI paper detail metadata and abstract extraction',
+  access: 'read',
+  domain: 'kns.cnki.net',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'url', positional: true, required: true, help: 'CNKI detail page URL' },
+  ],
+  columns: ['title', 'authors', 'journal', 'source', 'date', 'year', 'volume', 'issue', 'pages', 'startPage', 'endPage', 'doi', 'classification', 'album', 'subject', 'fund', 'onlinePublishedAt', 'cnkiId', 'abstract', 'keywords', 'url'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const url = normalizeCnkiUrl(kwargs.url);
+    const detail = await extractCnkiDetail(page, url);
+    return {
+      ...detail,
+      keywords: detail.keywords.join(', '),
+    };
+  },
+});
+
+

--- a/clis/cnki/search.js
+++ b/clis/cnki/search.js
@@ -1,61 +1,358 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { clampInt, requireNonEmptyQuery } from '../_shared/common.js';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import { cnkiSearchUrl, extractCnkiDetail, normalizeCnkiUrl } from './shared.js';
+
+function parseLimit(value, fallback = 10) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(0, parsed);
+}
+
+function requireNonEmptyQuery(value) {
+  const query = String(value ?? '').trim();
+  if (!query) {
+    throw new ArgumentError('Search query must not be empty.');
+  }
+  return query;
+}
+
+function normalizeList(value) {
+  return String(value ?? '')
+    .split(',')
+    .map(item => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function parseDocTypes(value) {
+  const map = {
+    all: '',
+    journal: 'YSTT4HG0',
+    journals: 'YSTT4HG0',
+    dissertation: 'LSTPFY1C',
+    dissertations: 'LSTPFY1C',
+    thesis: 'LSTPFY1C',
+    degree: 'LSTPFY1C',
+    conference: 'JUP3MUPD',
+    conferences: 'JUP3MUPD',
+    newspaper: 'MPMFIG1A',
+    newspapers: 'MPMFIG1A',
+    book: 'EMRPGLPA',
+    books: 'EMRPGLPA',
+    standard: 'WQ0UVIAA',
+    standards: 'WQ0UVIAA',
+    achievement: 'BLZOG7CK',
+    achievements: 'BLZOG7CK',
+    patent: 'VUDIXAIY',
+    patents: 'VUDIXAIY',
+    yearbook: 'HHCPM1F8',
+    yearbooks: 'HHCPM1F8',
+    ccjd: 'PWFIRAGL',
+    special: 'NN3FJMUV',
+    video: 'NLBO1Z6R',
+    videos: 'NLBO1Z6R',
+    library: 'T2VC03OH',
+    ystt4hg0: 'YSTT4HG0',
+    lstpfy1c: 'LSTPFY1C',
+    jup3mupd: 'JUP3MUPD',
+    mpmfig1a: 'MPMFIG1A',
+    emrpglpa: 'EMRPGLPA',
+    wq0uviaa: 'WQ0UVIAA',
+    blzog7ck: 'BLZOG7CK',
+    vudixaiy: 'VUDIXAIY',
+    hhcpm1f8: 'HHCPM1F8',
+    pwfiragl: 'PWFIRAGL',
+    nn3fjmuv: 'NN3FJMUV',
+    nlbo1z6r: 'NLBO1Z6R',
+    t2vc03oh: 'T2VC03OH',
+  };
+  const values = normalizeList(value);
+  if (values.length === 0 || values.includes('all')) return '';
+  return Array.from(new Set(values.map(item => map[item] || item.toUpperCase()))).join(',');
+}
+
+function validateDate(value, name) {
+  const text = String(value ?? '').trim();
+  if (!text) return '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    throw new ArgumentError(`${name} must be in YYYY-MM-DD format.`);
+  }
+  return text;
+}
+
+function normalizeField(value) {
+  const field = String(value ?? '').trim().toUpperCase();
+  if (!field) return '';
+  const allowed = new Set([
+    'SU', 'TKA', 'KY', 'TI', 'FT', 'AU', 'FI', 'RP', 'AF', 'FU',
+    'AB', 'CO', 'RF', 'CLC', 'LY', 'DOI', 'CF',
+  ]);
+  if (!allowed.has(field)) {
+    throw new ArgumentError(`Unsupported CNKI field: ${field}`);
+  }
+  return field;
+}
+
+function quoteCnkiTerm(value) {
+  return `'${String(value ?? '').replace(/'/g, "\\'")}'`;
+}
+
 cli({
-    site: 'cnki',
-    name: 'search',
-    access: 'read',
-    description: '中国知网论文搜索（海外版）',
-    domain: 'oversea.cnki.net',
-    strategy: Strategy.COOKIE,
-    args: [
-        { name: 'query', positional: true, required: true, help: '搜索关键词' },
-        { name: 'limit', type: 'int', default: 10, help: '返回结果数量 (max 20)' },
-    ],
-    columns: ['rank', 'title', 'authors', 'journal', 'date', 'url'],
-    navigateBefore: false,
-    func: async (page, kwargs) => {
-        const limit = clampInt(kwargs.limit, 10, 1, 20);
-        const query = requireNonEmptyQuery(kwargs.query);
-        await page.goto(`https://oversea.cnki.net/kns/search?dbcode=CFLS&kw=${encodeURIComponent(query)}&korder=SU`);
-        await page.wait(8);
-        const data = await page.evaluate(`
-      (async () => {
-        const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
-        for (let i = 0; i < 40; i++) {
-          if (document.querySelector('.result-table-list tbody tr, #gridTable tbody tr')) break;
-          await new Promise(r => setTimeout(r, 500));
-        }
-        const rows = document.querySelectorAll('.result-table-list tbody tr, #gridTable tbody tr');
-        const results = [];
-        for (const row of rows) {
-          const tds = row.querySelectorAll('td');
-          if (tds.length < 5) continue;
+  site: 'cnki',
+  name: 'search',
+  description: 'CNKI paper search',
+  access: 'read',
+  domain: 'kns.cnki.net',
+  strategy: Strategy.COOKIE,
+  args: [
+    { name: 'query', positional: true, required: false, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 10, help: 'Max results; 0 means all pages OpenCLI can reach' },
+    { name: 'with-abstract', type: 'bool', default: false, help: 'Open each detail page and extract abstracts' },
+    { name: 'expr', type: 'str', default: '', help: 'CNKI professional search expression, for example: TI=rutting and KY=pavement' },
+    { name: 'field', type: 'str', default: '', help: 'CNKI field for query when --expr is not used: SU,TKA,KY,TI,FT,AU,FI,RP,AF,FU,AB,CO,RF,CLC,LY,DOI,CF' },
+    { name: 'from', type: 'str', default: '', help: 'Publish date start, YYYY-MM-DD' },
+    { name: 'to', type: 'str', default: '', help: 'Publish date end, YYYY-MM-DD' },
+    { name: 'types', type: 'str', default: '', help: 'Comma-separated document types: journal,dissertation,conference,newspaper,book,patent,standard,achievement,yearbook' },
+  ],
+  columns: ['rank', 'title', 'authors', 'journal', 'date', 'year', 'volume', 'issue', 'pages', 'doi', 'classification', 'abstract', 'keywords', 'url'],
+  navigateBefore: false,
+  func: async (page, kwargs) => {
+    const limit = parseLimit(kwargs.limit, 10);
+    const unlimited = limit === 0;
+    const field = normalizeField(kwargs.field);
+    const query = (String(kwargs.query ?? '').trim() || '');
+    const expr = String(kwargs.expr ?? '').trim() || (field ? `${field}=${quoteCnkiTerm(requireNonEmptyQuery(query))}` : '');
+    if (!expr) requireNonEmptyQuery(query);
+    const withAbstract = Boolean(kwargs.withAbstract ?? kwargs['with-abstract']);
+    const fromDate = validateDate(kwargs.from, '--from');
+    const toDate = validateDate(kwargs.to, '--to');
+    const typeCodes = parseDocTypes(kwargs.types);
 
-          const nameCell = row.querySelector('td.name') || tds[2];
-          const titleEl = nameCell?.querySelector('a');
-          const title = normalize(titleEl?.textContent).replace(/免费$/, '');
-          if (!title) continue;
-
-          let url = titleEl?.getAttribute('href') || '';
-          if (url && !url.startsWith('http')) url = 'https://oversea.cnki.net' + url;
-
-          const authorCell = row.querySelector('td.author') || tds[3];
-          const journalCell = row.querySelector('td.source') || tds[4];
-          const dateCell = row.querySelector('td.date') || tds[5];
-
-          results.push({
-            rank: results.length + 1,
-            title,
-            authors: normalize(authorCell?.textContent),
-            journal: normalize(journalCell?.textContent),
-            date: normalize(dateCell?.textContent),
-            url,
-          });
-          if (results.length >= ${limit}) break;
-        }
-        return results;
+    if (expr) {
+      await page.goto('https://kns.cnki.net/kns8s/AdvSearch?type=expert', { waitUntil: 'none', settleMs: 1500 });
+      await page.wait(5);
+      await page.evaluate(`
+        (() => {
+          const setValue = (el, value) => {
+            if (!el) return false;
+            el.value = value;
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            return true;
+          };
+          setValue(document.querySelector('textarea.majorSearch'), ${JSON.stringify(expr)});
+          setValue(document.querySelector('#datebox0'), ${JSON.stringify(fromDate)});
+          setValue(document.querySelector('#datebox1'), ${JSON.stringify(toDate)});
+          const checkedDb = document.querySelector('#CheckedDB');
+          if (checkedDb && ${JSON.stringify(typeCodes)}) {
+            checkedDb.value = ${JSON.stringify(typeCodes)};
+            checkedDb.dispatchEvent(new Event('change', { bubbles: true }));
+          }
+          const button = document.querySelector('.search-middle .btn-search');
+          if (button) {
+            button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            button.click();
+          }
+          return true;
+        })()
+      `);
+    } else {
+      await page.goto('https://www.cnki.net/', { waitUntil: 'none', settleMs: 1500 });
+      await page.wait(4);
+      const clicked = await page.evaluate(`
+      (() => {
+        const input = document.querySelector('#txt_SearchText');
+        const button = document.querySelector('.search-form .search-btn');
+        if (!input || !button) return false;
+        input.value = ${JSON.stringify(query)};
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        button.click();
+        return true;
       })()
     `);
-        return Array.isArray(data) ? data : [];
-    },
+      if (!clicked) {
+        await page.goto(cnkiSearchUrl(query), { waitUntil: 'none', settleMs: 1500 });
+      }
+    }
+    await page.wait(8);
+
+    const results = [];
+    const seenItems = new Set();
+    const seenPages = new Set();
+
+    while (unlimited || results.length < limit) {
+      const pageKey = await page.evaluate(`
+        (() => {
+          const pageNo = document.querySelector('#curPageHid')?.value
+            || document.querySelector('.pages .cur, .page .cur, .page-nav .cur')?.textContent
+            || '';
+          return location.href + '#page=' + String(pageNo).trim();
+        })()
+      `);
+      if (pageKey) {
+        if (seenPages.has(pageKey)) break;
+        seenPages.add(pageKey);
+      }
+
+      const remaining = unlimited ? Number.MAX_SAFE_INTEGER : limit - results.length;
+      const payload = await page.evaluate(`
+        (async () => {
+          const normalize = v => (v || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
+          const rowsReady = () => document.querySelector('.result-table-list tbody tr, #gridTable tbody tr, table.result-table tbody tr, table.GridTableContent tbody tr');
+          for (let i = 0; i < 40; i++) {
+            if (rowsReady()) break;
+            await new Promise(r => setTimeout(r, 500));
+          }
+          if (/\\u5b89\\u5168\\u9a8c\\u8bc1|verify/i.test(document.title) || document.querySelector('[src*="/verify/"], [href*="/verify/"]')) {
+            return {
+              results: [{ rank: 0, title: 'CNKI security verification required', authors: '', journal: '', date: '', abstract: '', url: location.href, verificationRequired: true }],
+              nextUrl: '',
+              hasClickableNext: false,
+            };
+          }
+
+          const rowSelectors = '.result-table-list tbody tr, #gridTable tbody tr, table.result-table tbody tr, table.GridTableContent tbody tr';
+          const results = [];
+          for (const row of document.querySelectorAll(rowSelectors)) {
+            const tds = row.querySelectorAll('td');
+            const nameCell = row.querySelector('td.name') || row.querySelector('.name') || row.querySelector('.title') || tds[2] || row;
+            const titleEl = nameCell?.querySelector('a') || row.querySelector('a[href*="detail"], a[href*="kcms"], a[href*="KCMS"]');
+            const title = normalize(titleEl?.textContent).replace(/\\u514d\\u8d39$/, '');
+            if (!title) continue;
+
+            let url = titleEl?.getAttribute('href') || '';
+            if (url && !/^https?:\\/\\//i.test(url)) {
+              url = url.startsWith('//') ? 'https:' + url : 'https://kns.cnki.net' + (url.startsWith('/') ? url : '/' + url);
+            }
+
+            const authorCell = row.querySelector('td.author, .author, .authors') || tds[3];
+            const journalCell = row.querySelector('td.source, .source, .journal') || tds[4];
+            const dateCell = row.querySelector('td.date, .date, .year') || tds[5];
+
+            results.push({
+              rank: results.length + 1,
+              title,
+              authors: normalize(authorCell?.textContent),
+              journal: normalize(journalCell?.textContent),
+              date: normalize(dateCell?.textContent),
+              abstract: '',
+              url,
+            });
+            if (results.length >= ${remaining}) break;
+          }
+
+          const isDisabled = el => {
+            const cls = String(el.className || '');
+            return el.disabled || el.getAttribute('aria-disabled') === 'true' || /disabled|disable|unusable/i.test(cls);
+          };
+          const toAbsoluteUrl = href => {
+            if (!href || /^javascript:/i.test(href)) return '';
+            try { return new URL(href, location.href).href; } catch { return ''; }
+          };
+          const nextEl = document.querySelector('#PageNext') || Array.from(document.querySelectorAll('a, button')).find(el => {
+            if (isDisabled(el)) return false;
+            const text = normalize(el.textContent || el.getAttribute('aria-label') || el.title || '');
+            const rel = String(el.getAttribute('rel') || '').toLowerCase();
+            const cls = String(el.className || '').toLowerCase();
+            return rel === 'next' || /next/.test(cls) || /\\u4e0b\\u4e00\\u9875|Next|>/i.test(text);
+          }) || null;
+
+          const nextUrl = toAbsoluteUrl(nextEl?.getAttribute('href') || '');
+          return {
+            results,
+            nextUrl,
+            hasClickableNext: Boolean(nextEl && !nextUrl),
+          };
+        })()
+      `);
+
+      const pageResults = Array.isArray(payload?.results) ? payload.results : [];
+      const before = results.length;
+      for (const item of pageResults) {
+        const key = item.url || `${item.title}|${item.authors}|${item.journal}|${item.date}`;
+        if (seenItems.has(key)) continue;
+        seenItems.add(key);
+        results.push({ ...item, rank: results.length + 1 });
+        if (!unlimited && results.length >= limit) break;
+      }
+
+      if ((!unlimited && results.length >= limit) || pageResults.length === 0) break;
+
+      if (payload?.nextUrl) {
+        await page.goto(payload.nextUrl, { waitUntil: 'none', settleMs: 1500 });
+        await page.wait(4);
+        continue;
+      }
+
+      if (payload?.hasClickableNext) {
+        const clickedNext = await page.evaluate(`
+          (() => {
+            const normalize = v => (v || '').replace(/\\s+/g, ' ').trim();
+            const isDisabled = el => {
+              const cls = String(el.className || '');
+              return el.disabled || el.getAttribute('aria-disabled') === 'true' || /disabled|disable|unusable/i.test(cls);
+            };
+            const nextEl = document.querySelector('#PageNext') || Array.from(document.querySelectorAll('a, button')).find(el => {
+              if (isDisabled(el)) return false;
+              const text = normalize(el.textContent || el.getAttribute('aria-label') || el.title || '');
+              const rel = String(el.getAttribute('rel') || '').toLowerCase();
+              const cls = String(el.className || '').toLowerCase();
+              return rel === 'next' || /next/.test(cls) || /\\u4e0b\\u4e00\\u9875|Next|>/i.test(text);
+            });
+            if (!nextEl) return false;
+            nextEl.click();
+            return true;
+          })()
+        `);
+        if (clickedNext) {
+          await page.wait(5);
+          continue;
+        }
+      }
+
+      if (results.length === before) break;
+      break;
+    }
+
+    if (!withAbstract) return results;
+
+    const searchUrl = await page.getCurrentUrl?.();
+    for (const item of results) {
+      if (!item.url) continue;
+      try {
+        const detail = await extractCnkiDetail(page, normalizeCnkiUrl(item.url));
+        Object.assign(item, {
+          title: detail.title || item.title,
+          authors: detail.authors || item.authors,
+          journal: detail.journal || item.journal,
+          source: detail.source || '',
+          date: detail.date || item.date,
+          year: detail.year || '',
+          volume: detail.volume || '',
+          issue: detail.issue || '',
+          pages: detail.pages || '',
+          startPage: detail.startPage || '',
+          endPage: detail.endPage || '',
+          doi: detail.doi || '',
+          classification: detail.classification || '',
+          album: detail.album || '',
+          subject: detail.subject || '',
+          fund: detail.fund || '',
+          onlinePublishedAt: detail.onlinePublishedAt || '',
+          cnkiId: detail.cnkiId || '',
+          abstract: detail.abstract || '',
+          keywords: detail.keywords.join(', '),
+          detailVerificationRequired: detail.verificationRequired,
+        });
+      } catch (err) {
+        item.abstract = '';
+        item.detailError = err instanceof Error ? err.message : String(err);
+      }
+    }
+    if (searchUrl) {
+      await page.goto(searchUrl, { waitUntil: 'none', settleMs: 500 }).catch(() => undefined);
+    }
+    return results;
+  },
 });

--- a/clis/cnki/search.test.js
+++ b/clis/cnki/search.test.js
@@ -1,18 +1,120 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { cnkiSearchUrl, normalizeCnkiUrl } from './shared.js';
+import './detail.js';
 import './search.js';
+
 describe('cnki search command', () => {
-    const command = getRegistry().get('cnki/search');
-    it('registers the command', () => {
-        expect(command).toBeDefined();
-        expect(command.site).toBe('cnki');
-        expect(command.name).toBe('search');
+  const command = getRegistry().get('cnki/search');
+
+  it('registers the search command with advanced search options', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('cnki');
+    expect(command.name).toBe('search');
+    expect(command.domain).toBe('kns.cnki.net');
+    expect(command.args.map(arg => arg.name)).toEqual([
+      'query',
+      'limit',
+      'with-abstract',
+      'expr',
+      'field',
+      'from',
+      'to',
+      'types',
+    ]);
+    expect(command.columns).toContain('abstract');
+    expect(command.columns).toContain('doi');
+  });
+
+  it('rejects empty queries before browser navigation', async () => {
+    const page = { goto: vi.fn() };
+    await expect(command.func(page, { query: '   ' })).rejects.toMatchObject({
+      name: 'ArgumentError',
+      code: 'ARGUMENT',
     });
-    it('rejects empty queries before browser navigation', async () => {
-        const page = { goto: async () => undefined };
-        await expect(command.func(page, { query: '   ' })).rejects.toMatchObject({
-            name: 'ArgumentError',
-            code: 'ARGUMENT',
-        });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid fields and dates before browser navigation', async () => {
+    const page = { goto: vi.fn() };
+
+    await expect(command.func(page, { query: 'asphalt', field: 'bad' })).rejects.toMatchObject({
+      name: 'ArgumentError',
+      code: 'ARGUMENT',
     });
+    await expect(command.func(page, { query: 'asphalt', from: '2025' })).rejects.toMatchObject({
+      name: 'ArgumentError',
+      code: 'ARGUMENT',
+    });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+});
+
+describe('cnki detail command', () => {
+  const command = getRegistry().get('cnki/detail');
+
+  it('registers the detail command', () => {
+    expect(command).toBeDefined();
+    expect(command.site).toBe('cnki');
+    expect(command.name).toBe('detail');
+    expect(command.columns).toContain('keywords');
+    expect(command.columns).toContain('abstract');
+  });
+
+  it('normalizes detail URLs and joins keywords', async () => {
+    const page = {
+      goto: vi.fn(),
+      wait: vi.fn(),
+      evaluate: vi.fn(async () => ({
+        title: 'Paper title',
+        authors: 'A; B',
+        journal: 'Journal',
+        abstract: 'Abstract text',
+        keywords: ['rutting', 'asphalt'],
+        url: 'https://kns.cnki.net/kcms/detail/detail.aspx?filename=ABC',
+      })),
+    };
+
+    const result = await command.func(page, { url: '/kcms/detail/detail.aspx?filename=ABC' });
+
+    expect(page.goto).toHaveBeenCalledWith('https://kns.cnki.net/kcms/detail/detail.aspx?filename=ABC', {
+      waitUntil: 'none',
+      settleMs: 1200,
+    });
+    expect(result.keywords).toBe('rutting, asphalt');
+    expect(result.abstract).toBe('Abstract text');
+  });
+
+  it('rejects missing detail URLs before browser navigation', async () => {
+    const page = { goto: vi.fn() };
+
+    await expect(command.func(page, { url: '   ' })).rejects.toMatchObject({
+      name: 'ArgumentError',
+      code: 'ARGUMENT',
+    });
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+});
+
+describe('cnki shared helpers', () => {
+  it('normalizes CNKI URLs', () => {
+    expect(normalizeCnkiUrl('/kcms/detail/detail.aspx?filename=ABC')).toBe(
+      'https://kns.cnki.net/kcms/detail/detail.aspx?filename=ABC',
+    );
+    expect(normalizeCnkiUrl('//kns.cnki.net/kcms/detail/detail.aspx?filename=ABC')).toBe(
+      'https://kns.cnki.net/kcms/detail/detail.aspx?filename=ABC',
+    );
+    expect(normalizeCnkiUrl('kcms/detail/detail.aspx?filename=ABC')).toBe(
+      'https://kns.cnki.net/kcms/detail/detail.aspx?filename=ABC',
+    );
+  });
+
+  it('builds the fallback CNKI search URL', () => {
+    const url = new URL(cnkiSearchUrl('road rutting'));
+
+    expect(url.origin).toBe('https://kns.cnki.net');
+    expect(url.pathname).toBe('/starter');
+    expect(url.searchParams.get('kw')).toBe('road rutting');
+    expect(url.searchParams.get('rt')).toBe('journal');
+  });
 });

--- a/clis/cnki/shared.js
+++ b/clis/cnki/shared.js
@@ -1,0 +1,236 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+export function normalizeCnkiUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw) return '';
+  if (/^https?:\/\//i.test(raw)) return raw;
+  if (raw.startsWith('//')) return `https:${raw}`;
+  if (raw.startsWith('/')) return `https://kns.cnki.net${raw}`;
+  return `https://kns.cnki.net/${raw}`;
+}
+
+export function cnkiSearchUrl(query) {
+  const params = new URLSearchParams({
+    rc: 'CJFQ',
+    kw: query,
+    rt: 'journal',
+    fd: 'SU$%=|',
+  });
+  return `https://kns.cnki.net/starter?${params.toString()}`;
+}
+
+export const detailExtractor = String.raw`
+  (() => {
+    const normalize = v => (v || '')
+      .replace(/\u00a0/g, ' ')
+      .replace(/[\r\n\t]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const clean = v => normalize(v)
+      .replace(/^(?:\u6458\u8981|\u4e2d\u6587\u6458\u8981|Abstract)[:\uff1a\s]*/i, '')
+      .replace(/^(?:\u5173\u952e\u8bcd|Keywords)[:\uff1a\s]*/i, '')
+      .trim();
+    const pick = selectors => {
+      for (const selector of selectors) {
+        for (const el of document.querySelectorAll(selector)) {
+          const text = clean(el.innerText || el.textContent);
+          if (text) return text;
+        }
+      }
+      return '';
+    };
+    const pickAttr = (selectors, attr) => {
+      for (const selector of selectors) {
+        for (const el of document.querySelectorAll(selector)) {
+          const text = clean(el.getAttribute(attr));
+          if (text) return text;
+        }
+      }
+      return '';
+    };
+    const meta = names => {
+      for (const name of names) {
+        const value = pickAttr([
+          'meta[name="' + name + '"]',
+          'meta[property="' + name + '"]',
+          'meta[name="' + name.toLowerCase() + '"]',
+          'meta[property="' + name.toLowerCase() + '"]',
+        ], 'content');
+        if (value) return value;
+      }
+      return '';
+    };
+    const stripTail = value => clean(value)
+      .replace(/\s*\u67e5\u770b.*$/, '')
+      .replace(/\s*View.*$/, '')
+      .trim();
+    const textAfterLabel = labels => {
+      const nodes = Array.from(document.querySelectorAll('p, li, dd, div, section, span'));
+      for (const el of nodes) {
+        const text = normalize(el.innerText || el.textContent);
+        if (!text || text.length < 4 || text.length > 5000) continue;
+        for (const label of labels) {
+          const direct = new RegExp('^(?:' + label + ')\\s*[:\\uff1a]?\\s*(.+)$', 'i');
+          const match = text.match(direct);
+          if (match?.[1]) return clean(match[1]);
+        }
+      }
+      return '';
+    };
+    const labelValue = labels => {
+      const stopLabels = [
+        '\\u6458\\u8981', '\\u5173\\u952e\\u8bcd', '\\u4e13\\u8f91',
+        '\\u4e13\\u9898', '\\u5206\\u7c7b\\u53f7',
+        '\\u5728\\u7ebf\\u516c\\u5f00\\u65f6\\u95f4', '\\u57fa\\u91d1',
+        '\\u4f5c\\u8005', '\\u6765\\u6e90', 'DOI', 'CLC', 'Fund'
+      ];
+      const nodes = Array.from(document.querySelectorAll('p, li, dd, div, section, span'))
+        .sort((a, b) => normalize(a.innerText || a.textContent).length - normalize(b.innerText || b.textContent).length);
+      for (const el of nodes) {
+        const text = normalize(el.innerText || el.textContent);
+        if (!text || text.length < 4 || text.length > 1200) continue;
+        for (const label of labels) {
+          const others = stopLabels.filter(item => item !== label).join('|');
+          const pattern = new RegExp(label + '\\s*[:\\uff1a]\\s*(.+?)(?=\\s*(?:' + others + ')\\s*[:\\uff1a]|$)', 'i');
+          const match = text.match(pattern);
+          if (match?.[1]) return clean(match[1]);
+        }
+      }
+      return '';
+    };
+    const parseSource = source => {
+      const parsed = { journal: source, year: '', volume: '', issue: '', pages: '', startPage: '', endPage: '' };
+      const text = stripTail(source);
+      const match = text.match(/^(.+?)\s*[.\uFF0E]\s*(\d{4})(?:\s*[,\uFF0C]?\s*(?:Vol\.?\s*)?(\d+)\s*)?(?:\s*\(([^)]+)\))?(?:\s*[:\uFF1A]\s*([A-Za-z0-9]+(?:\s*[-\u2013\u2014]\s*[A-Za-z0-9]+)?))?/i);
+      if (match) {
+        parsed.journal = clean(match[1]);
+        parsed.year = match[2] || '';
+        parsed.volume = match[3] || '';
+        parsed.issue = match[4] || '';
+        parsed.pages = normalize(match[5] || '');
+      }
+      const pageMatch = parsed.pages.match(/^([A-Za-z0-9]+)\s*[-\u2013\u2014]\s*([A-Za-z0-9]+)$/);
+      if (pageMatch) {
+        parsed.startPage = pageMatch[1];
+        parsed.endPage = pageMatch[2];
+      }
+      return parsed;
+    };
+    const cleanAuthors = value => clean(value)
+      .replace(/^(?:\u4f5c\u8005|Author)[:\uff1a\s]*/i, '')
+      .replace(/([\u3400-\u9fff])\d+(?=[\u3400-\u9fff])/g, '$1;')
+      .replace(/([\u3400-\u9fff])\d+(?=\s|$)/g, '$1')
+      .replace(/\s+/g, '; ')
+      .replace(/;{2,}/g, ';')
+      .replace(/;\s*$/, '');
+    const keywordText = pick([
+      '.keywords',
+      '.keyword',
+      '.wxBaseinfo [class*=keyword]',
+      '#ChDivKeyWord',
+      '[id*=KeyWord]',
+      '[class*=KeyWord]',
+    ]) || textAfterLabel(['\\u5173\\u952e\\u8bcd', 'Keywords']);
+    const abstract = pick([
+      '#ChDivSummary',
+      '#ChDivSummaryMore',
+      '.abstract-text',
+      '.abstract',
+      '.brief',
+      '.summary',
+      '.wxBaseinfo [class*=abstract]',
+      '.doc-abstract',
+      '[id*=Summary]',
+      '[class*=Summary]',
+    ]) || textAfterLabel(['\\u6458\\u8981', '\\u4e2d\\u6587\\u6458\\u8981', 'Abstract']);
+    const rawKeywords = keywordText
+      .replace(/^(?:\u5173\u952e\u8bcd|Keywords)[:\uff1a\s]*/i, '')
+      .split(/[;,;\uff1b\uff0c\u3001]/)
+      .map(item => normalize(item))
+      .filter(Boolean);
+    const sourceClean = stripTail(
+      pick(['.top-tip span', '.sourcename', '.source', '.wxBaseinfo [class*=source]'])
+        .replace(/^(?:\u6765\u6e90|Source)[:\uff1a\s]*/i, '')
+    );
+    const parsedSource = parseSource(sourceClean);
+    const onlinePublishedAt = labelValue(['\\u5728\\u7ebf\\u516c\\u5f00\\u65f6\\u95f4']);
+    const date = pick(['.year', '.date', '.publish-date', '.wxBaseinfo [class*=date]'])
+      .replace(/^(?:\u53d1\u8868\u65f6\u95f4|\u65e5\u671f|Date)[:\uff1a\s]*/i, '')
+      || meta(['citation_publication_date', 'citation_date', 'dc.date'])
+      || (onlinePublishedAt.match(/\d{4}-\d{2}-\d{2}/)?.[0] || '');
+    const doi = meta(['citation_doi', 'dc.identifier', 'DC.Identifier']) || labelValue(['DOI']);
+    const classification = labelValue(['\\u5206\\u7c7b\\u53f7', 'CLC']);
+    const album = labelValue(['\\u4e13\\u8f91']);
+    const subject = labelValue(['\\u4e13\\u9898']);
+    const fund = labelValue(['\\u57fa\\u91d1', 'Fund']);
+    const year = parsedSource.year || meta(['citation_year']) || (date.match(/\d{4}/)?.[0] || '');
+    const pages = meta(['citation_pages']) || parsedSource.pages;
+    const startPage = meta(['citation_firstpage']) || parsedSource.startPage;
+    const endPage = meta(['citation_lastpage']) || parsedSource.endPage;
+    const url = new URL(location.href);
+    const cnkiId = url.searchParams.get('filename')
+      || url.searchParams.get('FileName')
+      || url.searchParams.get('dbname')
+      || url.searchParams.get('DbName')
+      || '';
+    return {
+      title: pick(['.wx-tit h1', 'h1', '#chTitle', '.title', '[class*=title]']) || meta(['citation_title', 'dc.title']),
+      authors: cleanAuthors(pick(['.author', '.authors', '.wxBaseinfo [class*=author]', '[class*=author]']) || meta(['citation_author', 'dc.creator'])),
+      journal: meta(['citation_journal_title']) || parsedSource.journal || sourceClean,
+      source: sourceClean,
+      date,
+      year,
+      volume: meta(['citation_volume']) || parsedSource.volume,
+      issue: meta(['citation_issue']) || parsedSource.issue,
+      pages,
+      startPage,
+      endPage,
+      doi,
+      classification,
+      album,
+      subject,
+      fund,
+      onlinePublishedAt,
+      cnkiId,
+      abstract,
+      keywords: Array.from(new Set(rawKeywords)),
+      url: location.href,
+      titleText: normalize(document.title),
+      verificationRequired: /\u5b89\u5168\u9a8c\u8bc1|verify/i.test(document.title) || !!document.querySelector('[src*="/verify/"], [href*="/verify/"]'),
+    };
+  })()
+`;
+
+export async function extractCnkiDetail(page, url) {
+  const targetUrl = normalizeCnkiUrl(url);
+  if (!targetUrl) throw new ArgumentError('Missing CNKI detail URL.');
+  await page.goto(targetUrl, { waitUntil: 'none', settleMs: 1200 });
+  await page.wait(2);
+  const data = await page.evaluate(detailExtractor);
+  return {
+    title: data?.title || '',
+    authors: data?.authors || '',
+    journal: data?.journal || '',
+    source: data?.source || '',
+    date: data?.date || '',
+    year: data?.year || '',
+    volume: data?.volume || '',
+    issue: data?.issue || '',
+    pages: data?.pages || '',
+    startPage: data?.startPage || '',
+    endPage: data?.endPage || '',
+    doi: data?.doi || '',
+    classification: data?.classification || '',
+    album: data?.album || '',
+    subject: data?.subject || '',
+    fund: data?.fund || '',
+    onlinePublishedAt: data?.onlinePublishedAt || '',
+    cnkiId: data?.cnkiId || '',
+    abstract: data?.abstract || '',
+    keywords: Array.isArray(data?.keywords) ? data.keywords : [],
+    url: data?.url || targetUrl,
+    verificationRequired: Boolean(data?.verificationRequired),
+  };
+}
+
+


### PR DESCRIPTION
## Summary
- add a cnki/detail command for metadata, abstract, and keyword extraction
- expand cnki/search with advanced query options, date/type filters, pagination, and optional abstract enrichment
- add shared CNKI helpers and adapter tests

## Tests
- npm run build
- npx vitest run --project adapter clis/cnki/search.test.js
- npm run check:silent-column-drop
- npm run check:typed-error-lint