### PR TITLE
fix(extension): 消除 macOS 自动化窗口的残留抢焦（#739 后续）

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1457,6 +1457,13 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
   container.windowId = win.id;
   await persistRuntimeState();
   console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
+  if (mode === "background") {
+    try {
+      await chrome.windows.update(container.windowId, { state: "minimized", focused: false });
+    } catch (e) {
+      console.warn("[opencli] minimize automation window failed:", e);
+    }
+  }
   const tabs = await chrome.tabs.query({ windowId: win.id });
   const initialTabId = tabs[0]?.id;
   if (initialTabId) {
@@ -1515,7 +1522,7 @@ async function createOwnedTabLeaseUnlocked(leaseKey, initialUrl) {
       tab = await chrome.tabs.get(initialTabId);
     }
   } else {
-    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: getWindowMode(leaseKey) === "foreground" });
   }
   const tabId = tab.id;
   if (!tabId) throw new Error("Failed to create tab lease in automation container");
@@ -1887,7 +1894,7 @@ async function resolveTab(tabId, leaseKey, initialUrl) {
     } catch {
     }
   }
-  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: getWindowMode(leaseKey) === "foreground" });
   if (!newTab.id) throw new Error("Failed to create tab in automation container");
   await ensureOwnedContainerGroup(role, scopedWindowId, [newTab.id]);
   return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
@@ -2080,7 +2087,7 @@ async function handleTabs(cmd, leaseKey) {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(leaseKey);
-      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: getWindowMode(leaseKey) === "foreground" });
       const tabId = tab.id;
       if (!tabId) return { id: cmd.id, ok: false, error: "Failed to create tab" };
       const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [tabId]);

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -201,6 +201,7 @@ function createChromeMock() {
     windows: {
       get: vi.fn(async (windowId: number) => ({ id: windowId, focused: windowId === lastFocusedWindowId })),
       create: vi.fn(async ({ url, focused, width, height, type }: any) => ({ id: 1, url, focused, width, height, type })),
+      update: vi.fn(async (_windowId: number, _updates: any) => {}),
       remove: vi.fn(async (_windowId: number) => {}),
       onRemoved: { addListener: vi.fn() } as Listener<(windowId: number) => void>,
     },
@@ -630,7 +631,9 @@ describe('background tab isolation', () => {
     const result = await mod.__test__.handleTabs({ id: '2', action: 'tabs', op: 'new', url: 'https://new.example', session: adapterKey('twitter') }, adapterKey('twitter'));
 
     expect(result.ok).toBe(true);
-    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'https://new.example', active: true });
+    // adapter sessions run in background window mode, so new tabs must not be
+    // activated (activating them can pull the window to the foreground on macOS).
+    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'https://new.example', active: false });
   });
 
   it('reuses the initial container tab for first tab-new lease instead of leaving a blank tab', async () => {
@@ -994,7 +997,8 @@ describe('background tab isolation', () => {
     }));
     expect(maxInFlight).toBe(2);
     expect(chrome.windows.create).toHaveBeenCalledTimes(1);
-    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: true });
+    // adapter (background) sessions create inactive tabs to avoid focus steal
+    expect(create).toHaveBeenCalledWith({ windowId: 1, url: 'about:blank', active: false });
   });
 
   it('releases owned sessions without closing the shared container', async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1010,6 +1010,18 @@ async function ensureOwnedContainerWindowUnlocked(
   await persistRuntimeState();
   console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);
 
+  // macOS 15.x (and intermittently 26.x) ignore `focused: false` on windows.create()
+  // and pull the new window to the foreground anyway. See jackwener/opencli#739.
+  // Counteract by minimizing right after creation. `state: 'minimized'` is rejected
+  // when combined with width/height on create(), but is accepted on update().
+  if (mode === 'background') {
+    try {
+      await chrome.windows.update(container.windowId, { state: 'minimized', focused: false });
+    } catch (e) {
+      console.warn('[opencli] minimize automation window failed:', e);
+    }
+  }
+
   // Wait for the initial tab to finish loading instead of a fixed 200ms sleep.
   const tabs = await chrome.tabs.query({ windowId: win.id! });
   const initialTabId = tabs[0]?.id;
@@ -1087,7 +1099,7 @@ async function createOwnedTabLeaseUnlocked(leaseKey: string, initialUrl?: string
       tab = await chrome.tabs.get(initialTabId);
     }
   } else {
-    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: true });
+    tab = await chrome.tabs.create({ windowId, url: targetUrl, active: getWindowMode(leaseKey) === 'foreground' });
   }
   const tabId = tab.id;
   if (!tabId) throw new Error('Failed to create tab lease in automation container');
@@ -1576,7 +1588,7 @@ async function resolveTab(tabId: number | undefined, leaseKey: string, initialUr
   }
 
   // Fallback: create a new tab
-  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: true });
+  const newTab = await chrome.tabs.create({ windowId: scopedWindowId, url: BLANK_PAGE, active: getWindowMode(leaseKey) === 'foreground' });
   if (!newTab.id) throw new Error('Failed to create tab in automation container');
   await ensureOwnedContainerGroup(role, scopedWindowId, [newTab.id]);
   return { tabId: newTab.id, tab: await chrome.tabs.get(newTab.id) };
@@ -1827,7 +1839,7 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
         return pageScopedResult(cmd.id, created.tabId, { url: created.tab?.url });
       }
       const windowId = await getAutomationWindow(leaseKey);
-      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: true });
+      let tab = await chrome.tabs.create({ windowId, url: cmd.url ?? BLANK_PAGE, active: getWindowMode(leaseKey) === 'foreground' });
       const tabId = tab.id;
       if (!tabId) return { id: cmd.id, ok: false, error: 'Failed to create tab' };
       const group = await ensureOwnedContainerGroup(getOwnedWindowRole(leaseKey), windowId, [tabId]);

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -340,6 +340,15 @@ async function sendCommandRaw(
   const contextId = routing.contextId;
   const preferredContextId = routing.preferredContextId;
   const windowMode = params.windowMode ?? envWindowMode;
+  // OPENCLI_IDLE_TIMEOUT_MS: keep automation window alive longer than the
+  // 30s adapter default so polling pipelines reuse the same window instead
+  // of forcing a new windows.create() — the real focus-steal trigger on
+  // macOS 15.x / 26.x. Caller-supplied params.idleTimeout (seconds) wins.
+  const rawIdleMs = process.env.OPENCLI_IDLE_TIMEOUT_MS;
+  const idleTimeoutFromEnv = rawIdleMs && /^\d+$/.test(rawIdleMs)
+    ? Math.max(0, Math.floor(parseInt(rawIdleMs, 10) / 1000))
+    : undefined;
+  const idleTimeout = params.idleTimeout ?? idleTimeoutFromEnv;
 
   let id = generateId();
   let ensureUsed = false;
@@ -379,6 +388,7 @@ async function sendCommandRaw(
       ...(contextId && { contextId }),
       ...(preferredContextId && { preferredContextId }),
       ...(windowMode && { windowMode }),
+      ...(idleTimeout !== undefined && { idleTimeout }),
       // Carry the run identity so the daemon can acquire/refresh the write
       // lease on the persistent site session. The same runId across every exec
       // of one command is the heartbeat that keeps a long-running holder alive.


### PR DESCRIPTION
## 背景:#739 的架构主因 vs 残留(避免误判为重复)

#739(macOS 自动化窗口抢焦)已在 v1.7.22 以「架构性原因已解决」关闭。被解决的**架构主因**是「每个 adapter 命令都新建一个 Chrome 窗口、每次都抢焦」——由 **#1457**(`rename adapter tab group`)/ **#1541**(`reuse existing adapter tab group`)改成**单一共享 Adapter 窗口、跨命令复用**,把抢焦频率从「每条命令一次」降到「每个窗口生命周期最多一次」。

但维护者关闭 #739 时明确承认**仍有残留**:macOS 15.x 会忽略窗口**首次** `windows.create()` 上的 `focused: false`,所以那「生命周期内的一次」创建仍会抢焦;后台自动化标签的激活也会把窗口拉到前台。

**本 PR 只处理这个残留,不碰已由 #1457/#1541 解决的架构主因**——minimize / tab-activation / idle-timeout 三处在当前 main 上都不存在,不是对既有逻辑的重写。

## 改动

1. **后台窗口创建后立即最小化**:`ensureOwnedContainerWindowUnlocked` 在 `mode === 'background'` 时调用 `chrome.windows.update(windowId, { state: 'minimized', focused: false })`。
   （`state: 'minimized'` 与 `width/height` 一起传给 `create()` 会被拒绝，但在 `update()` 上可接受——所以放在创建之后。）最小化的窗口不会夺取焦点，从而连「首次创建」那一次抢焦也消除。
2. **新标签仅在前台模式激活**:三处 `chrome.tabs.create({ ..., active: true })` 改为 `active: getWindowMode(leaseKey) === 'foreground'`，避免后台自动化标签把窗口拉到前台。
3. **新增 `OPENCLI_IDLE_TIMEOUT_MS`**:允许轮询型管线延长自动化窗口存活时间、复用窗口，避免反复 `windows.create()`（即抢焦的原始触发点）。对应 #739 讨论中 @gucasbrg 提出的「idle timeout 可配置」诉求。

## 为什么不用 `chrome.windows.getAll()` 复用方案

#739 讨论中有人提过用 `chrome.windows.getAll()` 复用已有窗口，但实测会**导致 service worker 崩溃**、并破坏 `getAutomationWindow()` 的窗口隔离设计（@rickexpgame、@Astro-Han 的反馈）。本 PR 不走这条路，只在 extension 自己拥有的窗口上做最小化，保持隔离不变。

## 测试

- `extension/src/background.test.ts`:更新 tab-isolation 用例,断言后台(adapter)会话创建标签时 `active: false`(本 PR 的目的正是后台标签不激活);前台模式仍 `active: true`。
- macOS 15.x 手测:运行后台自动化命令时,自动化窗口创建后立即最小化,不再抢占当前应用焦点。
- `npx tsc --noEmit` 通过；`extension/dist/background.js` 已同步更新以匹配 `extension/src/background.ts`。

## 说明

本 PR 只针对 #739 的残留抢焦，刻意保持最小范围。若需要我也可以补充集成测试或在后台/前台模式上加更明确的开关，请告知。