### PR TITLE
fix(browser): persist interceptor across navigation

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -875,6 +875,41 @@ describe('BasePage native input routing', () => {
   });
 });
 
+describe('BasePage installInterceptor', () => {
+  it('installs the interceptor into future documents when CDP is available', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn().mockResolvedValue({ identifier: 'interceptor-script' });
+
+    await page.installInterceptor('batchSearch');
+
+    expect(page.scripts).toHaveLength(1);
+    expect(page.scripts[0]).toContain('batchSearch');
+    expect(page.scripts[0]).toContain('__opencli_xhr');
+    expect(page.cdp).toHaveBeenCalledWith(
+      'Page.addScriptToEvaluateOnNewDocument',
+      {
+        source: expect.stringContaining('batchSearch'),
+      },
+    );
+  });
+
+  it('keeps the current-document interceptor when future-document registration fails', async () => {
+    const page = new ActionPage();
+    page.cdp = vi.fn().mockRejectedValue(new Error('not supported'));
+
+    await expect(page.installInterceptor('batchSearch')).resolves.toBeUndefined();
+
+    expect(page.scripts).toHaveLength(1);
+    expect(page.scripts[0]).toContain('batchSearch');
+    expect(page.cdp).toHaveBeenCalledWith(
+      'Page.addScriptToEvaluateOnNewDocument',
+      expect.objectContaining({
+        source: expect.stringContaining('batchSearch'),
+      }),
+    );
+  });
+});
+
 describe('BasePage.evaluateWithArgs scoping', () => {
   class EvalCapturePage extends BasePage {
     scripts: string[] = [];

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -1143,10 +1143,17 @@ export abstract class BasePage implements IPage {
 
   async installInterceptor(pattern: string): Promise<void> {
     const { generateInterceptorJs } = await import('../interceptor.js');
-    await this.evaluate(generateInterceptorJs(JSON.stringify(pattern), {
+    const interceptorJs = generateInterceptorJs(JSON.stringify(pattern), {
       arrayName: '__opencli_xhr',
       patchGuard: '__opencli_interceptor_patched',
-    }));
+    });
+    await this.evaluate(interceptorJs);
+
+    const cdp = (this as IPage).cdp;
+    if (typeof cdp !== 'function') return;
+    await cdp.call(this, 'Page.addScriptToEvaluateOnNewDocument', {
+      source: `(${interceptorJs})()`,
+    }).catch(() => {});
   }
 
   async getInterceptedRequests(): Promise<unknown[]> {


### PR DESCRIPTION
## Description

`installInterceptor(pattern)` only patched the current document before this change. If a caller installed the interceptor and then navigated, the new document lost the fetch/XHR monkey patch, so requests fired by the loaded page could not be captured.

This keeps the existing current-document `evaluate()` injection and, when the page exposes CDP, also registers the same interceptor source through `Page.addScriptToEvaluateOnNewDocument`. CDP registration is best-effort so non-CDP backends keep the previous behavior instead of failing interceptor setup.

Related issue: fixes #584

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

N/A: this PR does not add or modify an adapter.

## Screenshots / Output

```text
$ npx vitest run --project unit src/browser/base-page.test.ts
Test Files  1 passed (1)
Tests       44 passed (44)
```

```text
$ npx tsc --noEmit
# passed
```