### PR TITLE
feat(reddit): read 命令输出 post_hint / url / preview / gallery 媒体列

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -25050,7 +25050,11 @@
       "type",
       "author",
       "score",
-      "text"
+      "text",
+      "post_hint",
+      "url_overridden_by_dest",
+      "preview_image_url",
+      "gallery_urls"
     ],
     "type": "js",
     "modulePath": "reddit/read.js",

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -173,7 +173,7 @@ cli({
         }
         function extractRedditMedia(d) {
           var post_hint = (d && d.post_hint) || '';
-          var url_overridden_by_dest = (d && d.url_overridden_by_dest) || '';
+          var url_overridden_by_dest = decodeHtml((d && d.url_overridden_by_dest) || '');
           var preview_image_url = decodeHtml(
             (d && d.preview && d.preview.images && d.preview.images[0] && d.preview.images[0].source && d.preview.images[0].source.url) || ''
           );
@@ -184,7 +184,7 @@ cli({
             for (var gi = 0; gi < items.length; gi++) {
               var it = items[gi];
               var m = it && meta[it.media_id];
-              var u = m && m.s && m.s.u;
+              var u = m && m.s && (m.s.u || m.s.gif || m.s.mp4);
               if (u) gallery_urls.push(decodeHtml(u));
             }
           }

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -125,7 +125,7 @@ cli({
             help: `Max expansion passes when --expand-more is on (${REDDIT_EXPAND_ROUNDS_MIN}–${REDDIT_EXPAND_ROUNDS_MAX}; each round can fan out new "more" stubs)`,
         },
     ],
-    columns: ['type', 'author', 'score', 'text'],
+    columns: ['type', 'author', 'score', 'text', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     func: async (page, kwargs) => {
         // Note: --limit / --depth / --replies / --max-length keep their original
         // Math.max-style behaviour for backward compatibility (grandfathered in
@@ -161,6 +161,40 @@ cli({
         // `text`) to sidestep the silent-column-drop audit (PR #1329).
         const result = await page.evaluate(`
       (async function() {
+        function decodeHtml(s) {
+          if (typeof s !== 'string' || !s) return '';
+          return s
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#x27;/gi, "'")
+            .replace(/&#39;/g, "'");
+        }
+        function extractRedditMedia(d) {
+          var post_hint = (d && d.post_hint) || '';
+          var url_overridden_by_dest = (d && d.url_overridden_by_dest) || '';
+          var preview_image_url = decodeHtml(
+            (d && d.preview && d.preview.images && d.preview.images[0] && d.preview.images[0].source && d.preview.images[0].source.url) || ''
+          );
+          var gallery_urls = [];
+          var items = d && d.gallery_data && d.gallery_data.items;
+          var meta = d && d.media_metadata;
+          if (Array.isArray(items) && meta) {
+            for (var gi = 0; gi < items.length; gi++) {
+              var it = items[gi];
+              var m = it && meta[it.media_id];
+              var u = m && m.s && m.s.u;
+              if (u) gallery_urls.push(decodeHtml(u));
+            }
+          }
+          return {
+            post_hint: post_hint,
+            url_overridden_by_dest: url_overridden_by_dest,
+            preview_image_url: preview_image_url,
+            gallery_urls: gallery_urls,
+          };
+        }
         var postId = ${JSON.stringify(postId)};
         var linkFullname = 't3_' + postId;
 
@@ -392,11 +426,16 @@ cli({
         // Post header row.
         var body = post.selftext || '';
         if (body.length > maxLength) body = body.slice(0, maxLength) + '\\n... [truncated]';
+        var postMedia = extractRedditMedia(post);
         rows.push({
           type: 'POST',
           author: post.author || '[deleted]',
           score: post.score || 0,
           text: post.title + (body ? '\\n\\n' + body : '') + (post.url && !post.is_self ? '\\n' + post.url : ''),
+          post_hint: postMedia.post_hint,
+          url_overridden_by_dest: postMedia.url_overridden_by_dest,
+          preview_image_url: postMedia.preview_image_url,
+          gallery_urls: postMedia.gallery_urls,
         });
 
         // Recursive comment walker.
@@ -418,6 +457,10 @@ cli({
             author: d.author || '[deleted]',
             score: d.score || 0,
             text: indentedBody,
+            post_hint: '',
+            url_overridden_by_dest: '',
+            preview_image_url: '',
+            gallery_urls: [],
           });
 
           var t1Children = [];
@@ -443,6 +486,10 @@ cli({
                 author: '',
                 score: '',
                 text: cutoffIndent + '[+' + totalHidden + ' more replies]',
+                post_hint: '',
+                url_overridden_by_dest: '',
+                preview_image_url: '',
+                gallery_urls: [],
               });
             }
             return;
@@ -463,6 +510,10 @@ cli({
               author: '',
               score: '',
               text: moreIndent + '[+' + hidden + ' more replies]',
+              post_hint: '',
+              url_overridden_by_dest: '',
+              preview_image_url: '',
+              gallery_urls: [],
             });
           }
         }
@@ -489,6 +540,10 @@ cli({
             author: '',
             score: '',
             text: '[+' + hiddenTopLevel + ' more top-level comments]',
+            post_hint: '',
+            url_overridden_by_dest: '',
+            preview_image_url: '',
+            gallery_urls: [],
           });
         }
 

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -81,7 +81,18 @@ describe('reddit read adapter', () => {
     it('uses an ephemeral Reddit site tab by default', () => {
         expect(command?.browser).toBe(true);
         expect(command?.siteSession).toBeUndefined();
-        expect(command?.columns).toEqual(['type', 'author', 'score', 'text']);
+        expect(command?.columns).toEqual([
+            'type', 'author', 'score', 'text',
+            'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls',
+        ]);
+    });
+
+    it('embeds extractRedditMedia in the browser-evaluated source and applies it to the POST row', async () => {
+        const page = makePage({ kind: 'ok', rows: [], expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] } });
+        await command.func(page, { 'post-id': 'abc123', limit: 5 });
+        const src = page.evaluate.mock.calls[0][0];
+        expect(src).toContain('function extractRedditMedia');
+        expect(src).toContain('var postMedia = extractRedditMedia(post)');
     });
 
     it('exposes the new --expand-more / --expand-rounds args', () => {
@@ -153,16 +164,24 @@ describe('reddit read adapter', () => {
         const page = makePage({
             kind: 'ok',
             rows: [
-                { type: 'POST', author: 'alice', score: 10, text: 'Title' },
-                { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
+                { type: 'POST', author: 'alice', score: 10, text: 'Title',
+                  post_hint: 'image', url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+                  preview_image_url: 'https://preview.redd.it/a.jpg?width=640',
+                  gallery_urls: [] },
+                { type: 'L0', author: 'bob', score: 5, text: 'Comment',
+                  post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [] },
             ],
             expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] },
         });
         const result = await command.func(page, { 'post-id': 'abc123', limit: 5 });
         expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
         expect(result).toEqual([
-            { type: 'POST', author: 'alice', score: 10, text: 'Title' },
-            { type: 'L0', author: 'bob', score: 5, text: 'Comment' },
+            { type: 'POST', author: 'alice', score: 10, text: 'Title',
+              post_hint: 'image', url_overridden_by_dest: 'https://i.redd.it/a.jpg',
+              preview_image_url: 'https://preview.redd.it/a.jpg?width=640',
+              gallery_urls: [] },
+            { type: 'L0', author: 'bob', score: 5, text: 'Comment',
+              post_hint: '', url_overridden_by_dest: '', preview_image_url: '', gallery_urls: [] },
         ]);
     });
 

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -11,7 +11,7 @@ function makePage(result) {
     };
 }
 
-function redditPostEnvelope(children) {
+function redditPostEnvelope(children, postOverrides = {}) {
     return [
         {
             data: {
@@ -22,6 +22,7 @@ function redditPostEnvelope(children) {
                         author: 'op',
                         score: 10,
                         is_self: true,
+                        ...postOverrides,
                     },
                 }],
             },
@@ -281,6 +282,52 @@ describe('reddit read adapter', () => {
                 body: expect.stringContaining('link_id=t3_abc123'),
             }),
         );
+    });
+
+    it('extracts post media columns from the Reddit listing payload in order', async () => {
+        const fetchMock = vi.fn(async (url) => {
+            if (String(url).startsWith('/comments/')) {
+                return jsonResponse(redditPostEnvelope([], {
+                    is_self: false,
+                    post_hint: 'image',
+                    url: 'https://reddit.com/r/pics/comments/abc123/media_post/',
+                    url_overridden_by_dest: 'https://i.redd.it/a&amp;b.jpg',
+                    preview: {
+                        images: [{
+                            source: { url: 'https://preview.redd.it/source.jpg?width=960&amp;format=pjpg' },
+                        }],
+                    },
+                    gallery_data: {
+                        items: [
+                            { media_id: 'second' },
+                            { media_id: 'first' },
+                            { media_id: 'animated' },
+                        ],
+                    },
+                    media_metadata: {
+                        first: { s: { u: 'https://preview.redd.it/first.jpg?width=640&amp;format=pjpg' } },
+                        second: { s: { u: 'https://preview.redd.it/second.jpg?width=640&amp;format=pjpg' } },
+                        animated: { s: { gif: 'https://preview.redd.it/animated.gif?format=mp4&amp;s=123' } },
+                    },
+                }));
+            }
+            throw new Error(`unexpected URL ${url}`);
+        });
+        const page = makeRuntimePage(fetchMock);
+
+        const result = await command.func(page, { 'post-id': 'abc123' });
+
+        expect(result[0]).toMatchObject({
+            type: 'POST',
+            post_hint: 'image',
+            url_overridden_by_dest: 'https://i.redd.it/a&b.jpg',
+            preview_image_url: 'https://preview.redd.it/source.jpg?width=960&format=pjpg',
+            gallery_urls: [
+                'https://preview.redd.it/second.jpg?width=640&format=pjpg',
+                'https://preview.redd.it/first.jpg?width=640&format=pjpg',
+                'https://preview.redd.it/animated.gif?format=mp4&s=123',
+            ],
+        });
     });
 
     it('fails expand-more when Reddit returns a child that cannot be placed in the requested tree', async () => {


### PR DESCRIPTION
## 动机

Reddit `read` 命令此前丢弃了帖子的媒体元数据,调用方无法区分链接帖 / 图片帖 / 相册帖,也拿不到媒体地址。本 PR 在 `read` 的输出里补上 4 列:

- `post_hint`
- `url_overridden_by_dest`
- `preview_image_url`(从 `preview.images[0].source.url` 解码 HTML 实体得到)
- `gallery_urls`(从 `gallery_data` / `media_metadata` 解码得到)

## 兼容性

纯增量:仅新增列,未改动 `type`/`author`/`score`/`text` 等既有字段。文本帖在这些字段上回落为空串 / 空数组,行结构保持稳定。`cli-manifest.json` 已用 `npm run build-manifest` 重新生成(仅新增这 4 列)。

## 测试

`clis/reddit/read.test.js`:18 个用例通过(覆盖 link/image/gallery 帖的字段抽取与文本帖的空值回落)。
`npm run check:silent-column-drop` → new=0 OK;`tsc --noEmit` 通过。
