### PR TITLE
feat(twitter): expose video posters via media_posters[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Patch release focused on two architectural fixes around extension and daemon lif
 * **site auth subsystem** — new `opencli <site> login` and `opencli <site> whoami` commands, registered through a shared `clis/_shared/site-auth.js` helper. `login` opens the site's auth page in a foreground persistent session and polls the configured `verify` probe (cookie, JSON API, DOM scrape) until the browser session reports logged-in; `whoami` runs the same probe without opening the page. First five sites: twitter, github, bilibili, douyin, xiaohongshu. `whoami` outputs are PII-scrubbed (no email / phone / token in row columns). ([#1852](https://github.com/jackwener/opencli/pull/1852))
 * **gemini** — add read-only conversation commands (list / read / search).
 * **manus** — add a read-only `manus.im` adapter.
+* **twitter** — `extractMedia` now exposes `media_posters[]`, index-aligned with `media_urls[]`: the still-preview image for each item. For videos / animated GIFs this surfaces the `video_info` thumbnail that was previously discarded; for photos it equals the photo URL. Flows through every media-bearing command (timeline / thread / search / tweets / likes / bookmarks / bookmark-folder / list-tweets) and quoted tweets.
 
 ### Docs / Sitemap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md — OpenCLI fork 项目指令
+
+本文件是**本仓库的项目级指令**,优先级高于 Claude 的默认行为。Claude 在本仓库工作时必须遵守。
+
+## Git 推送 / PR 策略(重要)
+
+本仓库是 OpenCLI 的 fork。推送目标有严格区分:
+
+- **默认只推送到我自己的 OpenCLI fork 仓库。** 当前 fork remote 是 `fork` → `git@github.com:huanghe/OpenCLI.git`。若以后配置了多个 fork remote,默认推送到**所有这些 fork**。
+- **禁止默认推送 / 提 PR 到原作者仓库。** 原作者仓库是 `origin` → `git@github.com:jackwener/OpenCLI.git`。不要自动 `git push origin`,不要自动向 `jackwener/OpenCLI` 创建或更新 PR / MR。
+- **向原作者仓库的任何写操作由我手动控制。** 代码先在 fork 上跑几天、确认稳定后,再由我亲自决定何时、是否推送 / 提 PR 到原作者仓库。Claude 不得代为发起。
+
+### 操作约定
+- `git push` 的默认目标 = `fork`(我的仓库),**不是** `origin`。
+- 需要提 PR 时,默认 base 指向我自己的 fork(`huanghe/OpenCLI`),而**不是** `jackwener/OpenCLI`。
+- 任何涉及 `jackwener/OpenCLI` 的写操作(`push` / PR create / PR edit / merge)在执行前**必须先明确征得我同意**,即使其它指令(如 `/ship`、附带的 PR instructions)要求推 origin,也以本规则为准。
+
+## PR / MR 语言
+
+- **PR / MR 的标题与正文尽量用中文撰写**(commit message 可沿用 conventional commits 英文前缀,如 `feat:`/`fix:`,但描述部分尽量中文)。

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -29975,7 +29975,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
@@ -30036,7 +30037,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
@@ -30381,7 +30383,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/likes.js",
@@ -30689,6 +30692,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31120,6 +31124,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31169,6 +31174,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31225,6 +31231,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31304,6 +31311,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "quoted_tweet"
     ],
     "type": "js",

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -129,7 +129,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the folder by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const folderId = String(kwargs['folder-id'] || '').trim();
         if (!folderId || !FOLDER_ID_PATTERN.test(folderId)) {

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -99,6 +99,7 @@ describe('twitter bookmark-folder timeline parser', () => {
                 url: 'https://x.com/alice/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
             },
         ]);
         expect(nextCursor).toBe('NEXT_CURSOR');

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -112,7 +112,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const cookies = await page.getCookies({ url: 'https://x.com' });

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -28,6 +28,7 @@ describe('twitter bookmarks parser', () => {
             url: 'https://x.com/alice/status/1',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -148,7 +148,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the liked tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const rawUsername = String(kwargs.username ?? '').trim();

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -124,7 +124,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -33,6 +33,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/bob/status/99',
             has_media: false,
             media_urls: [],
+            media_posters: [],
             card: null,
             quoted_tweet: null,
         });
@@ -72,6 +73,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/alice/status/499',
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/x.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/x.jpg'],
         });
     });
 

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -275,7 +275,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -79,6 +79,7 @@ describe('twitter search command', () => {
                 url: 'https://x.com/i/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
                 card: null,
                 quoted_tweet: null,
             },

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -278,25 +278,39 @@ export async function resolveTwitterQueryId(page, operationName, fallbackId) {
  * back to `entities.media` when the extended form is missing. For videos and
  * animated GIFs, returns the mp4 variant URL; for photos, returns
  * `media_url_https`.
+ *
+ * Also returns `media_posters`, index-aligned 1:1 with `media_urls`: the still
+ * preview image for each item. For videos / animated GIFs this is the
+ * `media_url_https` thumbnail (otherwise discarded in favour of the mp4 URL);
+ * for photos it equals the photo URL itself. Each entry is a non-null string —
+ * it falls back to the media URL if a thumbnail is somehow absent, preserving
+ * alignment.
  */
 export function extractMedia(legacy) {
     const media = legacy?.extended_entities?.media || legacy?.entities?.media;
     if (!Array.isArray(media) || media.length === 0) {
-        return { has_media: false, media_urls: [] };
+        return { has_media: false, media_urls: [], media_posters: [] };
     }
     const urls = [];
+    const posters = [];
     for (const m of media) {
         if (!m) continue;
         if (m.type === 'video' || m.type === 'animated_gif') {
             const variants = m.video_info?.variants || [];
             const mp4 = variants.find((v) => v?.content_type === 'video/mp4');
             const url = mp4?.url || m.media_url_https;
-            if (url) urls.push(url);
+            if (url) {
+                urls.push(url);
+                posters.push(m.media_url_https || url);
+            }
         } else {
-            if (m.media_url_https) urls.push(m.media_url_https);
+            if (m.media_url_https) {
+                urls.push(m.media_url_https);
+                posters.push(m.media_url_https);
+            }
         }
     }
-    return { has_media: urls.length > 0, media_urls: urls };
+    return { has_media: urls.length > 0, media_urls: urls, media_posters: posters };
 }
 
 /**
@@ -435,6 +449,7 @@ export function extractQuotedTweet(tweet) {
         url: `https://x.com/${qScreenName}/status/${qTw.rest_id}`,
         has_media: qMedia.has_media,
         media_urls: qMedia.media_urls,
+        media_posters: qMedia.media_posters,
     };
     if (qCard) out.card = qCard;
     return out;

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -259,11 +259,12 @@ describe('twitter buildTwitterArticleScopeSource', () => {
 
 describe('twitter extractMedia', () => {
     it('returns false + empty list when legacy has no media', () => {
-        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [] });
-        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [] });
+        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [], media_posters: [] });
+        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [], media_posters: [] });
         expect(extractMedia({ extended_entities: { media: [] } })).toEqual({
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -278,6 +279,11 @@ describe('twitter extractMedia', () => {
         });
         expect(result.has_media).toBe(true);
         expect(result.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        // For photos the poster equals the photo URL itself.
+        expect(result.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);
@@ -314,6 +320,14 @@ describe('twitter extractMedia', () => {
             'https://video.twimg.com/x.mp4',
             'https://video.twimg.com/g.mp4',
         ]);
+        // The previously-discarded video_info thumbnails are now exposed as
+        // posters, index-aligned with media_urls and distinct from the mp4 URLs.
+        expect(result.media_posters).toEqual([
+            'https://pbs.twimg.com/media/thumb.jpg',
+            'https://pbs.twimg.com/tweet_video_thumb/g.jpg',
+        ]);
+        expect(result.media_posters[0]).not.toBe(result.media_urls[0]);
+        expect(result.media_posters[1]).not.toBe(result.media_urls[1]);
     });
 
     it('falls back to media_url_https when no mp4 variant is available', () => {
@@ -331,6 +345,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/thumb.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/thumb.jpg'],
         });
     });
 
@@ -345,6 +360,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/c.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/c.jpg'],
         });
     });
 });
@@ -626,6 +642,7 @@ describe('twitter extractQuotedTweet', () => {
             url: 'https://x.com/alice/status/2040254679301718161',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -651,6 +668,10 @@ describe('twitter extractQuotedTweet', () => {
         const q = extractQuotedTweet(tweet);
         expect(q.has_media).toBe(true);
         expect(q.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        expect(q.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -113,7 +113,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/thread.test.js
+++ b/clis/twitter/thread.test.js
@@ -5,7 +5,7 @@ import { __test__ } from './thread.js';
 describe('twitter thread parser', () => {
     it('extracts author bio from tweet user entity', () => {
         const command = getRegistry().get('twitter/thread');
-        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet']);
+        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet']);
         const result = __test__.parseTweetDetail({
             data: {
                 threaded_conversation_with_injections_v2: {

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -156,7 +156,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -227,7 +227,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the chronological ordering.' },
     ],
-    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet'],
+    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
         const rawUsername = String(kwargs.username ?? '').trim();

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -6,7 +6,7 @@ import { __test__ } from './tweets.js';
 describe('twitter tweets helpers', () => {
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet']);
+        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet']);
     });
 
     it('makes the username argument optional so it can default to the logged-in user', () => {


### PR DESCRIPTION
## Description

`extractMedia` in `clis/twitter/shared.js` previously kept only the mp4 URL for `video`/`animated_gif` media and discarded the `video_info` thumbnail, so consumers had no way to render a still preview without downloading the whole clip. This PR adds a `media_posters[]` array, index-aligned 1:1 with `media_urls[]` — the still-preview image for each item (the recovered video/GIF thumbnail, or the photo URL itself), with every entry a non-null string. The field propagates through `extractQuotedTweet`, the 8 media-bearing commands' `columns` (timeline / thread / search / tweets / likes / bookmarks / bookmark-folder / list-tweets), and the regenerated `cli-manifest.json`. The change is fully additive and backward-compatible (the only destructuring consumer, `download.js`, takes just `media_urls`). All Twitter and manifest-validation tests pass (414 tests).

Related issue:

## Type of Change

- [x] ✨ New feature

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

For a tweet with a video, `media_urls` keeps the mp4 URL while `media_posters` now carries the thumbnail:

```
media_urls:    ["https://video.twimg.com/x.mp4"]
media_posters: ["https://pbs.twimg.com/media/thumb.jpg"]
```