### PR TITLE
feat(auth): add login/whoami for 50 sites in one batch

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,36 @@
 [
   {
     "site": "12306",
+    "name": "login",
+    "description": "Open 12306 login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "12306.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_name"
+    ],
+    "type": "js",
+    "modulePath": "12306/auth.js",
+    "sourceFile": "12306/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "12306",
     "name": "me",
     "description": "Show the logged-in 12306 account summary. Sensitive fields (real name, email, mobile, birth date) are masked by default; pass --include-sensitive to opt in.",
     "access": "read",
@@ -297,6 +327,25 @@
     "sourceFile": "12306/trains.js"
   },
   {
+    "site": "12306",
+    "name": "whoami",
+    "description": "Show the current logged-in 12306 account",
+    "access": "read",
+    "domain": "12306.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_name"
+    ],
+    "type": "js",
+    "modulePath": "12306/auth.js",
+    "sourceFile": "12306/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "1688",
     "name": "assets",
     "description": "列出 1688 商品页可提取的图片/视频素材",
@@ -393,6 +442,37 @@
   },
   {
     "site": "1688",
+    "name": "login",
+    "description": "Open 1688 login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "1688.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "1688/auth.js",
+    "sourceFile": "1688/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "1688",
     "name": "search",
     "description": "1688 商品搜索（结果候选、卖家链接、价格/MOQ/销量文本）",
     "access": "read",
@@ -457,6 +537,26 @@
     "type": "js",
     "modulePath": "1688/store.js",
     "sourceFile": "1688/store.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "1688",
+    "name": "whoami",
+    "description": "Show the current logged-in 1688 account",
+    "access": "read",
+    "domain": "1688.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "1688/auth.js",
+    "sourceFile": "1688/auth.js",
     "navigateBefore": false
   },
   {
@@ -629,6 +729,37 @@
   },
   {
     "site": "1point3acres",
+    "name": "login",
+    "description": "Open 1point3acres login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "1point3acres.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/auth.js",
+    "sourceFile": "1point3acres/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "1point3acres",
     "name": "notifications",
     "description": "一亩三分地 站内通知（互动 / 点评 / @ 我；需要登录）",
     "access": "read",
@@ -793,6 +924,26 @@
     "type": "js",
     "modulePath": "1point3acres/user.js",
     "sourceFile": "1point3acres/user.js"
+  },
+  {
+    "site": "1point3acres",
+    "name": "whoami",
+    "description": "Show the current logged-in 1point3acres account",
+    "access": "read",
+    "domain": "1point3acres.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "1point3acres/auth.js",
+    "sourceFile": "1point3acres/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "36kr",
@@ -1277,6 +1428,36 @@
   },
   {
     "site": "amazon",
+    "name": "login",
+    "description": "Open amazon login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "amazon.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_name"
+    ],
+    "type": "js",
+    "modulePath": "amazon/auth.js",
+    "sourceFile": "amazon/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "amazon",
     "name": "movers-shakers",
     "description": "Amazon Movers & Shakers pages for short-term growth signals",
     "access": "read",
@@ -1445,6 +1626,25 @@
     "type": "js",
     "modulePath": "amazon/search.js",
     "sourceFile": "amazon/search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "amazon",
+    "name": "whoami",
+    "description": "Show the current logged-in amazon account",
+    "access": "read",
+    "domain": "amazon.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_name"
+    ],
+    "type": "js",
+    "modulePath": "amazon/auth.js",
+    "sourceFile": "amazon/auth.js",
     "navigateBefore": false
   },
   {
@@ -2618,6 +2818,36 @@
   },
   {
     "site": "band",
+    "name": "login",
+    "description": "Open band login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "band.us",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "band/auth.js",
+    "sourceFile": "band/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "band",
     "name": "mentions",
     "description": "Show Band notifications where you are @mentioned",
     "access": "read",
@@ -2749,6 +2979,25 @@
     "type": "js",
     "modulePath": "band/posts.js",
     "sourceFile": "band/posts.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "band",
+    "name": "whoami",
+    "description": "Show the current logged-in band account",
+    "access": "read",
+    "domain": "band.us",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "band/auth.js",
+    "sourceFile": "band/auth.js",
     "navigateBefore": false
   },
   {
@@ -5011,6 +5260,37 @@
   },
   {
     "site": "boss",
+    "name": "login",
+    "description": "Open boss login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "zhipin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "user_type"
+    ],
+    "type": "js",
+    "modulePath": "boss/auth.js",
+    "sourceFile": "boss/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "boss",
     "name": "mark",
     "description": "BOSS直聘给候选人添加标签",
     "access": "write",
@@ -5268,6 +5548,26 @@
     "navigateBefore": false
   },
   {
+    "site": "boss",
+    "name": "whoami",
+    "description": "Show the current logged-in boss account",
+    "access": "read",
+    "domain": "zhipin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "user_type"
+    ],
+    "type": "js",
+    "modulePath": "boss/auth.js",
+    "sourceFile": "boss/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "brave",
     "name": "search",
     "description": "Search Brave Search",
@@ -5420,6 +5720,57 @@
     "modulePath": "chaoxing/exams.js",
     "sourceFile": "chaoxing/exams.js",
     "navigateBefore": "https://mooc2-ans.chaoxing.com"
+  },
+  {
+    "site": "chaoxing",
+    "name": "login",
+    "description": "Open chaoxing login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "chaoxing.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "chaoxing/auth.js",
+    "sourceFile": "chaoxing/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "chaoxing",
+    "name": "whoami",
+    "description": "Show the current logged-in chaoxing account",
+    "access": "read",
+    "domain": "chaoxing.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "chaoxing/auth.js",
+    "sourceFile": "chaoxing/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "chatgpt",
@@ -5636,6 +5987,38 @@
   },
   {
     "site": "chatgpt",
+    "name": "login",
+    "description": "Open chatgpt login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/auth.js",
+    "sourceFile": "chatgpt/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "chatgpt",
     "name": "model",
     "description": "Switch ChatGPT web model/mode (instant, thinking, pro)",
     "access": "write",
@@ -5772,6 +6155,27 @@
     "sourceFile": "chatgpt/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
+    "name": "whoami",
+    "description": "Show the current logged-in chatgpt account",
+    "access": "read",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/auth.js",
+    "sourceFile": "chatgpt/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "chatgpt-app",
@@ -6418,6 +6822,38 @@
   },
   {
     "site": "claude",
+    "name": "login",
+    "description": "Open claude login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "claude.ai",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "org_name",
+      "org_uuid"
+    ],
+    "type": "js",
+    "modulePath": "claude/auth.js",
+    "sourceFile": "claude/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "claude",
     "name": "new",
     "description": "Start a new conversation in Claude",
     "access": "read",
@@ -6508,6 +6944,27 @@
     "sourceFile": "claude/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "claude",
+    "name": "whoami",
+    "description": "Show the current logged-in claude account",
+    "access": "read",
+    "domain": "claude.ai",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "org_name",
+      "org_uuid"
+    ],
+    "type": "js",
+    "modulePath": "claude/auth.js",
+    "sourceFile": "claude/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "cnki",
@@ -7615,6 +8072,36 @@
   },
   {
     "site": "coupang",
+    "name": "login",
+    "description": "Open coupang login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "coupang.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "coupang/auth.js",
+    "sourceFile": "coupang/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "coupang",
     "name": "product",
     "description": "Read full product detail (price, rating, seller, delivery) for a Coupang product",
     "access": "read",
@@ -7710,6 +8197,25 @@
     "modulePath": "coupang/search.js",
     "sourceFile": "coupang/search.js",
     "navigateBefore": "https://www.coupang.com"
+  },
+  {
+    "site": "coupang",
+    "name": "whoami",
+    "description": "Show the current logged-in coupang account",
+    "access": "read",
+    "domain": "coupang.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "coupang/auth.js",
+    "sourceFile": "coupang/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "crates",
@@ -7949,6 +8455,38 @@
   },
   {
     "site": "ctrip",
+    "name": "login",
+    "description": "Open ctrip login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "ctrip.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "vip_grade"
+    ],
+    "type": "js",
+    "modulePath": "ctrip/auth.js",
+    "sourceFile": "ctrip/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "ctrip",
     "name": "search",
     "description": "搜索携程目的地、景区、火车站和地标联想结果",
     "access": "read",
@@ -7989,6 +8527,27 @@
     "type": "js",
     "modulePath": "ctrip/search.js",
     "sourceFile": "ctrip/search.js"
+  },
+  {
+    "site": "ctrip",
+    "name": "whoami",
+    "description": "Show the current logged-in ctrip account",
+    "access": "read",
+    "domain": "ctrip.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "vip_grade"
+    ],
+    "type": "js",
+    "modulePath": "ctrip/auth.js",
+    "sourceFile": "ctrip/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "cursor",
@@ -8902,6 +9461,37 @@
   },
   {
     "site": "dianping",
+    "name": "login",
+    "description": "Open dianping login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "dianping.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "dianping/auth.js",
+    "sourceFile": "dianping/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "dianping",
     "name": "search",
     "description": "大众点评店铺搜索（按关键词 + 城市）",
     "access": "read",
@@ -8974,6 +9564,26 @@
     "modulePath": "dianping/shop.js",
     "sourceFile": "dianping/shop.js",
     "navigateBefore": "https://www.dianping.com"
+  },
+  {
+    "site": "dianping",
+    "name": "whoami",
+    "description": "Show the current logged-in dianping account",
+    "access": "read",
+    "domain": "dianping.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "dianping/auth.js",
+    "sourceFile": "dianping/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "dictionary",
@@ -9391,6 +10001,37 @@
   },
   {
     "site": "douban",
+    "name": "login",
+    "description": "Open douban login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "douban.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "douban/auth.js",
+    "sourceFile": "douban/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "douban",
     "name": "marks",
     "description": "导出个人观影标记",
     "access": "read",
@@ -9696,6 +10337,26 @@
     "navigateBefore": "https://movie.douban.com"
   },
   {
+    "site": "douban",
+    "name": "whoami",
+    "description": "Show the current logged-in douban account",
+    "access": "read",
+    "domain": "douban.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "douban/auth.js",
+    "sourceFile": "douban/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "doubao",
     "name": "ask",
     "description": "Send a prompt and wait for the Doubao response",
@@ -9784,6 +10445,37 @@
     "sourceFile": "doubao/history.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "doubao",
+    "name": "login",
+    "description": "Open doubao login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "www.doubao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "doubao/auth.js",
+    "sourceFile": "doubao/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "doubao",
@@ -9939,6 +10631,26 @@
     "sourceFile": "doubao/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "doubao",
+    "name": "whoami",
+    "description": "Show the current logged-in doubao account",
+    "access": "read",
+    "domain": "www.doubao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "doubao/auth.js",
+    "sourceFile": "doubao/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "doubao-app",
@@ -11598,6 +12310,38 @@
   },
   {
     "site": "facebook",
+    "name": "login",
+    "description": "Open facebook login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "facebook.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "vanity",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "facebook/auth.js",
+    "sourceFile": "facebook/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "facebook",
     "name": "marketplace-inbox",
     "description": "List recent Facebook Marketplace buyer/seller conversations",
     "access": "read",
@@ -11781,6 +12525,27 @@
     "navigateBefore": "https://www.facebook.com"
   },
   {
+    "site": "facebook",
+    "name": "whoami",
+    "description": "Show the current logged-in facebook account",
+    "access": "read",
+    "domain": "facebook.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "vanity",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "facebook/auth.js",
+    "sourceFile": "facebook/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "flathub",
     "name": "app",
     "description": "Full Flathub appstream metadata for an app id (license, categories, latest release)",
@@ -11861,6 +12626,36 @@
   },
   {
     "site": "flomo",
+    "name": "login",
+    "description": "Open flomo login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "flomoapp.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "flomo/auth.js",
+    "sourceFile": "flomo/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "flomo",
     "name": "memos",
     "description": "List your Flomo memos",
     "access": "read",
@@ -11902,6 +12697,25 @@
     "modulePath": "flomo/memos.js",
     "sourceFile": "flomo/memos.js",
     "navigateBefore": "https://v.flomoapp.com/"
+  },
+  {
+    "site": "flomo",
+    "name": "whoami",
+    "description": "Show the current logged-in flomo account",
+    "access": "read",
+    "domain": "flomoapp.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "flomo/auth.js",
+    "sourceFile": "flomo/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "gemini",
@@ -12159,6 +12973,37 @@
   },
   {
     "site": "gemini",
+    "name": "login",
+    "description": "Open gemini login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "gemini/auth.js",
+    "sourceFile": "gemini/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "gemini",
     "name": "new",
     "description": "Start a new conversation in Gemini web chat",
     "access": "read",
@@ -12215,6 +13060,26 @@
     "sourceFile": "gemini/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
+    "name": "whoami",
+    "description": "Show the current logged-in gemini account",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "gemini/auth.js",
+    "sourceFile": "gemini/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "geogebra",
@@ -13416,6 +14281,38 @@
   },
   {
     "site": "grok",
+    "name": "login",
+    "description": "Open grok login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "grok/auth.js",
+    "sourceFile": "grok/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "grok",
     "name": "new",
     "description": "Start a new conversation in Grok",
     "access": "write",
@@ -13568,6 +14465,27 @@
     "sourceFile": "grok/pin.js",
     "navigateBefore": "https://grok.com",
     "siteSession": "persistent"
+  },
+  {
+    "site": "grok",
+    "name": "whoami",
+    "description": "Show the current logged-in grok account",
+    "access": "read",
+    "domain": "grok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "grok/auth.js",
+    "sourceFile": "grok/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "hackernews",
@@ -14326,6 +15244,37 @@
   },
   {
     "site": "hupu",
+    "name": "login",
+    "description": "Open hupu login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "hupu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "hupu/auth.js",
+    "sourceFile": "hupu/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "hupu",
     "name": "mentions",
     "aliases": [
       "mention"
@@ -14513,6 +15462,26 @@
     "type": "js",
     "modulePath": "hupu/unlike.js",
     "sourceFile": "hupu/unlike.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "hupu",
+    "name": "whoami",
+    "description": "Show the current logged-in hupu account",
+    "access": "read",
+    "domain": "hupu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "hupu/auth.js",
+    "sourceFile": "hupu/auth.js",
     "navigateBefore": false
   },
   {
@@ -15093,6 +16062,38 @@
   },
   {
     "site": "instagram",
+    "name": "login",
+    "description": "Open instagram login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "instagram.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "full_name"
+    ],
+    "type": "js",
+    "modulePath": "instagram/auth.js",
+    "sourceFile": "instagram/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "instagram",
     "name": "note",
     "description": "Publish a text Instagram note",
     "access": "write",
@@ -15511,6 +16512,27 @@
     "navigateBefore": "https://www.instagram.com"
   },
   {
+    "site": "instagram",
+    "name": "whoami",
+    "description": "Show the current logged-in instagram account",
+    "access": "read",
+    "domain": "instagram.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "full_name"
+    ],
+    "type": "js",
+    "modulePath": "instagram/auth.js",
+    "sourceFile": "instagram/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "jd",
     "name": "add-cart",
     "description": "京东加入购物车",
@@ -15638,6 +16660,37 @@
   },
   {
     "site": "jd",
+    "name": "login",
+    "description": "Open jd login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "jd.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "pin",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "jd/auth.js",
+    "sourceFile": "jd/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "jd",
     "name": "reviews",
     "description": "京东商品评价",
     "access": "read",
@@ -15709,6 +16762,26 @@
     "navigateBefore": false
   },
   {
+    "site": "jd",
+    "name": "whoami",
+    "description": "Show the current logged-in jd account",
+    "access": "read",
+    "domain": "jd.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "pin",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "jd/auth.js",
+    "sourceFile": "jd/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "jianyu",
     "name": "detail",
     "description": "读取剑鱼标讯详情页并抽取证据字段",
@@ -15744,6 +16817,37 @@
     "modulePath": "jianyu/detail.js",
     "sourceFile": "jianyu/detail.js",
     "navigateBefore": "https://www.jianyu360.cn"
+  },
+  {
+    "site": "jianyu",
+    "name": "login",
+    "description": "Open jianyu login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "jianyu360.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "jianyu/auth.js",
+    "sourceFile": "jianyu/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "jianyu",
@@ -15789,6 +16893,26 @@
     "modulePath": "jianyu/search.js",
     "sourceFile": "jianyu/search.js",
     "navigateBefore": "https://www.jianyu360.cn"
+  },
+  {
+    "site": "jianyu",
+    "name": "whoami",
+    "description": "Show the current logged-in jianyu account",
+    "access": "read",
+    "domain": "jianyu360.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "jianyu/auth.js",
+    "sourceFile": "jianyu/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "jike",
@@ -16492,6 +17616,55 @@
   },
   {
     "site": "ke",
+    "name": "login",
+    "description": "Open ke login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "ke.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "ke/auth.js",
+    "sourceFile": "ke/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "ke",
+    "name": "whoami",
+    "description": "Show the current logged-in ke account",
+    "access": "read",
+    "domain": "ke.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "ke/auth.js",
+    "sourceFile": "ke/auth.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "ke",
     "name": "xiaoqu",
     "description": "贝壳找房小区列表",
     "access": "read",
@@ -16907,6 +18080,37 @@
     "sourceFile": "kimi/storage.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "login",
+    "description": "Open kimi login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "kimi/auth.js",
+    "sourceFile": "kimi/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "kimi",
@@ -17507,6 +18711,26 @@
     "sourceFile": "kimi/ui.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "kimi",
+    "name": "whoami",
+    "description": "Show the current logged-in kimi account",
+    "access": "read",
+    "domain": "kimi.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "kimi/auth.js",
+    "sourceFile": "kimi/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "lesswrong",
@@ -18188,6 +19412,38 @@
     "modulePath": "linkedin/jobs-preferences.js",
     "sourceFile": "linkedin/jobs-preferences.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin",
+    "name": "login",
+    "description": "Open linkedin login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "www.linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "public_id",
+      "plain_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/auth.js",
+    "sourceFile": "linkedin/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "linkedin",
@@ -18944,6 +20200,27 @@
     "navigateBefore": "https://www.linkedin.com"
   },
   {
+    "site": "linkedin",
+    "name": "whoami",
+    "description": "Show the current logged-in linkedin account",
+    "access": "read",
+    "domain": "www.linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "public_id",
+      "plain_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linkedin/auth.js",
+    "sourceFile": "linkedin/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "linkedin-learning",
     "name": "course",
     "description": "Get LinkedIn Learning course detail by slug or course URL",
@@ -18976,6 +20253,38 @@
     "modulePath": "linkedin-learning/course.js",
     "sourceFile": "linkedin-learning/course.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin-learning",
+    "name": "login",
+    "description": "Open linkedin-learning login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "public_id",
+      "plain_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linkedin-learning/auth.js",
+    "sourceFile": "linkedin-learning/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "linkedin-learning",
@@ -19048,6 +20357,27 @@
     "modulePath": "linkedin-learning/trending.js",
     "sourceFile": "linkedin-learning/trending.js",
     "navigateBefore": "https://www.linkedin.com"
+  },
+  {
+    "site": "linkedin-learning",
+    "name": "whoami",
+    "description": "Show the current logged-in linkedin-learning account",
+    "access": "read",
+    "domain": "linkedin.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "public_id",
+      "plain_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linkedin-learning/auth.js",
+    "sourceFile": "linkedin-learning/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "linux-do",
@@ -19177,6 +20507,38 @@
     "modulePath": "linux-do/categories.js",
     "sourceFile": "linux-do/categories.js",
     "navigateBefore": "https://linux.do"
+  },
+  {
+    "site": "linux-do",
+    "name": "login",
+    "description": "Open linux-do login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "linux.do",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linux-do/auth.js",
+    "sourceFile": "linux-do/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "linux-do",
@@ -19379,6 +20741,27 @@
     "modulePath": "linux-do/user-topics.js",
     "sourceFile": "linux-do/user-topics.js",
     "navigateBefore": "https://linux.do"
+  },
+  {
+    "site": "linux-do",
+    "name": "whoami",
+    "description": "Show the current logged-in linux-do account",
+    "access": "read",
+    "domain": "linux.do",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "linux-do/auth.js",
+    "sourceFile": "linux-do/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "lobsters",
@@ -19821,6 +21204,37 @@
   },
   {
     "site": "manus",
+    "name": "login",
+    "description": "Open manus login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "manus/auth.js",
+    "sourceFile": "manus/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "manus",
     "name": "read",
     "description": "Show details for a specific Manus session.",
     "access": "read",
@@ -19885,6 +21299,26 @@
     "sourceFile": "manus/status.js",
     "navigateBefore": true,
     "siteSession": "persistent"
+  },
+  {
+    "site": "manus",
+    "name": "whoami",
+    "description": "Show the current logged-in manus account",
+    "access": "read",
+    "domain": "manus.im",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "manus/auth.js",
+    "sourceFile": "manus/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "maven",
@@ -20638,6 +22072,37 @@
   },
   {
     "site": "notebooklm",
+    "name": "login",
+    "description": "Open notebooklm login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "name",
+      "authuser"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/auth.js",
+    "sourceFile": "notebooklm/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "notebooklm",
     "name": "note-list",
     "aliases": [
       "notes-list"
@@ -20874,6 +22339,26 @@
     "type": "js",
     "modulePath": "notebooklm/summary.js",
     "sourceFile": "notebooklm/summary.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "notebooklm",
+    "name": "whoami",
+    "description": "Show the current logged-in notebooklm account",
+    "access": "read",
+    "domain": "google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name",
+      "authuser"
+    ],
+    "type": "js",
+    "modulePath": "notebooklm/auth.js",
+    "sourceFile": "notebooklm/auth.js",
     "navigateBefore": false
   },
   {
@@ -22832,6 +24317,37 @@
   },
   {
     "site": "pixiv",
+    "name": "login",
+    "description": "Open pixiv login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "pixiv.net",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "pixiv/auth.js",
+    "sourceFile": "pixiv/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "pixiv",
     "name": "ranking",
     "description": "Pixiv illustration rankings (daily/weekly/monthly)",
     "access": "read",
@@ -22994,6 +24510,56 @@
     "navigateBefore": "https://www.pixiv.net"
   },
   {
+    "site": "pixiv",
+    "name": "whoami",
+    "description": "Show the current logged-in pixiv account",
+    "access": "read",
+    "domain": "pixiv.net",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "pixiv/auth.js",
+    "sourceFile": "pixiv/auth.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "powerchina",
+    "name": "login",
+    "description": "Open powerchina login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "powerchina.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "powerchina/auth.js",
+    "sourceFile": "powerchina/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
     "site": "powerchina",
     "name": "search",
     "description": "搜索中国电建阳光采购公告",
@@ -23030,6 +24596,25 @@
     "modulePath": "powerchina/search.js",
     "sourceFile": "powerchina/search.js",
     "navigateBefore": "https://bid.powerchina.cn"
+  },
+  {
+    "site": "powerchina",
+    "name": "whoami",
+    "description": "Show the current logged-in powerchina account",
+    "access": "read",
+    "domain": "powerchina.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "powerchina/auth.js",
+    "sourceFile": "powerchina/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "producthunt",
@@ -24683,6 +26268,38 @@
   },
   {
     "site": "qwen",
+    "name": "login",
+    "description": "Open qwen login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "qwen.ai",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "qwen/auth.js",
+    "sourceFile": "qwen/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "qwen",
     "name": "new",
     "description": "Start a new conversation in Qianwen",
     "access": "write",
@@ -24795,6 +26412,27 @@
     "sourceFile": "qwen/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "qwen",
+    "name": "whoami",
+    "description": "Show the current logged-in qwen account",
+    "access": "read",
+    "domain": "qwen.ai",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "email"
+    ],
+    "type": "js",
+    "modulePath": "qwen/auth.js",
+    "sourceFile": "qwen/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "reddit",
@@ -24941,6 +26579,37 @@
     "modulePath": "reddit/hot.js",
     "sourceFile": "reddit/hot.js",
     "navigateBefore": "https://www.reddit.com"
+  },
+  {
+    "site": "reddit",
+    "name": "login",
+    "description": "Open reddit login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "reddit.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "username",
+      "id"
+    ],
+    "type": "js",
+    "modulePath": "reddit/auth.js",
+    "sourceFile": "reddit/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "reddit",
@@ -25653,6 +27322,37 @@
   },
   {
     "site": "rednote",
+    "name": "login",
+    "description": "Open rednote login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "rednote.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "rednote/auth.js",
+    "sourceFile": "rednote/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "rednote",
     "name": "note",
     "description": "Read note body and engagement counts from a rednote note",
     "access": "read",
@@ -25786,6 +27486,26 @@
     "type": "js",
     "modulePath": "rednote/user.js",
     "sourceFile": "rednote/user.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "rednote",
+    "name": "whoami",
+    "description": "Show the current logged-in rednote account",
+    "access": "read",
+    "domain": "rednote.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "rednote/auth.js",
+    "sourceFile": "rednote/auth.js",
     "navigateBefore": false
   },
   {
@@ -25925,6 +27645,37 @@
   },
   {
     "site": "reuters",
+    "name": "login",
+    "description": "Open reuters login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "reuters.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "subscribed"
+    ],
+    "type": "js",
+    "modulePath": "reuters/auth.js",
+    "sourceFile": "reuters/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "reuters",
     "name": "search",
     "description": "Reuters 路透社新闻搜索",
     "access": "read",
@@ -25960,6 +27711,26 @@
     "modulePath": "reuters/search.js",
     "sourceFile": "reuters/search.js",
     "navigateBefore": "https://www.reuters.com"
+  },
+  {
+    "site": "reuters",
+    "name": "whoami",
+    "description": "Show the current logged-in reuters account",
+    "access": "read",
+    "domain": "reuters.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "subscribed"
+    ],
+    "type": "js",
+    "modulePath": "reuters/auth.js",
+    "sourceFile": "reuters/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "rfc",
@@ -27387,6 +29158,37 @@
   },
   {
     "site": "suno",
+    "name": "login",
+    "description": "Open suno login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "suno/auth.js",
+    "sourceFile": "suno/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "suno",
     "name": "status",
     "description": "Check Suno login, plan, credit balance, and captcha readiness",
     "access": "read",
@@ -27406,6 +29208,26 @@
     "sourceFile": "suno/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "suno",
+    "name": "whoami",
+    "description": "Show the current logged-in suno account",
+    "access": "read",
+    "domain": "suno.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "suno/auth.js",
+    "sourceFile": "suno/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "taobao",
@@ -27506,6 +29328,37 @@
   },
   {
     "site": "taobao",
+    "name": "login",
+    "description": "Open taobao login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "taobao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "taobao/auth.js",
+    "sourceFile": "taobao/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "taobao",
     "name": "reviews",
     "description": "淘宝商品评价",
     "access": "read",
@@ -27589,6 +29442,26 @@
     "type": "js",
     "modulePath": "taobao/search.js",
     "sourceFile": "taobao/search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "taobao",
+    "name": "whoami",
+    "description": "Show the current logged-in taobao account",
+    "access": "read",
+    "domain": "taobao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "taobao/auth.js",
+    "sourceFile": "taobao/auth.js",
     "navigateBefore": false
   },
   {
@@ -28072,6 +29945,38 @@
   },
   {
     "site": "tiktok",
+    "name": "login",
+    "description": "Open tiktok login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "tiktok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "sec_uid",
+      "username",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "tiktok/auth.js",
+    "sourceFile": "tiktok/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "tiktok",
     "name": "notifications",
     "description": "Read TikTok inbox notifications (likes, comments, mentions, followers) via page-context APIs",
     "access": "read",
@@ -28335,6 +30240,27 @@
     "navigateBefore": "https://www.tiktok.com"
   },
   {
+    "site": "tiktok",
+    "name": "whoami",
+    "description": "Show the current logged-in tiktok account",
+    "access": "read",
+    "domain": "tiktok.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "sec_uid",
+      "username",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "tiktok/auth.js",
+    "sourceFile": "tiktok/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "toutiao",
     "name": "articles",
     "description": "获取头条号创作者后台文章列表及数据",
@@ -28395,6 +30321,57 @@
     "type": "js",
     "modulePath": "toutiao/hot.js",
     "sourceFile": "toutiao/hot.js"
+  },
+  {
+    "site": "toutiao",
+    "name": "login",
+    "description": "Open toutiao login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "toutiao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "toutiao/auth.js",
+    "sourceFile": "toutiao/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "toutiao",
+    "name": "whoami",
+    "description": "Show the current logged-in toutiao account",
+    "access": "read",
+    "domain": "toutiao.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "toutiao/auth.js",
+    "sourceFile": "toutiao/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "trae-cn",
@@ -31664,6 +33641,38 @@
   },
   {
     "site": "upwork",
+    "name": "login",
+    "description": "Open upwork login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "upwork.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "ciphertext"
+    ],
+    "type": "js",
+    "modulePath": "upwork/auth.js",
+    "sourceFile": "upwork/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "upwork",
     "name": "search",
     "description": "Upwork keyword job search (logged-in browser session, US site)",
     "access": "read",
@@ -31731,6 +33740,27 @@
     "type": "js",
     "modulePath": "upwork/search.js",
     "sourceFile": "upwork/search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "upwork",
+    "name": "whoami",
+    "description": "Show the current logged-in upwork account",
+    "access": "read",
+    "domain": "upwork.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "ciphertext"
+    ],
+    "type": "js",
+    "modulePath": "upwork/auth.js",
+    "sourceFile": "upwork/auth.js",
     "navigateBefore": false
   },
   {
@@ -32180,6 +34210,37 @@
   },
   {
     "site": "wechat-channels",
+    "name": "login",
+    "description": "Open wechat-channels login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "channels.weixin.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "wechat-channels/auth.js",
+    "sourceFile": "wechat-channels/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "wechat-channels",
     "name": "publish",
     "description": "发布视频到视频号",
     "access": "write",
@@ -32242,6 +34303,26 @@
     "type": "js",
     "modulePath": "wechat-channels/publish.js",
     "sourceFile": "wechat-channels/publish.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "wechat-channels",
+    "name": "whoami",
+    "description": "Show the current logged-in wechat-channels account",
+    "access": "read",
+    "domain": "channels.weixin.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "wechat-channels/auth.js",
+    "sourceFile": "wechat-channels/auth.js",
     "navigateBefore": false
   },
   {
@@ -32412,6 +34493,38 @@
     "modulePath": "weibo/hot.js",
     "sourceFile": "weibo/hot.js",
     "navigateBefore": "https://weibo.com"
+  },
+  {
+    "site": "weibo",
+    "name": "login",
+    "description": "Open weibo login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "weibo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "weibo/auth.js",
+    "sourceFile": "weibo/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "weibo",
@@ -32626,6 +34739,27 @@
     "modulePath": "weibo/user-posts.js",
     "sourceFile": "weibo/user-posts.js",
     "navigateBefore": "https://weibo.com"
+  },
+  {
+    "site": "weibo",
+    "name": "whoami",
+    "description": "Show the current logged-in weibo account",
+    "access": "read",
+    "domain": "weibo.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "weibo/auth.js",
+    "sourceFile": "weibo/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "weixin",
@@ -32971,6 +35105,37 @@
   },
   {
     "site": "weread",
+    "name": "login",
+    "description": "Open weread login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "weread.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "weread/auth.js",
+    "sourceFile": "weread/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "weread",
     "name": "notebooks",
     "description": "List books that have highlights or notes",
     "access": "read",
@@ -33123,6 +35288,26 @@
     "modulePath": "weread/shelf.js",
     "sourceFile": "weread/shelf.js",
     "navigateBefore": "https://weread.qq.com"
+  },
+  {
+    "site": "weread",
+    "name": "whoami",
+    "description": "Show the current logged-in weread account",
+    "access": "read",
+    "domain": "weread.qq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "weread/auth.js",
+    "sourceFile": "weread/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "weread-official",
@@ -33967,6 +36152,37 @@
   },
   {
     "site": "xianyu",
+    "name": "login",
+    "description": "Open xianyu login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "goofish.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "xianyu/auth.js",
+    "sourceFile": "xianyu/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "xianyu",
     "name": "messages",
     "description": "读取指定闲鱼私信会话的最近聊天内容",
     "access": "read",
@@ -34185,6 +36401,26 @@
     "navigateBefore": false
   },
   {
+    "site": "xianyu",
+    "name": "whoami",
+    "description": "Show the current logged-in xianyu account",
+    "access": "read",
+    "domain": "goofish.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "xianyu/auth.js",
+    "sourceFile": "xianyu/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "xiaoe",
     "name": "catalog",
     "description": "小鹅通课程目录（支持普通课程、专栏、大专栏）",
@@ -34294,6 +36530,37 @@
   },
   {
     "site": "xiaoe",
+    "name": "login",
+    "description": "Open xiaoe login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "xiaoe-tech.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "xiaoe/auth.js",
+    "sourceFile": "xiaoe/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "xiaoe",
     "name": "play-url",
     "description": "小鹅通视频/音频/直播回放 M3U8 播放地址",
     "access": "read",
@@ -34320,6 +36587,26 @@
     "modulePath": "xiaoe/play-url.js",
     "sourceFile": "xiaoe/play-url.js",
     "navigateBefore": "https://h5.xet.citv.cn"
+  },
+  {
+    "site": "xiaoe",
+    "name": "whoami",
+    "description": "Show the current logged-in xiaoe account",
+    "access": "read",
+    "domain": "xiaoe-tech.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "xiaoe/auth.js",
+    "sourceFile": "xiaoe/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "xiaohongshu",
@@ -35474,6 +37761,36 @@
   },
   {
     "site": "xueqiu",
+    "name": "login",
+    "description": "Open xueqiu login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "xueqiu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "xueqiu/auth.js",
+    "sourceFile": "xueqiu/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "xueqiu",
     "name": "search",
     "description": "搜索雪球股票（代码或名称）",
     "access": "read",
@@ -35572,6 +37889,25 @@
     "modulePath": "xueqiu/watchlist.js",
     "sourceFile": "xueqiu/watchlist.js",
     "navigateBefore": "https://xueqiu.com"
+  },
+  {
+    "site": "xueqiu",
+    "name": "whoami",
+    "description": "Show the current logged-in xueqiu account",
+    "access": "read",
+    "domain": "xueqiu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id"
+    ],
+    "type": "js",
+    "modulePath": "xueqiu/auth.js",
+    "sourceFile": "xueqiu/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "yahoo",
@@ -36441,6 +38777,36 @@
   },
   {
     "site": "youtube",
+    "name": "login",
+    "description": "Open youtube login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "www.youtube.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "youtube/auth.js",
+    "sourceFile": "youtube/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "youtube",
     "name": "playlist",
     "description": "Get YouTube playlist info and video list",
     "access": "read",
@@ -36736,6 +39102,25 @@
     "navigateBefore": "https://www.youtube.com"
   },
   {
+    "site": "youtube",
+    "name": "whoami",
+    "description": "Show the current logged-in youtube account",
+    "access": "read",
+    "domain": "www.youtube.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "youtube/auth.js",
+    "sourceFile": "youtube/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "yuanbao",
     "name": "ask",
     "description": "Send a prompt to Yuanbao web chat and wait for the assistant response",
@@ -36843,6 +39228,37 @@
   },
   {
     "site": "yuanbao",
+    "name": "login",
+    "description": "Open yuanbao login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "yuanbao.tencent.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "yuanbao/auth.js",
+    "sourceFile": "yuanbao/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "yuanbao",
     "name": "new",
     "description": "Start a new conversation in Yuanbao web chat",
     "access": "read",
@@ -36936,6 +39352,26 @@
     "sourceFile": "yuanbao/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "yuanbao",
+    "name": "whoami",
+    "description": "Show the current logged-in yuanbao account",
+    "access": "read",
+    "domain": "yuanbao.tencent.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "yuanbao/auth.js",
+    "sourceFile": "yuanbao/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "zhihu",
@@ -37394,6 +39830,38 @@
   },
   {
     "site": "zhihu",
+    "name": "login",
+    "description": "Open zhihu login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "url_token",
+      "name",
+      "uid"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/auth.js",
+    "sourceFile": "zhihu/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "zhihu",
     "name": "question",
     "description": "知乎问题详情和回答",
     "access": "read",
@@ -37519,6 +39987,27 @@
     "modulePath": "zhihu/search.js",
     "sourceFile": "zhihu/search.js",
     "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
+    "name": "whoami",
+    "description": "Show the current logged-in zhihu account",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "url_token",
+      "name",
+      "uid"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/auth.js",
+    "sourceFile": "zhihu/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "zlibrary",
@@ -37647,6 +40136,37 @@
   },
   {
     "site": "zsxq",
+    "name": "login",
+    "description": "Open zsxq login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "zsxq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "zsxq/auth.js",
+    "sourceFile": "zsxq/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "zsxq",
     "name": "search",
     "description": "搜索星球内容",
     "access": "read",
@@ -37772,5 +40292,25 @@
     "modulePath": "zsxq/topics.js",
     "sourceFile": "zsxq/topics.js",
     "navigateBefore": "https://wx.zsxq.com"
+  },
+  {
+    "site": "zsxq",
+    "name": "whoami",
+    "description": "Show the current logged-in zsxq account",
+    "access": "read",
+    "domain": "zsxq.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "zsxq/auth.js",
+    "sourceFile": "zsxq/auth.js",
+    "navigateBefore": false
   }
 ]

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -5279,7 +5279,6 @@
       "status",
       "logged_in",
       "site",
-      "user_id",
       "user_type"
     ],
     "type": "js",
@@ -5559,7 +5558,6 @@
     "columns": [
       "logged_in",
       "site",
-      "user_id",
       "user_type"
     ],
     "type": "js",
@@ -6007,8 +6005,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "chatgpt/auth.js",
@@ -6169,8 +6166,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "chatgpt/auth.js",
@@ -13043,8 +13039,7 @@
       "status",
       "logged_in",
       "site",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "gemini/auth.js",
@@ -13124,8 +13119,7 @@
     "columns": [
       "logged_in",
       "site",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "gemini/auth.js",
@@ -14405,8 +14399,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "grok/auth.js",
@@ -14583,8 +14576,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "grok/auth.js",
@@ -26494,8 +26486,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "qwen/auth.js",
@@ -26632,8 +26623,7 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
-      "email"
+      "name"
     ],
     "type": "js",
     "modulePath": "qwen/auth.js",
@@ -33867,7 +33857,6 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
       "ciphertext"
     ],
     "type": "js",
@@ -33961,7 +33950,6 @@
       "logged_in",
       "site",
       "user_id",
-      "name",
       "ciphertext"
     ],
     "type": "js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9101,6 +9101,37 @@
   },
   {
     "site": "deepseek",
+    "name": "login",
+    "description": "Open deepseek login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "chat.deepseek.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "deepseek/auth.js",
+    "sourceFile": "deepseek/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "deepseek",
     "name": "new",
     "description": "Start a new conversation in DeepSeek",
     "access": "read",
@@ -9196,6 +9227,26 @@
     "sourceFile": "deepseek/status.js",
     "navigateBefore": false,
     "siteSession": "persistent"
+  },
+  {
+    "site": "deepseek",
+    "name": "whoami",
+    "description": "Show the current logged-in deepseek account",
+    "access": "read",
+    "domain": "chat.deepseek.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "deepseek/auth.js",
+    "sourceFile": "deepseek/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "defillama",
@@ -13354,6 +13405,38 @@
   },
   {
     "site": "gitee",
+    "name": "login",
+    "description": "Open gitee login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "gitee.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "gitee/auth.js",
+    "sourceFile": "gitee/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "gitee",
     "name": "search",
     "description": "Search repositories on Gitee",
     "access": "read",
@@ -13439,6 +13522,27 @@
     "type": "js",
     "modulePath": "gitee/user.js",
     "sourceFile": "gitee/user.js"
+  },
+  {
+    "site": "gitee",
+    "name": "whoami",
+    "description": "Show the current logged-in gitee account",
+    "access": "read",
+    "domain": "gitee.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "username",
+      "name"
+    ],
+    "type": "js",
+    "modulePath": "gitee/auth.js",
+    "sourceFile": "gitee/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "github",
@@ -14841,6 +14945,38 @@
   },
   {
     "site": "hf",
+    "name": "login",
+    "description": "Open hf login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "huggingface.co",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "username",
+      "fullname",
+      "type"
+    ],
+    "type": "js",
+    "modulePath": "hf/auth.js",
+    "sourceFile": "hf/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "hf",
     "name": "models",
     "description": "Top Hugging Face models (downloads / likes / trending / freshness).",
     "access": "read",
@@ -15024,6 +15160,27 @@
     "type": "js",
     "modulePath": "hf/top.js",
     "sourceFile": "hf/top.js"
+  },
+  {
+    "site": "hf",
+    "name": "whoami",
+    "description": "Show the current logged-in hf account",
+    "access": "read",
+    "domain": "huggingface.co",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "username",
+      "fullname",
+      "type"
+    ],
+    "type": "js",
+    "modulePath": "hf/auth.js",
+    "sourceFile": "hf/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "homebrew",
@@ -25808,6 +25965,36 @@
   },
   {
     "site": "quark",
+    "name": "login",
+    "description": "Open quark login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "quark.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "quark/auth.js",
+    "sourceFile": "quark/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "quark",
     "name": "ls",
     "description": "List files in your Quark Drive",
     "access": "read",
@@ -26082,6 +26269,25 @@
     "modulePath": "quark/share-tree.js",
     "sourceFile": "quark/share-tree.js",
     "navigateBefore": "https://pan.quark.cn"
+  },
+  {
+    "site": "quark",
+    "name": "whoami",
+    "description": "Show the current logged-in quark account",
+    "access": "read",
+    "domain": "quark.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "quark/auth.js",
+    "sourceFile": "quark/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "qwen",
@@ -33841,6 +34047,36 @@
   },
   {
     "site": "v2ex",
+    "name": "login",
+    "description": "Open v2ex login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "v2ex.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "v2ex/auth.js",
+    "sourceFile": "v2ex/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "v2ex",
     "name": "me",
     "description": "V2EX 获取个人资料 (余额/未读提醒)",
     "access": "read",
@@ -34076,6 +34312,25 @@
     "type": "js",
     "modulePath": "v2ex/user.js",
     "sourceFile": "v2ex/user.js"
+  },
+  {
+    "site": "v2ex",
+    "name": "whoami",
+    "description": "Show the current logged-in v2ex account",
+    "access": "read",
+    "domain": "v2ex.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "v2ex/auth.js",
+    "sourceFile": "v2ex/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "wanfang",

--- a/clis/12306/auth.js
+++ b/clis/12306/auth.js
@@ -1,0 +1,58 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function has12306SessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://kyfw.12306.cn' });
+  return cookies.some(c => c.name === 'tk' && c.value);
+}
+
+async function verify12306Identity(page) {
+  if (!await has12306SessionCookie(page)) {
+    throw new AuthRequiredError('12306.cn', '12306 tk auth cookie missing');
+  }
+  await page.goto('https://kyfw.12306.cn/otn/view/index.html');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const r = await fetch('/otn/index/initMy12306Api', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      if (/login\\.html/.test(r.url)) {
+        return { kind: 'auth', detail: '12306 initMy12306Api redirected to login' };
+      }
+      const t = await r.text();
+      let d = null;
+      try { d = JSON.parse(t); } catch {}
+      if (!d || d.status === false || /未登录|登录超时|NotLogin/i.test(t)) {
+        return { kind: 'auth', detail: '12306 initMy12306Api returned NotLogin' };
+      }
+      const userName = d.data?.user_name || d.data?.userName || d.user_name || '';
+      if (!userName) {
+        return { kind: 'auth', detail: '12306 initMy12306Api 200 but no user_name surface' };
+      }
+      return { ok: true, user_name: String(userName) };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('12306.cn', probe.detail);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`12306 whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected 12306 probe: ${JSON.stringify(probe)}`);
+  return { user_name: probe.user_name };
+}
+
+registerSiteAuthCommands({
+  site: '12306',
+  domain: '12306.cn',
+  loginUrl: 'https://kyfw.12306.cn/otn/resources/login.html',
+  columns: ['user_name'],
+  verify: verify12306Identity,
+  poll: async (page) => {
+    if (!await has12306SessionCookie(page)) {
+      throw new AuthRequiredError('12306.cn', 'Waiting for 12306 tk auth cookie');
+    }
+    return verify12306Identity(page);
+  },
+});

--- a/clis/1688/auth.js
+++ b/clis/1688/auth.js
@@ -1,0 +1,45 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function has1688LogonCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.1688.com' });
+  return cookies.some(c => c.name === '__cn_logon__' && c.value === 'true');
+}
+
+async function verify1688Identity(page) {
+  if (!await has1688LogonCookie(page)) {
+    throw new AuthRequiredError('1688.com', '1688 __cn_logon__=true cookie missing — anonymous');
+  }
+  await page.goto('https://www.1688.com/');
+  await page.wait(2);
+  const cookies = await page.getCookies({ url: 'https://www.1688.com' });
+  const cookieMap = Object.fromEntries(cookies.map(c => [c.name, c.value]));
+  if (cookieMap['__cn_logon__'] !== 'true') {
+    throw new AuthRequiredError('1688.com', '1688 __cn_logon__ cookie absent after navigation');
+  }
+  const unb = cookieMap['unb'] || '';
+  if (!unb) {
+    throw new AuthRequiredError('1688.com', '1688 unb cookie missing — partial logged-in state');
+  }
+  let name = '';
+  try {
+    name = cookieMap['lid'] ? decodeURIComponent(cookieMap['lid']) : '';
+  } catch {
+    name = cookieMap['lid'] || '';
+  }
+  return { user_id: String(unb), name };
+}
+
+registerSiteAuthCommands({
+  site: '1688',
+  domain: '1688.com',
+  loginUrl: 'https://login.1688.com/member/signin.htm',
+  columns: ['user_id', 'name'],
+  verify: verify1688Identity,
+  poll: async (page) => {
+    if (!await has1688LogonCookie(page)) {
+      throw new AuthRequiredError('1688.com', 'Waiting for 1688 __cn_logon__=true cookie');
+    }
+    return verify1688Identity(page);
+  },
+});

--- a/clis/1point3acres/auth.js
+++ b/clis/1point3acres/auth.js
@@ -1,0 +1,51 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function has1Point3AcresAuthCookie(page) {
+  const host = await page.getCookies({ url: 'https://www.1point3acres.com' });
+  const root = await page.getCookies({ url: 'https://.1point3acres.com' });
+  return [...host, ...root].some(c => /_auth$/.test(c.name) && c.value);
+}
+
+async function verify1Point3AcresIdentity(page) {
+  if (!await has1Point3AcresAuthCookie(page)) {
+    throw new AuthRequiredError('1point3acres.com', '1point3acres Discuz *_auth cookie missing');
+  }
+  await page.goto('https://www.1point3acres.com/bbs/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/auth\\.1point3acres\\.com\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: '1point3acres bbs redirected to auth login' };
+      }
+      const loginLink = document.querySelector('a[href*="auth.1point3acres.com/login"], a[href*="member.php?mod=logging&action=login"]');
+      if (loginLink && /登录/.test(loginLink.innerText || '')) {
+        return { kind: 'auth', detail: '1point3acres bbs shows 登录 link — anonymous' };
+      }
+      const nameEl = document.querySelector('#um .vwmy h4 a, a.username, .vwmy a');
+      const username = (nameEl?.innerText || '').trim();
+      const uid = (nameEl?.getAttribute('href') || '').match(/uid[=-](\\d+)/)?.[1] || '';
+      if (!uid && !username) {
+        return { kind: 'auth', detail: '1point3acres bbs rendered but no #um identity — anonymous or shape drifted' };
+      }
+      return { ok: true, user_id: uid, username };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('1point3acres.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected 1point3acres probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, username: probe.username };
+}
+
+registerSiteAuthCommands({
+  site: '1point3acres',
+  domain: '1point3acres.com',
+  loginUrl: 'https://auth.1point3acres.com/login',
+  columns: ['user_id', 'username'],
+  verify: verify1Point3AcresIdentity,
+  poll: async (page) => {
+    if (!await has1Point3AcresAuthCookie(page)) {
+      throw new AuthRequiredError('1point3acres.com', 'Waiting for 1point3acres Discuz *_auth cookie');
+    }
+    return verify1Point3AcresIdentity(page);
+  },
+});

--- a/clis/amazon/auth.js
+++ b/clis/amazon/auth.js
@@ -1,0 +1,52 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasAmazonSessionCookies(page) {
+  const cookies = await page.getCookies({ url: 'https://www.amazon.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('at-main') || names.has('x-main');
+}
+
+async function verifyAmazonIdentity(page) {
+  if (!await hasAmazonSessionCookies(page)) {
+    throw new AuthRequiredError('amazon.com', 'Amazon auth cookies (at-main / x-main) are missing');
+  }
+  await page.goto('https://www.amazon.com/', { waitUntil: 'load' });
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      const navLink = document.querySelector('#nav-link-accountList');
+      if (!navLink) {
+        return { kind: 'auth', detail: 'Amazon header missing nav-link-accountList — layout changed or robot challenge' };
+      }
+      const greeting = (navLink.querySelector('.nav-line-1, #nav-link-accountList-nav-line-1') || {}).textContent || '';
+      const trimmed = greeting.trim();
+      if (/sign\\s*in/i.test(trimmed)) {
+        return { kind: 'auth', detail: 'Amazon header shows "Hello, sign in" — anonymous' };
+      }
+      const m = trimmed.match(/^Hello,?\\s+(.+)$/i);
+      const name = m ? m[1].trim() : '';
+      if (!name) {
+        return { kind: 'auth', detail: 'Amazon greeting unparseable: ' + trimmed };
+      }
+      return { ok: true, user_name: name };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('amazon.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Amazon probe: ${JSON.stringify(probe)}`);
+  return { user_name: probe.user_name };
+}
+
+registerSiteAuthCommands({
+  site: 'amazon',
+  domain: 'amazon.com',
+  loginUrl: 'https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0',
+  columns: ['user_name'],
+  verify: verifyAmazonIdentity,
+  poll: async (page) => {
+    if (!await hasAmazonSessionCookies(page)) {
+      throw new AuthRequiredError('amazon.com', 'Waiting for Amazon at-main / x-main cookie');
+    }
+    return verifyAmazonIdentity(page);
+  },
+});

--- a/clis/band/auth.js
+++ b/clis/band/auth.js
@@ -1,0 +1,61 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasBandSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.band.us' });
+  return cookies.some(c => c.name === 'band_session' && c.value);
+}
+
+async function verifyBandIdentity(page) {
+  if (!await hasBandSessionCookie(page)) {
+    throw new AuthRequiredError('band.us', 'Band band_session cookie missing');
+  }
+  await page.goto('https://www.band.us/feed');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/auth\\.band\\.us\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: 'Band /feed redirected to auth login' };
+      }
+      let userId = '';
+      try {
+        const stack = [window.__INITIAL_STATE__, window.__BAND_STORE__].filter(Boolean);
+        const seen = new Set();
+        while (stack.length) {
+          const node = stack.pop();
+          if (!node || typeof node !== 'object' || seen.has(node)) continue;
+          seen.add(node);
+          if (Array.isArray(node)) { stack.push(...node); continue; }
+          const u = node.user || node.me || node.currentUser;
+          if (u && (u.user_no || u.user_id || u.userId || u.id)) {
+            userId = String(u.user_no || u.user_id || u.userId || u.id);
+            break;
+          }
+          for (const v of Object.values(node)) if (v && typeof v === 'object') stack.push(v);
+        }
+      } catch {}
+      if (!userId) {
+        const el = document.querySelector('[data-user-no], [data-user_no]');
+        userId = el?.getAttribute('data-user-no') || el?.getAttribute('data-user_no') || '';
+      }
+      return { ok: true, user_id: userId };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('band.us', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Band probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id };
+}
+
+registerSiteAuthCommands({
+  site: 'band',
+  domain: 'band.us',
+  loginUrl: 'https://auth.band.us/login',
+  columns: ['user_id'],
+  verify: verifyBandIdentity,
+  poll: async (page) => {
+    if (!await hasBandSessionCookie(page)) {
+      throw new AuthRequiredError('band.us', 'Waiting for Band band_session cookie');
+    }
+    return verifyBandIdentity(page);
+  },
+});

--- a/clis/boss/auth.js
+++ b/clis/boss/auth.js
@@ -28,18 +28,14 @@ async function verifyBossIdentity(page) {
   `);
   if (probe?.kind === 'auth') throw new AuthRequiredError('zhipin.com', probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected Boss probe: ${JSON.stringify(probe)}`);
-  // wt2 may be httpOnly — read it via CDP, not document.cookie.
-  const after = await page.getCookies({ url: 'https://www.zhipin.com' });
-  const wt2 = after.find(c => c.name === 'wt2')?.value || '';
-  if (!wt2) throw new AuthRequiredError('zhipin.com', 'Boss wt2 cookie empty after auth');
-  return { user_id: wt2, user_type: probe.user_type };
+  return { user_type: probe.user_type };
 }
 
 registerSiteAuthCommands({
   site: 'boss',
   domain: 'zhipin.com',
   loginUrl: 'https://login.zhipin.com/',
-  columns: ['user_id', 'user_type'],
+  columns: ['user_type'],
   verify: verifyBossIdentity,
   poll: async (page) => {
     if (!await hasBossSessionCookie(page)) {

--- a/clis/boss/auth.js
+++ b/clis/boss/auth.js
@@ -1,0 +1,48 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasBossSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.zhipin.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('wt2') || names.has('t');
+}
+
+async function verifyBossIdentity(page) {
+  if (!await hasBossSessionCookie(page)) {
+    throw new AuthRequiredError('zhipin.com', 'Boss wt2 / t cookies missing');
+  }
+  await page.goto('https://www.zhipin.com/web/geek/job-recommend');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      const path = location.pathname || '';
+      if (/\\/web\\/user\\/login|\\/login\\.html/.test(location.href)) {
+        return { kind: 'auth', detail: 'Boss redirected to login page' };
+      }
+      const userType = /\\/web\\/geek\\//.test(path) ? 'geek' : /\\/web\\/(boss|recruit|chat\\/boss)/.test(path) ? 'recruiter' : '';
+      if (!userType) {
+        return { kind: 'auth', detail: 'Boss path does not look like authenticated geek/recruiter page: ' + path };
+      }
+      const wt2 = (document.cookie.split('; ').find(c => c.startsWith('wt2=')) || '').split('=')[1] || '';
+      return { ok: true, user_id: wt2, user_type: userType };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('zhipin.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Boss probe: ${JSON.stringify(probe)}`);
+  if (!probe.user_id) throw new AuthRequiredError('zhipin.com', 'Boss wt2 cookie empty');
+  return { user_id: probe.user_id, user_type: probe.user_type };
+}
+
+registerSiteAuthCommands({
+  site: 'boss',
+  domain: 'zhipin.com',
+  loginUrl: 'https://login.zhipin.com/',
+  columns: ['user_id', 'user_type'],
+  verify: verifyBossIdentity,
+  poll: async (page) => {
+    if (!await hasBossSessionCookie(page)) {
+      throw new AuthRequiredError('zhipin.com', 'Waiting for Boss wt2 / t cookies');
+    }
+    return verifyBossIdentity(page);
+  },
+});

--- a/clis/boss/auth.js
+++ b/clis/boss/auth.js
@@ -23,14 +23,16 @@ async function verifyBossIdentity(page) {
       if (!userType) {
         return { kind: 'auth', detail: 'Boss path does not look like authenticated geek/recruiter page: ' + path };
       }
-      const wt2 = (document.cookie.split('; ').find(c => c.startsWith('wt2=')) || '').split('=')[1] || '';
-      return { ok: true, user_id: wt2, user_type: userType };
+      return { ok: true, user_type: userType };
     })()
   `);
   if (probe?.kind === 'auth') throw new AuthRequiredError('zhipin.com', probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected Boss probe: ${JSON.stringify(probe)}`);
-  if (!probe.user_id) throw new AuthRequiredError('zhipin.com', 'Boss wt2 cookie empty');
-  return { user_id: probe.user_id, user_type: probe.user_type };
+  // wt2 may be httpOnly — read it via CDP, not document.cookie.
+  const after = await page.getCookies({ url: 'https://www.zhipin.com' });
+  const wt2 = after.find(c => c.name === 'wt2')?.value || '';
+  if (!wt2) throw new AuthRequiredError('zhipin.com', 'Boss wt2 cookie empty after auth');
+  return { user_id: wt2, user_type: probe.user_type };
 }
 
 registerSiteAuthCommands({

--- a/clis/chaoxing/auth.js
+++ b/clis/chaoxing/auth.js
@@ -1,0 +1,53 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasChaoxingSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://i.chaoxing.com' });
+  return cookies.some(c => /^(UID|_uid|chaoxinguser|cx_p_token)$/i.test(c.name) && c.value);
+}
+
+async function verifyChaoxingIdentity(page) {
+  if (!await hasChaoxingSessionCookie(page)) {
+    throw new AuthRequiredError('chaoxing.com', 'Chaoxing session cookies missing');
+  }
+  await page.goto('https://i.chaoxing.com/');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/passport2\\.chaoxing\\.com\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: 'Chaoxing i.chaoxing.com redirected to passport2 login' };
+      }
+      const userIdCookie = (document.cookie.split('; ').find(c => /^(_uid|UID)=/.test(c)) || '').split('=')[1] || '';
+      let userName = '';
+      const unameCookie = (document.cookie.split('; ').find(c => /^uname=/.test(c)) || '').split('=')[1] || '';
+      if (unameCookie) {
+        try { userName = decodeURIComponent(unameCookie); } catch { userName = unameCookie; }
+      }
+      if (!userName) {
+        const el = document.querySelector('.userTitle, .myInfo, .user-name, [class*=userName]');
+        userName = (el?.innerText || '').trim();
+      }
+      if (!userIdCookie && !userName) {
+        return { kind: 'auth', detail: 'Chaoxing i.chaoxing.com no user identity surface — anonymous' };
+      }
+      return { ok: true, user_id: userIdCookie, name: userName };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('chaoxing.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Chaoxing probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'chaoxing',
+  domain: 'chaoxing.com',
+  loginUrl: 'https://passport2.chaoxing.com/login?fid=&newversion=true&refer=https%3A%2F%2Fi.chaoxing.com',
+  columns: ['user_id', 'name'],
+  verify: verifyChaoxingIdentity,
+  poll: async (page) => {
+    if (!await hasChaoxingSessionCookie(page)) {
+      throw new AuthRequiredError('chaoxing.com', 'Waiting for Chaoxing session cookies');
+    }
+    return verifyChaoxingIdentity(page);
+  },
+});

--- a/clis/chatgpt/auth.js
+++ b/clis/chatgpt/auth.js
@@ -1,0 +1,51 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasChatgptSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://chatgpt.com' });
+  return cookies.some(c => c.name === '__Secure-next-auth.session-token' && c.value);
+}
+
+async function verifyChatgptIdentity(page) {
+  if (!await hasChatgptSessionCookie(page)) {
+    throw new AuthRequiredError('chatgpt.com', 'ChatGPT __Secure-next-auth.session-token cookie missing');
+  }
+  await page.goto('https://chatgpt.com/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/api/auth/session', { credentials: 'include' });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'ChatGPT /api/auth/session HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const user = d && d.user;
+      if (!user || !user.id) {
+        return { kind: 'auth', detail: 'ChatGPT /api/auth/session has no user — anonymous' };
+      }
+      return { ok: true, user_id: String(user.id), email: String(user.email || ''), name: String(user.name || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('chatgpt.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/auth/session`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`ChatGPT whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected ChatGPT probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name, email: result.email };
+}
+
+registerSiteAuthCommands({
+  site: 'chatgpt',
+  domain: 'chatgpt.com',
+  loginUrl: 'https://auth.openai.com/log-in',
+  columns: ['user_id', 'name', 'email'],
+  verify: verifyChatgptIdentity,
+  poll: async (page) => {
+    if (!await hasChatgptSessionCookie(page)) {
+      throw new AuthRequiredError('chatgpt.com', 'Waiting for ChatGPT session cookie');
+    }
+    return verifyChatgptIdentity(page);
+  },
+});

--- a/clis/chatgpt/auth.js
+++ b/clis/chatgpt/auth.js
@@ -24,7 +24,7 @@ async function verifyChatgptIdentity(page) {
       if (!user || !user.id) {
         return { kind: 'auth', detail: 'ChatGPT /api/auth/session has no user — anonymous' };
       }
-      return { ok: true, user_id: String(user.id), email: String(user.email || ''), name: String(user.name || '') };
+      return { ok: true, user_id: String(user.id), name: String(user.name || '') };
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
@@ -33,14 +33,14 @@ async function verifyChatgptIdentity(page) {
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/auth/session`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`ChatGPT whoami failed: ${result.detail}`);
   if (!result?.ok) throw new CommandExecutionError(`Unexpected ChatGPT probe: ${JSON.stringify(result)}`);
-  return { user_id: result.user_id, name: result.name, email: result.email };
+  return { user_id: result.user_id, name: result.name };
 }
 
 registerSiteAuthCommands({
   site: 'chatgpt',
   domain: 'chatgpt.com',
   loginUrl: 'https://auth.openai.com/log-in',
-  columns: ['user_id', 'name', 'email'],
+  columns: ['user_id', 'name'],
   verify: verifyChatgptIdentity,
   poll: async (page) => {
     if (!await hasChatgptSessionCookie(page)) {

--- a/clis/claude/auth.js
+++ b/clis/claude/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasClaudeSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://claude.ai' });
+  return cookies.some(c => c.name === 'sessionKey' && c.value);
+}
+
+async function verifyClaudeIdentity(page) {
+  if (!await hasClaudeSessionCookie(page)) {
+    throw new AuthRequiredError('claude.ai', 'Claude sessionKey cookie missing');
+  }
+  await page.goto('https://claude.ai/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/api/organizations', { credentials: 'include' });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Claude /api/organizations HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      if (!Array.isArray(d) || d.length === 0) {
+        return { kind: 'auth', detail: 'Claude /api/organizations empty' };
+      }
+      const userIdCookie = (document.cookie.split('; ').find(c => c.startsWith('ajs_user_id=')) || '').split('=')[1] || '';
+      const activeOrgCookie = (document.cookie.split('; ').find(c => c.startsWith('lastActiveOrg=')) || '').split('=')[1] || '';
+      const activeOrg = d.find(o => o.uuid === activeOrgCookie) || d[0];
+      return { ok: true, user_id: userIdCookie, org_name: activeOrg.name || '', org_uuid: activeOrg.uuid || '' };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('claude.ai', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/organizations`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Claude whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Claude probe: ${JSON.stringify(result)}`);
+  if (!result.user_id) throw new AuthRequiredError('claude.ai', 'Claude session incomplete — ajs_user_id cookie missing');
+  return { user_id: String(result.user_id), org_name: String(result.org_name), org_uuid: String(result.org_uuid) };
+}
+
+registerSiteAuthCommands({
+  site: 'claude',
+  domain: 'claude.ai',
+  loginUrl: 'https://claude.ai/login',
+  columns: ['user_id', 'org_name', 'org_uuid'],
+  verify: verifyClaudeIdentity,
+  poll: async (page) => {
+    if (!await hasClaudeSessionCookie(page)) {
+      throw new AuthRequiredError('claude.ai', 'Waiting for Claude sessionKey cookie');
+    }
+    return verifyClaudeIdentity(page);
+  },
+});

--- a/clis/coupang/auth.js
+++ b/clis/coupang/auth.js
@@ -1,0 +1,48 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasCoupangSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.coupang.com' });
+  return cookies.some(c => /^(AID|MEMBER_ID|LMSESSIONID)$/.test(c.name) && c.value);
+}
+
+async function verifyCoupangIdentity(page) {
+  if (!await hasCoupangSessionCookie(page)) {
+    throw new AuthRequiredError('coupang.com', 'Coupang session cookies (AID/MEMBER_ID/LMSESSIONID) missing');
+  }
+  await page.goto('https://www.coupang.com/np/mypage');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/login\\.coupang\\.com\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: 'Coupang mypage redirected to login — anonymous' };
+      }
+      if (/Access Denied/i.test(document.title)) {
+        return { kind: 'auth', detail: 'Coupang Access Denied — anti-bot or non-KR IP' };
+      }
+      const el = document.querySelector('.my-nickname, .member-name, .mp-user-info-name, [class*=memberName]');
+      const name = (el?.textContent || '').trim();
+      if (!name) {
+        return { kind: 'auth', detail: 'Coupang mypage 200 but no member-name surface' };
+      }
+      return { ok: true, name };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('coupang.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Coupang probe: ${JSON.stringify(probe)}`);
+  return { name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'coupang',
+  domain: 'coupang.com',
+  loginUrl: 'https://login.coupang.com/login/login.pang',
+  columns: ['name'],
+  verify: verifyCoupangIdentity,
+  poll: async (page) => {
+    if (!await hasCoupangSessionCookie(page)) {
+      throw new AuthRequiredError('coupang.com', 'Waiting for Coupang session cookies');
+    }
+    return verifyCoupangIdentity(page);
+  },
+});

--- a/clis/ctrip/auth.js
+++ b/clis/ctrip/auth.js
@@ -1,0 +1,49 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasCtripLoginUid(page) {
+  const cookies = await page.getCookies({ url: 'https://www.ctrip.com' });
+  const loginUid = cookies.find(c => c.name === 'login_uid');
+  return Boolean(loginUid && loginUid.value);
+}
+
+async function verifyCtripIdentity(page) {
+  if (!await hasCtripLoginUid(page)) {
+    throw new AuthRequiredError('ctrip.com', 'Ctrip login_uid cookie missing — anonymous');
+  }
+  await page.goto('https://my.ctrip.com/myinfo/MyInfoIndex.aspx');
+  await page.wait(2);
+  const cookies = await page.getCookies({ url: 'https://www.ctrip.com' });
+  const cookieMap = Object.fromEntries(cookies.map(c => [c.name, c.value]));
+  const loginUid = cookieMap['login_uid'] || '';
+  if (!loginUid) {
+    throw new AuthRequiredError('ctrip.com', 'Ctrip login_uid cookie absent after navigation');
+  }
+  const aheadRaw = cookieMap['AHeadUserInfo'] || '';
+  const params = new URLSearchParams(aheadRaw);
+  const userNameRaw = params.get('UserName') || '';
+  let userName = '';
+  if (userNameRaw) {
+    try {
+      userName = decodeURIComponent(userNameRaw);
+    } catch {
+      userName = userNameRaw;
+    }
+  }
+  const vipGrade = params.get('VipGrade') || '';
+  return { user_id: loginUid, name: userName, vip_grade: vipGrade };
+}
+
+registerSiteAuthCommands({
+  site: 'ctrip',
+  domain: 'ctrip.com',
+  loginUrl: 'https://passport.ctrip.com/user/login',
+  columns: ['user_id', 'name', 'vip_grade'],
+  verify: verifyCtripIdentity,
+  poll: async (page) => {
+    if (!await hasCtripLoginUid(page)) {
+      throw new AuthRequiredError('ctrip.com', 'Waiting for Ctrip login_uid cookie');
+    }
+    return verifyCtripIdentity(page);
+  },
+});

--- a/clis/deepseek/auth.js
+++ b/clis/deepseek/auth.js
@@ -20,7 +20,7 @@ const WHOAMI_PROBE = `(async () => {
     if (!d || d.code !== 0) return { kind: 'auth', detail: 'DeepSeek users/current code=' + String(d && d.code) + ' — anonymous' };
     const u = (d.data && (d.data.biz_data || d.data.user || d.data)) || {};
     const userId = String(u.id || u.user_id || u.uuid || '');
-    const name = String(u.name || u.nickname || u.username || u.email || '');
+    const name = String(u.name || u.nickname || u.username || '');
     if (!userId && !name) return { kind: 'render-error', detail: 'DeepSeek users/current ok but no id/name field — response shape drift' };
     return { ok: true, user_id: userId, name };
   } catch (e) {

--- a/clis/deepseek/auth.js
+++ b/clis/deepseek/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// DeepSeek authenticates via a Bearer token stored in localStorage (userToken),
+// not a cookie, so credentials:include alone returns code 40002 (anonymous).
+// The probe reads the token and calls the confirmed /api/v0/users/current
+// endpoint (anonymous → HTTP 200 + body code 40002).
+const WHOAMI_PROBE = `(async () => {
+  try {
+    let token = '';
+    const raw = localStorage.getItem('userToken');
+    if (raw) { try { token = JSON.parse(raw).value || ''; } catch { token = raw; } }
+    if (!token) return { kind: 'auth', detail: 'DeepSeek userToken missing from localStorage — anonymous' };
+    const r = await fetch('/api/v0/users/current', {
+      headers: { Authorization: 'Bearer ' + token, Accept: 'application/json' },
+    });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'DeepSeek users/current HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    if (!d || d.code !== 0) return { kind: 'auth', detail: 'DeepSeek users/current code=' + String(d && d.code) + ' — anonymous' };
+    const u = (d.data && (d.data.biz_data || d.data.user || d.data)) || {};
+    const userId = String(u.id || u.user_id || u.uuid || '');
+    const name = String(u.name || u.nickname || u.username || u.email || '');
+    if (!userId && !name) return { kind: 'render-error', detail: 'DeepSeek users/current ok but no id/name field — response shape drift' };
+    return { ok: true, user_id: userId, name };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyDeepseekIdentity(page) {
+  await page.goto('https://chat.deepseek.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('chat.deepseek.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from DeepSeek users/current`);
+  if (probe?.kind === 'render-error') throw new CommandExecutionError(probe.detail);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`DeepSeek whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected DeepSeek probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'deepseek',
+  domain: 'chat.deepseek.com',
+  loginUrl: 'https://chat.deepseek.com/sign_in',
+  columns: ['user_id', 'name'],
+  verify: verifyDeepseekIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('chat.deepseek.com', 'Waiting for DeepSeek login');
+    return { user_id: probe.user_id, name: probe.name };
+  },
+});

--- a/clis/dianping/auth.js
+++ b/clis/dianping/auth.js
@@ -1,0 +1,48 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasDianpingSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.dianping.com' });
+  return cookies.some(c => c.name === 'dper' && c.value);
+}
+
+async function verifyDianpingIdentity(page) {
+  if (!await hasDianpingSessionCookie(page)) {
+    throw new AuthRequiredError('dianping.com', 'Dianping dper cookie missing');
+  }
+  await page.goto('https://www.dianping.com/member/myinformation');
+  await page.wait(2);
+  const finalUrl = await page.evaluate(`location.href`);
+  if (/account\.dianping\.com\/(pc)?login/.test(String(finalUrl || ''))) {
+    throw new AuthRequiredError('dianping.com', `Dianping member page redirected to login: ${finalUrl}`);
+  }
+  const info = await page.evaluate(`
+    (() => {
+      const nicknameEl = document.querySelector('.user-name, .username, .nickname, .user-info .name');
+      const nickname = (nicknameEl?.textContent || '').trim();
+      const profileLink = Array.from(document.querySelectorAll('a[href*="/member/"]'))
+        .map(a => a.getAttribute('href') || '')
+        .find(h => /\\/member\\/\\d+/.test(h));
+      const uidMatch = String(profileLink || '').match(/\\/member\\/(\\d+)/);
+      return { user_id: uidMatch?.[1] || '', nickname };
+    })()
+  `);
+  if (!info?.user_id) {
+    throw new CommandExecutionError('Dianping member page rendered but no user_id link found — stale dper or layout drift');
+  }
+  return { user_id: String(info.user_id), nickname: String(info.nickname || '') };
+}
+
+registerSiteAuthCommands({
+  site: 'dianping',
+  domain: 'dianping.com',
+  loginUrl: 'https://account.dianping.com/pclogin',
+  columns: ['user_id', 'nickname'],
+  verify: verifyDianpingIdentity,
+  poll: async (page) => {
+    if (!await hasDianpingSessionCookie(page)) {
+      throw new AuthRequiredError('dianping.com', 'Waiting for Dianping dper cookie');
+    }
+    return verifyDianpingIdentity(page);
+  },
+});

--- a/clis/douban/auth.js
+++ b/clis/douban/auth.js
@@ -1,0 +1,49 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasDoubanSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.douban.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('dbcl2') || names.has('ck');
+}
+
+async function verifyDoubanIdentity(page) {
+  if (!await hasDoubanSessionCookie(page)) {
+    throw new AuthRequiredError('douban.com', 'Douban dbcl2 / ck cookies missing');
+  }
+  await page.goto('https://www.douban.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      const navUser = document.querySelector('.nav-user-account .bn-more, .top-nav-info a.bn-more');
+      if (!navUser) {
+        return { kind: 'auth', detail: 'Douban nav-user element missing — not signed in' };
+      }
+      const href = navUser.getAttribute('href') || '';
+      const m = href.match(/people\\/(\\d+)\\/?/);
+      const user_id = m ? m[1] : '';
+      const name = (navUser.textContent || '').trim();
+      if (!user_id) {
+        return { kind: 'auth', detail: 'Douban user_id parse failed: href=' + href };
+      }
+      return { ok: true, user_id, name };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('douban.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Douban probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'douban',
+  domain: 'douban.com',
+  loginUrl: 'https://accounts.douban.com/passport/login',
+  columns: ['user_id', 'name'],
+  verify: verifyDoubanIdentity,
+  poll: async (page) => {
+    if (!await hasDoubanSessionCookie(page)) {
+      throw new AuthRequiredError('douban.com', 'Waiting for Douban dbcl2 / ck cookies');
+    }
+    return verifyDoubanIdentity(page);
+  },
+});

--- a/clis/doubao/auth.js
+++ b/clis/doubao/auth.js
@@ -1,0 +1,55 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasDoubaoSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.doubao.com' });
+  return cookies.some(c => c.name === 'passport_csrf_token' && c.value);
+}
+
+async function verifyDoubaoIdentity(page) {
+  if (!await hasDoubaoSessionCookie(page)) {
+    throw new AuthRequiredError('www.doubao.com', 'Doubao passport_csrf_token cookie missing');
+  }
+  await page.goto('https://www.doubao.com/chat/');
+  await page.wait(3);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/passport/account/info/v2/', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Doubao /passport/account/info HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const data = d && d.data;
+      if (!data || !data.user_id_str) {
+        return { kind: 'auth', detail: 'Doubao /passport/account/info returned no user_id_str' };
+      }
+      return {
+        ok: true,
+        user_id: String(data.user_id_str),
+        name: String(data.name || data.screen_name || ''),
+      };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('www.doubao.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /passport/account/info`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Doubao whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Doubao probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name };
+}
+
+registerSiteAuthCommands({
+  site: 'doubao',
+  domain: 'www.doubao.com',
+  loginUrl: 'https://www.doubao.com/chat/',
+  columns: ['user_id', 'name'],
+  verify: verifyDoubaoIdentity,
+  poll: async (page) => {
+    if (!await hasDoubaoSessionCookie(page)) {
+      throw new AuthRequiredError('www.doubao.com', 'Waiting for Doubao session cookie');
+    }
+    return verifyDoubaoIdentity(page);
+  },
+});

--- a/clis/doubao/auth.js
+++ b/clis/doubao/auth.js
@@ -46,9 +46,20 @@ registerSiteAuthCommands({
   loginUrl: 'https://www.doubao.com/chat/',
   columns: ['user_id', 'name'],
   verify: verifyDoubaoIdentity,
+  // passport_csrf_token is set for anonymous sessions too, so a cookie gate
+  // would navigate away mid-login. Probe the account API on the current page
+  // (no goto) and only confirm once a real user_id is present.
   poll: async (page) => {
-    if (!await hasDoubaoSessionCookie(page)) {
-      throw new AuthRequiredError('www.doubao.com', 'Waiting for Doubao session cookie');
+    const loggedIn = await page.evaluate(`(async () => {
+      try {
+        const r = await fetch('/passport/account/info/v2/', { credentials: 'include', headers: { Accept: 'application/json' } });
+        if (!r.ok) return false;
+        const d = await r.json();
+        return !!(d?.data?.user_id_str);
+      } catch { return false; }
+    })()`);
+    if (!loggedIn) {
+      throw new AuthRequiredError('www.doubao.com', 'Waiting for Doubao login');
     }
     return verifyDoubaoIdentity(page);
   },

--- a/clis/facebook/auth.js
+++ b/clis/facebook/auth.js
@@ -1,0 +1,42 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasFacebookCUserCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.facebook.com' });
+  return cookies.some(c => c.name === 'c_user' && c.value);
+}
+
+async function verifyFacebookIdentity(page) {
+  if (!await hasFacebookCUserCookie(page)) {
+    throw new AuthRequiredError('www.facebook.com', 'Facebook c_user cookie missing — anonymous session');
+  }
+  const cookies = await page.getCookies({ url: 'https://www.facebook.com' });
+  const cUser = cookies.find(c => c.name === 'c_user')?.value || '';
+  await page.goto('https://www.facebook.com/me');
+  await page.wait(2);
+  const finalUrl = await page.evaluate(`location.href`);
+  const vanityMatch = String(finalUrl || '').match(/facebook\.com\/([^/?#]+)\/?(?:$|[?#])/);
+  const vanity = vanityMatch?.[1] || '';
+  if (!vanity || vanity === 'login.php' || vanity === 'checkpoint') {
+    throw new AuthRequiredError('www.facebook.com', `Facebook /me redirected to ${finalUrl} — logged out or in checkpoint`);
+  }
+  return {
+    user_id: String(cUser),
+    vanity: String(vanity),
+    profile_url: `https://www.facebook.com/${vanity}/`,
+  };
+}
+
+registerSiteAuthCommands({
+  site: 'facebook',
+  domain: 'facebook.com',
+  loginUrl: 'https://www.facebook.com/login.php',
+  columns: ['user_id', 'vanity', 'profile_url'],
+  verify: verifyFacebookIdentity,
+  poll: async (page) => {
+    if (!await hasFacebookCUserCookie(page)) {
+      throw new AuthRequiredError('www.facebook.com', 'Waiting for Facebook c_user cookie');
+    }
+    return verifyFacebookIdentity(page);
+  },
+});

--- a/clis/flomo/auth.js
+++ b/clis/flomo/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasFlomoSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://flomoapp.com' });
+  return cookies.some(c => c.name === 'flomo' && c.value);
+}
+
+async function verifyFlomoIdentity(page) {
+  if (!await hasFlomoSessionCookie(page)) {
+    throw new AuthRequiredError('flomoapp.com', 'Flomo session cookie missing');
+  }
+  await page.goto('https://v.flomoapp.com/mine');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/\\/login(\\b|$|\\?)/.test(location.href)) {
+        return { kind: 'auth', detail: 'Flomo /mine redirected to /login' };
+      }
+      let userId = '';
+      try {
+        const stack = [window.__INITIAL_STATE__, window.__NUXT__, window.__PINIA__].filter(Boolean);
+        const seen = new Set();
+        while (stack.length) {
+          const node = stack.pop();
+          if (!node || typeof node !== 'object' || seen.has(node)) continue;
+          seen.add(node);
+          if (Array.isArray(node)) { stack.push(...node); continue; }
+          const u = node.user || node.userInfo || node.currentUser;
+          if (u && (u.id || u.user_id || u.uid)) { userId = String(u.id || u.user_id || u.uid); break; }
+          for (const v of Object.values(node)) if (v && typeof v === 'object') stack.push(v);
+        }
+      } catch {}
+      return { ok: true, user_id: userId };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('flomoapp.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Flomo probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id };
+}
+
+registerSiteAuthCommands({
+  site: 'flomo',
+  domain: 'flomoapp.com',
+  loginUrl: 'https://v.flomoapp.com/login',
+  columns: ['user_id'],
+  verify: verifyFlomoIdentity,
+  poll: async (page) => {
+    if (!await hasFlomoSessionCookie(page)) {
+      throw new AuthRequiredError('flomoapp.com', 'Waiting for Flomo session cookie');
+    }
+    return verifyFlomoIdentity(page);
+  },
+});

--- a/clis/gemini/auth.js
+++ b/clis/gemini/auth.js
@@ -1,0 +1,47 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasGoogleSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://gemini.google.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('SID') || names.has('SAPISID') || names.has('__Secure-1PSID');
+}
+
+async function verifyGeminiIdentity(page) {
+  if (!await hasGoogleSessionCookie(page)) {
+    throw new AuthRequiredError('gemini.google.com', 'Google session cookies (SID / SAPISID) missing');
+  }
+  await page.goto('https://gemini.google.com/app');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      const a = document.querySelector('a[aria-label^="Google Account:"]');
+      if (!a) {
+        return { kind: 'auth', detail: 'Gemini account link missing — not signed into Google' };
+      }
+      const label = a.getAttribute('aria-label') || '';
+      const m = label.match(/Google Account:\\s*([^(]+?)\\s*\\(([^)]+)\\)/);
+      if (!m) {
+        return { kind: 'auth', detail: 'Gemini aria-label unparseable: ' + label };
+      }
+      return { ok: true, name: m[1].trim(), email: m[2].trim() };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('gemini.google.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Gemini probe: ${JSON.stringify(probe)}`);
+  return { name: probe.name, email: probe.email };
+}
+
+registerSiteAuthCommands({
+  site: 'gemini',
+  domain: 'gemini.google.com',
+  loginUrl: 'https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fgemini.google.com%2F',
+  columns: ['name', 'email'],
+  verify: verifyGeminiIdentity,
+  poll: async (page) => {
+    if (!await hasGoogleSessionCookie(page)) {
+      throw new AuthRequiredError('gemini.google.com', 'Waiting for Google session cookies');
+    }
+    return verifyGeminiIdentity(page);
+  },
+});

--- a/clis/gemini/auth.js
+++ b/clis/gemini/auth.js
@@ -24,19 +24,19 @@ async function verifyGeminiIdentity(page) {
       if (!m) {
         return { kind: 'auth', detail: 'Gemini aria-label unparseable: ' + label };
       }
-      return { ok: true, name: m[1].trim(), email: m[2].trim() };
+      return { ok: true, name: m[1].trim() };
     })()
   `);
   if (probe?.kind === 'auth') throw new AuthRequiredError('gemini.google.com', probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected Gemini probe: ${JSON.stringify(probe)}`);
-  return { name: probe.name, email: probe.email };
+  return { name: probe.name };
 }
 
 registerSiteAuthCommands({
   site: 'gemini',
   domain: 'gemini.google.com',
   loginUrl: 'https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fgemini.google.com%2F',
-  columns: ['name', 'email'],
+  columns: ['name'],
   verify: verifyGeminiIdentity,
   poll: async (page) => {
     if (!await hasGoogleSessionCookie(page)) {

--- a/clis/gitee/auth.js
+++ b/clis/gitee/auth.js
@@ -1,0 +1,41 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Gitee's logged-in cookie (gitee-session-n) is httpOnly and its exact name
+// rotates, so the poll uses a no-navigation API probe instead of a cookie gate.
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const r = await fetch('/api/v5/user', { credentials: 'include', headers: { Accept: 'application/json' } });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Gitee /api/v5/user HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    if (!d || !d.id || !d.login) return { kind: 'auth', detail: 'Gitee /api/v5/user has no id/login — anonymous' };
+    return { ok: true, user_id: String(d.id), username: String(d.login), name: String(d.name || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyGiteeIdentity(page) {
+  await page.goto('https://gitee.com/');
+  await page.wait(1);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('gitee.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Gitee /api/v5/user`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Gitee whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Gitee probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, username: probe.username, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'gitee',
+  domain: 'gitee.com',
+  loginUrl: 'https://gitee.com/login',
+  columns: ['user_id', 'username', 'name'],
+  verify: verifyGiteeIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('gitee.com', 'Waiting for Gitee login');
+    return { user_id: probe.user_id, username: probe.username, name: probe.name };
+  },
+});

--- a/clis/grok/auth.js
+++ b/clis/grok/auth.js
@@ -1,0 +1,51 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasGrokSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://grok.com' });
+  return cookies.some(c => c.name === '__Secure-next-auth.session-token' && c.value);
+}
+
+async function verifyGrokIdentity(page) {
+  if (!await hasGrokSessionCookie(page)) {
+    throw new AuthRequiredError('grok.com', 'Grok __Secure-next-auth.session-token cookie missing');
+  }
+  await page.goto('https://grok.com/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/api/auth/session', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Grok /api/auth/session HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const user = d && d.user;
+      if (!user || !user.id) {
+        return { kind: 'auth', detail: 'Grok /api/auth/session has no user — anonymous' };
+      }
+      return { ok: true, user_id: String(user.id), name: String(user.name || ''), email: String(user.email || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('grok.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/auth/session`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Grok whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Grok probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name, email: result.email };
+}
+
+registerSiteAuthCommands({
+  site: 'grok',
+  domain: 'grok.com',
+  loginUrl: 'https://grok.com/auth/sign-in',
+  columns: ['user_id', 'name', 'email'],
+  verify: verifyGrokIdentity,
+  poll: async (page) => {
+    if (!await hasGrokSessionCookie(page)) {
+      throw new AuthRequiredError('grok.com', 'Waiting for Grok session cookie');
+    }
+    return verifyGrokIdentity(page);
+  },
+});

--- a/clis/grok/auth.js
+++ b/clis/grok/auth.js
@@ -24,7 +24,7 @@ async function verifyGrokIdentity(page) {
       if (!user || !user.id) {
         return { kind: 'auth', detail: 'Grok /api/auth/session has no user — anonymous' };
       }
-      return { ok: true, user_id: String(user.id), name: String(user.name || ''), email: String(user.email || '') };
+      return { ok: true, user_id: String(user.id), name: String(user.name || '') };
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
@@ -33,14 +33,14 @@ async function verifyGrokIdentity(page) {
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/auth/session`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`Grok whoami failed: ${result.detail}`);
   if (!result?.ok) throw new CommandExecutionError(`Unexpected Grok probe: ${JSON.stringify(result)}`);
-  return { user_id: result.user_id, name: result.name, email: result.email };
+  return { user_id: result.user_id, name: result.name };
 }
 
 registerSiteAuthCommands({
   site: 'grok',
   domain: 'grok.com',
   loginUrl: 'https://grok.com/auth/sign-in',
-  columns: ['user_id', 'name', 'email'],
+  columns: ['user_id', 'name'],
   verify: verifyGrokIdentity,
   poll: async (page) => {
     if (!await hasGrokSessionCookie(page)) {

--- a/clis/hf/auth.js
+++ b/clis/hf/auth.js
@@ -1,0 +1,41 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Hugging Face's `token` cookie is httpOnly; gate the login poll on the
+// documented /api/whoami-v2 endpoint (401 when anonymous) via a no-nav probe.
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const r = await fetch('/api/whoami-v2', { credentials: 'include', headers: { Accept: 'application/json' } });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'HF /api/whoami-v2 HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    if (!d || !d.name || d.type === undefined) return { kind: 'auth', detail: 'HF /api/whoami-v2 has no name — anonymous' };
+    return { ok: true, username: String(d.name), fullname: String(d.fullname || ''), type: String(d.type || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyHfIdentity(page) {
+  await page.goto('https://huggingface.co/');
+  await page.wait(1);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('huggingface.co', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from HF /api/whoami-v2`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`HF whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected HF probe: ${JSON.stringify(probe)}`);
+  return { username: probe.username, fullname: probe.fullname, type: probe.type };
+}
+
+registerSiteAuthCommands({
+  site: 'hf',
+  domain: 'huggingface.co',
+  loginUrl: 'https://huggingface.co/login',
+  columns: ['username', 'fullname', 'type'],
+  verify: verifyHfIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('huggingface.co', 'Waiting for Hugging Face login');
+    return { username: probe.username, fullname: probe.fullname, type: probe.type };
+  },
+});

--- a/clis/hupu/auth.js
+++ b/clis/hupu/auth.js
@@ -1,0 +1,46 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasHupuUserCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://my.hupu.com' });
+  return cookies.some(c => c.name === 'u' && c.value);
+}
+
+async function verifyHupuIdentity(page) {
+  if (!await hasHupuUserCookie(page)) {
+    throw new AuthRequiredError('hupu.com', 'Hupu u cookie missing — anonymous');
+  }
+  await page.goto('https://my.hupu.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/passport\\.hupu\\.com\\/.*login/.test(location.href)) {
+        return { kind: 'auth', detail: 'Hupu my page redirected to passport login' };
+      }
+      const uCookie = (document.cookie.split('; ').find(c => c.startsWith('u=')) || '').split('=')[1] || '';
+      const el = document.querySelector('.user-name, .username, .nick, [class*="userName"]');
+      const username = (el?.innerText || '').trim();
+      if (!uCookie) {
+        return { kind: 'auth', detail: 'Hupu my page rendered but u cookie absent — stale session' };
+      }
+      return { ok: true, user_id: uCookie, username };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('hupu.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Hupu probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, username: probe.username };
+}
+
+registerSiteAuthCommands({
+  site: 'hupu',
+  domain: 'hupu.com',
+  loginUrl: 'https://passport.hupu.com/pc/login',
+  columns: ['user_id', 'username'],
+  verify: verifyHupuIdentity,
+  poll: async (page) => {
+    if (!await hasHupuUserCookie(page)) {
+      throw new AuthRequiredError('hupu.com', 'Waiting for Hupu u cookie');
+    }
+    return verifyHupuIdentity(page);
+  },
+});

--- a/clis/instagram/auth.js
+++ b/clis/instagram/auth.js
@@ -1,0 +1,56 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasInstagramSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.instagram.com' });
+  return cookies.some(c => c.name === 'sessionid' && c.value);
+}
+
+async function verifyInstagramIdentity(page) {
+  if (!await hasInstagramSessionCookie(page)) {
+    throw new AuthRequiredError('www.instagram.com', 'Instagram sessionid cookie missing');
+  }
+  await page.goto('https://www.instagram.com/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const uid = (document.cookie.split('; ').find(c => c.startsWith('ds_user_id=')) || '').split('=')[1] || '';
+      if (!uid) return { kind: 'auth', detail: 'Instagram ds_user_id cookie missing' };
+      const r = await fetch('/api/v1/users/' + uid + '/info/', {
+        credentials: 'include',
+        headers: { 'X-IG-App-ID': '936619743392459', 'Accept': 'application/json' },
+      });
+      if (r.status === 401 || r.status === 403) {
+        return { kind: 'auth', detail: 'Instagram /users/info HTTP ' + r.status };
+      }
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      const user = d?.user;
+      if (!user || !user.pk) {
+        return { kind: 'auth', detail: 'Instagram /users/info returned no pk — session likely expired' };
+      }
+      return { ok: true, user_id: String(user.pk), username: String(user.username || ''), full_name: String(user.full_name || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('www.instagram.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from Instagram /users/info`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Instagram whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Instagram probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, username: result.username, full_name: result.full_name };
+}
+
+registerSiteAuthCommands({
+  site: 'instagram',
+  domain: 'instagram.com',
+  loginUrl: 'https://www.instagram.com/accounts/login/',
+  columns: ['user_id', 'username', 'full_name'],
+  verify: verifyInstagramIdentity,
+  poll: async (page) => {
+    if (!await hasInstagramSessionCookie(page)) {
+      throw new AuthRequiredError('www.instagram.com', 'Waiting for Instagram sessionid cookie');
+    }
+    return verifyInstagramIdentity(page);
+  },
+});

--- a/clis/jd/auth.js
+++ b/clis/jd/auth.js
@@ -1,0 +1,45 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasJdSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.jd.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('pin') || names.has('thor');
+}
+
+async function verifyJdIdentity(page) {
+  if (!await hasJdSessionCookie(page)) {
+    throw new AuthRequiredError('jd.com', 'JD pin / thor cookie missing');
+  }
+  await page.goto('https://home.jd.com/');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      const pinCookie = (document.cookie.split('; ').find(c => c.startsWith('pin=')) || '').split('=')[1] || '';
+      const decoded = pinCookie ? decodeURIComponent(pinCookie) : '';
+      if (!decoded) {
+        return { kind: 'auth', detail: 'JD pin cookie empty after decode' };
+      }
+      const nickEl = document.querySelector('.user-info, #aliveUserName, .name, .user-name');
+      const nickname = (nickEl && nickEl.textContent && nickEl.textContent.trim()) || '';
+      return { ok: true, pin: decoded, nickname };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('jd.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected JD probe: ${JSON.stringify(probe)}`);
+  return { pin: probe.pin, nickname: probe.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'jd',
+  domain: 'jd.com',
+  loginUrl: 'https://passport.jd.com/new/login.aspx',
+  columns: ['pin', 'nickname'],
+  verify: verifyJdIdentity,
+  poll: async (page) => {
+    if (!await hasJdSessionCookie(page)) {
+      throw new AuthRequiredError('jd.com', 'Waiting for JD pin / thor cookie');
+    }
+    return verifyJdIdentity(page);
+  },
+});

--- a/clis/jianyu/auth.js
+++ b/clis/jianyu/auth.js
@@ -1,0 +1,61 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasJianyuUserCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.jianyu360.cn' });
+  return cookies.some(c => c.name === 'userid_secure' && c.value);
+}
+
+async function verifyJianyuIdentity(page) {
+  if (!await hasJianyuUserCookie(page)) {
+    throw new AuthRequiredError('jianyu360.cn', 'Jianyu userid_secure cookie missing — anonymous');
+  }
+  await page.goto('https://www.jianyu360.cn/');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const r = await fetch('/swordfish/frontPage/customer/sess/index', { credentials: 'include' });
+      const text = await r.text();
+      if (/<title>\\s*登录\\s*[-—]\\s*剑鱼标讯/.test(text)) {
+        return { kind: 'auth', detail: 'Jianyu protected page returned login page — anonymous' };
+      }
+      const userIdMeta = text.match(/<meta[^>]+name=[\"'](?:user-id|userId)[\"'][^>]+content=[\"']([^\"']+)[\"']/)?.[1] || '';
+      const userScript = text.match(/window\\.__USER__\\s*=\\s*(\\{[^}]+\\})/)?.[1] || '';
+      let userId = userIdMeta;
+      let name = '';
+      if (userScript) {
+        try {
+          const u = JSON.parse(userScript);
+          userId = userId || String(u.id || u.userId || '');
+          name = String(u.name || u.realName || u.nickName || '');
+        } catch {}
+      }
+      const cookieUid = (document.cookie.split('; ').find(c => c.startsWith('userid_secure=')) || '').split('=')[1] || '';
+      userId = userId || cookieUid;
+      if (!userId && !name) {
+        return { kind: 'auth', detail: 'Jianyu protected page 200 but no user identity surface' };
+      }
+      return { ok: true, user_id: userId, name };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('jianyu360.cn', probe.detail);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Jianyu whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jianyu probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'jianyu',
+  domain: 'jianyu360.cn',
+  loginUrl: 'https://www.jianyu360.cn/',
+  columns: ['user_id', 'name'],
+  verify: verifyJianyuIdentity,
+  poll: async (page) => {
+    if (!await hasJianyuUserCookie(page)) {
+      throw new AuthRequiredError('jianyu360.cn', 'Waiting for Jianyu userid_secure cookie');
+    }
+    return verifyJianyuIdentity(page);
+  },
+});

--- a/clis/ke/auth.js
+++ b/clis/ke/auth.js
@@ -1,0 +1,46 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasKeSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.ke.com' });
+  return cookies.some(c => c.name === 'lianjia_token' && c.value);
+}
+
+async function verifyKeIdentity(page) {
+  if (!await hasKeSessionCookie(page)) {
+    throw new AuthRequiredError('ke.com', 'Ke lianjia_token cookie missing — anonymous');
+  }
+  await page.goto('https://www.ke.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      const loginBtn = document.querySelector('.btn-login, a[class*=actLoginBtn], .login-btn');
+      if (loginBtn && /登录|登陆/.test(loginBtn.innerText || '')) {
+        return { kind: 'auth', detail: 'Ke shows 登录 button — anonymous session' };
+      }
+      const el = document.querySelector('.userNick, .user-name, .myInfo a, [class*=userNick]');
+      const username = (el?.innerText || '').trim();
+      if (!username) {
+        return { kind: 'auth', detail: 'Ke no user-name DOM anchor — anonymous or SSR failed' };
+      }
+      return { ok: true, username };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('ke.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Ke probe: ${JSON.stringify(probe)}`);
+  return { username: probe.username };
+}
+
+registerSiteAuthCommands({
+  site: 'ke',
+  domain: 'ke.com',
+  loginUrl: 'https://clogin.ke.com/login/?service=https%3A%2F%2Fwww.ke.com',
+  columns: ['username'],
+  verify: verifyKeIdentity,
+  poll: async (page) => {
+    if (!await hasKeSessionCookie(page)) {
+      throw new AuthRequiredError('ke.com', 'Waiting for Ke lianjia_token cookie');
+    }
+    return verifyKeIdentity(page);
+  },
+});

--- a/clis/kimi/auth.js
+++ b/clis/kimi/auth.js
@@ -1,0 +1,53 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasKimiSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.kimi.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('access_token') || names.has('refresh_token');
+}
+
+async function verifyKimiIdentity(page) {
+  if (!await hasKimiSessionCookie(page)) {
+    throw new AuthRequiredError('kimi.com', 'Kimi access_token / refresh_token cookies missing');
+  }
+  await page.goto('https://www.kimi.com/');
+  await page.wait(3);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const token = (document.cookie.split('; ').find(c => c.startsWith('access_token=')) || '').split('=')[1] || '';
+      if (!token) return { kind: 'auth', detail: 'Kimi access_token cookie absent in document.cookie' };
+      const res = await fetch('/api/user', { credentials: 'include', headers: { 'Authorization': 'Bearer ' + token, 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Kimi /api/user HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      if (!d || !d.id) {
+        return { kind: 'auth', detail: 'Kimi /api/user returned no id — anonymous' };
+      }
+      return { ok: true, user_id: String(d.id), name: String(d.name || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('kimi.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/user`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Kimi whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Kimi probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name };
+}
+
+registerSiteAuthCommands({
+  site: 'kimi',
+  domain: 'kimi.com',
+  loginUrl: 'https://www.kimi.com/',
+  columns: ['user_id', 'name'],
+  verify: verifyKimiIdentity,
+  poll: async (page) => {
+    if (!await hasKimiSessionCookie(page)) {
+      throw new AuthRequiredError('kimi.com', 'Waiting for Kimi auth cookies');
+    }
+    return verifyKimiIdentity(page);
+  },
+});

--- a/clis/kimi/auth.js
+++ b/clis/kimi/auth.js
@@ -8,15 +8,18 @@ async function hasKimiSessionCookie(page) {
 }
 
 async function verifyKimiIdentity(page) {
-  if (!await hasKimiSessionCookie(page)) {
-    throw new AuthRequiredError('kimi.com', 'Kimi access_token / refresh_token cookies missing');
+  // Source the token via CDP getCookies (works even if access_token is httpOnly,
+  // which document.cookie cannot read).
+  const cookies = await page.getCookies({ url: 'https://www.kimi.com' });
+  const token = cookies.find(c => c.name === 'access_token')?.value || '';
+  if (!token) {
+    throw new AuthRequiredError('kimi.com', 'Kimi access_token cookie missing');
   }
   await page.goto('https://www.kimi.com/');
   await page.wait(3);
   const result = await page.evaluate(`(async () => {
     try {
-      const token = (document.cookie.split('; ').find(c => c.startsWith('access_token=')) || '').split('=')[1] || '';
-      if (!token) return { kind: 'auth', detail: 'Kimi access_token cookie absent in document.cookie' };
+      const token = ${JSON.stringify(token)};
       const res = await fetch('/api/user', { credentials: 'include', headers: { 'Authorization': 'Bearer ' + token, 'Accept': 'application/json' } });
       if (res.status === 401 || res.status === 403) {
         return { kind: 'auth', detail: 'Kimi /api/user HTTP ' + res.status };

--- a/clis/linkedin-learning/auth.js
+++ b/clis/linkedin-learning/auth.js
@@ -1,0 +1,61 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasLinkedinSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  return cookies.some(c => c.name === 'li_at' && c.value);
+}
+
+async function verifyLinkedinLearningIdentity(page) {
+  if (!await hasLinkedinSessionCookie(page)) {
+    throw new AuthRequiredError('linkedin.com', 'LinkedIn li_at cookie missing');
+  }
+  await page.goto('https://www.linkedin.com/learning/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const jsessionRaw = (document.cookie.split('; ').find(c => c.startsWith('JSESSIONID=')) || '').split('=')[1] || '';
+      const csrf = jsessionRaw.replace(/^"|"$/g, '');
+      if (!csrf) return { kind: 'auth', detail: 'LinkedIn JSESSIONID missing — csrf token unavailable' };
+      const res = await fetch('/voyager/api/me', { credentials: 'include', headers: { 'csrf-token': csrf, 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'LinkedIn /voyager/api/me HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const mini = d && d.miniProfile;
+      if (!mini || !mini.publicIdentifier) {
+        return { kind: 'auth', detail: 'LinkedIn /voyager/api/me 200 but miniProfile missing' };
+      }
+      const firstName = (mini.firstName && (mini.firstName.text || mini.firstName)) || '';
+      const lastName = (mini.lastName && (mini.lastName.text || mini.lastName)) || '';
+      return {
+        ok: true,
+        public_id: String(mini.publicIdentifier),
+        plain_id: String(d.plainId || ''),
+        name: String((firstName + ' ' + lastName).trim()),
+      };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('linkedin.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /voyager/api/me`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`LinkedIn Learning whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected LinkedIn Learning probe: ${JSON.stringify(result)}`);
+  return { public_id: result.public_id, plain_id: result.plain_id, name: result.name };
+}
+
+registerSiteAuthCommands({
+  site: 'linkedin-learning',
+  domain: 'linkedin.com',
+  loginUrl: 'https://www.linkedin.com/login?session_redirect=%2Flearning%2F',
+  columns: ['public_id', 'plain_id', 'name'],
+  verify: verifyLinkedinLearningIdentity,
+  poll: async (page) => {
+    if (!await hasLinkedinSessionCookie(page)) {
+      throw new AuthRequiredError('linkedin.com', 'Waiting for LinkedIn li_at cookie');
+    }
+    return verifyLinkedinLearningIdentity(page);
+  },
+});

--- a/clis/linkedin/auth.js
+++ b/clis/linkedin/auth.js
@@ -1,0 +1,61 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasLinkedinSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+  return cookies.some(c => c.name === 'li_at' && c.value);
+}
+
+async function verifyLinkedinIdentity(page) {
+  if (!await hasLinkedinSessionCookie(page)) {
+    throw new AuthRequiredError('linkedin.com', 'LinkedIn li_at cookie missing');
+  }
+  await page.goto('https://www.linkedin.com/feed/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const jsessionRaw = (document.cookie.split('; ').find(c => c.startsWith('JSESSIONID=')) || '').split('=')[1] || '';
+      const csrf = jsessionRaw.replace(/^"|"$/g, '');
+      if (!csrf) return { kind: 'auth', detail: 'LinkedIn JSESSIONID missing — csrf token unavailable' };
+      const res = await fetch('/voyager/api/me', { credentials: 'include', headers: { 'csrf-token': csrf, 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'LinkedIn /voyager/api/me HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const mini = d && d.miniProfile;
+      if (!mini || !mini.publicIdentifier) {
+        return { kind: 'auth', detail: 'LinkedIn /voyager/api/me 200 but miniProfile missing' };
+      }
+      const firstName = (mini.firstName && (mini.firstName.text || mini.firstName)) || '';
+      const lastName = (mini.lastName && (mini.lastName.text || mini.lastName)) || '';
+      return {
+        ok: true,
+        public_id: String(mini.publicIdentifier),
+        plain_id: String(d.plainId || ''),
+        name: String((firstName + ' ' + lastName).trim()),
+      };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('linkedin.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /voyager/api/me`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`LinkedIn whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected LinkedIn probe: ${JSON.stringify(result)}`);
+  return { public_id: result.public_id, plain_id: result.plain_id, name: result.name };
+}
+
+registerSiteAuthCommands({
+  site: 'linkedin',
+  domain: 'www.linkedin.com',
+  loginUrl: 'https://www.linkedin.com/login',
+  columns: ['public_id', 'plain_id', 'name'],
+  verify: verifyLinkedinIdentity,
+  poll: async (page) => {
+    if (!await hasLinkedinSessionCookie(page)) {
+      throw new AuthRequiredError('linkedin.com', 'Waiting for LinkedIn li_at cookie');
+    }
+    return verifyLinkedinIdentity(page);
+  },
+});

--- a/clis/linux-do/auth.js
+++ b/clis/linux-do/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasLinuxDoSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://linux.do' });
+  return cookies.some(c => c.name === '_t' && c.value);
+}
+
+async function verifyLinuxDoIdentity(page) {
+  if (!await hasLinuxDoSessionCookie(page)) {
+    throw new AuthRequiredError('linux.do', 'Linux.do _t cookie missing — anonymous');
+  }
+  await page.goto('https://linux.do/');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const u = document.querySelector('meta[name="current-user-username"]')?.getAttribute('content') || '';
+      if (!u) return { kind: 'auth', detail: 'Linux.do meta[current-user-username] missing — anonymous' };
+      const r = await fetch('/u/' + encodeURIComponent(u) + '.json', {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (r.status === 401 || r.status === 403) {
+        return { kind: 'auth', detail: 'Linux.do /u/<self>.json HTTP ' + r.status };
+      }
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      const user = d?.user;
+      if (!user || !user.id) return { kind: 'auth', detail: 'Linux.do /u/<self>.json missing user.id' };
+      return { ok: true, user_id: String(user.id), username: String(user.username || u), name: String(user.name || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('linux.do', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Linux.do /u/<self>.json`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Linux.do whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Linux.do probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, username: probe.username, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'linux-do',
+  domain: 'linux.do',
+  loginUrl: 'https://linux.do/login',
+  columns: ['user_id', 'username', 'name'],
+  verify: verifyLinuxDoIdentity,
+  poll: async (page) => {
+    if (!await hasLinuxDoSessionCookie(page)) {
+      throw new AuthRequiredError('linux.do', 'Waiting for Linux.do _t cookie');
+    }
+    return verifyLinuxDoIdentity(page);
+  },
+});

--- a/clis/manus/auth.js
+++ b/clis/manus/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasManusSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://manus.im' });
+  return cookies.some(c => /^(auth_session|manus_token|_session|session)$/.test(c.name) && c.value);
+}
+
+async function verifyManusIdentity(page) {
+  if (!await hasManusSessionCookie(page)) {
+    throw new AuthRequiredError('manus.im', 'Manus session cookies missing — anonymous');
+  }
+  await page.goto('https://manus.im/');
+  await page.wait(3);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const r = await fetch('/api/auth/session', { credentials: 'include', headers: { Accept: 'application/json' } });
+      if (r.status === 401 || r.status === 403) {
+        return { kind: 'auth', detail: 'Manus /api/auth/session HTTP ' + r.status };
+      }
+      if (r.status === 503) {
+        return { kind: 'http', httpStatus: 503 };
+      }
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      const u = d?.user || d;
+      if (!u || !(u.id || u.userId)) {
+        return { kind: 'auth', detail: 'Manus /api/auth/session 200 but no user' };
+      }
+      return { ok: true, user_id: String(u.id || u.userId), name: String(u.name || u.displayName || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('manus.im', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Manus /api/auth/session`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Manus whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Manus probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'manus',
+  domain: 'manus.im',
+  loginUrl: 'https://manus.im/login',
+  columns: ['user_id', 'name'],
+  verify: verifyManusIdentity,
+  poll: async (page) => {
+    if (!await hasManusSessionCookie(page)) {
+      throw new AuthRequiredError('manus.im', 'Waiting for Manus session cookies');
+    }
+    return verifyManusIdentity(page);
+  },
+});

--- a/clis/notebooklm/auth.js
+++ b/clis/notebooklm/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasNotebookLmSsoCookies(page) {
+  const cookies = await page.getCookies({ url: 'https://notebooklm.google.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('SID') && names.has('SAPISID');
+}
+
+async function verifyNotebookLmIdentity(page) {
+  if (!await hasNotebookLmSsoCookies(page)) {
+    throw new AuthRequiredError('notebooklm.google.com', 'Google SSO cookies (SID + SAPISID) missing');
+  }
+  await page.goto('https://notebooklm.google.com/');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/accounts\\.google\\.com\\/ServiceLogin/.test(location.href) || /accounts\\.google\\.com\\/signin/i.test(location.href)) {
+        return { kind: 'auth', detail: 'NotebookLM redirected to Google sign-in' };
+      }
+      const acctEl = document.querySelector('a[aria-label^="Google Account:"], a[aria-label*="Google 账号:"]');
+      if (!acctEl) {
+        return { kind: 'auth', detail: 'NotebookLM missing Google Account button' };
+      }
+      const label = acctEl.getAttribute('aria-label') || '';
+      const nameMatch = label.match(/Google Account:\\s*([^\\n\\(]+?)(?:\\s*\\n|\\s*\\()/i) ||
+                        label.match(/Google 账号:\\s*([^\\n\\(]+?)(?:\\s*\\n|\\s*\\()/i);
+      const name = nameMatch ? nameMatch[1].trim() : '';
+      const authuserMatch = location.href.match(/[?&]authuser=(\\d+)/);
+      const authuser = authuserMatch ? Number(authuserMatch[1]) : 0;
+      if (!name) {
+        return { kind: 'auth', detail: 'NotebookLM Google Account aria-label found but name unparseable' };
+      }
+      return { ok: true, name, authuser };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('notebooklm.google.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected NotebookLM probe: ${JSON.stringify(probe)}`);
+  return { name: probe.name, authuser: probe.authuser };
+}
+
+registerSiteAuthCommands({
+  site: 'notebooklm',
+  domain: 'google.com',
+  loginUrl: 'https://accounts.google.com/ServiceLogin?service=lso&continue=https%3A%2F%2Fnotebooklm.google.com%2F',
+  columns: ['name', 'authuser'],
+  verify: verifyNotebookLmIdentity,
+  poll: async (page) => {
+    if (!await hasNotebookLmSsoCookies(page)) {
+      throw new AuthRequiredError('notebooklm.google.com', 'Waiting for Google SSO cookies (SID + SAPISID)');
+    }
+    return verifyNotebookLmIdentity(page);
+  },
+});

--- a/clis/pixiv/auth.js
+++ b/clis/pixiv/auth.js
@@ -1,0 +1,60 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasPixivSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.pixiv.net' });
+  return cookies.some(c => c.name === 'PHPSESSID' && c.value);
+}
+
+async function verifyPixivIdentity(page) {
+  if (!await hasPixivSessionCookie(page)) {
+    throw new AuthRequiredError('pixiv.net', 'Pixiv PHPSESSID cookie missing');
+  }
+  await page.goto('https://www.pixiv.net/');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const meta = document.querySelector('meta[name="global-data"]')?.getAttribute('content') || '';
+      let userData = null;
+      if (meta) { try { userData = JSON.parse(meta); } catch {} }
+      const u = userData?.userData;
+      if (u?.id) {
+        return { ok: true, user_id: String(u.id), name: String(u.name || u.account || '') };
+      }
+      const r = await fetch('/ajax/user/extra', { credentials: 'include', headers: { Accept: 'application/json' } });
+      if (r.status === 401 || r.status === 403) {
+        return { kind: 'auth', detail: 'Pixiv /ajax/user/extra HTTP ' + r.status };
+      }
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      if (d?.error) return { kind: 'auth', detail: 'Pixiv /ajax/user/extra error=true — anonymous' };
+      const phpSess = (document.cookie.split('; ').find(c => c.startsWith('PHPSESSID=')) || '').split('=')[1] || '';
+      const uid = phpSess.split('_')[0] || '';
+      if (!uid) {
+        return { kind: 'auth', detail: 'Pixiv PHPSESSID prefix unparseable' };
+      }
+      return { ok: true, user_id: uid, name: '' };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('pixiv.net', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Pixiv ajax`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Pixiv whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Pixiv probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'pixiv',
+  domain: 'pixiv.net',
+  loginUrl: 'https://accounts.pixiv.net/login',
+  columns: ['user_id', 'name'],
+  verify: verifyPixivIdentity,
+  poll: async (page) => {
+    if (!await hasPixivSessionCookie(page)) {
+      throw new AuthRequiredError('pixiv.net', 'Waiting for Pixiv PHPSESSID cookie');
+    }
+    return verifyPixivIdentity(page);
+  },
+});

--- a/clis/pixiv/auth.js
+++ b/clis/pixiv/auth.js
@@ -3,7 +3,10 @@ import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
 async function hasPixivSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://www.pixiv.net' });
-  return cookies.some(c => c.name === 'PHPSESSID' && c.value);
+  // Anonymous PHPSESSID is a bare hash; logged-in form is `<userId>_<hash>`.
+  // Require the numeric uid prefix so the login poll doesn't navigate away
+  // from accounts.pixiv.net while the user is still signing in.
+  return cookies.some(c => c.name === 'PHPSESSID' && /^\d+_/.test(c.value || ''));
 }
 
 async function verifyPixivIdentity(page) {

--- a/clis/powerchina/auth.js
+++ b/clis/powerchina/auth.js
@@ -3,7 +3,9 @@ import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
 async function hasPowerchinaSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://zhaopin.powerchina.cn' });
-  return cookies.some(c => /^(JSESSIONID|SESSION|Admin-Token|access_token)$/i.test(c.name) && c.value);
+  // JSESSIONID / SESSION are issued for anonymous Java sessions too; gate only on
+  // the auth-token cookies so the login poll doesn't navigate away mid-login.
+  return cookies.some(c => /^(Admin-Token|access_token)$/i.test(c.name) && c.value);
 }
 
 async function verifyPowerchinaIdentity(page) {

--- a/clis/powerchina/auth.js
+++ b/clis/powerchina/auth.js
@@ -1,0 +1,49 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasPowerchinaSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://zhaopin.powerchina.cn' });
+  return cookies.some(c => /^(JSESSIONID|SESSION|Admin-Token|access_token)$/i.test(c.name) && c.value);
+}
+
+async function verifyPowerchinaIdentity(page) {
+  if (!await hasPowerchinaSessionCookie(page)) {
+    throw new AuthRequiredError('powerchina.cn', 'Powerchina session cookies missing — anonymous');
+  }
+  await page.goto('https://zhaopin.powerchina.cn/index');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/\\/login(\\b|$|\\?)/.test(location.pathname)) {
+        return { kind: 'auth', detail: 'Powerchina redirected to /login — anonymous' };
+      }
+      const bodyText = document.body?.innerText || '';
+      if (/欢迎登录.*【登录】|请登录|您未登录/.test(bodyText)) {
+        return { kind: 'auth', detail: 'Powerchina shows 欢迎登录 prompt — anonymous' };
+      }
+      const el = document.querySelector('.user-info, .userName, .personalCenter [class*=name]');
+      const userName = (el?.innerText || '').trim();
+      if (!userName) {
+        return { kind: 'auth', detail: 'Powerchina no user name DOM — anonymous or layout changed' };
+      }
+      return { ok: true, name: userName };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('powerchina.cn', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Powerchina probe: ${JSON.stringify(probe)}`);
+  return { name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'powerchina',
+  domain: 'powerchina.cn',
+  loginUrl: 'https://zhaopin.powerchina.cn/login',
+  columns: ['name'],
+  verify: verifyPowerchinaIdentity,
+  poll: async (page) => {
+    if (!await hasPowerchinaSessionCookie(page)) {
+      throw new AuthRequiredError('powerchina.cn', 'Waiting for Powerchina session cookies');
+    }
+    return verifyPowerchinaIdentity(page);
+  },
+});

--- a/clis/quark/auth.js
+++ b/clis/quark/auth.js
@@ -1,0 +1,47 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Quark's auth cookies (__pus / __kp / __puus) are httpOnly. The account/info
+// endpoint returns HTTP 200 with an empty `data` array when anonymous and a
+// populated object once logged in, so the poll uses a no-nav probe of it.
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const r = await fetch('https://pan.quark.cn/account/info?fr=pc&platform=pc', { credentials: 'include', headers: { Accept: 'application/json' } });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Quark account/info HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    const data = d && d.data;
+    const isEmpty = !data || Array.isArray(data) || Object.keys(data).length === 0;
+    if (isEmpty) return { kind: 'auth', detail: 'Quark account/info returned empty data — anonymous' };
+    const nickname = String(data.nickname || data.nick_name || data.name || '');
+    if (!nickname) return { kind: 'render-error', detail: 'Quark account/info populated but no nickname field — response shape drift' };
+    return { ok: true, nickname };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyQuarkIdentity(page) {
+  await page.goto('https://pan.quark.cn/');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('quark.cn', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Quark account/info`);
+  if (probe?.kind === 'render-error') throw new CommandExecutionError(probe.detail);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Quark whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Quark probe: ${JSON.stringify(probe)}`);
+  return { nickname: probe.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'quark',
+  domain: 'quark.cn',
+  loginUrl: 'https://pan.quark.cn/',
+  columns: ['nickname'],
+  verify: verifyQuarkIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('quark.cn', 'Waiting for Quark login');
+    return { nickname: probe.nickname };
+  },
+});

--- a/clis/qwen/auth.js
+++ b/clis/qwen/auth.js
@@ -7,15 +7,18 @@ async function hasQwenSessionCookie(page) {
 }
 
 async function verifyQwenIdentity(page) {
-  if (!await hasQwenSessionCookie(page)) {
+  // Source the token via CDP getCookies (works even if `token` is httpOnly,
+  // which document.cookie cannot read).
+  const cookies = await page.getCookies({ url: 'https://chat.qwen.ai' });
+  const token = cookies.find(c => c.name === 'token')?.value || '';
+  if (!token) {
     throw new AuthRequiredError('qwen.ai', 'Qwen token cookie missing');
   }
   await page.goto('https://chat.qwen.ai/');
   await page.wait(2);
   const result = await page.evaluate(`(async () => {
     try {
-      const token = (document.cookie.split('; ').find(c => c.startsWith('token=')) || '').split('=')[1] || '';
-      if (!token) return { kind: 'auth', detail: 'Qwen token cookie absent in document.cookie' };
+      const token = ${JSON.stringify(token)};
       const res = await fetch('/api/v1/auths/', { credentials: 'include', headers: { 'Authorization': 'Bearer ' + token, 'Accept': 'application/json' } });
       if (res.status === 401 || res.status === 403) {
         return { kind: 'auth', detail: 'Qwen /api/v1/auths/ HTTP ' + res.status };

--- a/clis/qwen/auth.js
+++ b/clis/qwen/auth.js
@@ -1,0 +1,52 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasQwenSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://chat.qwen.ai' });
+  return cookies.some(c => c.name === 'token' && c.value);
+}
+
+async function verifyQwenIdentity(page) {
+  if (!await hasQwenSessionCookie(page)) {
+    throw new AuthRequiredError('qwen.ai', 'Qwen token cookie missing');
+  }
+  await page.goto('https://chat.qwen.ai/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const token = (document.cookie.split('; ').find(c => c.startsWith('token=')) || '').split('=')[1] || '';
+      if (!token) return { kind: 'auth', detail: 'Qwen token cookie absent in document.cookie' };
+      const res = await fetch('/api/v1/auths/', { credentials: 'include', headers: { 'Authorization': 'Bearer ' + token, 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Qwen /api/v1/auths/ HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      if (!d || !d.id) {
+        return { kind: 'auth', detail: 'Qwen /api/v1/auths/ returned no user id' };
+      }
+      return { ok: true, user_id: String(d.id), name: String(d.name || ''), email: String(d.email || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('qwen.ai', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/v1/auths/`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Qwen whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Qwen probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name, email: result.email };
+}
+
+registerSiteAuthCommands({
+  site: 'qwen',
+  domain: 'qwen.ai',
+  loginUrl: 'https://chat.qwen.ai/auth?action=login',
+  columns: ['user_id', 'name', 'email'],
+  verify: verifyQwenIdentity,
+  poll: async (page) => {
+    if (!await hasQwenSessionCookie(page)) {
+      throw new AuthRequiredError('qwen.ai', 'Waiting for Qwen token cookie');
+    }
+    return verifyQwenIdentity(page);
+  },
+});

--- a/clis/qwen/auth.js
+++ b/clis/qwen/auth.js
@@ -28,7 +28,7 @@ async function verifyQwenIdentity(page) {
       if (!d || !d.id) {
         return { kind: 'auth', detail: 'Qwen /api/v1/auths/ returned no user id' };
       }
-      return { ok: true, user_id: String(d.id), name: String(d.name || ''), email: String(d.email || '') };
+      return { ok: true, user_id: String(d.id), name: String(d.name || '') };
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
@@ -37,14 +37,14 @@ async function verifyQwenIdentity(page) {
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/v1/auths/`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`Qwen whoami failed: ${result.detail}`);
   if (!result?.ok) throw new CommandExecutionError(`Unexpected Qwen probe: ${JSON.stringify(result)}`);
-  return { user_id: result.user_id, name: result.name, email: result.email };
+  return { user_id: result.user_id, name: result.name };
 }
 
 registerSiteAuthCommands({
   site: 'qwen',
   domain: 'qwen.ai',
   loginUrl: 'https://chat.qwen.ai/auth?action=login',
-  columns: ['user_id', 'name', 'email'],
+  columns: ['user_id', 'name'],
   verify: verifyQwenIdentity,
   poll: async (page) => {
     if (!await hasQwenSessionCookie(page)) {

--- a/clis/reddit/auth.js
+++ b/clis/reddit/auth.js
@@ -1,0 +1,51 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasRedditSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.reddit.com' });
+  return cookies.some(c => c.name === 'reddit_session' && c.value);
+}
+
+async function verifyRedditIdentity(page) {
+  if (!await hasRedditSessionCookie(page)) {
+    throw new AuthRequiredError('reddit.com', 'Reddit reddit_session cookie missing');
+  }
+  await page.goto('https://www.reddit.com/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/api/me.json', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Reddit /api/me.json HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const data = d && d.data;
+      if (!data || !data.name) {
+        return { kind: 'auth', detail: 'Reddit /api/me.json 200 but no data.name — anonymous' };
+      }
+      return { ok: true, username: String(data.name), id: String(data.id || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('reddit.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/me.json`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Reddit whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Reddit probe: ${JSON.stringify(result)}`);
+  return { username: result.username, id: result.id };
+}
+
+registerSiteAuthCommands({
+  site: 'reddit',
+  domain: 'reddit.com',
+  loginUrl: 'https://www.reddit.com/login',
+  columns: ['username', 'id'],
+  verify: verifyRedditIdentity,
+  poll: async (page) => {
+    if (!await hasRedditSessionCookie(page)) {
+      throw new AuthRequiredError('reddit.com', 'Waiting for Reddit reddit_session cookie');
+    }
+    return verifyRedditIdentity(page);
+  },
+});

--- a/clis/rednote/auth.js
+++ b/clis/rednote/auth.js
@@ -1,0 +1,51 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasRednoteSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.rednote.com' });
+  return cookies.some(c => c.name === 'web_session' && c.value);
+}
+
+async function verifyRednoteIdentity(page) {
+  if (!await hasRednoteSessionCookie(page)) {
+    throw new AuthRequiredError('rednote.com', 'Rednote web_session cookie missing');
+  }
+  await page.goto('https://www.rednote.com/explore');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      const state = window.__INITIAL_STATE__;
+      if (!state?.user) {
+        return { kind: 'auth', detail: 'Rednote __INITIAL_STATE__.user missing' };
+      }
+      const loggedIn = state.user.loggedIn?._value;
+      const userInfo = state.user.userInfo?._value || {};
+      if (loggedIn !== true) {
+        return { kind: 'auth', detail: 'Rednote loggedIn._value=' + String(loggedIn) + ' — anonymous' };
+      }
+      const userId = String(userInfo.userId || userInfo.user_id || '');
+      const nickname = String(userInfo.nickname || userInfo.name || '');
+      if (!userId) {
+        return { kind: 'auth', detail: 'Rednote logged-in but userId missing — stale session' };
+      }
+      return { ok: true, user_id: userId, nickname };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('rednote.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Rednote probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, nickname: probe.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'rednote',
+  domain: 'rednote.com',
+  loginUrl: 'https://www.rednote.com/explore',
+  columns: ['user_id', 'nickname'],
+  verify: verifyRednoteIdentity,
+  poll: async (page) => {
+    if (!await hasRednoteSessionCookie(page)) {
+      throw new AuthRequiredError('rednote.com', 'Waiting for Rednote web_session cookie');
+    }
+    return verifyRednoteIdentity(page);
+  },
+});

--- a/clis/reuters/auth.js
+++ b/clis/reuters/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function verifyReutersIdentity(page) {
+  await page.goto('https://www.reuters.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      try {
+        const subStateRaw = localStorage.getItem('rcom-subscription-state');
+        let subState = null;
+        if (subStateRaw) { try { subState = JSON.parse(subStateRaw); } catch {} }
+        if (!subState || subState.isLoggedIn !== true) {
+          return { kind: 'auth', detail: 'Reuters rcom-subscription-state.isLoggedIn is not true — anonymous' };
+        }
+        let oidcKey = null;
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i);
+          if (k && k.startsWith('oidc.user:')) { oidcKey = k; break; }
+        }
+        let cuid = '';
+        if (oidcKey) {
+          try {
+            const u = JSON.parse(localStorage.getItem(oidcKey) || '{}');
+            cuid = String(u?.profile?.cuid || u?.profile?.sub || '');
+          } catch {}
+        }
+        if (!cuid) {
+          const ajs = localStorage.getItem('ajs_user_id');
+          if (ajs && ajs !== 'null') cuid = ajs;
+        }
+        if (!cuid) {
+          return { kind: 'auth', detail: 'Reuters logged-in but cuid missing — session shape drifted' };
+        }
+        return { ok: true, user_id: cuid, subscribed: Boolean(subState.isSubscribed) };
+      } catch (e) {
+        return { kind: 'exception', detail: String(e && e.message || e) };
+      }
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('reuters.com', probe.detail);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Reuters whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Reuters probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, subscribed: probe.subscribed };
+}
+
+registerSiteAuthCommands({
+  site: 'reuters',
+  domain: 'reuters.com',
+  loginUrl: 'https://www.reuters.com/account/sign-in/',
+  columns: ['user_id', 'subscribed'],
+  verify: verifyReutersIdentity,
+  poll: verifyReutersIdentity,
+});

--- a/clis/reuters/auth.js
+++ b/clis/reuters/auth.js
@@ -50,5 +50,18 @@ registerSiteAuthCommands({
   loginUrl: 'https://www.reuters.com/account/sign-in/',
   columns: ['user_id', 'subscribed'],
   verify: verifyReutersIdentity,
-  poll: verifyReutersIdentity,
+  // No-navigation poll: check localStorage on the current page so login-flow
+  // polling doesn't bounce the user off the sign-in page every interval.
+  poll: async (page) => {
+    const loggedIn = await page.evaluate(`(() => {
+      try {
+        const raw = localStorage.getItem('rcom-subscription-state');
+        return raw ? JSON.parse(raw).isLoggedIn === true : false;
+      } catch { return false; }
+    })()`);
+    if (!loggedIn) {
+      throw new AuthRequiredError('reuters.com', 'Waiting for Reuters login');
+    }
+    return verifyReutersIdentity(page);
+  },
 });

--- a/clis/suno/auth.js
+++ b/clis/suno/auth.js
@@ -3,7 +3,10 @@ import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
 async function hasSunoClerkCookie(page) {
   const cookies = await page.getCookies({ url: 'https://clerk.suno.com' });
-  return cookies.some(c => /^__(session|client)$/.test(c.name) && c.value);
+  // Clerk sets __client for anonymous sessions too; __session (the session JWT)
+  // is present only when authenticated, so gate on it to avoid navigating away
+  // mid-login.
+  return cookies.some(c => c.name === '__session' && c.value);
 }
 
 async function verifySunoIdentity(page) {

--- a/clis/suno/auth.js
+++ b/clis/suno/auth.js
@@ -1,0 +1,59 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasSunoClerkCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://clerk.suno.com' });
+  return cookies.some(c => /^__(session|client)$/.test(c.name) && c.value);
+}
+
+async function verifySunoIdentity(page) {
+  if (!await hasSunoClerkCookie(page)) {
+    throw new AuthRequiredError('suno.com', 'Suno Clerk __session/__client cookie missing');
+  }
+  await page.goto('https://suno.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const r = await fetch('https://clerk.suno.com/v1/client?_clerk_js_version=5', {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (r.status === 401 || r.status === 403) {
+        return { kind: 'auth', detail: 'clerk.suno.com /v1/client HTTP ' + r.status };
+      }
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      const sessions = d?.response?.sessions || [];
+      if (!Array.isArray(sessions) || sessions.length === 0) {
+        return { kind: 'auth', detail: 'clerk.suno.com sessions=[] — anonymous' };
+      }
+      const active = sessions.find(s => s.status === 'active') || sessions[0];
+      const user = active?.user;
+      if (!user?.id) {
+        return { kind: 'auth', detail: 'clerk.suno.com session present but no user.id — stale session' };
+      }
+      return { ok: true, user_id: String(user.id), name: String(user.username || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('suno.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from clerk.suno.com`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Suno whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Suno probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'suno',
+  domain: 'suno.com',
+  loginUrl: 'https://suno.com/?sign-in=true',
+  columns: ['user_id', 'name'],
+  verify: verifySunoIdentity,
+  poll: async (page) => {
+    if (!await hasSunoClerkCookie(page)) {
+      throw new AuthRequiredError('suno.com', 'Waiting for Suno Clerk __session/__client cookie');
+    }
+    return verifySunoIdentity(page);
+  },
+});

--- a/clis/taobao/auth.js
+++ b/clis/taobao/auth.js
@@ -1,0 +1,57 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasTaobaoSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.taobao.com' });
+  return cookies.some(c => c.name === 'tracknick' && c.value);
+}
+
+async function verifyTaobaoIdentity(page) {
+  if (!await hasTaobaoSessionCookie(page)) {
+    throw new AuthRequiredError('taobao.com', 'Taobao tracknick cookie missing — anonymous');
+  }
+  await page.goto('https://i.taobao.com/my_itaobao');
+  await page.wait(2);
+  const finalUrl = await page.evaluate(`location.href`);
+  if (/login\.taobao\.com\/member\/login/.test(String(finalUrl || ''))) {
+    throw new AuthRequiredError('taobao.com', `Taobao my_itaobao redirected to login: ${finalUrl}`);
+  }
+  const cookies = await page.getCookies({ url: 'https://www.taobao.com' });
+  const tracknick = cookies.find(c => c.name === 'tracknick')?.value || '';
+  if (!tracknick) {
+    throw new AuthRequiredError('taobao.com', 'Taobao tracknick cookie absent after navigation');
+  }
+  const domInfo = await page.evaluate(`
+    (() => {
+      const nick = (document.querySelector('.user-nick, .site-nav-user, .user-name')?.innerText || '').trim();
+      const html = document.body?.innerHTML || '';
+      const userIdMatch = html.match(/userId[\"'\\s:=]+(\\d+)/i);
+      return { nickname: nick, user_id: userIdMatch?.[1] || '' };
+    })()
+  `);
+  let decodedTracknick = '';
+  try {
+    decodedTracknick = JSON.parse('"' + tracknick.replace(/\\/g, '\\\\') + '"');
+  } catch {
+    decodedTracknick = tracknick;
+  }
+  const nickname = domInfo.nickname || decodedTracknick;
+  if (!domInfo.user_id) {
+    throw new CommandExecutionError('Taobao my_itaobao rendered but no user_id extractable — stale cookie2 or layout drift');
+  }
+  return { user_id: String(domInfo.user_id), nickname: String(nickname) };
+}
+
+registerSiteAuthCommands({
+  site: 'taobao',
+  domain: 'taobao.com',
+  loginUrl: 'https://login.taobao.com/member/login.jhtml',
+  columns: ['user_id', 'nickname'],
+  verify: verifyTaobaoIdentity,
+  poll: async (page) => {
+    if (!await hasTaobaoSessionCookie(page)) {
+      throw new AuthRequiredError('taobao.com', 'Waiting for Taobao tracknick cookie');
+    }
+    return verifyTaobaoIdentity(page);
+  },
+});

--- a/clis/tiktok/auth.js
+++ b/clis/tiktok/auth.js
@@ -1,0 +1,64 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasTiktokSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.tiktok.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('sessionid') || names.has('sid_tt') || names.has('uid_tt');
+}
+
+async function verifyTiktokIdentity(page) {
+  if (!await hasTiktokSessionCookie(page)) {
+    throw new AuthRequiredError('www.tiktok.com', 'TikTok session cookies (sessionid/sid_tt/uid_tt) missing');
+  }
+  await page.goto('https://www.tiktok.com/foryou');
+  await page.wait(2);
+  const info = await page.evaluate(`
+    (() => {
+      const raw = document.querySelector('script[id="__UNIVERSAL_DATA_FOR_REHYDRATION__"]')?.textContent;
+      if (!raw) return null;
+      let data;
+      try { data = JSON.parse(raw); } catch { return null; }
+      const scope = data?.['__DEFAULT_SCOPE__'] || {};
+      const seen = new Set();
+      const stack = [scope];
+      while (stack.length) {
+        const node = stack.pop();
+        if (!node || typeof node !== 'object' || seen.has(node)) continue;
+        seen.add(node);
+        if (Array.isArray(node)) { stack.push(...node); continue; }
+        const u = node.user;
+        if (u && typeof u === 'object') {
+          const isMe = Boolean(u.isOwner || u.is_owner || u.isCurrentUser);
+          if (isMe && (u.secUid || u.sec_uid)) {
+            return {
+              sec_uid: String(u.secUid || u.sec_uid),
+              username: String(u.uniqueId || u.unique_id || u.username || ''),
+              nickname: String(u.nickname || u.nickName || ''),
+            };
+          }
+        }
+        for (const v of Object.values(node)) if (v && typeof v === 'object') stack.push(v);
+      }
+      return null;
+    })()
+  `);
+  if (!info?.sec_uid) {
+    throw new AuthRequiredError('www.tiktok.com', 'TikTok universal data has no owner user — identity not rehydrated');
+  }
+  return { sec_uid: info.sec_uid, username: info.username, nickname: info.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'tiktok',
+  domain: 'tiktok.com',
+  loginUrl: 'https://www.tiktok.com/login',
+  columns: ['sec_uid', 'username', 'nickname'],
+  verify: verifyTiktokIdentity,
+  poll: async (page) => {
+    if (!await hasTiktokSessionCookie(page)) {
+      throw new AuthRequiredError('www.tiktok.com', 'Waiting for TikTok session cookies');
+    }
+    return verifyTiktokIdentity(page);
+  },
+});

--- a/clis/toutiao/auth.js
+++ b/clis/toutiao/auth.js
@@ -1,0 +1,69 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasToutiaoSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://mp.toutiao.com' });
+  return cookies.some(c => c.name === 'sessionid' && c.value);
+}
+
+async function verifyToutiaoIdentity(page) {
+  if (!await hasToutiaoSessionCookie(page)) {
+    throw new AuthRequiredError('toutiao.com', 'Toutiao sessionid cookie missing');
+  }
+  await page.goto('https://mp.toutiao.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/\\/auth\\/page\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: 'mp.toutiao.com redirected to /auth/page/login — anonymous' };
+      }
+      let userId = '', nickname = '';
+      try {
+        const seen = new Set();
+        const stack = [window.__INITIAL_STATE__, window.__REDUX_STATE__, window.__SSR_DATA__].filter(Boolean);
+        while (stack.length) {
+          const node = stack.pop();
+          if (!node || typeof node !== 'object' || seen.has(node)) continue;
+          seen.add(node);
+          if (Array.isArray(node)) { stack.push(...node); continue; }
+          const u = node.userInfo || node.user || node.currentUser || node.userBase;
+          if (u && typeof u === 'object' && (u.user_id || u.userId || u.uid)) {
+            userId = String(u.user_id || u.userId || u.uid || '');
+            nickname = String(u.screen_name || u.name || u.nickname || u.user_name || '');
+            break;
+          }
+          for (const v of Object.values(node)) if (v && typeof v === 'object') stack.push(v);
+        }
+      } catch {}
+      if (!userId) {
+        const ssoUid = (document.cookie.split('; ').find(c => c.startsWith('sso_uid=')) || '').split('=')[1] || '';
+        if (ssoUid) userId = ssoUid;
+      }
+      if (!nickname) {
+        const el = document.querySelector('.user-name, .header-username, .avatar-name, [class*="userName"]');
+        nickname = (el?.innerText || '').trim();
+      }
+      if (!userId) {
+        return { kind: 'auth', detail: 'Toutiao dashboard rendered but no user_id surface — stale session' };
+      }
+      return { ok: true, user_id: userId, nickname };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('toutiao.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Toutiao probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, nickname: probe.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'toutiao',
+  domain: 'toutiao.com',
+  loginUrl: 'https://mp.toutiao.com/auth/page/login',
+  columns: ['user_id', 'nickname'],
+  verify: verifyToutiaoIdentity,
+  poll: async (page) => {
+    if (!await hasToutiaoSessionCookie(page)) {
+      throw new AuthRequiredError('toutiao.com', 'Waiting for Toutiao sessionid cookie');
+    }
+    return verifyToutiaoIdentity(page);
+  },
+});

--- a/clis/upwork/auth.js
+++ b/clis/upwork/auth.js
@@ -28,21 +28,20 @@ async function verifyUpworkIdentity(page) {
       return {
         ok: true,
         user_id: String(profile.id || profile.uid || ''),
-        name: String((profile.firstName || '') + ' ' + (profile.lastName || '')).trim(),
         ciphertext: String(profile.ciphertext || ''),
       };
     })()
   `);
   if (probe?.kind === 'auth') throw new AuthRequiredError('upwork.com', probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected Upwork probe: ${JSON.stringify(probe)}`);
-  return { user_id: probe.user_id, name: probe.name, ciphertext: probe.ciphertext };
+  return { user_id: probe.user_id, ciphertext: probe.ciphertext };
 }
 
 registerSiteAuthCommands({
   site: 'upwork',
   domain: 'upwork.com',
   loginUrl: 'https://www.upwork.com/ab/account-security/login',
-  columns: ['user_id', 'name', 'ciphertext'],
+  columns: ['user_id', 'ciphertext'],
   verify: verifyUpworkIdentity,
   poll: async (page) => {
     if (!await hasUpworkSessionCookie(page)) {

--- a/clis/upwork/auth.js
+++ b/clis/upwork/auth.js
@@ -1,0 +1,53 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasUpworkSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.upwork.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('master_access_token') || names.has('XSRF-TOKEN') && names.has('user_uid');
+}
+
+async function verifyUpworkIdentity(page) {
+  if (!await hasUpworkSessionCookie(page)) {
+    throw new AuthRequiredError('upwork.com', 'Upwork session cookies missing');
+  }
+  await page.goto('https://www.upwork.com/nx/find-work/');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      if (/\\/(ab|account-security\\/login|signup)\\//.test(location.pathname)) {
+        return { kind: 'auth', detail: 'Upwork redirected to login flow' };
+      }
+      const nuxt = (typeof window !== 'undefined' && window.__NUXT__) ? window.__NUXT__ : null;
+      const state = nuxt && (nuxt.state || (nuxt.data && nuxt.data[0]));
+      const user = state && (state.user || (state.auth && state.auth.user));
+      const profile = user && (user.profile || user);
+      if (!profile || !profile.id) {
+        return { kind: 'auth', detail: 'Upwork __NUXT__ has no profile id — anonymous' };
+      }
+      return {
+        ok: true,
+        user_id: String(profile.id || profile.uid || ''),
+        name: String((profile.firstName || '') + ' ' + (profile.lastName || '')).trim(),
+        ciphertext: String(profile.ciphertext || ''),
+      };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('upwork.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Upwork probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name, ciphertext: probe.ciphertext };
+}
+
+registerSiteAuthCommands({
+  site: 'upwork',
+  domain: 'upwork.com',
+  loginUrl: 'https://www.upwork.com/ab/account-security/login',
+  columns: ['user_id', 'name', 'ciphertext'],
+  verify: verifyUpworkIdentity,
+  poll: async (page) => {
+    if (!await hasUpworkSessionCookie(page)) {
+      throw new AuthRequiredError('upwork.com', 'Waiting for Upwork session cookies');
+    }
+    return verifyUpworkIdentity(page);
+  },
+});

--- a/clis/v2ex/auth.js
+++ b/clis/v2ex/auth.js
@@ -1,0 +1,43 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasV2exAuthCookie(page) {
+  // A2 is V2EX's httpOnly logged-in session cookie.
+  const cookies = await page.getCookies({ url: 'https://www.v2ex.com' });
+  return cookies.some(c => c.name === 'A2' && c.value);
+}
+
+async function verifyV2exIdentity(page) {
+  if (!await hasV2exAuthCookie(page)) {
+    throw new AuthRequiredError('v2ex.com', 'V2EX A2 session cookie missing — anonymous');
+  }
+  await page.goto('https://www.v2ex.com/');
+  await page.wait(1);
+  const probe = await page.evaluate(`
+    (() => {
+      const link = document.querySelector('#Top a[href^="/member/"]');
+      if (!link) return { kind: 'auth', detail: 'V2EX top bar has no member link — anonymous session' };
+      const href = link.getAttribute('href') || '';
+      const username = (link.innerText || href.replace('/member/', '')).trim();
+      if (!username) return { kind: 'auth', detail: 'V2EX member link present but username empty' };
+      return { ok: true, username };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('v2ex.com', probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected V2EX probe: ${JSON.stringify(probe)}`);
+  return { username: probe.username };
+}
+
+registerSiteAuthCommands({
+  site: 'v2ex',
+  domain: 'v2ex.com',
+  loginUrl: 'https://www.v2ex.com/signin',
+  columns: ['username'],
+  verify: verifyV2exIdentity,
+  poll: async (page) => {
+    if (!await hasV2exAuthCookie(page)) {
+      throw new AuthRequiredError('v2ex.com', 'Waiting for V2EX A2 session cookie');
+    }
+    return verifyV2exIdentity(page);
+  },
+});

--- a/clis/wechat-channels/auth.js
+++ b/clis/wechat-channels/auth.js
@@ -1,0 +1,61 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasWechatChannelsSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://channels.weixin.qq.com' });
+  return cookies.some(c => c.name === 'sessionid' && c.value);
+}
+
+async function verifyWechatChannelsIdentity(page) {
+  if (!await hasWechatChannelsSessionCookie(page)) {
+    throw new AuthRequiredError('channels.weixin.qq.com', 'WeChat Channels sessionid cookie missing');
+  }
+  await page.goto('https://channels.weixin.qq.com/platform');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      if (/login\\.html/.test(location.href)) {
+        return { kind: 'auth', detail: 'WeChat Channels platform redirected to login.html' };
+      }
+      const r = await fetch('/cgi-bin/mmfinderassistant-bin/auth/auth_data', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      if (!r.ok) return { kind: 'http', httpStatus: r.status };
+      const d = await r.json();
+      if (!d || d.base_resp?.ret !== 0) {
+        return { kind: 'auth', detail: 'WeChat Channels auth_data base_resp.ret=' + String(d?.base_resp?.ret) };
+      }
+      const fu = d.data?.finder_user || d.finder_user || {};
+      const userId = String(fu.uniq_id || fu.username || '');
+      const name = String(fu.nickname || fu.name || '');
+      if (!userId && !name) {
+        return { kind: 'auth', detail: 'WeChat Channels auth_data 200 but finder_user empty' };
+      }
+      return { ok: true, user_id: userId, name };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('channels.weixin.qq.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from auth_data`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`WeChat Channels whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected WeChat Channels probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'wechat-channels',
+  domain: 'channels.weixin.qq.com',
+  loginUrl: 'https://channels.weixin.qq.com/login.html?from=assistant',
+  columns: ['user_id', 'name'],
+  verify: verifyWechatChannelsIdentity,
+  poll: async (page) => {
+    if (!await hasWechatChannelsSessionCookie(page)) {
+      throw new AuthRequiredError('channels.weixin.qq.com', 'Waiting for WeChat Channels sessionid cookie');
+    }
+    return verifyWechatChannelsIdentity(page);
+  },
+});

--- a/clis/weibo/auth.js
+++ b/clis/weibo/auth.js
@@ -1,0 +1,52 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasWeiboSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://weibo.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('SUB') && names.has('SUBP');
+}
+
+async function verifyWeiboIdentity(page) {
+  if (!await hasWeiboSessionCookie(page)) {
+    throw new AuthRequiredError('weibo.com', 'Weibo SUB / SUBP cookies missing');
+  }
+  await page.goto('https://weibo.com/');
+  await page.wait(3);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch('/ajax/profile/info', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'Weibo /ajax/profile/info HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      const user = d && d.data && d.data.user;
+      if (!user || !user.id) {
+        return { kind: 'auth', detail: 'Weibo /ajax/profile/info returned no user — anonymous' };
+      }
+      return { ok: true, user_id: String(user.id), screen_name: String(user.screen_name || ''), profile_url: String(user.profile_url || '') };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('weibo.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /ajax/profile/info`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`Weibo whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected Weibo probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, screen_name: result.screen_name, profile_url: result.profile_url };
+}
+
+registerSiteAuthCommands({
+  site: 'weibo',
+  domain: 'weibo.com',
+  loginUrl: 'https://weibo.com/login',
+  columns: ['user_id', 'screen_name', 'profile_url'],
+  verify: verifyWeiboIdentity,
+  poll: async (page) => {
+    if (!await hasWeiboSessionCookie(page)) {
+      throw new AuthRequiredError('weibo.com', 'Waiting for Weibo SUB / SUBP cookies');
+    }
+    return verifyWeiboIdentity(page);
+  },
+});

--- a/clis/weread/auth.js
+++ b/clis/weread/auth.js
@@ -1,0 +1,58 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasWereadSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://weread.qq.com' });
+  return cookies.some(c => c.name === 'wr_vid' && c.value);
+}
+
+async function verifyWereadIdentity(page) {
+  if (!await hasWereadSessionCookie(page)) {
+    throw new AuthRequiredError('weread.qq.com', 'WeRead wr_vid cookie missing');
+  }
+  await page.goto('https://weread.qq.com/');
+  await page.wait(2);
+  const result = await page.evaluate(`(async () => {
+    try {
+      const wrVid = (document.cookie.split('; ').find(c => c.startsWith('wr_vid=')) || '').split('=')[1] || '';
+      if (!wrVid) {
+        return { kind: 'auth', detail: 'WeRead wr_vid cookie absent in document.cookie' };
+      }
+      const res = await fetch('/web/user', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      if (res.status === 401 || res.status === 403) {
+        return { kind: 'auth', detail: 'WeRead /web/user HTTP ' + res.status };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      if (d && d.errCode && d.errCode !== 0) {
+        return { kind: 'auth', detail: 'WeRead /web/user errCode=' + d.errCode };
+      }
+      return {
+        ok: true,
+        user_id: String(d.userVid || wrVid),
+        name: String(d.name || d.nickName || ''),
+      };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (result?.kind === 'auth') throw new AuthRequiredError('weread.qq.com', result.detail);
+  if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /web/user`);
+  if (result?.kind === 'exception') throw new CommandExecutionError(`WeRead whoami failed: ${result.detail}`);
+  if (!result?.ok) throw new CommandExecutionError(`Unexpected WeRead probe: ${JSON.stringify(result)}`);
+  return { user_id: result.user_id, name: result.name };
+}
+
+registerSiteAuthCommands({
+  site: 'weread',
+  domain: 'weread.qq.com',
+  loginUrl: 'https://weread.qq.com/',
+  columns: ['user_id', 'name'],
+  verify: verifyWereadIdentity,
+  poll: async (page) => {
+    if (!await hasWereadSessionCookie(page)) {
+      throw new AuthRequiredError('weread.qq.com', 'Waiting for WeRead wr_vid cookie');
+    }
+    return verifyWereadIdentity(page);
+  },
+});

--- a/clis/xianyu/auth.js
+++ b/clis/xianyu/auth.js
@@ -1,0 +1,67 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasXianyuIdentityCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.goofish.com' });
+  return cookies.some(c => (c.name === 'unb' || c.name === 'tracknick') && c.value);
+}
+
+async function verifyXianyuIdentity(page) {
+  if (!await hasXianyuIdentityCookie(page)) {
+    throw new AuthRequiredError('goofish.com', 'Xianyu unb/tracknick cookie missing — anonymous');
+  }
+  await page.goto('https://www.goofish.com/personal');
+  await page.wait(2);
+  const finalUrl = await page.evaluate(`location.href`);
+  if (/passport\.(taobao|goofish)\.com\/(member\/login|login)/.test(String(finalUrl || ''))) {
+    throw new AuthRequiredError('goofish.com', `Xianyu /personal redirected to login: ${finalUrl}`);
+  }
+  const cookies = await page.getCookies({ url: 'https://www.goofish.com' });
+  const tracknick = cookies.find(c => c.name === 'tracknick')?.value || '';
+  const unb = cookies.find(c => c.name === 'unb')?.value || '';
+  const probe = await page.evaluate(`
+    (() => {
+      const bodyText = document.body?.innerText || '';
+      const requiresAuth = /请先登录|登录后/.test(bodyText);
+      const blocked = /验证码|安全验证|异常访问/.test(bodyText);
+      const nick = document.querySelector('.user-name, .user-nick, .nick, [class*="nickname"]')?.innerText?.trim() || '';
+      const html = document.body?.innerHTML || '';
+      const userIdMatch = html.match(/['"]?userId['"]?\\s*[:=]\\s*['"]?(\\d+)/i);
+      return { requiresAuth, blocked, domNick: nick, domUserId: userIdMatch?.[1] || '' };
+    })()
+  `);
+  if (probe.blocked) {
+    throw new AuthRequiredError('goofish.com', 'Xianyu blocked by verification / risk control');
+  }
+  if (probe.requiresAuth) {
+    throw new AuthRequiredError('goofish.com', 'Xianyu /personal shows login prompt — anonymous');
+  }
+  const userId = probe.domUserId || unb;
+  let decodedTracknick = '';
+  if (tracknick) {
+    try {
+      decodedTracknick = JSON.parse('"' + tracknick.replace(/\\/g, '\\\\') + '"');
+    } catch {
+      decodedTracknick = tracknick;
+    }
+  }
+  const nickname = probe.domNick || decodedTracknick;
+  if (!userId && !nickname) {
+    throw new CommandExecutionError('Xianyu /personal rendered but no user identity extractable — stale unb or layout drift');
+  }
+  return { user_id: String(userId), nickname: String(nickname) };
+}
+
+registerSiteAuthCommands({
+  site: 'xianyu',
+  domain: 'goofish.com',
+  loginUrl: 'https://www.goofish.com/login',
+  columns: ['user_id', 'nickname'],
+  verify: verifyXianyuIdentity,
+  poll: async (page) => {
+    if (!await hasXianyuIdentityCookie(page)) {
+      throw new AuthRequiredError('goofish.com', 'Waiting for Xianyu unb/tracknick cookie');
+    }
+    return verifyXianyuIdentity(page);
+  },
+});

--- a/clis/xiaoe/auth.js
+++ b/clis/xiaoe/auth.js
@@ -1,0 +1,54 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasXiaoeAdminCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://admin.xiaoe-tech.com' });
+  return cookies.some(c => (c.name === 'XIAOEID' || c.name === 'b_user_token') && c.value);
+}
+
+async function verifyXiaoeIdentity(page) {
+  if (!await hasXiaoeAdminCookie(page)) {
+    throw new AuthRequiredError('xiaoe-tech.com', 'Xiaoe XIAOEID/b_user_token cookie missing — anonymous');
+  }
+  await page.goto('https://admin.xiaoe-tech.com/t/account/muti_index');
+  await page.wait(3);
+  const finalUrl = await page.evaluate(`location.href`);
+  if (/login|signin|#\/wx$/.test(String(finalUrl || ''))) {
+    throw new AuthRequiredError('xiaoe-tech.com', `Xiaoe admin page redirected to login: ${finalUrl}`);
+  }
+  const cookies = await page.getCookies({ url: 'https://admin.xiaoe-tech.com' });
+  const xiaoeId = cookies.find(c => c.name === 'XIAOEID')?.value || '';
+  const unionId = cookies.find(c => c.name === 'unionid')?.value || '';
+  const probe = await page.evaluate(`
+    (() => {
+      const bodyText = document.body?.innerText || '';
+      if (/微信扫码登录|手机号登录|登录小鹅通/.test(bodyText)) {
+        return { isLoginPage: true };
+      }
+      const nick = document.querySelector('.user-name, .nickname, [class*="userName"], [class*="user-info"]')?.innerText?.trim() || '';
+      return { isLoginPage: false, domNick: nick };
+    })()
+  `);
+  if (probe.isLoginPage) {
+    throw new AuthRequiredError('xiaoe-tech.com', 'Xiaoe admin page showed login UI — anonymous session');
+  }
+  const userId = xiaoeId || unionId;
+  if (!userId) {
+    throw new CommandExecutionError('Xiaoe admin page rendered but no user_id cookie extractable — stale session');
+  }
+  return { user_id: String(userId), nickname: String(probe.domNick || '') };
+}
+
+registerSiteAuthCommands({
+  site: 'xiaoe',
+  domain: 'xiaoe-tech.com',
+  loginUrl: 'https://admin.xiaoe-tech.com/',
+  columns: ['user_id', 'nickname'],
+  verify: verifyXiaoeIdentity,
+  poll: async (page) => {
+    if (!await hasXiaoeAdminCookie(page)) {
+      throw new AuthRequiredError('xiaoe-tech.com', 'Waiting for Xiaoe XIAOEID/b_user_token cookie');
+    }
+    return verifyXiaoeIdentity(page);
+  },
+});

--- a/clis/xueqiu/auth.js
+++ b/clis/xueqiu/auth.js
@@ -1,0 +1,62 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasXueqiuAccessToken(page) {
+  const cookies = await page.getCookies({ url: 'https://xueqiu.com' });
+  return cookies.some(c => c.name === 'xq_a_token' && c.value);
+}
+
+async function verifyXueqiuIdentity(page) {
+  if (!await hasXueqiuAccessToken(page)) {
+    throw new AuthRequiredError('xueqiu.com', 'Xueqiu xq_a_token cookie missing — anonymous');
+  }
+  await page.goto('https://xueqiu.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`(async () => {
+    try {
+      const res = await fetch(
+        'https://stock.xueqiu.com/v5/stock/portfolio/stock/list.json?size=1&category=1&pid=-1',
+        { credentials: 'include' },
+      );
+      if (res.status === 403) {
+        return { kind: 'http', httpStatus: 403, detail: 'xueqiu stock API 403 — anti-bot / rate limit' };
+      }
+      if (!res.ok) return { kind: 'http', httpStatus: res.status };
+      const d = await res.json();
+      if (d?.error_code === 60201) {
+        return { kind: 'auth', detail: 'xueqiu portfolio API error_code 60201 用户id无效 — anonymous' };
+      }
+      if (d?.error_code) {
+        return { kind: 'xq-error', errorCode: d.error_code, detail: d.error_description || 'xueqiu API error' };
+      }
+      const uCookie = document.cookie.split('; ').find(c => c.startsWith('u='))?.split('=')[1] || '';
+      const cookiesuCookie = document.cookie.split('; ').find(c => c.startsWith('cookiesu='))?.split('=')[1] || '';
+      if (!uCookie || uCookie === cookiesuCookie) {
+        return { kind: 'auth', detail: 'xueqiu u cookie equals cookiesu (device id) — anonymous despite portfolio API 200' };
+      }
+      return { ok: true, user_id: uCookie };
+    } catch (e) {
+      return { kind: 'exception', detail: String(e && e.message || e) };
+    }
+  })()`);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('xueqiu.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from xueqiu stock API: ${probe.detail || ''}`);
+  if (probe?.kind === 'xq-error') throw new CommandExecutionError(`xueqiu API error_code ${probe.errorCode}: ${probe.detail}`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`xueqiu whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected xueqiu probe: ${JSON.stringify(probe)}`);
+  return { user_id: String(probe.user_id) };
+}
+
+registerSiteAuthCommands({
+  site: 'xueqiu',
+  domain: 'xueqiu.com',
+  loginUrl: 'https://xueqiu.com/',
+  columns: ['user_id'],
+  verify: verifyXueqiuIdentity,
+  poll: async (page) => {
+    if (!await hasXueqiuAccessToken(page)) {
+      throw new AuthRequiredError('xueqiu.com', 'Waiting for Xueqiu xq_a_token cookie');
+    }
+    return verifyXueqiuIdentity(page);
+  },
+});

--- a/clis/youtube/auth.js
+++ b/clis/youtube/auth.js
@@ -1,0 +1,52 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasGoogleSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.youtube.com' });
+  const names = new Set(cookies.map(c => c.name));
+  return names.has('SID') || names.has('SAPISID') || names.has('__Secure-1PSID');
+}
+
+async function verifyYoutubeIdentity(page) {
+  if (!await hasGoogleSessionCookie(page)) {
+    throw new AuthRequiredError('www.youtube.com', 'Google session cookies missing');
+  }
+  await page.goto('https://www.youtube.com/');
+  await page.wait(3);
+  const probe = await page.evaluate(`
+    (() => {
+      const cfg = (typeof window !== 'undefined' && window.ytcfg && typeof window.ytcfg.get === 'function')
+        ? window.ytcfg.get('INNERTUBE_CONTEXT')
+        : null;
+      const user = cfg && cfg.client && cfg.client.userIdentity;
+      const loggedIn = !!(cfg && cfg.user && cfg.user.lockedSafetyMode === false);
+      const account = document.querySelector('button#avatar-btn, ytd-topbar-menu-button-renderer #avatar-btn');
+      if (!account) {
+        return { kind: 'auth', detail: 'YouTube avatar button missing — not signed in' };
+      }
+      const name = (cfg && cfg.user && cfg.user.identityName) || (account.getAttribute('aria-label') || '').replace(/^Account menu.*/i, '').trim();
+      if (!name) {
+        return { kind: 'render-error', detail: 'YouTube avatar present but identity name not extractable — layout drift' };
+      }
+      return { ok: true, name };
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('www.youtube.com', probe.detail);
+  if (probe?.kind === 'render-error') throw new CommandExecutionError(probe.detail);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected YouTube probe: ${JSON.stringify(probe)}`);
+  return { name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'youtube',
+  domain: 'www.youtube.com',
+  loginUrl: 'https://accounts.google.com/ServiceLogin?service=youtube&continue=https%3A%2F%2Fwww.youtube.com%2F',
+  columns: ['name'],
+  verify: verifyYoutubeIdentity,
+  poll: async (page) => {
+    if (!await hasGoogleSessionCookie(page)) {
+      throw new AuthRequiredError('www.youtube.com', 'Waiting for Google session cookies');
+    }
+    return verifyYoutubeIdentity(page);
+  },
+});

--- a/clis/youtube/auth.js
+++ b/clis/youtube/auth.js
@@ -15,24 +15,25 @@ async function verifyYoutubeIdentity(page) {
   await page.wait(3);
   const probe = await page.evaluate(`
     (() => {
-      const cfg = (typeof window !== 'undefined' && window.ytcfg && typeof window.ytcfg.get === 'function')
-        ? window.ytcfg.get('INNERTUBE_CONTEXT')
-        : null;
-      const user = cfg && cfg.client && cfg.client.userIdentity;
-      const loggedIn = !!(cfg && cfg.user && cfg.user.lockedSafetyMode === false);
-      const account = document.querySelector('button#avatar-btn, ytd-topbar-menu-button-renderer #avatar-btn');
-      if (!account) {
-        return { kind: 'auth', detail: 'YouTube avatar button missing — not signed in' };
+      const cfg = (typeof window !== 'undefined' && window.ytcfg && typeof window.ytcfg.get === 'function') ? window.ytcfg : null;
+      // ytcfg LOGGED_IN is the reliable signed-in signal; the avatar button is a fallback.
+      const loggedIn = !!(cfg && cfg.get('LOGGED_IN') === true) || !!document.querySelector('#avatar-btn');
+      if (!loggedIn) {
+        return { kind: 'auth', detail: 'YouTube ytcfg LOGGED_IN not true and no avatar — not signed in' };
       }
-      const name = (cfg && cfg.user && cfg.user.identityName) || (account.getAttribute('aria-label') || '').replace(/^Account menu.*/i, '').trim();
+      // Name is best-effort: YouTube's masthead avatar exposes a generic
+      // "Account menu" aria-label, so the channel name is often unavailable
+      // without opening the menu. Surface it when present, else leave empty.
+      let name = '';
+      try { const ctx = cfg && cfg.get('INNERTUBE_CONTEXT'); name = (ctx && ctx.user && ctx.user.identityName) || ''; } catch {}
       if (!name) {
-        return { kind: 'render-error', detail: 'YouTube avatar present but identity name not extractable — layout drift' };
+        const aria = (document.querySelector('#avatar-btn')?.getAttribute('aria-label') || '').trim();
+        if (aria && !/^account menu$/i.test(aria)) name = aria;
       }
-      return { ok: true, name };
+      return { ok: true, name: String(name || '') };
     })()
   `);
   if (probe?.kind === 'auth') throw new AuthRequiredError('www.youtube.com', probe.detail);
-  if (probe?.kind === 'render-error') throw new CommandExecutionError(probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected YouTube probe: ${JSON.stringify(probe)}`);
   return { name: probe.name };
 }

--- a/clis/yuanbao/auth.js
+++ b/clis/yuanbao/auth.js
@@ -1,0 +1,58 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+import { hasLoginGate, ensureYuanbaoPage, YUANBAO_DOMAIN, YUANBAO_URL } from './shared.js';
+
+async function hasYuanbaoUserCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://yuanbao.tencent.com' });
+  return cookies.some(c => c.name === 'hy_user' && c.value);
+}
+
+async function verifyYuanbaoIdentity(page) {
+  await ensureYuanbaoPage(page);
+  if (await hasLoginGate(page)) {
+    throw new AuthRequiredError(YUANBAO_DOMAIN, 'Yuanbao showed wx login gate — anonymous session');
+  }
+  const cookies = await page.getCookies({ url: 'https://yuanbao.tencent.com' });
+  const hyUser = cookies.find(c => c.name === 'hy_user')?.value || '';
+  if (!hyUser) {
+    throw new AuthRequiredError(YUANBAO_DOMAIN, 'Yuanbao hy_user cookie missing — anonymous session');
+  }
+  const probe = await page.evaluate(`
+    (() => {
+      const bodyText = document.body?.innerText || '';
+      const nickMatch = bodyText.match(/用户[a-z0-9]{4,}/i);
+      const state = window.__INITIAL_STATE__ || {};
+      const seen = new Set();
+      const stack = [state];
+      let stateNick = '';
+      while (stack.length) {
+        const node = stack.pop();
+        if (!node || typeof node !== 'object' || seen.has(node)) continue;
+        seen.add(node);
+        if (Array.isArray(node)) { stack.push(...node); continue; }
+        const u = node.userInfo || node.user;
+        if (u && typeof u === 'object' && (u.nickname || u.nick)) {
+          stateNick = String(u.nickname || u.nick);
+          break;
+        }
+        for (const v of Object.values(node)) if (v && typeof v === 'object') stack.push(v);
+      }
+      return { nickname: stateNick || (nickMatch ? nickMatch[0] : '') };
+    })()
+  `);
+  return { user_id: String(hyUser), nickname: String(probe.nickname || '') };
+}
+
+registerSiteAuthCommands({
+  site: 'yuanbao',
+  domain: YUANBAO_DOMAIN,
+  loginUrl: YUANBAO_URL,
+  columns: ['user_id', 'nickname'],
+  verify: verifyYuanbaoIdentity,
+  poll: async (page) => {
+    if (!await hasYuanbaoUserCookie(page)) {
+      throw new AuthRequiredError(YUANBAO_DOMAIN, 'Waiting for Yuanbao hy_user cookie');
+    }
+    return verifyYuanbaoIdentity(page);
+  },
+});

--- a/clis/zhihu/auth.js
+++ b/clis/zhihu/auth.js
@@ -1,0 +1,58 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+async function hasZhihuAuthCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.zhihu.com' });
+  return cookies.some(c => c.name === 'z_c0' && c.value);
+}
+
+async function verifyZhihuIdentity(page) {
+  if (!await hasZhihuAuthCookie(page)) {
+    throw new AuthRequiredError('www.zhihu.com', 'Zhihu z_c0 cookie missing — anonymous');
+  }
+  await page.goto('https://www.zhihu.com/');
+  await page.wait(2);
+  const data = await page.evaluate(`
+    (async () => {
+      try {
+        const r = await fetch('https://www.zhihu.com/api/v4/me?include=url_token', { credentials: 'include' });
+        if (!r.ok) return { __httpError: r.status };
+        return await r.json();
+      } catch (e) {
+        return { __exception: String(e && e.message || e) };
+      }
+    })()
+  `);
+  if (data?.__exception) {
+    throw new CommandExecutionError(`Zhihu whoami failed: ${data.__exception}`);
+  }
+  if (!data || data.__httpError) {
+    const status = data?.__httpError;
+    if (status === 401 || status === 403) {
+      throw new AuthRequiredError('www.zhihu.com', `Zhihu /api/v4/me returned HTTP ${status} — anonymous`);
+    }
+    throw new CommandExecutionError(`Zhihu identity probe failed (HTTP ${status ?? 'unknown'})`);
+  }
+  if (!data.url_token) {
+    throw new AuthRequiredError('www.zhihu.com', 'Zhihu /api/v4/me returned no url_token — anonymous session');
+  }
+  return {
+    url_token: String(data.url_token),
+    name: String(data.name ?? ''),
+    uid: String(data.uid ?? data.id ?? ''),
+  };
+}
+
+registerSiteAuthCommands({
+  site: 'zhihu',
+  domain: 'www.zhihu.com',
+  loginUrl: 'https://www.zhihu.com/signin',
+  columns: ['url_token', 'name', 'uid'],
+  verify: verifyZhihuIdentity,
+  poll: async (page) => {
+    if (!await hasZhihuAuthCookie(page)) {
+      throw new AuthRequiredError('www.zhihu.com', 'Waiting for Zhihu z_c0 cookie');
+    }
+    return verifyZhihuIdentity(page);
+  },
+});

--- a/clis/zsxq/auth.js
+++ b/clis/zsxq/auth.js
@@ -1,0 +1,53 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// zsxq auth cookies are all httpOnly and span multiple subdomains
+// (wx.zsxq.com / api.zsxq.com / .zsxq.com), so document.cookie / cookie
+// probes are unreliable. Verify via a lightweight API 401 probe instead.
+async function verifyZsxqIdentity(page) {
+  await page.goto('https://wx.zsxq.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(`
+    (async () => {
+      const url = location.href;
+      if (/\\/login(\\b|$)/.test(url)) {
+        return { kind: 'auth', detail: 'zsxq wx page redirected to /login — anonymous session' };
+      }
+      try {
+        const r = await fetch('https://api.zsxq.com/v2/users/self', {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        });
+        if (r.status === 401 || r.status === 403) {
+          return { kind: 'auth', detail: 'zsxq /v2/users/self returned HTTP ' + r.status };
+        }
+        if (!r.ok) return { kind: 'http', httpStatus: r.status };
+        const d = await r.json();
+        if (d?.succeeded === false || !d?.resp_data?.user) {
+          return { kind: 'auth', detail: 'zsxq /v2/users/self returned succeeded=false — anonymous' };
+        }
+        const u = d.resp_data.user;
+        return { ok: true, user_id: String(u.user_id || u.id || ''), name: String(u.name || u.nickname || '') };
+      } catch (e) {
+        return { kind: 'exception', detail: String(e && e.message || e) };
+      }
+    })()
+  `);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('zsxq.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from zsxq /v2/users/self`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`zsxq whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected zsxq probe: ${JSON.stringify(probe)}`);
+  if (!probe.user_id) {
+    throw new AuthRequiredError('zsxq.com', 'zsxq /v2/users/self 200 but user_id missing — incomplete session');
+  }
+  return { user_id: probe.user_id, name: probe.name };
+}
+
+registerSiteAuthCommands({
+  site: 'zsxq',
+  domain: 'zsxq.com',
+  loginUrl: 'https://wx.zsxq.com/login',
+  columns: ['user_id', 'name'],
+  verify: verifyZsxqIdentity,
+  poll: verifyZsxqIdentity,
+});

--- a/clis/zsxq/auth.js
+++ b/clis/zsxq/auth.js
@@ -49,5 +49,20 @@ registerSiteAuthCommands({
   loginUrl: 'https://wx.zsxq.com/login',
   columns: ['user_id', 'name'],
   verify: verifyZsxqIdentity,
-  poll: verifyZsxqIdentity,
+  // No-navigation poll: probe the API from the current page so the login-page
+  // QR code isn't reset by a goto on every interval.
+  poll: async (page) => {
+    const loggedIn = await page.evaluate(`(async () => {
+      try {
+        const r = await fetch('https://api.zsxq.com/v2/users/self', { credentials: 'include', headers: { Accept: 'application/json' } });
+        if (!r.ok) return false;
+        const d = await r.json();
+        return !!(d?.resp_data?.user);
+      } catch { return false; }
+    })()`);
+    if (!loggedIn) {
+      throw new AuthRequiredError('zsxq.com', 'Waiting for zsxq login');
+    }
+    return verifyZsxqIdentity(page);
+  },
 });


### PR DESCRIPTION
## What

Adds `opencli <site> login` + `opencli <site> whoami` for **50 sites** in a single batch, via the `registerSiteAuthCommands` framework (#1852), extending the 5-site MVP (twitter / bilibili / xiaohongshu / github / douyin).

50 new sites:

`12306` `1688` `1point3acres` `amazon` `band` `boss` `chaoxing` `chatgpt` `claude` `coupang` `ctrip` `dianping` `douban` `doubao` `facebook` `flomo` `gemini` `grok` `hupu` `instagram` `jd` `jianyu` `ke` `kimi` `linkedin` `linkedin-learning` `linux-do` `manus` `notebooklm` `pixiv` `powerchina` `qwen` `reddit` `rednote` `reuters` `suno` `taobao` `tiktok` `toutiao` `upwork` `wechat-channels` `weibo` `weread` `xianyu` `xiaoe` `xueqiu` `youtube` `yuanbao` `zhihu` `zsxq`

## How

Each `clis/<site>/auth.js` follows the same contract:

- **Two-pronged auth detection**: cheap cookie-SoT `poll` probe + an HTTP/DOM/state `verify` probe. Cookie presence alone never counts as logged-in where the site returns 200 + empty body for stale sessions (xueqiu `u===cookiesu`, claude empty org list, etc.).
- **Typed errors only**: `AuthRequiredError` for anonymous/stale, `CommandExecutionError` for layout drift / HTTP / parse failures. No silent `return []`, no sentinel rows, no `Math.min` clamps.
- **Plain-object identity return**; the framework prefixes `logged_in` + `site` columns and wraps with `normalizeIdentity`.
- `page.getCookies({url})` (CDP layer, handles httpOnly) for cookie checks; discriminated-union probe inside `page.evaluate`.

Probe strategies vary by site: cookie-SoT-only (1688/taobao/ctrip), HTTP whoami endpoint (instagram/suno/claude/zhihu/12306), DOM-only (ke/powerchina/dianping/xiaoe), SPA state walk (rednote/tiktok/toutiao/yuanbao/flomo), and localStorage-OIDC (reuters). Several reuse existing site helpers (yuanbao `shared.js`).

## Verification

- `npm run build` → manifest 1149 entries (100 new commands)
- `npm test` → **462 files, 5029 passed**, 1 skipped
- `npm run check:typed-error-lint` → **new=0** (resolved 7)
- `npm run check:silent-column-drop` → **new=0** (resolved 1)

## Notes / follow-ups

- Discriminated-union success variant uses `ok: true` (already exempted by the silent-column-drop audit) rather than `kind: 'ok'`, since `kind` is a real data column on other adapters (weread-official/chess/notebooklm) and can't be globally exempted.
- A few sites carry caveats from discovery (weixin web phase-out, atlassian workspace-scoped — excluded; manus endpoint, xianyu/xiaoe DOM selectors pending a logged-in live retest). Marked in each adapter's comments where relevant.