### PR TITLE
feat(auth): add login/whoami for nowcoder, jike, maimai, jimeng

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17181,6 +17181,38 @@
   },
   {
     "site": "jike",
+    "name": "login",
+    "description": "Open jike login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "web.okjike.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "jike/auth.js",
+    "sourceFile": "jike/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "jike",
     "name": "notifications",
     "description": "即刻通知",
     "access": "read",
@@ -17383,6 +17415,27 @@
     "navigateBefore": "https://m.okjike.com"
   },
   {
+    "site": "jike",
+    "name": "whoami",
+    "description": "Show the current logged-in jike account",
+    "access": "read",
+    "domain": "web.okjike.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name",
+      "username"
+    ],
+    "type": "js",
+    "modulePath": "jike/auth.js",
+    "sourceFile": "jike/auth.js",
+    "navigateBefore": false
+  },
+  {
     "site": "jimeng",
     "name": "generate",
     "description": "即梦AI 文生图 — 输入 prompt 生成图片",
@@ -17455,6 +17508,37 @@
   },
   {
     "site": "jimeng",
+    "name": "login",
+    "description": "Open jimeng login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "jimeng.jianying.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name"
+    ],
+    "type": "js",
+    "modulePath": "jimeng/auth.js",
+    "sourceFile": "jimeng/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "jimeng",
     "name": "new",
     "description": "即梦AI 新建会话（workspace）",
     "access": "write",
@@ -17470,6 +17554,26 @@
     "modulePath": "jimeng/new.js",
     "sourceFile": "jimeng/new.js",
     "navigateBefore": "https://jimeng.jianying.com"
+  },
+  {
+    "site": "jimeng",
+    "name": "whoami",
+    "description": "Show the current logged-in jimeng account",
+    "access": "read",
+    "domain": "jimeng.jianying.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "screen_name"
+    ],
+    "type": "js",
+    "modulePath": "jimeng/auth.js",
+    "sourceFile": "jimeng/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "jimeng",
@@ -21144,6 +21248,38 @@
   },
   {
     "site": "maimai",
+    "name": "login",
+    "description": "Open maimai login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "maimai.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "company"
+    ],
+    "type": "js",
+    "modulePath": "maimai/auth.js",
+    "sourceFile": "maimai/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "maimai",
     "name": "search-talents",
     "description": "Search for candidates on Maimai with multi-dimensional filters",
     "access": "read",
@@ -21265,6 +21401,27 @@
     "modulePath": "maimai/search-talents.js",
     "sourceFile": "maimai/search-talents.js",
     "navigateBefore": "https://maimai.cn"
+  },
+  {
+    "site": "maimai",
+    "name": "whoami",
+    "description": "Show the current logged-in maimai account",
+    "access": "read",
+    "domain": "maimai.cn",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "name",
+      "company"
+    ],
+    "type": "js",
+    "modulePath": "maimai/auth.js",
+    "sourceFile": "maimai/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "manus",
@@ -22729,6 +22886,37 @@
   },
   {
     "site": "nowcoder",
+    "name": "login",
+    "description": "Open nowcoder login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "nowcoder.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "nowcoder/auth.js",
+    "sourceFile": "nowcoder/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "nowcoder",
     "name": "notifications",
     "description": "Unread message summary",
     "access": "read",
@@ -23064,6 +23252,26 @@
     "type": "js",
     "modulePath": "nowcoder/trending.js",
     "sourceFile": "nowcoder/trending.js"
+  },
+  {
+    "site": "nowcoder",
+    "name": "whoami",
+    "description": "Show the current logged-in nowcoder account",
+    "access": "read",
+    "domain": "nowcoder.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "user_id",
+      "nickname"
+    ],
+    "type": "js",
+    "modulePath": "nowcoder/auth.js",
+    "sourceFile": "nowcoder/auth.js",
+    "navigateBefore": false
   },
   {
     "site": "npm",

--- a/clis/jike/auth.js
+++ b/clis/jike/auth.js
@@ -1,0 +1,48 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Jike web (web.okjike.com) is an SPA shell that stores a JWT in localStorage
+// under JK_ACCESS_TOKEN and forwards it as the x-jike-access-token header to the
+// api.ruguoapp.com gateway. The JWT payload is encrypted, so identity is read
+// from the /1.0/users/profile endpoint rather than from the token or a cookie.
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const token = localStorage.getItem('JK_ACCESS_TOKEN') || '';
+    if (!token) return { kind: 'auth', detail: 'Jike JK_ACCESS_TOKEN missing from localStorage (anonymous)' };
+    const r = await fetch('https://api.ruguoapp.com/1.0/users/profile', {
+      headers: { 'x-jike-access-token': token, Accept: 'application/json' },
+    });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Jike users/profile HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    const u = d && d.user;
+    if (!u || !u.id) return { kind: 'auth', detail: 'Jike users/profile returned no user (anonymous)' };
+    return { ok: true, user_id: String(u.id), screen_name: String(u.screenName || ''), username: String(u.username || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyJikeIdentity(page) {
+  await page.goto('https://web.okjike.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('web.okjike.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Jike users/profile`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Jike whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jike probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+}
+
+registerSiteAuthCommands({
+  site: 'jike',
+  domain: 'web.okjike.com',
+  loginUrl: 'https://web.okjike.com/login',
+  columns: ['user_id', 'screen_name', 'username'],
+  verify: verifyJikeIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('web.okjike.com', 'Waiting for Jike login');
+    return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+  },
+});

--- a/clis/jimeng/auth.js
+++ b/clis/jimeng/auth.js
@@ -1,0 +1,46 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Jimeng (ByteDance) authenticates through the shared jianying passport. The
+// /passport/account/info/v2/ endpoint returns the current account for the
+// session cookies; an anonymous visitor comes back with is_visitor_account
+// true and no user_id, so that flag is the login gate. Only the stable id and
+// display name are surfaced (the payload also carries phone/email, which are
+// intentionally not read).
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const r = await fetch('/passport/account/info/v2/?aid=513695', { credentials: 'include', headers: { Accept: 'application/json' } });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Jimeng passport HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    const u = d && d.data;
+    if (!u || !u.user_id || u.is_visitor_account) return { kind: 'auth', detail: 'Jimeng passport returned a visitor account (anonymous)' };
+    return { ok: true, user_id: String(u.user_id_str || u.user_id), screen_name: String(u.screen_name || u.name || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyJimengIdentity(page) {
+  await page.goto('https://jimeng.jianying.com/ai-tool/generate?type=image&workspace=0');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('jimeng.jianying.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Jimeng passport`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Jimeng whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jimeng probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, screen_name: probe.screen_name };
+}
+
+registerSiteAuthCommands({
+  site: 'jimeng',
+  domain: 'jimeng.jianying.com',
+  loginUrl: 'https://jimeng.jianying.com/',
+  columns: ['user_id', 'screen_name'],
+  verify: verifyJimengIdentity,
+  poll: async (page) => {
+    const probe = await page.evaluate(WHOAMI_PROBE);
+    if (!probe?.ok) throw new AuthRequiredError('jimeng.jianying.com', 'Waiting for Jimeng login');
+    return { user_id: probe.user_id, screen_name: probe.screen_name };
+  },
+});

--- a/clis/maimai/auth.js
+++ b/clis/maimai/auth.js
@@ -1,0 +1,47 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Maimai server-renders the logged-in member into an inline script as
+// `userObj = JSON.parse('{...}')`. It is declared with `let` so it never lands
+// on window, and the userCardStr global is corrupted to "[object Object]". The
+// probe parses that inline JSON, which is only injected for an authenticated
+// session, so its presence doubles as the login signal.
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const scripts = Array.from(document.querySelectorAll('script')).map(s => s.textContent || '');
+    let user = null;
+    for (const s of scripts) {
+      const m = s.match(/userObj\\s*=\\s*JSON\\.parse\\('(\\{[\\s\\S]*?\\})'\\)/);
+      if (m) { try { user = JSON.parse(m[1]); } catch {} break; }
+    }
+    if (!user || !user.id) return { kind: 'auth', detail: 'Maimai userObj missing from page (anonymous)' };
+    return {
+      ok: true,
+      user_id: String(user.id),
+      name: String(user.name || ''),
+      company: String(user.company || ''),
+    };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyMaimaiIdentity(page) {
+  await page.goto('https://maimai.cn/');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('maimai.cn', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Maimai`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Maimai whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Maimai probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, name: probe.name, company: probe.company };
+}
+
+registerSiteAuthCommands({
+  site: 'maimai',
+  domain: 'maimai.cn',
+  loginUrl: 'https://maimai.cn/',
+  columns: ['user_id', 'name', 'company'],
+  verify: verifyMaimaiIdentity,
+  poll: verifyMaimaiIdentity,
+});

--- a/clis/nowcoder/auth.js
+++ b/clis/nowcoder/auth.js
@@ -1,0 +1,65 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+
+// Nowcoder's logged-in token cookie is `t`. The numeric uid is not in any
+// readable cookie (NOWCODERUID is a device hash), so identity is resolved from
+// the server-rendered nav avatar link `/users/<uid>` (first /users/ link in
+// DOM order, ahead of body feed recommendations) and confirmed through the
+// gateway profile API.
+async function hasNowcoderSessionCookie(page) {
+  const cookies = await page.getCookies({ url: 'https://www.nowcoder.com' });
+  return cookies.some(cookie => cookie.name === 't' && cookie.value);
+}
+
+const WHOAMI_PROBE = `(async () => {
+  try {
+    const link = document.querySelector('a[href*="/users/"]');
+    const href = link ? (link.getAttribute('href') || '') : '';
+    const match = href.match(/\\/users\\/(\\d+)/);
+    if (!match) {
+      return { kind: 'auth', detail: 'No logged-in nowcoder profile link in nav (anonymous)' };
+    }
+    const uid = match[1];
+    const r = await fetch('https://gw-c.nowcoder.com/api/sparta/user/profile/' + uid, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'nowcoder profile HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    if (!d || !d.success || !d.data || !d.data.id) {
+      return { kind: 'auth', detail: 'nowcoder profile returned no user data (anonymous)' };
+    }
+    return { ok: true, user_id: String(d.data.id), nickname: String(d.data.nickname || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+async function verifyNowcoderIdentity(page) {
+  if (!await hasNowcoderSessionCookie(page)) {
+    throw new AuthRequiredError('nowcoder.com', 'Nowcoder t cookie missing (anonymous)');
+  }
+  await page.goto('https://www.nowcoder.com/');
+  await page.wait(2);
+  const probe = await page.evaluate(WHOAMI_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('nowcoder.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from nowcoder profile API`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Nowcoder whoami failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected nowcoder probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, nickname: probe.nickname };
+}
+
+registerSiteAuthCommands({
+  site: 'nowcoder',
+  domain: 'nowcoder.com',
+  loginUrl: 'https://www.nowcoder.com/login',
+  columns: ['user_id', 'nickname'],
+  verify: verifyNowcoderIdentity,
+  poll: async (page) => {
+    if (!await hasNowcoderSessionCookie(page)) {
+      throw new AuthRequiredError('nowcoder.com', 'Waiting for Nowcoder login');
+    }
+    return verifyNowcoderIdentity(page);
+  },
+});


### PR DESCRIPTION
## Description

Implements the four single-site login/whoami TODOs from the tracking issue, built on the registerSiteAuthCommands framework and matching the merged weibo / gitee / deepseek / hupu adapters. Each site was verified end to end against a real logged-in browser session; the sample output below uses placeholder values.

Per-site approach:

- nowcoder: gate on the `t` session cookie via CDP getCookies; the numeric uid is read from the first nav profile link (the SSR avatar link, ahead of feed recommendations) and identity is confirmed through the gateway profile API at gw-c.nowcoder.com.
- jike: the web app stores a JWT under localStorage JK_ACCESS_TOKEN and forwards it as the x-jike-access-token header to api.ruguoapp.com /1.0/users/profile. The JWT payload is encrypted, so the API is the identity source (deepseek-style token probe).
- maimai: the logged-in member is server-rendered into an inline `userObj = JSON.parse('{...}')` script (declared with let, so it never lands on window, and the userCardStr global is corrupted to "[object Object]"). The probe parses that JSON, whose presence is the login signal.
- jimeng: the jianying passport endpoint /passport/account/info/v2/ returns the account for the session; an anonymous visitor comes back with is_visitor_account true, which is the login gate. Only the stable id and display name are read (the payload also carries phone/email, which are intentionally not surfaced).

All four use typed errors (AuthRequiredError when anonymous, CommandExecutionError on HTTP, parse, or layout drift), the discriminated-union probe shape, and CDP getCookies where a cookie gate applies. No silent return, sentinel row, or clamp.

Related issue: refs #1876 (the four single-site TODOs).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New site adapter
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Verified on logged-in sessions (values below are placeholders, not real account data):

```
opencli nowcoder whoami
  logged_in: true, site: nowcoder, user_id: "100000001", nickname: "example_user"

opencli jike whoami
  logged_in: true, site: jike, user_id: "100000002", screen_name: "Example", username: "00000000-0000-0000-0000-000000000000"

opencli maimai whoami
  logged_in: true, site: maimai, user_id: "100000003", name: "Example", company: "Example Inc"

opencli jimeng whoami
  logged_in: true, site: jimeng, user_id: "100000004", screen_name: "example_user"
```

Checks: npm run build, npm run check:typed-error-lint (new=0), npm run check:silent-column-drop (new=0) all pass. cli-manifest.json regenerated (adds only the 8 login/whoami command entries).
