### PR TITLE
feat(twitter): 读命令字段增强 + API 错误/queryId 健壮性

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -29975,7 +29975,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
@@ -30036,7 +30037,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
@@ -30381,7 +30383,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/likes.js",
@@ -30687,10 +30690,11 @@
       "replies",
       "created_at",
       "url",
+      "card",
+      "quoted_tweet",
       "has_media",
       "media_urls",
-      "card",
-      "quoted_tweet"
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/list-tweets.js",
@@ -31120,6 +31124,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31169,6 +31174,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31225,6 +31231,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -31304,6 +31311,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "quoted_tweet"
     ],
     "type": "js",

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { resolveTwitterQueryId } from './shared.js';
+import { resolveTwitterQueryId, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 const TWEET_RESULT_BY_REST_ID_QUERY_ID = '7xflPyRiUxGVbJd4uWmbfg';
 cli({
@@ -96,7 +96,7 @@ cli({
           + '&fieldToggles=' + encodeURIComponent(fieldToggles);
 
         const resp = await fetch(url, {headers, credentials: 'include'});
-        if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Tweet may not exist or queryId expired'};
+        if (!resp.ok) return {httpStatus: resp.status};
         const d = await resp.json();
 
         const result = d.data?.tweetResult?.result;
@@ -159,6 +159,9 @@ cli({
         }];
       }
     `);
+        if (result?.httpStatus) {
+            throw new CommandExecutionError(describeTwitterApiError('TweetResultByRestId', result.httpStatus));
+        }
         if (result?.error) {
             throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
         }

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
-import { extractMedia, resolveTwitterQueryId } from './shared.js';
+import { extractMedia, resolveTwitterQueryId, describeTwitterApiError } from './shared.js';
 
 // Companion to bookmark-folders.js: reads tweets inside a single folder.
 // X exposes folder contents through a separate timeline operation
@@ -129,7 +129,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the folder by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const folderId = String(kwargs['folder-id'] || '').trim();
         if (!folderId || !FOLDER_ID_PATTERN.test(folderId)) {
@@ -169,7 +169,7 @@ cli({
             }`);
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch folder ${folderId}. queryId may have expired, or the folder may not exist.`);
+                    throw new CommandExecutionError(describeTwitterApiError('BookmarkFolderTimeline', data.error, `folder=${folderId}`));
                 break;
             }
             const { tweets, nextCursor } = parseBookmarkFolderTimeline(data, seen);

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -99,6 +99,7 @@ describe('twitter bookmark-folder timeline parser', () => {
                 url: 'https://x.com/alice/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
             },
         ]);
         expect(nextCursor).toBe('NEXT_CURSOR');

--- a/clis/twitter/bookmark-folders.js
+++ b/clis/twitter/bookmark-folders.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
-import { resolveTwitterQueryId } from './shared.js';
+import { resolveTwitterQueryId, describeTwitterApiError } from './shared.js';
 
 // X surfaces user-created bookmark folders through a GraphQL slice query.
 // We mirror the patterns used in bookmarks.js / lists.js: a literal
@@ -101,7 +101,7 @@ cli({
             return r.ok ? await r.json() : { error: r.status };
         }`);
         if (data?.error) {
-            throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch bookmark folders. queryId may have expired, or your account may not have folder access.`);
+            throw new CommandExecutionError(describeTwitterApiError('bookmarkFoldersSlice', data.error, 'account may not have folder access'));
         }
         const seen = new Set();
         return parseBookmarkFolders(data, seen);

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia } from './shared.js';
+import { extractMedia, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const BOOKMARKS_QUERY_ID = 'Fy0QMy4q_aZCpkO0PnyLYw';
 const MAX_PAGINATION_PAGES = 100;
@@ -112,7 +112,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const cookies = await page.getCookies({ url: 'https://x.com' });
@@ -162,7 +162,7 @@ cli({
       }`);
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch bookmarks. queryId may have expired.`);
+                    throw new CommandExecutionError(describeTwitterApiError('Bookmarks', data.error));
                 break;
             }
             const { tweets, nextCursor } = parseBookmarks(data, seen);

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -28,6 +28,7 @@ describe('twitter bookmarks parser', () => {
             url: 'https://x.com/alice/status/1',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 

--- a/clis/twitter/device-follow.js
+++ b/clis/twitter/device-follow.js
@@ -11,6 +11,7 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
+import { describeTwitterApiError } from './shared.js';
 
 const DEVICE_FOLLOW_PATH = '/i/api/2/notifications/device_follow.json';
 const MAX_LIMIT = 200;
@@ -165,7 +166,7 @@ cli({
             if (data.error === 401 || data.error === 403) {
                 throw new AuthRequiredError('x.com', `Twitter device-follow returned HTTP ${data.error}`);
             }
-            throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch device-follow notification stream.`);
+            throw new CommandExecutionError(describeTwitterApiError('device_follow', data.error));
         }
         const parsed = parseDeviceFollow(data, new Set());
         if (!parsed) {

--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, unwrapBrowserResult } from './shared.js';
+import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const FOLLOWING_QUERY_ID = 'F42cDX8PDFxkbjjq6JrM2w';
@@ -238,7 +238,7 @@ cli({
             if (data?.error) {
                 if (data.error === 401 || data.error === 403)
                     throw new AuthRequiredError('x.com', `Twitter following request failed (HTTP ${data.error})`);
-                throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch following list. queryId may have expired.`);
+                throw new CommandExecutionError(describeTwitterApiError('Following', data.error));
             }
             lastRawResponse = data;
             const { users, nextCursor } = parseFollowing(data);

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, extractMedia, unwrapBrowserResult } from './shared.js';
+import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, extractMedia, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const LIKES_QUERY_ID = 'CDWHmpZeSdIJ3HGeRbNm0w';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
@@ -148,7 +148,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the liked tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const rawUsername = String(kwargs.username ?? '').trim();
@@ -213,7 +213,7 @@ cli({
       }`));
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch likes. queryId may have expired.`);
+                    throw new CommandExecutionError(describeTwitterApiError('Likes', data.error));
                 break;
             }
             lastRawResponse = data;

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -1,7 +1,8 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia, extractCard, extractQuotedTweet } from './shared.js';
+import { BROWSER_JSON_SNIFF_FN, throwIfLoginWall } from '@jackwener/opencli/utils';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
+import { extractCard, extractQuotedTweet, extractMedia, describeTwitterApiError } from './shared.js';
 
 const LIST_TWEETS_QUERY_ID = 'RlZzktZY_9wJynoepm8ZsA';
 const OPERATION_NAME = 'ListLatestTweetsTimeline';
@@ -74,6 +75,8 @@ export function extractTimelineTweet(result, seen) {
         replies: legacy.reply_count || 0,
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
+        card: extractCard(tw),
+        quoted_tweet: extractQuotedTweet(tw),
         ...extractMedia(legacy),
         card: extractCard(tw),
         quoted_tweet: extractQuotedTweet(tw),
@@ -124,7 +127,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'card', 'quoted_tweet', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {
@@ -177,13 +180,13 @@ cli({
         for (let i = 0; i < MAX_PAGINATION_PAGES && allTweets.length < limit; i++) {
             const fetchCount = Math.min(100, limit - allTweets.length + 10);
             const apiUrl = buildUrl(queryId, listId, fetchCount, cursor);
-            const data = await page.evaluate(`async () => {
-                const r = await fetch(${JSON.stringify(apiUrl)}, { headers: ${headers}, credentials: 'include' });
-                return r.ok ? await r.json() : { error: r.status };
-            }`);
+            const data = throwIfLoginWall(await page.evaluate(`async () => {
+                ${BROWSER_JSON_SNIFF_FN}
+                return await fetchJsonOrLoginWall(${JSON.stringify(apiUrl)}, { headers: ${headers}, credentials: 'include' });
+            }`), { url: apiUrl });
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch list timeline. queryId may have expired or list may be private.`);
+                    throw new CommandExecutionError(describeTwitterApiError('ListLatestTweetsTimeline', data.error, 'list may be private'));
                 break;
             }
             const { tweets, nextCursor } = parseListTimeline(data, seen);

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -31,8 +31,11 @@ describe('twitter list-tweets parser', () => {
             replies: 2,
             created_at: 'Wed Apr 16 10:00:00 +0000 2026',
             url: 'https://x.com/bob/status/99',
+            card: null,
+            quoted_tweet: null,
             has_media: false,
             media_urls: [],
+            media_posters: [],
             card: null,
             quoted_tweet: null,
         });
@@ -72,6 +75,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/alice/status/499',
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/x.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/x.jpg'],
         });
     });
 

--- a/clis/twitter/lists.js
+++ b/clis/twitter/lists.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
+import { describeTwitterApiError } from './shared.js';
 
 const LISTS_QUERY_ID = '78UbkyXwXBD98IgUWXOy9g';
 const OPERATION_NAME = 'ListsManagementPageTimeline';
@@ -162,7 +163,7 @@ export const command = cli({
             return r.ok ? await r.json() : { error: r.status };
         }`);
         if (data?.error) {
-            throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch lists. queryId may have expired.`);
+            throw new CommandExecutionError(describeTwitterApiError('ListsManagementPageTimeline', data.error));
         }
         const seen = new Set();
         if (!getListsManagementInstructions(data)) {

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { normalizeTwitterScreenName, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+import { describeTwitterApiError, normalizeTwitterScreenName, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
 
@@ -132,6 +132,7 @@ cli({
           return {
             ok: false,
             auth: resp.status === 401 || resp.status === 403,
+            httpStatus: resp.status,
             error: 'HTTP ' + resp.status,
             hint: 'User may not exist, auth may be required, or queryId expired'
           };
@@ -152,7 +153,12 @@ cli({
             throw new CommandExecutionError('Twitter profile response payload is malformed');
         }
         if (!rawResult.ok) {
-            const message = rawResult.error + (rawResult.hint ? ` (${rawResult.hint})` : '');
+            // For HTTP errors, use fork's rich code mapping (429/401/403/404/5xx differentiation
+            // from describeTwitterApiError); fall back to the plain message for non-HTTP failures
+            // (fetch threw, JSON parse failed, payload malformed).
+            const message = typeof rawResult.httpStatus === 'number'
+                ? describeTwitterApiError('UserByScreenName', rawResult.httpStatus, rawResult.hint)
+                : rawResult.error + (rawResult.hint ? ` (${rawResult.hint})` : '');
             if (rawResult.auth) {
                 throw new AuthRequiredError('x.com', message);
             }

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { extractMedia, extractCard, extractQuotedTweet, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata } from './shared.js';
+import { extractMedia, extractCard, extractQuotedTweet, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 // ── Public-search operator surface ─────────────────────────────────────
@@ -44,7 +44,7 @@ const PRODUCT_TO_GRAPHQL_PRODUCT = Object.freeze({
 const MAX_PAGINATION_PAGES = 100;
 
 const SEARCH_TIMELINE_OPERATION = {
-    queryId: 'VhUd6vHVmLBcw0uX-6jMLA',
+    queryId: 'Yw6L66Pw54NHKuq4Dp7b4Q',
     features: {
     rweb_video_screen_enabled: true,
     rweb_cashtags_enabled: true,
@@ -275,7 +275,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {
@@ -318,7 +318,7 @@ cli({
         return r.ok ? await r.json() : { error: r.status };
       }`));
             if (data?.error) {
-                if (results.length === 0) throw new CommandExecutionError(`HTTP ${data.error}: SearchTimeline fetch failed — queryId may have expired`);
+                if (results.length === 0) throw new CommandExecutionError(describeTwitterApiError('SearchTimeline', data.error));
                 break;
             }
             const { rows, nextCursor } = parseSearchTimeline(data, seen);

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -4,12 +4,22 @@ import { __test__ } from './search.js';
 
 const { buildSearchQuery, resolveSearchFParam, resolveSearchProduct, buildSearchTimelineRequest, parseSearchTimeline, HAS_CHOICES, EXCLUDE_CHOICES, PRODUCT_CHOICES, EXCLUDE_TO_OPERATOR, PRODUCT_TO_F_PARAM, FROM_USER_PATTERN } = __test__;
 describe('twitter search command', () => {
+    // Mocked SearchTimeline operation metadata. The dynamic resolver
+    // (resolveTwitterOperationMetadata) is exercised via page.evaluate's first
+    // call. Returning a full {queryId, features, fieldToggles} validates the
+    // happy path where bundle scan / GitHub fallback succeeds — not the stale
+    // hardcoded path that previously masked the regex bug.
+    const DYNAMIC_OP = {
+        queryId: 'DynamicSearchQid42',
+        features: { dynamic_test_feature: true },
+        fieldToggles: { dynamic_test_toggle: true },
+    };
     function makeSearchPage(data) {
         return {
             getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf' }]),
             goto: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn()
-                .mockResolvedValueOnce(null) // resolveTwitterQueryId fallback
+                .mockResolvedValueOnce(DYNAMIC_OP) // resolveTwitterOperationMetadata dynamic result
                 .mockResolvedValueOnce(data),
         };
     }
@@ -79,6 +89,7 @@ describe('twitter search command', () => {
                 url: 'https://x.com/i/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
                 card: null,
                 quoted_tweet: null,
             },
@@ -89,6 +100,11 @@ describe('twitter search command', () => {
         expect(searchFetch).toContain('/SearchTimeline');
         expect(searchFetch).toContain("method: 'POST'");
         expect(searchFetch).toContain('\\"rawQuery\\":\\"from:alice\\"');
+        // Regression guard: the dynamic queryId from resolveTwitterOperationMetadata
+        // must propagate to the actual GraphQL URL. Previously a bug in the bundle
+        // parser would return a wrong queryId silently, Twitter would 4xx, and
+        // search.js raised "queryId may have expired".
+        expect(searchFetch).toContain('/DynamicSearchQid42/SearchTimeline');
     });
 
     it('uses the requested GraphQL product', async () => {

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -205,28 +205,86 @@ export function sanitizeTwitterOperationMetadata(resolved, fallback) {
     };
 }
 
+// Pure helper extracted for unit testing. Used both directly in tests and
+// serialized into page.evaluate() below so the same logic runs in-browser.
+//
+// Why two regexes with [^}] separator instead of cutting a snippet around
+// the operationName marker:
+//   The old approach (lastIndexOf 'e.exports=' / indexOf '}}}') was prone to
+//   cross-module pollution. In a minified bundle 'e.exports=' is dense, and
+//   the snippet often spanned multiple operation modules. snippet.match(/queryId/)
+//   would then return the FIRST queryId in the snippet — frequently belonging
+//   to a different operation — and Twitter would reject it as expired.
+//   Anchoring queryId immediately adjacent to operationName (≤400 chars,
+//   non-} characters only) guarantees the queryId belongs to this operation.
+export function parseOperationFromBundleText(text, operationName) {
+    if (!text || !operationName) return null;
+    const esc = operationName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const reA = new RegExp(`queryId:"([A-Za-z0-9_-]+)"[^}]{0,400}operationName:"${esc}"`);
+    const reB = new RegExp(`operationName:"${esc}"[^}]{0,400}queryId:"([A-Za-z0-9_-]+)"`);
+    let queryId = null;
+    let matchIndex = -1;
+    const mA = text.match(reA);
+    if (mA && typeof mA.index === 'number') {
+        queryId = mA[1];
+        matchIndex = mA.index;
+    } else {
+        const mB = text.match(reB);
+        if (mB && typeof mB.index === 'number') {
+            queryId = mB[1];
+            matchIndex = mB.index;
+        }
+    }
+    if (!queryId) return null;
+    const winStart = Math.max(0, matchIndex - 500);
+    const winEnd = Math.min(text.length, matchIndex + 1500);
+    const win = text.slice(winStart, winEnd);
+    const quotedKeys = (source) => source
+        ? Array.from(source.matchAll(/"([^"]+)"/g)).map((m) => m[1])
+        : [];
+    const flags = (keys) => Object.fromEntries(
+        (keys || []).filter((k) => typeof k === 'string' && k).map((k) => [k, true]),
+    );
+    return {
+        queryId,
+        features: flags(quotedKeys(win.match(/featureSwitches:\[([^\]]*)\]/)?.[1])),
+        fieldToggles: flags(quotedKeys(win.match(/fieldToggles:\[([^\]]*)\]/)?.[1])),
+    };
+}
+
 export async function resolveTwitterOperationMetadata(page, operationName, fallback) {
+    const parserSource = parseOperationFromBundleText.toString();
+    // Order: GitHub placeholder.json FIRST (more reliable — fa0311/twitter-openapi
+    // tracks Twitter's queryId rotation), bundle scan SECOND as offline fallback.
+    // The previous order (bundle-first) silently returned wrong queryIds from
+    // cross-module snippet pollution and never reached the GitHub path.
     const resolved = await page.evaluate(`async () => {
     const operationName = ${JSON.stringify(operationName)};
-    const keysToFlags = (keys) => Object.fromEntries((keys || []).map((key) => [key, true]));
-    const quotedKeys = (source) => source
-      ? Array.from(source.matchAll(/"([^"]+)"/g)).map((match) => match[1])
-      : [];
-    const parseOperation = (text) => {
-      const marker = 'operationName:"' + operationName + '"';
-      const index = text.indexOf(marker);
-      if (index < 0) return null;
-      const start = Math.max(0, text.lastIndexOf('e.exports=', index));
-      const endMarker = text.indexOf('}}}', index);
-      const snippet = text.slice(start, endMarker > index ? endMarker + 3 : index + 2500);
-      const queryId = snippet.match(/queryId:"([A-Za-z0-9_-]+)"/)?.[1] || null;
-      if (!queryId) return null;
-      return {
-        queryId,
-        features: keysToFlags(quotedKeys(snippet.match(/featureSwitches:\\[([^\\]]*)\\]/)?.[1])),
-        fieldToggles: keysToFlags(quotedKeys(snippet.match(/fieldToggles:\\[([^\\]]*)\\]/)?.[1])),
-      };
-    };
+    const keysToFlags = (keys) => Object.fromEntries((keys || []).filter((k) => typeof k === 'string' && k).map((key) => [key, true]));
+    const parseOperationFromBundleText = ${parserSource};
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      try {
+        const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json', { signal: controller.signal });
+        clearTimeout(timeout);
+        if (ghResp.ok) {
+          const data = await ghResp.json();
+          const entry = data && data[operationName];
+          if (entry && entry.queryId) {
+            return {
+              queryId: entry.queryId,
+              features: keysToFlags(entry.featureSwitches),
+              fieldToggles: keysToFlags(entry.fieldToggles),
+            };
+          }
+        }
+      } catch {
+        clearTimeout(timeout);
+      }
+    } catch {}
+
     try {
       const scripts = Array.from(document.scripts)
         .map(s => s.src)
@@ -235,33 +293,18 @@ export async function resolveTwitterOperationMetadata(page, operationName, fallb
           .map(r => r.name)
           .filter(r => r.includes('client-web') && r.endsWith('.js')));
       const uniqueScripts = Array.from(new Set(scripts));
-      for (const scriptUrl of uniqueScripts.slice(-30)) {
+      const head = uniqueScripts.slice(0, 15);
+      const tail = uniqueScripts.slice(-15);
+      const candidates = Array.from(new Set([...head, ...tail]));
+      for (const scriptUrl of candidates) {
         try {
           const text = await (await fetch(scriptUrl)).text();
-          const operation = parseOperation(text);
+          const operation = parseOperationFromBundleText(text, operationName);
           if (operation) return operation;
         } catch {}
       }
     } catch {}
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-    try {
-      const ghResp = await fetch('https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json', { signal: controller.signal });
-      clearTimeout(timeout);
-      if (ghResp.ok) {
-        const data = await ghResp.json();
-        const entry = data?.[operationName];
-        if (entry && entry.queryId) {
-          return {
-            queryId: entry.queryId,
-            features: keysToFlags(entry.featureSwitches),
-            fieldToggles: keysToFlags(entry.fieldToggles),
-          };
-        }
-      }
-    } catch {
-      clearTimeout(timeout);
-    }
+
     return null;
   }`);
     return sanitizeTwitterOperationMetadata(resolved, fallback);
@@ -278,25 +321,39 @@ export async function resolveTwitterQueryId(page, operationName, fallbackId) {
  * back to `entities.media` when the extended form is missing. For videos and
  * animated GIFs, returns the mp4 variant URL; for photos, returns
  * `media_url_https`.
+ *
+ * Also returns `media_posters`, index-aligned 1:1 with `media_urls`: the still
+ * preview image for each item. For videos / animated GIFs this is the
+ * `media_url_https` thumbnail (otherwise discarded in favour of the mp4 URL);
+ * for photos it equals the photo URL itself. Each entry is a non-null string —
+ * it falls back to the media URL if a thumbnail is somehow absent, preserving
+ * alignment.
  */
 export function extractMedia(legacy) {
     const media = legacy?.extended_entities?.media || legacy?.entities?.media;
     if (!Array.isArray(media) || media.length === 0) {
-        return { has_media: false, media_urls: [] };
+        return { has_media: false, media_urls: [], media_posters: [] };
     }
     const urls = [];
+    const posters = [];
     for (const m of media) {
         if (!m) continue;
         if (m.type === 'video' || m.type === 'animated_gif') {
             const variants = m.video_info?.variants || [];
             const mp4 = variants.find((v) => v?.content_type === 'video/mp4');
             const url = mp4?.url || m.media_url_https;
-            if (url) urls.push(url);
+            if (url) {
+                urls.push(url);
+                posters.push(m.media_url_https || url);
+            }
         } else {
-            if (m.media_url_https) urls.push(m.media_url_https);
+            if (m.media_url_https) {
+                urls.push(m.media_url_https);
+                posters.push(m.media_url_https);
+            }
         }
     }
-    return { has_media: urls.length > 0, media_urls: urls };
+    return { has_media: urls.length > 0, media_urls: urls, media_posters: posters };
 }
 
 /**
@@ -394,7 +451,8 @@ export function extractQuotedTweet(tweet) {
     const q = tweet?.quoted_status_result?.result
         ?? tweet?.legacy?.quoted_status_result?.result;
     // `result` can be a tombstone (`__typename: 'TweetTombstone'`) or
-    // `'TweetUnavailable'` when the quoted tweet was deleted / privacy-restricted.
+    // `'TweetUnavailable'` when the quoted tweet was deleted / privacy-restricted —
+    // it has no `legacy`, so the downstream null-check covers both cases.
     if (!q) return null;
     // Nested `tweet` wrapper appears on TweetWithVisibilityResults — same
     // shim that callers already do at the top level (`tw.tweet || tw`).
@@ -435,9 +493,47 @@ export function extractQuotedTweet(tweet) {
         url: `https://x.com/${qScreenName}/status/${qTw.rest_id}`,
         has_media: qMedia.has_media,
         media_urls: qMedia.media_urls,
+        media_posters: qMedia.media_posters,
     };
     if (qCard) out.card = qCard;
     return out;
+}
+
+/**
+ * Translate a non-200 Twitter API response into a message that distinguishes
+ * the actual HTTP failure mode, so callers (scripts / scrapers / pipelines)
+ * can choose retry / cooldown / re-auth / drop without misreading "queryId
+ * expired" as the universal cause.
+ *
+ * @param {string} operation - GraphQL operationName or REST endpoint label
+ *                             (e.g. 'SearchTimeline', 'TweetDetail',
+ *                             'device_follow'); used in the error prefix.
+ * @param {number|string} status - HTTP status code from page.evaluate fetch
+ *                                 (e.g. r.status); coerced to Number.
+ * @param {string} [extraHint] - Optional adapter-specific hint appended after
+ *                               the generic explanation (e.g. "list may be
+ *                               private", "folder may not exist").
+ * @returns {string} Message intended for `new CommandExecutionError(...)`.
+ */
+export function describeTwitterApiError(operation, status, extraHint) {
+    const code = Number(status);
+    const prefix = `HTTP ${status}: ${operation} fetch failed`;
+    let suffix;
+    if (code === 429) {
+        suffix = 'rate-limited by Twitter (session quota); retry after cooldown (typically 15-30 min)';
+    } else if (code === 401) {
+        suffix = 'auth failed (cookie expired or invalidated); re-login required';
+    } else if (code === 403) {
+        suffix = 'forbidden (cookie lacks scope, or resource is private)';
+    } else if (code === 404) {
+        suffix = 'resource not found (deleted, suspended, or private)';
+    } else if (code >= 500 && code < 600) {
+        suffix = 'Twitter server error; retry later';
+    } else {
+        suffix = 'possibly queryId expired, schema change, or transient';
+    }
+    if (extraHint) suffix = `${suffix} (${extraHint})`;
+    return `${prefix} — ${suffix}`;
 }
 
 export const __test__ = {
@@ -452,4 +548,6 @@ export const __test__ = {
     parseTweetUrl,
     buildTwitterArticleScopeSource,
     looksLikePrivateTwitterTimeline,
+    parseOperationFromBundleText,
+    describeTwitterApiError,
 };

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -3,7 +3,20 @@ import { JSDOM } from 'jsdom';
 import { __test__ } from './shared.js';
 import { ArgumentError } from '@jackwener/opencli/errors';
 
-const { extractMedia, extractCard, extractQuotedTweet, parseTweetUrl, buildTwitterArticleScopeSource, unwrapBrowserResult, normalizeTwitterGraphqlPayload, normalizeTwitterScreenName, sanitizeTwitterOperationMetadata, looksLikePrivateTwitterTimeline } = __test__;
+const {
+    extractMedia,
+    extractCard,
+    extractQuotedTweet,
+    parseTweetUrl,
+    buildTwitterArticleScopeSource,
+    unwrapBrowserResult,
+    normalizeTwitterGraphqlPayload,
+    normalizeTwitterScreenName,
+    sanitizeTwitterOperationMetadata,
+    looksLikePrivateTwitterTimeline,
+    parseOperationFromBundleText,
+    describeTwitterApiError,
+} = __test__;
 
 function makeCardTweet({ name, bindings, expandedUrl, urls }) {
     const tweet = {
@@ -48,12 +61,6 @@ describe('twitter browser result helpers', () => {
     });
 
     it('falls back to baked features / fieldToggles when the bundle parser returns empty maps', () => {
-        // Regression guard: resolveTwitterOperationMetadata's bundle parser can
-        // find a queryId but miss `featureSwitches:[...]` (e.g. minification
-        // change, or the 2500-char snippet window truncating before the array).
-        // In that case keysToFlags(undefined) returns {}; if sanitize kept the
-        // empty map, Twitter would receive a request with no features and reply
-        // 400, surfacing a misleading "queryId expired" error.
         const result = sanitizeTwitterOperationMetadata({
             queryId: 'newQueryId',
             features: {},
@@ -92,6 +99,76 @@ describe('twitter browser result helpers', () => {
             data: { search_by_raw_query: { search_timeline: {} } },
         });
         expect(normalizeTwitterGraphqlPayload({ data: { user: {} } })).toEqual({ data: { user: {} } });
+    });
+});
+
+describe('parseOperationFromBundleText (bundle queryId resolver)', () => {
+    it('extracts queryId + featureSwitches + fieldToggles when queryId precedes operationName', () => {
+        const bundle = 'something={queryId:"FRESH_ID_AAA",operationName:"SearchTimeline",metadata:{featureSwitches:["feat_one","feat_two"],fieldToggles:["ft_one"]}};other';
+        const result = parseOperationFromBundleText(bundle, 'SearchTimeline');
+        expect(result).toEqual({
+            queryId: 'FRESH_ID_AAA',
+            features: { feat_one: true, feat_two: true },
+            fieldToggles: { ft_one: true },
+        });
+    });
+
+    it('extracts queryId when operationName precedes queryId (reverse order)', () => {
+        const bundle = 'mod={operationName:"SearchTimeline",queryId:"REVERSED_ID_BBB",metadata:{featureSwitches:["x"],fieldToggles:[]}};tail';
+        const result = parseOperationFromBundleText(bundle, 'SearchTimeline');
+        expect(result?.queryId).toBe('REVERSED_ID_BBB');
+        expect(result?.features).toEqual({ x: true });
+    });
+
+    it("does not return another operation's queryId from a neighboring module (cross-module pollution)", () => {
+        // Regression guard: the previous resolver cut a snippet via lastIndexOf('e.exports=')
+        // / indexOf('}}}') around the operationName marker, then ran /queryId:"..."/
+        // unanchored. That returned the first queryId in the snippet — often
+        // belonging to a different operation in the same chunk. Twitter then
+        // rejected the request as a stale queryId, surfacing as "queryId expired".
+        const bundle = [
+            'e.exports={queryId:"OTHER_QID_AAA",operationName:"UserTweets",metadata:{}};',
+            'e.exports={queryId:"SEARCH_QID_BBB",operationName:"SearchTimeline",metadata:{featureSwitches:["f1"],fieldToggles:[]}};',
+        ].join('');
+        const result = parseOperationFromBundleText(bundle, 'SearchTimeline');
+        expect(result?.queryId).toBe('SEARCH_QID_BBB');
+        expect(result?.queryId).not.toBe('OTHER_QID_AAA');
+    });
+
+    it('returns null when operationName is absent from the bundle', () => {
+        const bundle = 'no operation here, just queryId:"STRAY_QID" floating around';
+        expect(parseOperationFromBundleText(bundle, 'SearchTimeline')).toBeNull();
+    });
+
+    it('returns null when queryId is too far from operationName (cross-object)', () => {
+        // The [^}]{0,400} separator prevents matches that cross object boundaries
+        // (a `}` between queryId and operationName means they belong to different
+        // objects/modules).
+        const bundle = 'e.exports={queryId:"WRONG_QID"};lots_of_other_code={};e.exports={operationName:"SearchTimeline",noQueryIdHere:true};';
+        expect(parseOperationFromBundleText(bundle, 'SearchTimeline')).toBeNull();
+    });
+
+    it('falls back to empty features when featureSwitches array is not in the window', () => {
+        // sanitizeTwitterOperationMetadata then uses the baked fallback features.
+        const bundle = 'e.exports={queryId:"BARE_QID",operationName:"SearchTimeline"};';
+        const result = parseOperationFromBundleText(bundle, 'SearchTimeline');
+        expect(result?.queryId).toBe('BARE_QID');
+        expect(result?.features).toEqual({});
+        expect(result?.fieldToggles).toEqual({});
+    });
+
+    it('escapes regex metacharacters in operationName', () => {
+        // Defensive — operationName values are controlled by callers but escaping
+        // protects against future operation names with special chars.
+        const bundle = 'queryId:"ESCAPED_QID"___operationName:"Foo.Bar"___';
+        const result = parseOperationFromBundleText(bundle, 'Foo.Bar');
+        expect(result?.queryId).toBe('ESCAPED_QID');
+    });
+
+    it('returns null for empty / invalid input', () => {
+        expect(parseOperationFromBundleText('', 'SearchTimeline')).toBeNull();
+        expect(parseOperationFromBundleText('text', '')).toBeNull();
+        expect(parseOperationFromBundleText(null, 'SearchTimeline')).toBeNull();
     });
 });
 
@@ -259,11 +336,12 @@ describe('twitter buildTwitterArticleScopeSource', () => {
 
 describe('twitter extractMedia', () => {
     it('returns false + empty list when legacy has no media', () => {
-        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [] });
-        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [] });
+        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [], media_posters: [] });
+        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [], media_posters: [] });
         expect(extractMedia({ extended_entities: { media: [] } })).toEqual({
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -278,6 +356,11 @@ describe('twitter extractMedia', () => {
         });
         expect(result.has_media).toBe(true);
         expect(result.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        // For photos the poster equals the photo URL itself.
+        expect(result.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);
@@ -314,6 +397,14 @@ describe('twitter extractMedia', () => {
             'https://video.twimg.com/x.mp4',
             'https://video.twimg.com/g.mp4',
         ]);
+        // The previously-discarded video_info thumbnails are now exposed as
+        // posters, index-aligned with media_urls and distinct from the mp4 URLs.
+        expect(result.media_posters).toEqual([
+            'https://pbs.twimg.com/media/thumb.jpg',
+            'https://pbs.twimg.com/tweet_video_thumb/g.jpg',
+        ]);
+        expect(result.media_posters[0]).not.toBe(result.media_urls[0]);
+        expect(result.media_posters[1]).not.toBe(result.media_urls[1]);
     });
 
     it('falls back to media_url_https when no mp4 variant is available', () => {
@@ -331,6 +422,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/thumb.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/thumb.jpg'],
         });
     });
 
@@ -345,6 +437,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/c.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/c.jpg'],
         });
     });
 });
@@ -626,6 +719,7 @@ describe('twitter extractQuotedTweet', () => {
             url: 'https://x.com/alice/status/2040254679301718161',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -651,6 +745,10 @@ describe('twitter extractQuotedTweet', () => {
         const q = extractQuotedTweet(tweet);
         expect(q.has_media).toBe(true);
         expect(q.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        expect(q.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);
@@ -790,5 +888,82 @@ describe('looksLikePrivateTwitterTimeline', () => {
         expect(looksLikePrivateTwitterTimeline({
             data: { user: { result: { timeline_v2: { timeline: {} } } } },
         })).toBe(true);
+    });
+});
+
+describe('describeTwitterApiError', () => {
+    it('429 -> rate-limited language so callers cool down instead of treating as queryId expiry', () => {
+        const msg = describeTwitterApiError('SearchTimeline', 429);
+        expect(msg).toContain('HTTP 429');
+        expect(msg).toContain('SearchTimeline');
+        expect(msg).toContain('rate-limited');
+        expect(msg).toContain('cooldown');
+        expect(msg).not.toContain('queryId');
+    });
+
+    it('401 -> auth-failed language so callers trigger re-login instead of retrying', () => {
+        const msg = describeTwitterApiError('TweetDetail', 401);
+        expect(msg).toContain('HTTP 401');
+        expect(msg).toContain('auth failed');
+        expect(msg).toContain('re-login');
+    });
+
+    it('403 -> forbidden language with cookie-scope hint', () => {
+        const msg = describeTwitterApiError('Likes', 403);
+        expect(msg).toContain('HTTP 403');
+        expect(msg).toContain('forbidden');
+    });
+
+    it('404 -> not-found language so callers map to empty/missing', () => {
+        const msg = describeTwitterApiError('UserByScreenName', 404);
+        expect(msg).toContain('HTTP 404');
+        expect(msg).toContain('not found');
+    });
+
+    it('5xx (500) -> server-error language so callers retry later', () => {
+        const msg = describeTwitterApiError('Bookmarks', 500);
+        expect(msg).toContain('HTTP 500');
+        expect(msg).toContain('server error');
+    });
+
+    it('5xx (503) -> server-error language', () => {
+        const msg = describeTwitterApiError('UserTweets', 503);
+        expect(msg).toContain('HTTP 503');
+        expect(msg).toContain('server error');
+    });
+
+    it('unknown code -> falls back to queryId/schema-change hint (the original guess, now scoped)', () => {
+        const msg = describeTwitterApiError('SearchTimeline', 999);
+        expect(msg).toContain('HTTP 999');
+        expect(msg).toContain('queryId');
+        expect(msg).toContain('schema change');
+    });
+
+    it('numeric-string status (e.g. "429" from JSON) still routes to rate-limited branch', () => {
+        const msg = describeTwitterApiError('SearchTimeline', '429');
+        expect(msg).toContain('rate-limited');
+    });
+
+    it('appends adapter-specific extraHint in parentheses after the generic suffix', () => {
+        const msg = describeTwitterApiError('ListLatestTweetsTimeline', 404, 'list may be private');
+        expect(msg).toContain('not found');
+        expect(msg).toContain('(list may be private)');
+    });
+
+    it('runtime-interpolated extraHint (e.g. folder id) is preserved verbatim', () => {
+        const msg = describeTwitterApiError('BookmarkFolderTimeline', 404, 'folder=abc123');
+        expect(msg).toContain('(folder=abc123)');
+    });
+
+    it('preserves "HTTP <status>:" prefix for backward-compat string matching by downstream pipelines', () => {
+        // Downstream callers (ml-scout, ad-hoc scripts) may regex-match
+        // /HTTP (\d+):/ to extract status code. The refactor must keep
+        // that prefix verbatim so existing log parsers don't break.
+        const cases = [400, 401, 403, 404, 429, 500, 503, 999];
+        for (const code of cases) {
+            const msg = describeTwitterApiError('SearchTimeline', code);
+            expect(msg).toMatch(/^HTTP \d+: /);
+            expect(msg).toContain(`HTTP ${code}:`);
+        }
     });
 });

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia, extractCard, extractQuotedTweet } from './shared.js';
+import { BROWSER_JSON_SNIFF_FN, throwIfLoginWall } from '@jackwener/opencli/utils';
+import { extractMedia, extractCard, extractQuotedTweet, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const TWEET_DETAIL_QUERY_ID = 'nBS-WpgA6ZG0CyNHD517JQ';
@@ -113,7 +114,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);
@@ -138,14 +139,16 @@ cli({
         let cursor = null;
         for (let i = 0; i < 5; i++) {
             const apiUrl = buildTweetDetailUrl(tweetId, cursor);
-            // Browser-side: just fetch + return JSON (3 lines)
-            const data = await page.evaluate(`async () => {
-        const r = await fetch("${apiUrl}", { headers: ${headers}, credentials: 'include' });
-        return r.ok ? await r.json() : { error: r.status };
-      }`);
+            // Browser-side: fetch + JSON parse with HTML-as-JSON sniffer so a
+            // login wall / WAF page surfaces as a structured LoginWallError
+            // instead of `SyntaxError: Unexpected token '<'`.
+            const data = throwIfLoginWall(await page.evaluate(`async () => {
+        ${BROWSER_JSON_SNIFF_FN}
+        return await fetchJsonOrLoginWall("${apiUrl}", { headers: ${headers}, credentials: 'include' });
+      }`), { url: apiUrl });
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Tweet not found or queryId expired`);
+                    throw new CommandExecutionError(describeTwitterApiError('TweetDetail', data.error));
                 break;
             }
             // TypeScript-side: type-safe parsing + cursor extraction

--- a/clis/twitter/thread.test.js
+++ b/clis/twitter/thread.test.js
@@ -5,7 +5,7 @@ import { __test__ } from './thread.js';
 describe('twitter thread parser', () => {
     it('extracts author bio from tweet user entity', () => {
         const command = getRegistry().get('twitter/thread');
-        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet']);
+        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet']);
         const result = __test__.parseTweetDetail({
             data: {
                 threaded_conversation_with_injections_v2: {

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { resolveTwitterQueryId, extractMedia, extractCard, extractQuotedTweet } from './shared.js';
+import { resolveTwitterQueryId, extractMedia, extractCard, extractQuotedTweet, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const HOME_TIMELINE_QUERY_ID = 'c-CzHF1LboFilMpsx4ZCrQ';
@@ -156,7 +156,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';
@@ -191,7 +191,7 @@ cli({
       }`);
             if (data?.error) {
                 if (allTweets.length === 0)
-                    throw new CommandExecutionError(`HTTP ${data.error}: Failed to fetch timeline. queryId may have expired.`);
+                    throw new CommandExecutionError(describeTwitterApiError(endpoint, data.error));
                 break;
             }
             const { tweets, nextCursor } = parseHomeTimeline(data, seen);

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -1,7 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { resolveTwitterOperationMetadata, sanitizeQueryId, extractMedia, extractQuotedTweet, normalizeTwitterGraphqlPayload, unwrapBrowserResult } from './shared.js';
-import { normalizeTwitterScreenName } from './shared.js';
+import { resolveTwitterOperationMetadata, sanitizeQueryId, extractMedia, extractQuotedTweet, normalizeTwitterGraphqlPayload, unwrapBrowserResult, normalizeTwitterScreenName, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 const USER_TWEETS_QUERY_ID = 'lrMzG9qPQHpqJdP3AbM-bQ';
@@ -227,7 +226,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the chronological ordering.' },
     ],
-    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet'],
+    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
         const rawUsername = String(kwargs.username ?? '').trim();
@@ -291,7 +290,7 @@ cli({
         return r.ok ? await r.json() : { error: r.status };
       }`));
             if (data?.error) {
-                if (all.length === 0) throw new CommandExecutionError(`HTTP ${data.error}: UserTweets fetch failed — queryId may have expired`);
+                if (all.length === 0) throw new CommandExecutionError(describeTwitterApiError('UserTweets', data.error));
                 break;
             }
             const { tweets, nextCursor } = parseUserTweets(data, seen);

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -6,7 +6,7 @@ import { __test__ } from './tweets.js';
 describe('twitter tweets helpers', () => {
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet']);
+        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet']);
     });
 
     it('makes the username argument optional so it can default to the logged-in user', () => {


### PR DESCRIPTION
本 PR 集中提升 Twitter 适配器的读命令信息量与健壮性。改动主要落在 `clis/twitter/shared.js`(被各读命令共享),分两类。

## 一、健壮性

- **`describeTwitterApiError()`**:按 HTTP 状态码翻译 API 失败,取代笼统的 "queryId may have expired" 提示。调用方据此能区分限流 / 鉴权 / schema 变更 / 瞬时错误,采取重试 / 冷却 / 重新登录 / 丢弃等不同处理。
- **`parseOperationFromBundleText()` + `resolveTwitterOperationMetadata()`**:用「operationName 锚定」的正则解析 SearchTimeline 的 queryId,并采用 network / GitHub-first 回退顺序。修复此前在多 operation 的 bundle 文本里取到**错误 queryId**的问题(旧逻辑按 bundle 优先,会静默返回相邻 operation 的 id)。

## 二、读字段增强

横跨 timeline / search / thread / tweets / list-tweets / likes / bookmarks / profile 等读命令:

- **`media_posters[]`**:与 `media_urls` 1:1 对齐(视频/动图的静帧 poster 帧)。
- **`quoted_tweet`**:在读命令上暴露被引用推文。
- **card `binding_values`**:暴露卡片绑定值。
- **内联作者 bio**。

## 兼容性与范围

纯增量字段/列,未改既有字段语义;`cli-manifest.json` 已 `npm run build-manifest` 重新生成。所有 hunk 都落在同一批 twitter 文件里(共享 `shared.js`),不易无损拆分,故合并为一个 PR。

## 测试

twitter 全量适配器测试:**35 文件 / 411 用例通过**(含 `shared.test.js` 对错误翻译、queryId 解析、各新字段抽取的覆盖)。`check:silent-column-drop`(new=0)、`check:typed-error-lint`(new=0)、`tsc --noEmit` 均通过。
