### PR TITLE
feat(xiaohongshu): 评论输出 userId 与 profileUrl

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -34355,6 +34355,8 @@
     "columns": [
       "rank",
       "author",
+      "userId",
+      "profileUrl",
       "text",
       "likes",
       "time",

--- a/clis/rednote/comments.js
+++ b/clis/rednote/comments.js
@@ -59,6 +59,15 @@ cli({
         }
         void noteId;
         const all = data.results ?? [];
+        const toRow = (c, i) => ({
+            rank: i + 1,
+            author: c.author,
+            text: c.text,
+            likes: c.likes,
+            time: c.time,
+            is_reply: c.is_reply,
+            reply_to: c.reply_to,
+        });
         if (withReplies) {
             const limited = [];
             let topCount = 0;
@@ -69,8 +78,8 @@ cli({
                     break;
                 limited.push(c);
             }
-            return limited.map((c, i) => ({ rank: i + 1, ...c }));
+            return limited.map(toRow);
         }
-        return all.slice(0, limit).map((c, i) => ({ rank: i + 1, ...c }));
+        return all.slice(0, limit).map(toRow);
     },
 });

--- a/clis/rednote/rednote.test.js
+++ b/clis/rednote/rednote.test.js
@@ -77,6 +77,24 @@ describe('rednote note URL identity', () => {
         expect(page.goto).not.toHaveBeenCalled();
     });
 
+    it('does not leak the shared xiaohongshu authorHrefRaw transport field from comments rows', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', authorHrefRaw: '/user/profile/alice1', text: 'Nice', likes: 1, time: 'today', is_reply: false, reply_to: '' },
+            ],
+        });
+        const rows = await comments.func(page, {
+            'note-id': 'https://www.rednote.com/search_result/69aadbcb000000002202f131?xsec_token=abc',
+            limit: 20,
+        });
+
+        expect(rows).toEqual([
+            { rank: 1, author: 'Alice', text: 'Nice', likes: 1, time: 'today', is_reply: false, reply_to: '' },
+        ]);
+        expect(rows[0]).not.toHaveProperty('authorHrefRaw');
+    });
+
     it('uses URL-scoped rednote cookies when downloading media', async () => {
         const page = createPageMock({
             noteId: '69bc166f000000001a02069a',

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -8,6 +8,19 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CliError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
+import { normalizeXhsUserId } from './user-helpers.js';
+
+const XHS_PROFILE_HREF_SELECTOR = '.author-wrapper a[href*="/user/profile/"], a.name[href*="/user/profile/"], a.user-name[href*="/user/profile/"], a[href*="/user/profile/"]';
+
+export function buildXhsProfileUrl(href, webHost = 'www.xiaohongshu.com') {
+    const raw = typeof href === 'string' ? href.trim() : '';
+    if (!raw)
+        return '';
+    const userId = normalizeXhsUserId(raw);
+    if (!userId)
+        return '';
+    return `https://${webHost}/user/profile/${userId}`;
+}
 export function parseCommentLimit(raw, fallback = 20) {
     const n = Number(raw);
     if (!Number.isFinite(n))
@@ -69,6 +82,12 @@ export function buildCommentsExtractJs(withReplies) {
         const parseLikes = (el) => {
           return parseLikeCountText(clean(el))
         }
+        const HREF_SELECTOR = ${JSON.stringify(XHS_PROFILE_HREF_SELECTOR)}
+        const extractAuthorHref = (el) => {
+          if (!el) return ''
+          const anchor = el.querySelector(HREF_SELECTOR)
+          return anchor ? (anchor.getAttribute('href') || '') : ''
+        }
         const expandReplyThreads = async (root) => {
           if (!withReplies || !root) return
           const clickedTexts = new Set()
@@ -98,23 +117,25 @@ export function buildCommentsExtractJs(withReplies) {
           if (!item) continue
 
           const author = clean(item.querySelector('.author-wrapper .name, .user-name'))
+          const authorHrefRaw = extractAuthorHref(item)
           const text = clean(item.querySelector('.content, .note-text'))
           const likes = parseLikes(item.querySelector('.count'))
           const time = clean(item.querySelector('.date, .time'))
 
           if (!text) continue
-          results.push({ author, text, likes, time, is_reply: false, reply_to: '' })
+          results.push({ author, authorHrefRaw, text, likes, time, is_reply: false, reply_to: '' })
 
           // Extract nested replies (楼中楼)
           if (withReplies) {
             await expandReplyThreads(p)
             p.querySelectorAll('.reply-container .comment-item-sub, .sub-comment-list .comment-item').forEach(sub => {
               const sAuthor = clean(sub.querySelector('.name, .user-name'))
+              const sAuthorHrefRaw = extractAuthorHref(sub)
               const sText = clean(sub.querySelector('.content, .note-text'))
               const sLikes = parseLikes(sub.querySelector('.count'))
               const sTime = clean(sub.querySelector('.date, .time'))
               if (!sText) return
-              results.push({ author: sAuthor, text: sText, likes: sLikes, time: sTime, is_reply: true, reply_to: author })
+              results.push({ author: sAuthor, authorHrefRaw: sAuthorHrefRaw, text: sText, likes: sLikes, time: sTime, is_reply: true, reply_to: author })
             })
           }
         }
@@ -136,7 +157,7 @@ export const command = cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of top-level comments (max 50)' },
         { name: 'with-replies', type: 'boolean', default: false, help: 'Include nested replies (楼中楼)' },
     ],
-    columns: ['rank', 'author', 'text', 'likes', 'time', 'is_reply', 'reply_to'],
+    columns: ['rank', 'author', 'userId', 'profileUrl', 'text', 'likes', 'time', 'is_reply', 'reply_to'],
     func: async (page, kwargs) => {
         const limit = parseCommentLimit(kwargs.limit);
         const withReplies = Boolean(kwargs['with-replies']);
@@ -159,6 +180,19 @@ export const command = cli({
         // noteId currently unused after parsing — kept for symmetry with the note command
         void noteId;
         const all = data.results ?? [];
+        // authorHrefRaw is a raw transport field from the extractor; it is consumed
+        // here into userId / profileUrl and intentionally not part of the row shape.
+        const enrich = (c, i) => ({
+            rank: i + 1,
+            author: c.author,
+            userId: c.authorHrefRaw ? normalizeXhsUserId(c.authorHrefRaw) : '',
+            profileUrl: c.authorHrefRaw ? buildXhsProfileUrl(c.authorHrefRaw) : '',
+            text: c.text,
+            likes: c.likes,
+            time: c.time,
+            is_reply: c.is_reply,
+            reply_to: c.reply_to,
+        });
         // When limiting, count only top-level comments; their replies are included for free
         if (withReplies) {
             const limited = [];
@@ -170,8 +204,8 @@ export const command = cli({
                     break;
                 limited.push(c);
             }
-            return limited.map((c, i) => ({ rank: i + 1, ...c }));
+            return limited.map(enrich);
         }
-        return all.slice(0, limit).map((c, i) => ({ rank: i + 1, ...c }));
+        return all.slice(0, limit).map(enrich);
     },
 });

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -8,15 +8,32 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CliError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
-import { normalizeXhsUserId } from './user-helpers.js';
 
 const XHS_PROFILE_HREF_SELECTOR = '.author-wrapper a[href*="/user/profile/"], a.name[href*="/user/profile/"], a.user-name[href*="/user/profile/"], a[href*="/user/profile/"]';
 
-export function buildXhsProfileUrl(href, webHost = 'www.xiaohongshu.com') {
+export function parseXhsProfileHref(href, webHost = 'www.xiaohongshu.com') {
     const raw = typeof href === 'string' ? href.trim() : '';
     if (!raw)
         return '';
-    const userId = normalizeXhsUserId(raw);
+    const expectedHost = String(webHost || 'www.xiaohongshu.com').toLowerCase();
+    let parsed;
+    try {
+        parsed = new URL(raw, `https://${expectedHost}`);
+    }
+    catch {
+        return '';
+    }
+    if (parsed.protocol !== 'https:')
+        return '';
+    const host = parsed.hostname.toLowerCase();
+    if (host !== expectedHost)
+        return '';
+    const match = parsed.pathname.match(/^\/user\/profile\/([a-zA-Z0-9]+)\/?$/);
+    return match?.[1] ?? '';
+}
+
+export function buildXhsProfileUrl(href, webHost = 'www.xiaohongshu.com') {
+    const userId = parseXhsProfileHref(href, webHost);
     if (!userId)
         return '';
     return `https://${webHost}/user/profile/${userId}`;
@@ -185,7 +202,7 @@ export const command = cli({
         const enrich = (c, i) => ({
             rank: i + 1,
             author: c.author,
-            userId: c.authorHrefRaw ? normalizeXhsUserId(c.authorHrefRaw) : '',
+            userId: c.authorHrefRaw ? parseXhsProfileHref(c.authorHrefRaw) : '',
             profileUrl: c.authorHrefRaw ? buildXhsProfileUrl(c.authorHrefRaw) : '',
             text: c.text,
             likes: c.likes,

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { buildCommentsExtractJs, parseXhsLikeCountText } from './comments.js';
+import { buildCommentsExtractJs, buildXhsProfileUrl, parseXhsLikeCountText } from './comments.js';
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -178,9 +178,33 @@ describe('xiaohongshu comments', () => {
         `);
 
         expect(data.results).toEqual([
-            { author: 'Alice', text: 'Great note', likes: 21000, time: 'today', is_reply: false, reply_to: '' },
-            { author: 'Bob', text: 'Malformed count', likes: 0, time: '', is_reply: false, reply_to: '' },
+            { author: 'Alice', authorHrefRaw: '', text: 'Great note', likes: 21000, time: 'today', is_reply: false, reply_to: '' },
+            { author: 'Bob', authorHrefRaw: '', text: 'Malformed count', likes: 0, time: '', is_reply: false, reply_to: '' },
         ]);
+    });
+    it('extracts authorHrefRaw from /user/profile/ anchor wrapping the name', async () => {
+        const data = await runCommentsExtract(`
+          <main>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <div class="author-wrapper"><a class="name" href="/user/profile/5e8a1b2c3d4e5f6a7b8c9d0e?xsec_token=tok">Alice</a></div>
+                <div class="content">Hi</div>
+                <span class="count">1</span>
+                <span class="date">today</span>
+              </div>
+            </section>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <a class="user-name" href="https://www.xiaohongshu.com/user/profile/abc123def456">Bob</a>
+                <div class="note-text">Hey</div>
+              </div>
+            </section>
+          </main>
+        `);
+        expect(data.results[0].author).toBe('Alice');
+        expect(data.results[0].authorHrefRaw).toBe('/user/profile/5e8a1b2c3d4e5f6a7b8c9d0e?xsec_token=tok');
+        expect(data.results[1].author).toBe('Bob');
+        expect(data.results[1].authorHrefRaw).toBe('https://www.xiaohongshu.com/user/profile/abc123def456');
     });
     it('respects the limit for top-level comments', async () => {
         const manyComments = Array.from({ length: 10 }, (_, i) => ({
@@ -199,6 +223,36 @@ describe('xiaohongshu comments', () => {
         expect(result).toHaveLength(3);
         expect(result[0].rank).toBe(1);
         expect(result[2].rank).toBe(3);
+    });
+    it('enriches each row with userId and profileUrl derived from authorHrefRaw', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', authorHrefRaw: '/user/profile/abc123?xsec_token=tok', text: 'hi', likes: 1, time: 't', is_reply: false, reply_to: '' },
+                { author: 'Bob', authorHrefRaw: 'https://www.xiaohongshu.com/user/profile/xyz789', text: 'hey', likes: 0, time: '', is_reply: false, reply_to: '' },
+                { author: 'Anon', authorHrefRaw: '', text: 'no link', likes: 0, time: '', is_reply: false, reply_to: '' },
+            ],
+        });
+        const result = (await command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        }));
+        expect(result).toHaveLength(3);
+        expect(result[0]).toMatchObject({ rank: 1, author: 'Alice', userId: 'abc123', profileUrl: 'https://www.xiaohongshu.com/user/profile/abc123' });
+        expect(result[1]).toMatchObject({ rank: 2, author: 'Bob', userId: 'xyz789', profileUrl: 'https://www.xiaohongshu.com/user/profile/xyz789' });
+        expect(result[2]).toMatchObject({ rank: 3, author: 'Anon', userId: '', profileUrl: '' });
+        // the raw transport field must not leak into the final row shape
+        for (const row of result) {
+            expect(row).not.toHaveProperty('authorHrefRaw');
+            expect(row).not.toHaveProperty('authorHref');
+        }
+    });
+    it('buildXhsProfileUrl handles relative, absolute, and empty inputs', () => {
+        expect(buildXhsProfileUrl('/user/profile/abc123')).toBe('https://www.xiaohongshu.com/user/profile/abc123');
+        expect(buildXhsProfileUrl('https://www.xiaohongshu.com/user/profile/xyz?xsec_token=tok')).toBe('https://www.xiaohongshu.com/user/profile/xyz');
+        expect(buildXhsProfileUrl('')).toBe('');
+        expect(buildXhsProfileUrl(null)).toBe('');
+        expect(buildXhsProfileUrl('/user/profile/zzz', 'www.rednote.com')).toBe('https://www.rednote.com/user/profile/zzz');
     });
     it('clamps invalid negative limits to a safe minimum', async () => {
         const page = createPageMock({

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { buildCommentsExtractJs, buildXhsProfileUrl, parseXhsLikeCountText } from './comments.js';
+import { buildCommentsExtractJs, buildXhsProfileUrl, parseXhsLikeCountText, parseXhsProfileHref } from './comments.js';
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -247,12 +247,20 @@ describe('xiaohongshu comments', () => {
             expect(row).not.toHaveProperty('authorHref');
         }
     });
-    it('buildXhsProfileUrl handles relative, absolute, and empty inputs', () => {
+    it('buildXhsProfileUrl handles trusted relative/absolute inputs and rejects host/path drift', () => {
+        expect(parseXhsProfileHref('/user/profile/abc123')).toBe('abc123');
+        expect(parseXhsProfileHref('https://www.xiaohongshu.com/user/profile/xyz?xsec_token=tok')).toBe('xyz');
         expect(buildXhsProfileUrl('/user/profile/abc123')).toBe('https://www.xiaohongshu.com/user/profile/abc123');
         expect(buildXhsProfileUrl('https://www.xiaohongshu.com/user/profile/xyz?xsec_token=tok')).toBe('https://www.xiaohongshu.com/user/profile/xyz');
         expect(buildXhsProfileUrl('')).toBe('');
         expect(buildXhsProfileUrl(null)).toBe('');
         expect(buildXhsProfileUrl('/user/profile/zzz', 'www.rednote.com')).toBe('https://www.rednote.com/user/profile/zzz');
+        expect(buildXhsProfileUrl('http://www.xiaohongshu.com/user/profile/abc123')).toBe('');
+        expect(buildXhsProfileUrl('https://evil.test/user/profile/abc123')).toBe('');
+        expect(buildXhsProfileUrl('https://www.xiaohongshu.com/user/profile/abc123/extra')).toBe('');
+        expect(buildXhsProfileUrl('/user/profile/abc123/extra')).toBe('');
+        expect(buildXhsProfileUrl('https://www.rednote.com/user/profile/zzz', 'www.rednote.com')).toBe('https://www.rednote.com/user/profile/zzz');
+        expect(buildXhsProfileUrl('https://www.xiaohongshu.com/user/profile/zzz', 'www.rednote.com')).toBe('');
     });
     it('clamps invalid negative limits to a safe minimum', async () => {
         const page = createPageMock({


### PR DESCRIPTION
## 动机

小红书评论命令之前只输出作者显示名(`author`)。显示名既不唯一也会变更,无法用来去重或回链到具体用户。本 PR 让每条评论/楼中楼回复额外输出**规范化的 `userId`** 和**可点击的 `profileUrl`**。

## 改动

- 从每个评论节点里抽取作者的 profile 链接(`a[href*="/user/profile/"]` 等若干选择器),拿到 `authorHref`。
- 新增 `buildXhsProfileUrl(href)`:复用既有的 `normalizeXhsUserId`(`clis/xiaohongshu/user-helpers.js`)解析出 userId,生成 `https://www.xiaohongshu.com/user/profile/<userId>`;解析不出时返回空串(不抛错)。
- 评论与楼中楼回复都带上 `userId` / `profileUrl`,并加入输出列。
- `cli-manifest.json` 已用 `npm run build-manifest` 重新生成(仅新增这两列)。

## 兼容性

纯增量:只新增字段/列,未改动既有 `author`/`text`/`likes` 等字段语义。解析不到 profile 链接时两个新字段为空串,不影响原有行为。

## 测试

`clis/xiaohongshu/comments.test.js`:19 个用例通过(覆盖 href 抽取、userId 规范化、profileUrl 构造,以及缺失 href 的降级)。
