### PR TITLE
fix(extension): close SW-restart race that spawns duplicate OpenCLI Adapter groups

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1147,7 +1147,7 @@ async function attachTabsToOwnedGroup(role, group, ids) {
   updateOwnedSessionWindowForTabs(role, ids, group.windowId);
   return group;
 }
-async function createOwnedGroupWithRollback(role, windowId, ids) {
+async function createOwnedGroup(role, windowId, ids) {
   if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
   await ensureTabsInWindow(ids, windowId);
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
@@ -1183,7 +1183,7 @@ async function ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids) {
       canonical = await ensureCanonicalGroupTitle(role, canonical);
       canonical = await attachTabsToOwnedGroup(role, canonical, ids);
     } else if (fallbackWindowId !== null && ids.length > 0) {
-      canonical = await createOwnedGroupWithRollback(role, fallbackWindowId, ids);
+      canonical = await createOwnedGroup(role, fallbackWindowId, ids);
     }
     if (canonical) {
       ownedContainers[role].windowId = canonical.windowId;

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1072,6 +1072,25 @@ async function collectOwnedGroupCandidates(role) {
     } catch {
     }
   }
+  const ownedPreferredTabIds = /* @__PURE__ */ new Set();
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role || session.preferredTabId === null) continue;
+    ownedPreferredTabIds.add(session.preferredTabId);
+  }
+  if (ownedPreferredTabIds.size > 0) {
+    try {
+      const allGroups = await chrome.tabGroups.query({});
+      for (const group of allGroups) {
+        if (group.title) continue;
+        if (groupsById.has(group.id)) continue;
+        const tabsInGroup = await chrome.tabs.query({ groupId: group.id });
+        if (tabsInGroup.some((tab) => tab.id !== void 0 && ownedPreferredTabIds.has(tab.id))) {
+          groupsById.set(group.id, group);
+        }
+      }
+    } catch {
+    }
+  }
   const candidates = await Promise.all([...groupsById.values()].map(toOwnedContainerGroupCandidate));
   return candidates.filter((candidate) => candidate !== null);
 }
@@ -1132,19 +1151,16 @@ async function createOwnedGroupWithRollback(role, windowId, ids) {
   if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
   await ensureTabsInWindow(ids, windowId);
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-  try {
-    const group = await chrome.tabGroups.update(groupId, {
-      color: AUTOMATION_TAB_GROUP_COLOR,
-      title: CONTAINER_TAB_GROUP_TITLE[role],
-      collapsed: false
-    });
-    updateOwnedSessionWindowForTabs(role, ids, group.windowId);
-    return { id: group.id, windowId: group.windowId, title: group.title };
-  } catch (err) {
-    await chrome.tabs.ungroup(ids).catch(() => {
-    });
-    throw err;
-  }
+  ownedContainers[role].groupId = groupId;
+  ownedContainers[role].windowId = windowId;
+  await persistRuntimeState();
+  const group = await chrome.tabGroups.update(groupId, {
+    color: AUTOMATION_TAB_GROUP_COLOR,
+    title: CONTAINER_TAB_GROUP_TITLE[role],
+    collapsed: false
+  });
+  updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+  return { id: group.id, windowId: group.windowId, title: group.title };
 }
 async function ensureOwnedContainerGroup(role, fallbackWindowId, tabIds) {
   const ids = [...new Set(tabIds.filter((id) => id !== void 0))];
@@ -1241,6 +1257,7 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
     type: "normal"
   });
   container.windowId = win.id;
+  await persistRuntimeState();
   console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
   const tabs = await chrome.tabs.query({ windowId: win.id });
   const initialTabId = tabs[0]?.id;

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -169,9 +169,10 @@ function createChromeMock() {
         if (!group) throw new Error(`Unknown group ${groupId}`);
         return group;
       }),
-      query: vi.fn(async (queryInfo: { windowId?: number; title?: string } = {}) => groups.filter((group) => {
+      query: vi.fn(async (queryInfo: { windowId?: number; title?: string; color?: chrome.tabGroups.ColorEnum } = {}) => groups.filter((group) => {
         if (queryInfo.windowId !== undefined && group.windowId !== queryInfo.windowId) return false;
         if (queryInfo.title !== undefined && group.title !== queryInfo.title) return false;
+        if (queryInfo.color !== undefined && group.color !== queryInfo.color) return false;
         return true;
       })),
       update: vi.fn(async (groupId: number, updates: { title?: string; color?: chrome.tabGroups.ColorEnum; collapsed?: boolean }) => {
@@ -1225,7 +1226,7 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getAutomationWindowId(adapterKey('twitter'))).toBe(7);
   });
 
-  it('rolls back a newly created group when setting the canonical title fails', async () => {
+  it('keeps the group and persisted groupId when setting the canonical title fails so the next ensure cycle self-heals', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     chrome.tabGroups.update = vi.fn(async () => {
       throw new Error('title update failed');
@@ -1236,9 +1237,98 @@ describe('background tab isolation', () => {
     await expect(mod.__test__.resolveTabId(undefined, adapterKey('twitter'))).rejects.toThrow('title update failed');
 
     expect(chrome.tabs.group).toHaveBeenCalledWith({ tabIds: [1], createProperties: { windowId: 1 } });
-    expect(chrome.tabs.ungroup).toHaveBeenCalledWith([1]);
-    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(-1);
-    expect(groups).toHaveLength(0);
+    // Group stays grouped; persisted groupId continues to point at it so
+    // ensureCanonicalGroupTitle can repair the title on a later ensure cycle.
+    expect(chrome.tabs.ungroup).not.toHaveBeenCalled();
+    expect(tabs.find((tab) => tab.id === 1)?.groupId).toBe(100);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('reuses the persisted owned window after a worker restart so the next ensure does not spawn a second window', async () => {
+    // Fix 2 regression: simulate SW dying between `windows.create()` returning
+    // and a subsequent owned-group create. The next reconcile sees a persisted
+    // windowId but no persisted groupId. ensureOwnedContainerWindowUnlocked
+    // must reuse window 1 instead of calling chrome.windows.create again.
+    const { chrome, tabs, groups } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      opencli_target_lease_registry_v2: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: null },
+          automation: { windowId: 1, groupId: null },
+        },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+    chrome.windows.create.mockClear();
+
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    expect(tabs.find((tab) => tab.id === tabId)?.windowId).toBe(1);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toEqual(expect.objectContaining({ windowId: 1, title: 'OpenCLI Adapter' }));
+  });
+
+  it('adopts an empty-title orphan group that holds an owned session tab via the ownership-tab signal', async () => {
+    // Fix 3 positive: simulate SW dying between `chrome.tabs.group()` returning
+    // and the title/color `tabGroups.update` landing. The orphan group has no
+    // title and the persisted ownedContainers pointers are stale, but an
+    // owned automationSession still records the orphan's preferredTabId.
+    // The 4th-layer scan must recover the orphan via that tab signal and
+    // rename it to the canonical title on the next ensure cycle.
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push(
+      { id: 77, windowId: 7, url: 'about:blank', title: 'blank', active: false, status: 'complete', groupId: 301 },
+    );
+    groups.push(
+      { id: 301, windowId: 7, title: '', color: 'grey', collapsed: false },
+    );
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 7, owned: true, preferredTabId: 77 });
+
+    const recovered = await mod.__test__.ensureOwnedContainerGroup('automation', null, []);
+
+    expect(recovered).toEqual(expect.objectContaining({ id: 301, windowId: 7, title: 'OpenCLI Adapter' }));
+    expect(groups).toEqual([
+      expect.objectContaining({ id: 301, windowId: 7, title: 'OpenCLI Adapter' }),
+    ]);
+    expect(tabs.find((tab) => tab.id === 77)?.groupId).toBe(301);
+  });
+
+  it('does not adopt an empty-title group with no owned-tab signal so user-created groups stay untouched', async () => {
+    // Fix 3 hijack defense (regression guard for the #1794/#1816 boundary):
+    // an empty-title group containing only a user tab carries no ownership
+    // signal. The 4th-layer scan must not adopt it. The owned session here
+    // has a preferredTabId outside the group, so the group must remain user
+    // property and a fresh canonical group must be created elsewhere.
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push(
+      { id: 88, windowId: 9, url: 'https://user.example/page', title: 'user', active: true, status: 'complete', groupId: 401 },
+    );
+    groups.push(
+      { id: 401, windowId: 9, title: '', color: 'grey', collapsed: false },
+    );
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    const tabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'));
+
+    expect(tabId).not.toBe(88);
+    expect(tabs.find((tab) => tab.id === 88)?.groupId).toBe(401);
+    expect(groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 401, title: '' }),
+    ]));
+    const canonicalGroups = groups.filter((group) => group.title === 'OpenCLI Adapter');
+    expect(canonicalGroups).toHaveLength(1);
+    expect(canonicalGroups[0]?.id).not.toBe(401);
   });
 
   it('serializes concurrent owned tab grouping so duplicate adapter groups are not created', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -697,7 +697,7 @@ async function attachTabsToOwnedGroup(
   return group;
 }
 
-async function createOwnedGroupWithRollback(
+async function createOwnedGroup(
   role: OwnedWindowRole,
   windowId: number,
   ids: number[],
@@ -757,7 +757,7 @@ async function ensureOwnedContainerGroupUnlocked(
       canonical = await ensureCanonicalGroupTitle(role, canonical);
       canonical = await attachTabsToOwnedGroup(role, canonical, ids);
     } else if (fallbackWindowId !== null && ids.length > 0) {
-      canonical = await createOwnedGroupWithRollback(role, fallbackWindowId, ids);
+      canonical = await createOwnedGroup(role, fallbackWindowId, ids);
     }
 
     if (canonical) {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -593,6 +593,37 @@ async function collectOwnedGroupCandidates(role: OwnedWindowRole): Promise<Owned
     }
   }
 
+  // 4th layer: scan every window for empty-title orphan groups left behind
+  // when the worker died between `chrome.tabs.group` returning and the
+  // title/color `tabGroups.update` landing. We cannot use color as a signal
+  // (Chrome assigns a default palette color before our update lands), and we
+  // cannot scope by `container.windowId` because the canonical group can
+  // converge into the user window after cross-window moves so `windowId`
+  // would miss the multi-window orphan symptom. Hijack-protected via a
+  // per-role ownership-tab signal: the orphan must contain a tab that is the
+  // `preferredTabId` of a still-registered owned session for this role.
+  // User-built untitled groups never satisfy that condition.
+  const ownedPreferredTabIds = new Set<number>();
+  for (const [leaseKey, session] of automationSessions.entries()) {
+    if (!session.owned || getOwnedWindowRole(leaseKey) !== role || session.preferredTabId === null) continue;
+    ownedPreferredTabIds.add(session.preferredTabId);
+  }
+  if (ownedPreferredTabIds.size > 0) {
+    try {
+      const allGroups = await chrome.tabGroups.query({});
+      for (const group of allGroups) {
+        if (group.title) continue;
+        if (groupsById.has(group.id)) continue;
+        const tabsInGroup = await chrome.tabs.query({ groupId: group.id });
+        if (tabsInGroup.some((tab) => tab.id !== undefined && ownedPreferredTabIds.has(tab.id))) {
+          groupsById.set(group.id, group);
+        }
+      }
+    } catch {
+      // Transient query failure: convergence proceeds with the other layers.
+    }
+  }
+
   const candidates = await Promise.all([...groupsById.values()].map(toOwnedContainerGroupCandidate));
   return candidates.filter((candidate): candidate is OwnedContainerGroupCandidate => candidate !== null);
 }
@@ -674,18 +705,20 @@ async function createOwnedGroupWithRollback(
   if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
   await ensureTabsInWindow(ids, windowId);
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-  try {
-    const group = await chrome.tabGroups.update(groupId, {
-      color: AUTOMATION_TAB_GROUP_COLOR,
-      title: CONTAINER_TAB_GROUP_TITLE[role],
-      collapsed: false,
-    });
-    updateOwnedSessionWindowForTabs(role, ids, group.windowId);
-    return { id: group.id, windowId: group.windowId, title: group.title };
-  } catch (err) {
-    await chrome.tabs.ungroup(ids).catch(() => {});
-    throw err;
-  }
+  // Persist groupId before the title/color update so a worker crash between
+  // the two API calls can self-heal on resume. `ensureCanonicalGroupTitle`
+  // will repair the title on the next ensure cycle if the update never lands;
+  // we must not `tabs.ungroup` on failure or the persisted id dangles.
+  ownedContainers[role].groupId = groupId;
+  ownedContainers[role].windowId = windowId;
+  await persistRuntimeState();
+  const group = await chrome.tabGroups.update(groupId, {
+    color: AUTOMATION_TAB_GROUP_COLOR,
+    title: CONTAINER_TAB_GROUP_TITLE[role],
+    collapsed: false,
+  });
+  updateOwnedSessionWindowForTabs(role, ids, group.windowId);
+  return { id: group.id, windowId: group.windowId, title: group.title };
 }
 
 async function ensureOwnedContainerGroup(
@@ -824,6 +857,11 @@ async function ensureOwnedContainerWindowUnlocked(
     type: 'normal',
   });
   container.windowId = win.id!;
+  // Persist windowId before any further awaits so a worker crash between
+  // `windows.create` returning and the subsequent `tabs.group` call still
+  // lets the next ensure cycle reuse this window instead of spawning a
+  // second owned window in `chrome.windows.create`.
+  await persistRuntimeState();
   console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
 
   // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.


### PR DESCRIPTION
## Summary

Fix the user-reported bug where the extension repeatedly creates new ``OpenCLI Adapter`` tab groups (and entire owned windows) after a Chrome MV3 Service Worker restart.

The user observed not only multiple groups but **multiple owned windows each holding a group** — see ``WAWQAQ`` thread context. The race fires every time the SW gets evicted (~30s idle on MV3) between an owned-window/group setup step and its persist.

## Original bug report

### Trigger

```
1. 首次执行 opencli 浏览器命令 → daemon 未启动或 extension 未连接 → 失败
2. 用户修复连接（打开 Chrome 或启用扩展）→ extension 的 Service Worker 冷启动
3. 重新执行同一命令 → extension 创建了又一个 "OpenCLI Adapter" 分组
4. 重复步骤 2-3 → 分组不断累积
```

### Reproduce (8-step, from report)

```
1. 确保 Chrome 已打开且 OpenCLI 扩展已启用
2. 等待 30 秒以上确保 extension Service Worker 被终止
3. 执行 opencli gemini gem-chat <gem名称> "test prompt"（或任何 browser: true 的命令）
4. 在 Chrome 中观察 OpenCLI Adapter 分组被创建
5. 在命令完成前关闭 Chrome 或断开 daemon（模拟连接中断）
6. 重新打开 Chrome，等待 extension 重连
7. 再次执行步骤 3 的命令
8. 预期：复用已有分组 / 实际：创建了第二个 OpenCLI Adapter 分组
```

### Three-defect chain

| Defect | Symptom |
|---|---|
| 1. ``createOwnedGroupWithRollback`` atomicity gap | ``tabs.group()`` returns → SW dies → ``tabGroups.update`` never runs → empty-title group with no persisted ``groupId`` |
| 2. ``collectOwnedGroupCandidates`` three-layer fallback all miss | stored ``groupId``=null, title query returns ``[]`` (title never set), ``automationSessions`` empty on cold SW |
| 3. ``ensureOwnedContainerGroupUnlocked`` unconditional new-group | empty candidates + non-null ``fallbackWindowId`` → second group; same flow in ``ensureOwnedContainerWindowUnlocked`` produces a second owned window |

## Fixes

| User report § | This PR |
|---|---|
| Plan A (atomicity in ``createOwnedGroupWithRollback``) | **Fix 1**: persist ``groupId``+``windowId`` immediately after ``chrome.tabs.group`` returns; do **not** ``tabs.ungroup`` on update failure (lets ``ensureCanonicalGroupTitle`` self-heal title on the next cycle) |
| Plan C / WAWQAQ multi-window concern | **Fix 2**: persist ``windowId`` immediately after ``chrome.windows.create`` returns in ``ensureOwnedContainerWindowUnlocked``; the existing ``container.windowId != null`` reuse path then closes the multi-window race |
| Plan B (orphan recovery) — refined | **Fix 3**: 4th layer in ``collectOwnedGroupCandidates`` — scan every Chrome tab group, filter by ``empty title`` + per-role **ownership-tab signal** (group must contain a tab matching a still-registered owned session's ``preferredTabId``) |

### Why drop the color signal from Plan B

The original report suggested filtering orphans by ``color === 'orange'``. ``chrome.tabs.group()`` does **not** accept a color, so Chrome assigns a default palette color before our ``tabGroups.update`` runs. The orphan is *not* reliably orange. The ownership-tab signal is the strong evidence path: the orphan must contain a tab from one of our owned sessions, because we just put it there.

### Why drop the ``windowId`` scope from Plan B

``container.windowId`` can drift to the user window after cross-window convergence (see #1794 / #1816). Scoping the 4th-layer scan to ``container.windowId`` would either miss the multi-window orphan symptom (Fix 2's storage-loss boundary) or hijack untitled user groups when ``container.windowId`` drifted. The ownership-tab signal is independent of ``windowId`` and is still hijack-safe: user-built untitled groups never contain a tab matching one of our ``automationSessions[].preferredTabId``.

### Boundary explicitly accepted

If the SW dies between ``chrome.windows.create`` returning and ``persistRuntimeState`` (microsecond window) **and** no owned session ever got its ``preferredTabId`` persisted before death, there is no remaining ownership evidence to safely adopt the orphan. We accept that case as unrecoverable rather than fall back to weak heuristics that could hijack user content.

## Tests

``extension/src/background.test.ts``:

- **Existing** ``keeps the group and persisted groupId when setting the canonical title fails so the next ensure cycle self-heals`` — updated to the no-ungroup contract for Fix 1.
- **New** ``reuses the persisted owned window after a worker restart so the next ensure does not spawn a second window`` — Fix 2 regression gate.
- **New** ``adopts an empty-title orphan group that holds an owned session tab via the ownership-tab signal`` — Fix 3 positive recovery.
- **New** ``does not adopt an empty-title group with no owned-tab signal so user-created groups stay untouched`` — Fix 3 hijack defense, guards the #1794/#1816 boundary.

## Test plan

- [x] ``npx vitest run --project extension`` (85/85 pass)
- [x] ``npm run typecheck`` (extension)
- [x] ``npm run build`` (extension, dist refreshed)
- [ ] Reviewers walk the original 8-step repro against the new code paths

cc @opencli-质量官 (primary review) @codex-coder (secondary)