### PR TITLE
docs(readme): clarify profile browser session examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Each Chrome profile runs its own OpenCLI extension instance. If you use multiple
 opencli profile list
 opencli profile rename <contextId> work
 opencli profile use work
-opencli --profile work browser state
 ```
+
+Use `--profile work` to route a single command without changing the default. Browser commands still require their own session name, e.g. `opencli --profile work browser demo state`.
 
 With only one connected profile, OpenCLI uses it automatically. With multiple connected profiles and no default, OpenCLI asks you to choose instead of guessing.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,21 @@ OpenCLI 通过轻量 Browser Bridge 扩展和本地微型 daemon 与 Chrome/Chro
 opencli doctor
 ```
 
-### 4. 跑第一个命令
+### 4. 可选：给 Chrome profile 起别名
+
+每个 Chrome profile 都会运行自己的 OpenCLI 扩展实例。如果你同时使用多个 Chrome profile，可以先列出已连接的 profile，再给本地常用的 profile 起一个别名：
+
+```bash
+opencli profile list
+opencli profile rename <contextId> work
+opencli profile use work
+```
+
+如果只想让单条命令使用这个 profile，而不修改默认 profile，可以传 `--profile work`。注意 `browser` 命令仍然需要自己的 session 名，例如：`opencli --profile work browser demo state`。
+
+只有一个 profile 连接时，OpenCLI 会自动使用它；多个 profile 同时连接且没有默认值时，OpenCLI 会要求你明确选择，而不是自动猜测。
+
+### 5. 跑第一个命令
 
 ```bash
 opencli list


### PR DESCRIPTION
## Description

- clarify the profile browser session examples in the README
- add the corresponding Chinese README wording

Related issue:
#1893

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful
- Not run; documentation-only change
### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [x] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

No Screenshots

