### PR TITLE
feat(auth): add aggregate status command

### DIFF
--- a/clis/_shared/site-auth.js
+++ b/clis/_shared/site-auth.js
@@ -29,6 +29,14 @@ function commandColumns(config) {
   return ['logged_in', 'site', ...identityColumns];
 }
 
+function normalizeQuickCheck(result) {
+  if (typeof result === 'boolean') return { logged_in: result };
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return { logged_in: !!result.logged_in, ...result };
+  }
+  return { logged_in: false };
+}
+
 export function registerSiteAuthCommands(config) {
   if (!config?.site || !config?.domain || !config?.loginUrl || typeof config.verify !== 'function') {
     throw new Error('registerSiteAuthCommands requires site, domain, loginUrl, and verify(page)');
@@ -45,6 +53,9 @@ export function registerSiteAuthCommands(config) {
     navigateBefore: false,
     args: [],
     columns: commandColumns(config),
+    authStatus: typeof config.quickCheck === 'function'
+      ? { quickCheck: async (page) => normalizeQuickCheck(await config.quickCheck(page)) }
+      : undefined,
     func: async (page) => tryProbe(config, page, 'identity'),
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -66,11 +66,45 @@ describe('createProgram root help descriptions', () => {
     expect(descriptionFor(program, 'browser')).toContain('type');
     expect(descriptionFor(program, 'browser')).toContain('verify');
     expect(descriptionFor(program, 'browser')).not.toContain('Browser control');
+    expect(descriptionFor(program, 'auth')).toBe('status');
     expect(descriptionFor(program, 'plugin')).toBe('create, install, list, uninstall, update');
     expect(descriptionFor(program, 'adapter')).toBe('eject, reset, status');
     expect(descriptionFor(program, 'profile')).toBe('list, rename, use');
     expect(descriptionFor(program, 'daemon')).toBe('restart, status, stop');
     expect(descriptionFor(program, 'external')).toBe('install, list, register');
+  });
+
+  it('renders auth namespace structured help', () => {
+    const argv = process.argv;
+    try {
+      const program = createProgram('', '');
+      const auth = program.commands.find(cmd => cmd.name() === 'auth')!;
+      expect(auth).toBeTruthy();
+
+      process.argv = ['node', 'opencli', 'auth', '--help', '-f', 'yaml'];
+      const data = yaml.load(auth.helpInformation()) as any;
+
+      expect(data).toMatchObject({
+        namespace: 'auth',
+        description: 'Inspect website login status',
+        command_count: 1,
+      });
+      expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['status']);
+      const status = auth.commands.find(cmd => cmd.name() === 'status')!;
+      process.argv = ['node', 'opencli', 'auth', 'status', '--help', '-f', 'yaml'];
+      const statusData = yaml.load(status.helpInformation()) as any;
+      expect(statusData.command).toBe('opencli auth status');
+      expect(statusData.command_options.map((option: any) => option.name)).toEqual(expect.arrayContaining([
+        'site',
+        'full',
+        'concurrency',
+        'timeout',
+        'only',
+        'format',
+      ]));
+    } finally {
+      process.argv = argv;
+    }
   });
 
   it('keeps leaf command descriptions unchanged', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import { parseFilter, shapeMatchesFilter } from './browser/shape-filter.js';
 import { buildHtmlTreeJs, type HtmlTreeResult } from './browser/html-tree.js';
 import { buildExtractHtmlJs, runExtractFromHtml } from './browser/extract.js';
 import { analyzeSite, type PageSignals } from './browser/analyze.js';
+import { registerAuthCommands } from './commands/auth.js';
 import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, fetchDaemonStatus, sendCommand } from './browser/daemon-client.js';
@@ -795,6 +796,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       console.log(renderVerifyReport(r));
       process.exitCode = r.ok ? EXIT_CODES.SUCCESS : EXIT_CODES.GENERIC_ERROR;
     });
+
+  const authCmd = registerAuthCommands(program);
 
   program
     .command('convention-audit')
@@ -3470,6 +3473,7 @@ cli({
   const adapterGroups: RootAdapterGroups = { external: externalHelpEntries, apps, sites };
   const adapterNameSet = new Set<string>([...externalNames, ...siteNames]);
   installCommanderNamespaceStructuredHelp(browser, { globalCommand: program, description: originalBrowserDescription });
+  installCommanderNamespaceStructuredHelp(authCmd, { globalCommand: program, description: 'Inspect website login status' });
   installCommanderNamespaceStructuredHelp(daemonCmd, { globalCommand: program, description: originalDaemonDescription });
   installCommanderNamespaceStructuredHelp(pluginCmd, { globalCommand: program, description: originalPluginDescription });
   installCommanderNamespaceStructuredHelp(adapterCmd, { globalCommand: program, description: originalAdapterDescription });

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserCliCommand } from '../registry.js';
+
+const executeCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../execution.js', () => ({
+  executeCommand: executeCommandMock,
+}));
+
+import { collectAuthStatus } from './auth.js';
+import { AuthRequiredError } from '../errors.js';
+import { cli, getRegistry, Strategy } from '../registry.js';
+
+function registerWhoami(site: string, opts: {
+  quick?: boolean;
+  quickLoggedIn?: boolean;
+  identity?: Record<string, unknown>;
+} = {}): void {
+  cli({
+    site,
+    name: 'whoami',
+    access: 'read',
+    description: `${site} whoami`,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    domain: `${site}.example.com`,
+    navigateBefore: false,
+    args: [],
+    columns: ['logged_in', 'site', 'username'],
+    authStatus: opts.quick
+      ? { quickCheck: async () => ({ logged_in: opts.quickLoggedIn ?? false }) }
+      : undefined,
+    func: async () => opts.identity ?? { logged_in: true, site, username: site },
+  });
+}
+
+beforeEach(() => {
+  getRegistry().clear();
+  executeCommandMock.mockReset();
+  executeCommandMock.mockImplementation(async (cmd: BrowserCliCommand, kwargs: Record<string, unknown>) => {
+    if (!cmd.func) return {};
+    return cmd.func({} as never, kwargs);
+  });
+});
+
+describe('auth status collection', () => {
+  it('uses quickCheck by default and does not run full whoami', async () => {
+    registerWhoami('alpha', { quick: true, quickLoggedIn: true, identity: { username: 'full-alpha' } });
+
+    const rows = await collectAuthStatus({ sites: 'alpha' });
+
+    expect(rows).toEqual([
+      { site: 'alpha', status: 'logged_in', logged_in: true, identity: '', checked: 'quick', error: '' },
+    ]);
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    expect(executeCommandMock.mock.calls[0]?.[0]).toMatchObject({
+      site: 'alpha',
+      name: 'whoami',
+      navigateBefore: false,
+      siteSession: 'ephemeral',
+      defaultWindowMode: 'background',
+    });
+  });
+
+  it('marks sites without quickCheck as unknown unless --full is used', async () => {
+    registerWhoami('beta');
+
+    const rows = await collectAuthStatus({ sites: 'beta' });
+
+    expect(rows).toEqual([
+      {
+        site: 'beta',
+        status: 'unknown',
+        logged_in: '',
+        identity: '',
+        checked: 'skipped',
+        error: 'quickCheck not implemented; use --full to run whoami',
+      },
+    ]);
+    expect(executeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('runs full whoami with --full and returns a safe identity summary', async () => {
+    registerWhoami('gamma', {
+      identity: {
+        logged_in: true,
+        site: 'gamma',
+        email: 'hidden@example.com',
+        username: 'public-handle',
+      },
+    });
+
+    const rows = await collectAuthStatus({ sites: 'gamma', full: true });
+
+    expect(rows).toEqual([
+      { site: 'gamma', status: 'logged_in', logged_in: true, identity: 'public-handle', checked: 'full', error: '' },
+    ]);
+  });
+
+  it('converts AuthRequiredError into not_logged_in rows', async () => {
+    registerWhoami('delta', { quick: true });
+    executeCommandMock.mockRejectedValueOnce(new AuthRequiredError('delta.example.com'));
+
+    const rows = await collectAuthStatus({ sites: 'delta' });
+
+    expect(rows).toEqual([
+      { site: 'delta', status: 'not_logged_in', logged_in: false, identity: '', checked: 'quick', error: '' },
+    ]);
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,0 +1,277 @@
+import { pathToFileURL } from 'node:url';
+import { Command, InvalidArgumentError, Option } from 'commander';
+import { AuthRequiredError, CliError, getErrorMessage } from '../errors.js';
+import { executeCommand } from '../execution.js';
+import {
+  type BrowserCliCommand,
+  type CliCommand,
+  type CommandArgs,
+  type InternalCliCommand,
+  fullName,
+  getRegistry,
+} from '../registry.js';
+import { render as renderOutput } from '../output.js';
+
+type AuthStatus = 'logged_in' | 'not_logged_in' | 'unknown' | 'error';
+type AuthStatusMode = 'quick' | 'full';
+
+export interface AuthStatusRow {
+  site: string;
+  status: AuthStatus;
+  logged_in: boolean | '';
+  identity: string;
+  checked: AuthStatusMode | 'skipped';
+  error: string;
+}
+
+interface AuthStatusOptions {
+  sites?: string;
+  only?: string;
+  full?: boolean;
+  concurrency?: string | number;
+  timeout?: string | number;
+  profile?: string;
+}
+
+function parsePositiveInt(raw: string | number | undefined, label: string, fallback: number): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError(`${label} must be a positive integer. Received: "${String(raw)}"`);
+  }
+  return parsed;
+}
+
+function parseSiteFilter(raw: string | undefined): Set<string> | null {
+  if (!raw || !raw.trim()) return null;
+  const sites = raw.split(',').map(site => site.trim()).filter(Boolean);
+  return sites.length > 0 ? new Set(sites) : null;
+}
+
+function authWhoamiCommands(): CliCommand[] {
+  const seen = new Set<CliCommand>();
+  return [...getRegistry().values()]
+    .filter((cmd) => {
+      if (seen.has(cmd)) return false;
+      seen.add(cmd);
+      return cmd.name === 'whoami' && cmd.browser === true && cmd.access === 'read';
+    })
+    .sort((a, b) => a.site.localeCompare(b.site));
+}
+
+async function loadLazyCommand(cmd: CliCommand): Promise<CliCommand> {
+  const internal = cmd as InternalCliCommand;
+  if (!internal._lazy || !internal._modulePath) return cmd;
+  await import(pathToFileURL(internal._modulePath).href);
+  return getRegistry().get(fullName(cmd)) ?? cmd;
+}
+
+function withTimeoutArg(cmd: CliCommand, timeoutSeconds: number): CliCommand {
+  const hasTimeout = cmd.args.some(arg => arg.name === 'timeout');
+  return {
+    ...cmd,
+    args: hasTimeout
+      ? cmd.args
+      : [...cmd.args, { name: 'timeout', type: 'int', default: timeoutSeconds, help: 'Per-site auth status timeout in seconds' }],
+  };
+}
+
+function quickCheckCommand(cmd: CliCommand, timeoutSeconds: number): BrowserCliCommand | null {
+  if (cmd.browser !== true || typeof cmd.authStatus?.quickCheck !== 'function') return null;
+  return withTimeoutArg({
+    ...cmd,
+    func: cmd.authStatus.quickCheck,
+    navigateBefore: false,
+    siteSession: 'ephemeral',
+    defaultWindowMode: 'background',
+  }, timeoutSeconds) as BrowserCliCommand;
+}
+
+function normalizeQuickResult(result: unknown): boolean | null {
+  if (typeof result === 'boolean') return result;
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    const value = (result as Record<string, unknown>).logged_in;
+    if (typeof value === 'boolean') return value;
+  }
+  return null;
+}
+
+function safeIdentityValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
+}
+
+function identitySummary(result: unknown): string {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return '';
+  const row = result as Record<string, unknown>;
+  const blocked = /(?:email|phone|real.?name|first.?name|last.?name|cookie|token|session|secret|password|csrf|jwt|bearer|wt2)/i;
+  for (const key of ['username', 'handle', 'user_id', 'id', 'name', 'nickname', 'user_type', 'url']) {
+    if (blocked.test(key)) continue;
+    const value = safeIdentityValue(row[key]);
+    if (value) return value;
+  }
+  for (const [key, raw] of Object.entries(row)) {
+    if (key === 'site' || key === 'logged_in' || blocked.test(key)) continue;
+    const value = safeIdentityValue(raw);
+    if (value) return value;
+  }
+  return '';
+}
+
+function rowForError(site: string, checked: AuthStatusMode, error: unknown): AuthStatusRow {
+  if (error instanceof AuthRequiredError) {
+    return { site, status: 'not_logged_in', logged_in: false, identity: '', checked, error: '' };
+  }
+  const code = error instanceof CliError ? error.code : '';
+  const message = getErrorMessage(error);
+  return {
+    site,
+    status: 'error',
+    logged_in: '',
+    identity: '',
+    checked,
+    error: code ? `${code}: ${message}` : message,
+  };
+}
+
+async function runQuick(cmd: CliCommand, opts: { timeoutSeconds: number; profile?: string }): Promise<AuthStatusRow> {
+  const loaded = await loadLazyCommand(cmd);
+  const quickCmd = quickCheckCommand(loaded, opts.timeoutSeconds);
+  if (!quickCmd) {
+    return {
+      site: cmd.site,
+      status: 'unknown',
+      logged_in: '',
+      identity: '',
+      checked: 'skipped',
+      error: 'quickCheck not implemented; use --full to run whoami',
+    };
+  }
+
+  try {
+    const result = await executeCommand(quickCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
+      siteSession: 'ephemeral',
+      keepTab: 'false',
+      windowMode: 'background',
+      ...(opts.profile ? { profile: opts.profile } : {}),
+    });
+    const loggedIn = normalizeQuickResult(result);
+    if (loggedIn === true) {
+      return { site: cmd.site, status: 'logged_in', logged_in: true, identity: '', checked: 'quick', error: '' };
+    }
+    if (loggedIn === false) {
+      return { site: cmd.site, status: 'not_logged_in', logged_in: false, identity: '', checked: 'quick', error: '' };
+    }
+    return {
+      site: cmd.site,
+      status: 'unknown',
+      logged_in: '',
+      identity: '',
+      checked: 'quick',
+      error: 'quickCheck returned no boolean logged_in signal',
+    };
+  } catch (error) {
+    return rowForError(cmd.site, 'quick', error);
+  }
+}
+
+async function runFull(cmd: CliCommand, opts: { timeoutSeconds: number; profile?: string }): Promise<AuthStatusRow> {
+  const loaded = await loadLazyCommand(cmd);
+  const fullCmd = withTimeoutArg(loaded, opts.timeoutSeconds);
+  try {
+    const result = await executeCommand(fullCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
+      siteSession: 'ephemeral',
+      keepTab: 'false',
+      windowMode: 'background',
+      ...(opts.profile ? { profile: opts.profile } : {}),
+    });
+    return {
+      site: cmd.site,
+      status: 'logged_in',
+      logged_in: true,
+      identity: identitySummary(result),
+      checked: 'full',
+      error: '',
+    };
+  } catch (error) {
+    return rowForError(cmd.site, 'full', error);
+  }
+}
+
+async function mapConcurrent<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await worker(items[index]);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+export async function collectAuthStatus(options: AuthStatusOptions): Promise<AuthStatusRow[]> {
+  const selectedSites = parseSiteFilter(options.sites);
+  const mode: AuthStatusMode = options.full ? 'full' : 'quick';
+  const concurrency = parsePositiveInt(options.concurrency, '--concurrency', mode === 'full' ? 3 : 8);
+  const timeoutSeconds = parsePositiveInt(options.timeout, '--timeout', mode === 'full' ? 20 : 8);
+  const only = String(options.only ?? 'all');
+  if (!['all', 'logged-in', 'not-logged-in', 'unknown', 'error'].includes(only)) {
+    throw new InvalidArgumentError('--only must be one of: all, logged-in, not-logged-in, unknown, error');
+  }
+
+  const commands = authWhoamiCommands().filter(cmd => !selectedSites || selectedSites.has(cmd.site));
+  const rows = await mapConcurrent(commands, concurrency, cmd => (
+    mode === 'full'
+      ? runFull(cmd, { timeoutSeconds, profile: options.profile })
+      : runQuick(cmd, { timeoutSeconds, profile: options.profile })
+  ));
+
+  const normalizedOnly = only.replace(/-/g, '_');
+  return normalizedOnly === 'all'
+    ? rows
+    : rows.filter(row => row.status === normalizedOnly);
+}
+
+export function registerAuthCommands(program: Command): Command {
+  const auth = program
+    .command('auth')
+    .description('Inspect website login status');
+
+  const status = auth
+    .command('status')
+    .description('Show login status for sites with auth adapters')
+    .option('--site <sites>', 'Comma-separated site names to check, e.g. github,chatgpt')
+    .option('--full', 'Run full per-site whoami probes instead of quick no-navigation checks', false)
+    .option('--concurrency <n>', 'Maximum sites to check at once')
+    .option('--timeout <seconds>', 'Per-site timeout in seconds')
+    .addOption(new Option('--only <status>', 'Filter rows by status').choices(['all', 'logged-in', 'not-logged-in', 'unknown', 'error']).default('all'))
+    .option('-f, --format <fmt>', 'Output format: table, plain, json, yaml, md, csv', 'table')
+    .action(async (opts) => {
+      const globals = typeof status.optsWithGlobals === 'function' ? status.optsWithGlobals() as Record<string, unknown> : {};
+      const rows = await collectAuthStatus({
+        sites: opts.site,
+        full: opts.full === true,
+        concurrency: opts.concurrency,
+        timeout: opts.timeout,
+        only: opts.only,
+        profile: typeof globals.profile === 'string' && globals.profile.trim() ? globals.profile.trim() : undefined,
+      });
+      const fmt = typeof opts.format === 'string' ? opts.format : 'table';
+      renderOutput(rows, {
+        fmt,
+        fmtExplicit: status.getOptionValueSource('format') === 'cli',
+        columns: ['site', 'status', 'identity', 'checked', 'error'],
+        title: 'opencli/auth status',
+        source: opts.full ? 'full whoami probe' : 'quick auth check',
+      });
+    });
+
+  return auth;
+}

--- a/src/completion-shared.ts
+++ b/src/completion-shared.ts
@@ -12,6 +12,7 @@ export const BUILTIN_COMMANDS = [
   'list',
   'validate',
   'verify',
+  'auth',
   'browser',
   'tab',
   'doctor',

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -29,6 +29,10 @@ export type NonBrowserCommandFunc = (kwargs: CommandArgs, debug?: boolean) => Pr
 export type CommandAccess = 'read' | 'write';
 export type SiteSessionMode = 'ephemeral' | 'persistent';
 
+export interface AuthStatusMetadata {
+  quickCheck?: BrowserCommandFunc;
+}
+
 interface BaseCliCommand {
   site: string;
   name: string;
@@ -68,6 +72,8 @@ interface BaseCliCommand {
   defaultWindowMode?: 'foreground' | 'background';
   /** Override the default CLI output format when the user does not pass -f/--format. */
   defaultFormat?: 'table' | 'plain' | 'json' | 'yaml' | 'yml' | 'md' | 'markdown' | 'csv';
+  /** Optional auth-status metadata attached by shared auth adapters. */
+  authStatus?: AuthStatusMetadata;
 }
 
 export interface BrowserCliCommand extends BaseCliCommand {
@@ -142,6 +148,7 @@ export function cli(opts: CliOptions): CliCommand {
     siteSession: opts.siteSession,
     defaultWindowMode: opts.defaultWindowMode,
     defaultFormat: opts.defaultFormat,
+    authStatus: opts.authStatus,
   };
 
   registerCommand(cmd);


### PR DESCRIPTION
## Summary

Adds `opencli auth status` as a top-level aggregate login-status command.

Behavior:
- default mode is quick/no-navigation and only consumes adapter `quickCheck(page)` metadata;
- `--full` runs the existing per-site `whoami` probes for full identity checks;
- supports `--site`, `--only`, `--concurrency`, `--timeout`, `--profile`, and structured output via `-f`;
- converts per-site `AuthRequiredError` into `not_logged_in` rows instead of failing the whole sweep;
- avoids sensitive identity summaries by skipping email/phone/real-name/cookie/token/session-like keys.

Framework contract for adapters:
- `registerSiteAuthCommands({ quickCheck })` accepts async `quickCheck(page)` returning `boolean` or `{ logged_in: boolean }`;
- quick checks may use CDP cookies, localStorage, or no-navigation fetch probes;
- adapters without quickCheck show `unknown` in default mode and can still be checked with `--full`.

## Validation

- `npx tsc --noEmit`
- clean-HOME `npx vitest run --project unit src/commands/auth.test.ts src/cli.test.ts src/registry.test.ts src/build-manifest.test.ts src/completion-fast.test.ts src/completion.test.ts` — 203 passed
- `npm run build`
- `git diff --check`
- `node dist/src/main.js auth status --site github -f json`
- `node dist/src/main.js --get-completions --cursor 1 a | rg '^auth$'`

## Follow-up

@opencli-user can now mechanically add `quickCheck` to the existing auth adapters. Until those land, `--full` works immediately and default quick mode returns `unknown` for adapters without `quickCheck`.
