### PR TITLE
fix(browser): goto 重试覆盖裸 'Page not found:' 失效身份

### DIFF
--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -323,6 +323,28 @@ describe('Page active target tracking', () => {
     expect(retryCall[1]).not.toHaveProperty('page');
   });
 
+  it('retries on a bare "Page not found:" error without the stale-identity suffix', async () => {
+    // Under concurrent adapter calls the extension can reject with just
+    // "Page not found: <id>" (no "— stale page identity" suffix) when the cached
+    // targetId was evicted. That still means the identity is dead, so goto() must
+    // drop it and retry once instead of cascading failures.
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/first' }, page: 'page-1' })
+      .mockRejectedValueOnce(new Error('Page not found: deadbeef'))
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/second' }, page: 'page-2' });
+
+    const page = new Page('site:youtube', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await page.goto('https://example.com/first', { waitUntil: 'none' });
+    await page.goto('https://example.com/second', { waitUntil: 'none' });
+    expect(page.getActivePage()).toBe('page-2');
+
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(3);
+    const retryCall = sendCommandFullMock.mock.calls[2];
+    expect(retryCall[0]).toBe('navigate');
+    expect(retryCall[1]).not.toHaveProperty('page');
+  });
+
   it('does not retry stale page errors when no identity was cached', async () => {
     // _page is undefined on a fresh Page — there's nothing to drop, so propagate the
     // error instead of silently retrying with the same params.

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -372,6 +372,19 @@ describe('Page active target tracking', () => {
     expect(sendCommandFullMock).toHaveBeenCalledTimes(2);
   });
 
+  it('does not retry unrelated navigate errors that only mention Page not found in details', async () => {
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/first' }, page: 'page-1' })
+      .mockRejectedValueOnce(new Error('Navigation failed: upstream says Page not found: /missing'));
+
+    const page = new Page('site:youtube', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await page.goto('https://example.com/first', { waitUntil: 'none' });
+    await expect(page.goto('https://example.com/missing', { waitUntil: 'none' }))
+      .rejects.toThrow('Navigation failed');
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(2);
+  });
+
   it('creates a new tab without changing the current active page binding', async () => {
     sendCommandFullMock
       .mockResolvedValueOnce({ data: { url: 'https://first.example' }, page: 'page-1' })

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -33,7 +33,7 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
 // to the session lease (or create a fresh tab).
 function isStalePageIdentityError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return message.includes('stale page identity') || message.includes('Page not found:');
+  return message.includes('stale page identity') || /^Page not found:\s*\S+\s*$/.test(message);
 }
 
 /**

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -33,7 +33,7 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
 // to the session lease (or create a fresh tab).
 function isStalePageIdentityError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return message.includes('stale page identity');
+  return message.includes('stale page identity') || message.includes('Page not found:');
 }
 
 /**
@@ -94,9 +94,9 @@ export class Page extends BasePage {
     } catch (err) {
       // If our cached targetId went stale (tab closed externally, identity evicted),
       // drop the dead id and retry without it — the extension will resolve through the
-      // session lease or open a fresh automation tab. Without this, subsequent
-      // navigations in the same Page instance keep re-sending the same dead targetId
-      // and cascade into "Page not found:" failures.
+      // session lease or open a fresh automation tab. Without this, every subsequent
+      // adapter call in the same process keeps re-sending the same dead targetId and
+      // cascades into "Page not found:" failures across concurrent calls.
       if (!isStalePageIdentityError(err) || this._page === undefined) throw err;
       this._page = undefined;
       result = await sendCommandFull('navigate', {


### PR DESCRIPTION
## 问题

`Page.goto()` 已有「stale page identity 自动重试」逻辑:当缓存的 `targetId` 失效(标签被外部关闭、identity 被驱逐)时,丢弃死 id 并经 session lease 重试一次。

但判定函数 `isStalePageIdentityError()` 只匹配错误信息里包含 `stale page identity` 的情况。在**并发 adapter 调用**下,扩展有时只抛出 `Page not found: <id>`(**不带** `— stale page identity` 后缀)。这类错误没被识别为「身份失效」,于是不会重试——同一个死 `targetId` 被反复发送,导致后续调用连环失败。

## 改动

把 `isStalePageIdentityError()` 放宽为同时匹配 `Page not found:`:

```diff
-  return message.includes('stale page identity');
+  return message.includes('stale page identity') || message.includes('Page not found:');
```

这样 `goto()` 在收到裸 `Page not found:` 时也会丢弃失效身份、重试一次。重试本身是安全的:只是清掉缓存 `targetId` 后让扩展的 session lease 重新解析到活标签(已有逻辑),`_page` 为空时仍照旧直接抛错、不重试。

## 测试

新增用例 `retries on a bare "Page not found:" error without the stale-identity suffix`:
- **有本修复**:`src/browser/page.test.ts` 25 个用例全部通过。
- **去掉本修复**(对照):该用例失败,第二次 `goto()` 直接抛 `Page not found: deadbeef`,证明它精确覆盖了新分支。

`npx tsc --noEmit` 通过。
