### PR TITLE
feat(auth): wire quickCheck into 50 adapters for auth status

### DIFF
--- a/clis/12306/auth.js
+++ b/clis/12306/auth.js
@@ -48,6 +48,7 @@ registerSiteAuthCommands({
   domain: '12306.cn',
   loginUrl: 'https://kyfw.12306.cn/otn/resources/login.html',
   columns: ['user_name'],
+  quickCheck: has12306SessionCookie,
   verify: verify12306Identity,
   poll: async (page) => {
     if (!await has12306SessionCookie(page)) {

--- a/clis/1688/auth.js
+++ b/clis/1688/auth.js
@@ -35,6 +35,7 @@ registerSiteAuthCommands({
   domain: '1688.com',
   loginUrl: 'https://login.1688.com/member/signin.htm',
   columns: ['user_id', 'name'],
+  quickCheck: has1688LogonCookie,
   verify: verify1688Identity,
   poll: async (page) => {
     if (!await has1688LogonCookie(page)) {

--- a/clis/1point3acres/auth.js
+++ b/clis/1point3acres/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: '1point3acres.com',
   loginUrl: 'https://auth.1point3acres.com/login',
   columns: ['user_id', 'username'],
+  quickCheck: has1Point3AcresAuthCookie,
   verify: verify1Point3AcresIdentity,
   poll: async (page) => {
     if (!await has1Point3AcresAuthCookie(page)) {

--- a/clis/amazon/auth.js
+++ b/clis/amazon/auth.js
@@ -42,6 +42,7 @@ registerSiteAuthCommands({
   domain: 'amazon.com',
   loginUrl: 'https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2F&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0',
   columns: ['user_name'],
+  quickCheck: hasAmazonSessionCookies,
   verify: verifyAmazonIdentity,
   poll: async (page) => {
     if (!await hasAmazonSessionCookies(page)) {

--- a/clis/band/auth.js
+++ b/clis/band/auth.js
@@ -51,6 +51,7 @@ registerSiteAuthCommands({
   domain: 'band.us',
   loginUrl: 'https://auth.band.us/login',
   columns: ['user_id'],
+  quickCheck: hasBandSessionCookie,
   verify: verifyBandIdentity,
   poll: async (page) => {
     if (!await hasBandSessionCookie(page)) {

--- a/clis/bilibili/auth.js
+++ b/clis/bilibili/auth.js
@@ -25,6 +25,7 @@ registerSiteAuthCommands({
   domain: 'www.bilibili.com',
   loginUrl: 'https://passport.bilibili.com/login',
   columns: ['id', 'username', 'level'],
+  quickCheck: hasBilibiliSessionCookies,
   verify: verifyBilibiliIdentity,
   poll: async (page) => {
     if (!await hasBilibiliSessionCookies(page)) {

--- a/clis/boss/auth.js
+++ b/clis/boss/auth.js
@@ -36,6 +36,7 @@ registerSiteAuthCommands({
   domain: 'zhipin.com',
   loginUrl: 'https://login.zhipin.com/',
   columns: ['user_type'],
+  quickCheck: hasBossSessionCookie,
   verify: verifyBossIdentity,
   poll: async (page) => {
     if (!await hasBossSessionCookie(page)) {

--- a/clis/chaoxing/auth.js
+++ b/clis/chaoxing/auth.js
@@ -43,6 +43,7 @@ registerSiteAuthCommands({
   domain: 'chaoxing.com',
   loginUrl: 'https://passport2.chaoxing.com/login?fid=&newversion=true&refer=https%3A%2F%2Fi.chaoxing.com',
   columns: ['user_id', 'name'],
+  quickCheck: hasChaoxingSessionCookie,
   verify: verifyChaoxingIdentity,
   poll: async (page) => {
     if (!await hasChaoxingSessionCookie(page)) {

--- a/clis/chatgpt/auth.js
+++ b/clis/chatgpt/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: 'chatgpt.com',
   loginUrl: 'https://auth.openai.com/log-in',
   columns: ['user_id', 'name'],
+  quickCheck: hasChatgptSessionCookie,
   verify: verifyChatgptIdentity,
   poll: async (page) => {
     if (!await hasChatgptSessionCookie(page)) {

--- a/clis/claude/auth.js
+++ b/clis/claude/auth.js
@@ -44,6 +44,7 @@ registerSiteAuthCommands({
   domain: 'claude.ai',
   loginUrl: 'https://claude.ai/login',
   columns: ['user_id', 'org_name', 'org_uuid'],
+  quickCheck: hasClaudeSessionCookie,
   verify: verifyClaudeIdentity,
   poll: async (page) => {
     if (!await hasClaudeSessionCookie(page)) {

--- a/clis/ctrip/auth.js
+++ b/clis/ctrip/auth.js
@@ -39,6 +39,7 @@ registerSiteAuthCommands({
   domain: 'ctrip.com',
   loginUrl: 'https://passport.ctrip.com/user/login',
   columns: ['user_id', 'name', 'vip_grade'],
+  quickCheck: hasCtripLoginUid,
   verify: verifyCtripIdentity,
   poll: async (page) => {
     if (!await hasCtripLoginUid(page)) {

--- a/clis/dianping/auth.js
+++ b/clis/dianping/auth.js
@@ -38,6 +38,7 @@ registerSiteAuthCommands({
   domain: 'dianping.com',
   loginUrl: 'https://account.dianping.com/pclogin',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasDianpingSessionCookie,
   verify: verifyDianpingIdentity,
   poll: async (page) => {
     if (!await hasDianpingSessionCookie(page)) {

--- a/clis/douban/auth.js
+++ b/clis/douban/auth.js
@@ -39,6 +39,7 @@ registerSiteAuthCommands({
   domain: 'douban.com',
   loginUrl: 'https://accounts.douban.com/passport/login',
   columns: ['user_id', 'name'],
+  quickCheck: hasDoubanSessionCookie,
   verify: verifyDoubanIdentity,
   poll: async (page) => {
     if (!await hasDoubanSessionCookie(page)) {

--- a/clis/douyin/auth.js
+++ b/clis/douyin/auth.js
@@ -28,6 +28,7 @@ registerSiteAuthCommands({
   domain: 'creator.douyin.com',
   loginUrl: 'https://creator.douyin.com/',
   columns: ['id', 'username', 'followers'],
+  quickCheck: hasDouyinSessionCookies,
   verify: verifyDouyinIdentity,
   poll: async (page) => {
     if (!await hasDouyinSessionCookies(page)) {

--- a/clis/facebook/auth.js
+++ b/clis/facebook/auth.js
@@ -32,6 +32,7 @@ registerSiteAuthCommands({
   domain: 'facebook.com',
   loginUrl: 'https://www.facebook.com/login.php',
   columns: ['user_id', 'vanity', 'profile_url'],
+  quickCheck: hasFacebookCUserCookie,
   verify: verifyFacebookIdentity,
   poll: async (page) => {
     if (!await hasFacebookCUserCookie(page)) {

--- a/clis/flomo/auth.js
+++ b/clis/flomo/auth.js
@@ -44,6 +44,7 @@ registerSiteAuthCommands({
   domain: 'flomoapp.com',
   loginUrl: 'https://v.flomoapp.com/login',
   columns: ['user_id'],
+  quickCheck: hasFlomoSessionCookie,
   verify: verifyFlomoIdentity,
   poll: async (page) => {
     if (!await hasFlomoSessionCookie(page)) {

--- a/clis/gemini/auth.js
+++ b/clis/gemini/auth.js
@@ -37,6 +37,7 @@ registerSiteAuthCommands({
   domain: 'gemini.google.com',
   loginUrl: 'https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fgemini.google.com%2F',
   columns: ['name'],
+  quickCheck: hasGoogleSessionCookie,
   verify: verifyGeminiIdentity,
   poll: async (page) => {
     if (!await hasGoogleSessionCookie(page)) {

--- a/clis/github/auth.js
+++ b/clis/github/auth.js
@@ -33,6 +33,7 @@ registerSiteAuthCommands({
   domain: 'github.com',
   loginUrl: 'https://github.com/login',
   columns: ['id', 'username', 'name', 'url'],
+  quickCheck: hasGithubSessionCookies,
   verify: verifyGithubIdentity,
   poll: async (page) => {
     if (!await hasGithubSessionCookies(page)) {

--- a/clis/grok/auth.js
+++ b/clis/grok/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: 'grok.com',
   loginUrl: 'https://grok.com/auth/sign-in',
   columns: ['user_id', 'name'],
+  quickCheck: hasGrokSessionCookie,
   verify: verifyGrokIdentity,
   poll: async (page) => {
     if (!await hasGrokSessionCookie(page)) {

--- a/clis/hupu/auth.js
+++ b/clis/hupu/auth.js
@@ -36,6 +36,7 @@ registerSiteAuthCommands({
   domain: 'hupu.com',
   loginUrl: 'https://passport.hupu.com/pc/login',
   columns: ['user_id', 'username'],
+  quickCheck: hasHupuUserCookie,
   verify: verifyHupuIdentity,
   poll: async (page) => {
     if (!await hasHupuUserCookie(page)) {

--- a/clis/instagram/auth.js
+++ b/clis/instagram/auth.js
@@ -46,6 +46,7 @@ registerSiteAuthCommands({
   domain: 'instagram.com',
   loginUrl: 'https://www.instagram.com/accounts/login/',
   columns: ['user_id', 'username', 'full_name'],
+  quickCheck: hasInstagramSessionCookie,
   verify: verifyInstagramIdentity,
   poll: async (page) => {
     if (!await hasInstagramSessionCookie(page)) {

--- a/clis/jd/auth.js
+++ b/clis/jd/auth.js
@@ -35,6 +35,7 @@ registerSiteAuthCommands({
   domain: 'jd.com',
   loginUrl: 'https://passport.jd.com/new/login.aspx',
   columns: ['pin', 'nickname'],
+  quickCheck: hasJdSessionCookie,
   verify: verifyJdIdentity,
   poll: async (page) => {
     if (!await hasJdSessionCookie(page)) {

--- a/clis/jianyu/auth.js
+++ b/clis/jianyu/auth.js
@@ -51,6 +51,7 @@ registerSiteAuthCommands({
   domain: 'jianyu360.cn',
   loginUrl: 'https://www.jianyu360.cn/',
   columns: ['user_id', 'name'],
+  quickCheck: hasJianyuUserCookie,
   verify: verifyJianyuIdentity,
   poll: async (page) => {
     if (!await hasJianyuUserCookie(page)) {

--- a/clis/kimi/auth.js
+++ b/clis/kimi/auth.js
@@ -46,6 +46,7 @@ registerSiteAuthCommands({
   domain: 'kimi.com',
   loginUrl: 'https://www.kimi.com/',
   columns: ['user_id', 'name'],
+  quickCheck: hasKimiSessionCookie,
   verify: verifyKimiIdentity,
   poll: async (page) => {
     if (!await hasKimiSessionCookie(page)) {

--- a/clis/linkedin-learning/auth.js
+++ b/clis/linkedin-learning/auth.js
@@ -51,6 +51,7 @@ registerSiteAuthCommands({
   domain: 'linkedin.com',
   loginUrl: 'https://www.linkedin.com/login?session_redirect=%2Flearning%2F',
   columns: ['public_id', 'plain_id', 'name'],
+  quickCheck: hasLinkedinSessionCookie,
   verify: verifyLinkedinLearningIdentity,
   poll: async (page) => {
     if (!await hasLinkedinSessionCookie(page)) {

--- a/clis/linkedin/auth.js
+++ b/clis/linkedin/auth.js
@@ -51,6 +51,7 @@ registerSiteAuthCommands({
   domain: 'www.linkedin.com',
   loginUrl: 'https://www.linkedin.com/login',
   columns: ['public_id', 'plain_id', 'name'],
+  quickCheck: hasLinkedinSessionCookie,
   verify: verifyLinkedinIdentity,
   poll: async (page) => {
     if (!await hasLinkedinSessionCookie(page)) {

--- a/clis/linux-do/auth.js
+++ b/clis/linux-do/auth.js
@@ -44,6 +44,7 @@ registerSiteAuthCommands({
   domain: 'linux.do',
   loginUrl: 'https://linux.do/login',
   columns: ['user_id', 'username', 'name'],
+  quickCheck: hasLinuxDoSessionCookie,
   verify: verifyLinuxDoIdentity,
   poll: async (page) => {
     if (!await hasLinuxDoSessionCookie(page)) {

--- a/clis/notebooklm/auth.js
+++ b/clis/notebooklm/auth.js
@@ -44,6 +44,7 @@ registerSiteAuthCommands({
   domain: 'google.com',
   loginUrl: 'https://accounts.google.com/ServiceLogin?service=lso&continue=https%3A%2F%2Fnotebooklm.google.com%2F',
   columns: ['name', 'authuser'],
+  quickCheck: hasNotebookLmSsoCookies,
   verify: verifyNotebookLmIdentity,
   poll: async (page) => {
     if (!await hasNotebookLmSsoCookies(page)) {

--- a/clis/pixiv/auth.js
+++ b/clis/pixiv/auth.js
@@ -53,6 +53,7 @@ registerSiteAuthCommands({
   domain: 'pixiv.net',
   loginUrl: 'https://accounts.pixiv.net/login',
   columns: ['user_id', 'name'],
+  quickCheck: hasPixivSessionCookie,
   verify: verifyPixivIdentity,
   poll: async (page) => {
     if (!await hasPixivSessionCookie(page)) {

--- a/clis/powerchina/auth.js
+++ b/clis/powerchina/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: 'powerchina.cn',
   loginUrl: 'https://zhaopin.powerchina.cn/login',
   columns: ['name'],
+  quickCheck: hasPowerchinaSessionCookie,
   verify: verifyPowerchinaIdentity,
   poll: async (page) => {
     if (!await hasPowerchinaSessionCookie(page)) {

--- a/clis/qwen/auth.js
+++ b/clis/qwen/auth.js
@@ -45,6 +45,7 @@ registerSiteAuthCommands({
   domain: 'qwen.ai',
   loginUrl: 'https://chat.qwen.ai/auth?action=login',
   columns: ['user_id', 'name'],
+  quickCheck: hasQwenSessionCookie,
   verify: verifyQwenIdentity,
   poll: async (page) => {
     if (!await hasQwenSessionCookie(page)) {

--- a/clis/reddit/auth.js
+++ b/clis/reddit/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: 'reddit.com',
   loginUrl: 'https://www.reddit.com/login',
   columns: ['username', 'id'],
+  quickCheck: hasRedditSessionCookie,
   verify: verifyRedditIdentity,
   poll: async (page) => {
     if (!await hasRedditSessionCookie(page)) {

--- a/clis/rednote/auth.js
+++ b/clis/rednote/auth.js
@@ -41,6 +41,7 @@ registerSiteAuthCommands({
   domain: 'rednote.com',
   loginUrl: 'https://www.rednote.com/explore',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasRednoteSessionCookie,
   verify: verifyRednoteIdentity,
   poll: async (page) => {
     if (!await hasRednoteSessionCookie(page)) {

--- a/clis/suno/auth.js
+++ b/clis/suno/auth.js
@@ -52,6 +52,7 @@ registerSiteAuthCommands({
   domain: 'suno.com',
   loginUrl: 'https://suno.com/?sign-in=true',
   columns: ['user_id', 'name'],
+  quickCheck: hasSunoClerkCookie,
   verify: verifySunoIdentity,
   poll: async (page) => {
     if (!await hasSunoClerkCookie(page)) {

--- a/clis/taobao/auth.js
+++ b/clis/taobao/auth.js
@@ -47,6 +47,7 @@ registerSiteAuthCommands({
   domain: 'taobao.com',
   loginUrl: 'https://login.taobao.com/member/login.jhtml',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasTaobaoSessionCookie,
   verify: verifyTaobaoIdentity,
   poll: async (page) => {
     if (!await hasTaobaoSessionCookie(page)) {

--- a/clis/tiktok/auth.js
+++ b/clis/tiktok/auth.js
@@ -54,6 +54,7 @@ registerSiteAuthCommands({
   domain: 'tiktok.com',
   loginUrl: 'https://www.tiktok.com/login',
   columns: ['sec_uid', 'username', 'nickname'],
+  quickCheck: hasTiktokSessionCookie,
   verify: verifyTiktokIdentity,
   poll: async (page) => {
     if (!await hasTiktokSessionCookie(page)) {

--- a/clis/toutiao/auth.js
+++ b/clis/toutiao/auth.js
@@ -59,6 +59,7 @@ registerSiteAuthCommands({
   domain: 'toutiao.com',
   loginUrl: 'https://mp.toutiao.com/auth/page/login',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasToutiaoSessionCookie,
   verify: verifyToutiaoIdentity,
   poll: async (page) => {
     if (!await hasToutiaoSessionCookie(page)) {

--- a/clis/twitter/auth.js
+++ b/clis/twitter/auth.js
@@ -30,6 +30,7 @@ registerSiteAuthCommands({
   domain: 'x.com',
   loginUrl: 'https://x.com/i/flow/login',
   columns: ['username', 'url'],
+  quickCheck: hasTwitterSessionCookies,
   verify: verifyTwitterIdentity,
   poll: async (page) => {
     if (!await hasTwitterSessionCookies(page)) {

--- a/clis/upwork/auth.js
+++ b/clis/upwork/auth.js
@@ -42,6 +42,7 @@ registerSiteAuthCommands({
   domain: 'upwork.com',
   loginUrl: 'https://www.upwork.com/ab/account-security/login',
   columns: ['user_id', 'ciphertext'],
+  quickCheck: hasUpworkSessionCookie,
   verify: verifyUpworkIdentity,
   poll: async (page) => {
     if (!await hasUpworkSessionCookie(page)) {

--- a/clis/v2ex/auth.js
+++ b/clis/v2ex/auth.js
@@ -33,6 +33,7 @@ registerSiteAuthCommands({
   domain: 'v2ex.com',
   loginUrl: 'https://www.v2ex.com/signin',
   columns: ['username'],
+  quickCheck: hasV2exAuthCookie,
   verify: verifyV2exIdentity,
   poll: async (page) => {
     if (!await hasV2exAuthCookie(page)) {

--- a/clis/wechat-channels/auth.js
+++ b/clis/wechat-channels/auth.js
@@ -51,6 +51,7 @@ registerSiteAuthCommands({
   domain: 'channels.weixin.qq.com',
   loginUrl: 'https://channels.weixin.qq.com/login.html?from=assistant',
   columns: ['user_id', 'name'],
+  quickCheck: hasWechatChannelsSessionCookie,
   verify: verifyWechatChannelsIdentity,
   poll: async (page) => {
     if (!await hasWechatChannelsSessionCookie(page)) {

--- a/clis/weibo/auth.js
+++ b/clis/weibo/auth.js
@@ -42,6 +42,7 @@ registerSiteAuthCommands({
   domain: 'weibo.com',
   loginUrl: 'https://weibo.com/login',
   columns: ['user_id', 'screen_name', 'profile_url'],
+  quickCheck: hasWeiboSessionCookie,
   verify: verifyWeiboIdentity,
   poll: async (page) => {
     if (!await hasWeiboSessionCookie(page)) {

--- a/clis/weread/auth.js
+++ b/clis/weread/auth.js
@@ -48,6 +48,7 @@ registerSiteAuthCommands({
   domain: 'weread.qq.com',
   loginUrl: 'https://weread.qq.com/',
   columns: ['user_id', 'name'],
+  quickCheck: hasWereadSessionCookie,
   verify: verifyWereadIdentity,
   poll: async (page) => {
     if (!await hasWereadSessionCookie(page)) {

--- a/clis/xianyu/auth.js
+++ b/clis/xianyu/auth.js
@@ -57,6 +57,7 @@ registerSiteAuthCommands({
   domain: 'goofish.com',
   loginUrl: 'https://www.goofish.com/login',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasXianyuIdentityCookie,
   verify: verifyXianyuIdentity,
   poll: async (page) => {
     if (!await hasXianyuIdentityCookie(page)) {

--- a/clis/xiaoe/auth.js
+++ b/clis/xiaoe/auth.js
@@ -44,6 +44,7 @@ registerSiteAuthCommands({
   domain: 'xiaoe-tech.com',
   loginUrl: 'https://admin.xiaoe-tech.com/',
   columns: ['user_id', 'nickname'],
+  quickCheck: hasXiaoeAdminCookie,
   verify: verifyXiaoeIdentity,
   poll: async (page) => {
     if (!await hasXiaoeAdminCookie(page)) {

--- a/clis/xiaohongshu/auth.js
+++ b/clis/xiaohongshu/auth.js
@@ -42,6 +42,7 @@ registerSiteAuthCommands({
   domain: 'creator.xiaohongshu.com',
   loginUrl: 'https://creator.xiaohongshu.com/',
   columns: ['username', 'followers'],
+  quickCheck: hasXhsSessionCookies,
   verify: verifyXhsIdentity,
   poll: async (page) => {
     if (!await hasXhsSessionCookies(page)) {

--- a/clis/xueqiu/auth.js
+++ b/clis/xueqiu/auth.js
@@ -52,6 +52,7 @@ registerSiteAuthCommands({
   domain: 'xueqiu.com',
   loginUrl: 'https://xueqiu.com/',
   columns: ['user_id'],
+  quickCheck: hasXueqiuAccessToken,
   verify: verifyXueqiuIdentity,
   poll: async (page) => {
     if (!await hasXueqiuAccessToken(page)) {

--- a/clis/youtube/auth.js
+++ b/clis/youtube/auth.js
@@ -43,6 +43,7 @@ registerSiteAuthCommands({
   domain: 'www.youtube.com',
   loginUrl: 'https://accounts.google.com/ServiceLogin?service=youtube&continue=https%3A%2F%2Fwww.youtube.com%2F',
   columns: ['name'],
+  quickCheck: hasGoogleSessionCookie,
   verify: verifyYoutubeIdentity,
   poll: async (page) => {
     if (!await hasGoogleSessionCookie(page)) {

--- a/clis/yuanbao/auth.js
+++ b/clis/yuanbao/auth.js
@@ -48,6 +48,7 @@ registerSiteAuthCommands({
   domain: YUANBAO_DOMAIN,
   loginUrl: YUANBAO_URL,
   columns: ['user_id', 'nickname'],
+  quickCheck: hasYuanbaoUserCookie,
   verify: verifyYuanbaoIdentity,
   poll: async (page) => {
     if (!await hasYuanbaoUserCookie(page)) {

--- a/clis/zhihu/auth.js
+++ b/clis/zhihu/auth.js
@@ -48,6 +48,7 @@ registerSiteAuthCommands({
   domain: 'www.zhihu.com',
   loginUrl: 'https://www.zhihu.com/signin',
   columns: ['url_token', 'name', 'uid'],
+  quickCheck: hasZhihuAuthCookie,
   verify: verifyZhihuIdentity,
   poll: async (page) => {
     if (!await hasZhihuAuthCookie(page)) {


### PR DESCRIPTION
## What

Wires the no-navigation `quickCheck` (contract from #1879) into **50** adapters so `opencli auth status` resolves login state in **quick mode** instead of reporting `unknown` for everything.

Builds on #1879 (`auth status` command + `registerSiteAuthCommands({ quickCheck })` contract).

## How

- `quickCheck` reuses each adapter's existing poll cookie gate (`has<Site>Cookie`) — a logged-in-only, no-nav check (CDP `getCookies`) returning boolean. No per-site `goto`, so `auth status` quick mode is seconds, not minutes.

### Deliberately NOT wired (stay `unknown` in quick mode; available via `--full`)

- **gitee / hf / deepseek / quark / reuters / zsxq** — no reliable logged-in cookie; they detect via no-nav `fetch` / `localStorage` / Bearer token, which need the site's own origin (won't work on the blank quick-mode page).
- **doubao / ke / coupang / manus** — the session cookie is also present for anonymous users, so a cookie quickCheck would **false-positive**. `unknown` is more honest than a wrong `logged_in`.

This matches #1879's design (absent quickCheck → `unknown`, never a silent slow scan).

## Verification

- Live `auth status --site …` (quick mode, real session): v2ex / github / zhihu / claude / taobao / twitter / bilibili → `logged_in (quick)`; chatgpt → `not_logged_in`; deepseek/doubao/gitee → `unknown` (as designed).
- `npm test` 5054 passed / 1 skipped; `check:typed-error-lint` new=0; `check:silent-column-drop` new=0; `npm run build`.

## Follow-up

The 6 no-cookie sites could get a quickCheck if `auth status` optionally navigated to the site origin first (then relative `fetch`/`localStorage` work). Tracked alongside the remaining sites in #1876.