### PR TITLE
feat(auth): add refresh maintenance command

### DIFF
--- a/clis/_shared/site-auth.js
+++ b/clis/_shared/site-auth.js
@@ -37,6 +37,11 @@ function normalizeQuickCheck(result) {
   return { logged_in: false };
 }
 
+function normalizeRefreshResult(result) {
+  if (result && typeof result === 'object' && !Array.isArray(result)) return result;
+  return { touched: true };
+}
+
 export function registerSiteAuthCommands(config) {
   if (!config?.site || !config?.domain || !config?.loginUrl || typeof config.verify !== 'function') {
     throw new Error('registerSiteAuthCommands requires site, domain, loginUrl, and verify(page)');
@@ -53,9 +58,14 @@ export function registerSiteAuthCommands(config) {
     navigateBefore: false,
     args: [],
     columns: commandColumns(config),
-    authStatus: typeof config.quickCheck === 'function'
-      ? { quickCheck: async (page) => normalizeQuickCheck(await config.quickCheck(page)) }
-      : undefined,
+    authStatus: {
+      ...(typeof config.quickCheck === 'function'
+        ? { quickCheck: async (page) => normalizeQuickCheck(await config.quickCheck(page)) }
+        : {}),
+      ...(typeof config.refresh === 'function'
+        ? { refresh: async (page, kwargs) => normalizeRefreshResult(await config.refresh(page, kwargs)) }
+        : {}),
+    },
     func: async (page) => tryProbe(config, page, 'identity'),
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -66,7 +66,7 @@ describe('createProgram root help descriptions', () => {
     expect(descriptionFor(program, 'browser')).toContain('type');
     expect(descriptionFor(program, 'browser')).toContain('verify');
     expect(descriptionFor(program, 'browser')).not.toContain('Browser control');
-    expect(descriptionFor(program, 'auth')).toBe('status');
+    expect(descriptionFor(program, 'auth')).toBe('refresh, status');
     expect(descriptionFor(program, 'plugin')).toBe('create, install, list, uninstall, update');
     expect(descriptionFor(program, 'adapter')).toBe('eject, reset, status');
     expect(descriptionFor(program, 'profile')).toBe('list, rename, use');
@@ -87,9 +87,9 @@ describe('createProgram root help descriptions', () => {
       expect(data).toMatchObject({
         namespace: 'auth',
         description: 'Inspect website login status',
-        command_count: 1,
+        command_count: 2,
       });
-      expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['status']);
+      expect(data.commands.map((cmd: any) => cmd.name)).toEqual(['refresh', 'status']);
       const status = auth.commands.find(cmd => cmd.name() === 'status')!;
       process.argv = ['node', 'opencli', 'auth', 'status', '--help', '-f', 'yaml'];
       const statusData = yaml.load(status.helpInformation()) as any;

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
   executeCommandMock.mockReset();
   executeCommandMock.mockImplementation(async (cmd: BrowserCliCommand, kwargs: Record<string, unknown>) => {
     if (!cmd.func) return {};
-    return cmd.func({} as never, kwargs);
+    return cmd.func({ goto: vi.fn(), wait: vi.fn() } as never, kwargs);
   });
 });
 
@@ -121,7 +121,7 @@ describe('auth status collection', () => {
 
 describe('auth refresh collection', () => {
   it('touches sites through persistent sessions and writes last_touched_at on success', async () => {
-    registerWhoami('alpha');
+    registerWhoami('alpha', { quick: true, quickLoggedIn: true });
     const statePath = await tempStatePath();
     const now = new Date('2026-06-06T12:00:00.000Z');
 
@@ -172,7 +172,7 @@ describe('auth refresh collection', () => {
   });
 
   it('skips sites touched within the hidden 24h throttle', async () => {
-    registerWhoami('gamma');
+    registerWhoami('gamma', { quick: true, quickLoggedIn: true });
     const statePath = await tempStatePath();
     await collectAuthRefresh({
       sites: 'gamma',
@@ -200,7 +200,7 @@ describe('auth refresh collection', () => {
   });
 
   it('lets --all bypass the 24h throttle', async () => {
-    registerWhoami('delta');
+    registerWhoami('delta', { quick: true, quickLoggedIn: true });
     const statePath = await tempStatePath();
     await collectAuthRefresh({
       sites: 'delta',
@@ -222,7 +222,7 @@ describe('auth refresh collection', () => {
   });
 
   it('does not throttle not_logged_in results', async () => {
-    registerWhoami('epsilon');
+    registerWhoami('epsilon', { quick: true, quickLoggedIn: true });
     const statePath = await tempStatePath();
     executeCommandMock.mockRejectedValueOnce(new AuthRequiredError('epsilon.example.com'));
 
@@ -252,7 +252,7 @@ describe('auth refresh collection', () => {
   });
 
   it('does not update last_touched_at for generic errors', async () => {
-    registerWhoami('zeta');
+    registerWhoami('zeta', { quick: true, quickLoggedIn: true });
     const statePath = await tempStatePath();
     executeCommandMock.mockRejectedValueOnce(new Error('network down'));
 
@@ -271,5 +271,27 @@ describe('auth refresh collection', () => {
       last_status: 'error',
     });
     expect(state.sites.zeta.last_touched_at).toBeUndefined();
+  });
+
+  it('marks sites without quickCheck or refresh hook as unsupported instead of running DOM whoami fallback', async () => {
+    registerWhoami('eta');
+    const statePath = await tempStatePath();
+
+    const rows = await collectAuthRefresh({
+      sites: 'eta',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+
+    expect(rows).toEqual([
+      {
+        site: 'eta',
+        status: 'unsupported',
+        last_touched_at: '',
+        next_refresh_at: '',
+        error: 'refresh probe is not available for this site',
+      },
+    ]);
+    expect(executeCommandMock).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserCliCommand } from '../registry.js';
 
@@ -7,13 +10,14 @@ vi.mock('../execution.js', () => ({
   executeCommand: executeCommandMock,
 }));
 
-import { collectAuthStatus } from './auth.js';
+import { collectAuthRefresh, collectAuthStatus } from './auth.js';
 import { AuthRequiredError } from '../errors.js';
 import { cli, getRegistry, Strategy } from '../registry.js';
 
 function registerWhoami(site: string, opts: {
   quick?: boolean;
   quickLoggedIn?: boolean;
+  refresh?: 'touched' | 'refreshed';
   identity?: Record<string, unknown>;
 } = {}): void {
   cli({
@@ -27,11 +31,17 @@ function registerWhoami(site: string, opts: {
     navigateBefore: false,
     args: [],
     columns: ['logged_in', 'site', 'username'],
-    authStatus: opts.quick
-      ? { quickCheck: async () => ({ logged_in: opts.quickLoggedIn ?? false }) }
-      : undefined,
+    authStatus: {
+      ...(opts.quick ? { quickCheck: async () => ({ logged_in: opts.quickLoggedIn ?? false }) } : {}),
+      ...(opts.refresh ? { refresh: async () => ({ status: opts.refresh }) } : {}),
+    },
     func: async () => opts.identity ?? { logged_in: true, site, username: site },
   });
+}
+
+async function tempStatePath(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'opencli-auth-refresh-test-'));
+  return join(dir, 'auth-refresh.json');
 }
 
 beforeEach(() => {
@@ -106,5 +116,160 @@ describe('auth status collection', () => {
     expect(rows).toEqual([
       { site: 'delta', status: 'not_logged_in', logged_in: false, identity: '', checked: 'quick', error: '' },
     ]);
+  });
+});
+
+describe('auth refresh collection', () => {
+  it('touches sites through persistent sessions and writes last_touched_at on success', async () => {
+    registerWhoami('alpha');
+    const statePath = await tempStatePath();
+    const now = new Date('2026-06-06T12:00:00.000Z');
+
+    const rows = await collectAuthRefresh({ sites: 'alpha', statePath, now });
+
+    expect(rows).toEqual([
+      {
+        site: 'alpha',
+        status: 'touched',
+        last_touched_at: now.toISOString(),
+        next_refresh_at: '2026-06-07T12:00:00.000Z',
+        error: '',
+      },
+    ]);
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    expect(executeCommandMock.mock.calls[0]?.[0]).toMatchObject({
+      site: 'alpha',
+      name: 'whoami',
+      navigateBefore: false,
+      siteSession: 'persistent',
+      defaultWindowMode: 'background',
+    });
+    expect(executeCommandMock.mock.calls[0]?.[3]).toMatchObject({
+      siteSession: 'persistent',
+      keepTab: 'true',
+      windowMode: 'background',
+    });
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    expect(state.sites.alpha).toMatchObject({
+      last_touched_at: now.toISOString(),
+      last_attempt_at: now.toISOString(),
+      last_status: 'touched',
+    });
+  });
+
+  it('uses adapter refresh hooks when present and records refreshed', async () => {
+    registerWhoami('beta', { refresh: 'refreshed' });
+    const statePath = await tempStatePath();
+
+    const rows = await collectAuthRefresh({
+      sites: 'beta',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+
+    expect(rows[0]?.status).toBe('refreshed');
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips sites touched within the hidden 24h throttle', async () => {
+    registerWhoami('gamma');
+    const statePath = await tempStatePath();
+    await collectAuthRefresh({
+      sites: 'gamma',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+    executeCommandMock.mockClear();
+
+    const rows = await collectAuthRefresh({
+      sites: 'gamma',
+      statePath,
+      now: new Date('2026-06-07T11:59:00.000Z'),
+    });
+
+    expect(rows).toEqual([
+      {
+        site: 'gamma',
+        status: 'skipped',
+        last_touched_at: '2026-06-06T12:00:00.000Z',
+        next_refresh_at: '2026-06-07T12:00:00.000Z',
+        error: '',
+      },
+    ]);
+    expect(executeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('lets --all bypass the 24h throttle', async () => {
+    registerWhoami('delta');
+    const statePath = await tempStatePath();
+    await collectAuthRefresh({
+      sites: 'delta',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+    executeCommandMock.mockClear();
+
+    const rows = await collectAuthRefresh({
+      sites: 'delta',
+      all: true,
+      statePath,
+      now: new Date('2026-06-07T11:59:00.000Z'),
+    });
+
+    expect(rows[0]?.status).toBe('touched');
+    expect(rows[0]?.last_touched_at).toBe('2026-06-07T11:59:00.000Z');
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throttle not_logged_in results', async () => {
+    registerWhoami('epsilon');
+    const statePath = await tempStatePath();
+    executeCommandMock.mockRejectedValueOnce(new AuthRequiredError('epsilon.example.com'));
+
+    const rows = await collectAuthRefresh({
+      sites: 'epsilon',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+
+    expect(rows).toEqual([
+      { site: 'epsilon', status: 'not_logged_in', last_touched_at: '', next_refresh_at: '', error: '' },
+    ]);
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    expect(state.sites.epsilon).toMatchObject({
+      last_attempt_at: '2026-06-06T12:00:00.000Z',
+      last_status: 'not_logged_in',
+    });
+    expect(state.sites.epsilon.last_touched_at).toBeUndefined();
+
+    executeCommandMock.mockClear();
+    await collectAuthRefresh({
+      sites: 'epsilon',
+      statePath,
+      now: new Date('2026-06-06T12:01:00.000Z'),
+    });
+    expect(executeCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not update last_touched_at for generic errors', async () => {
+    registerWhoami('zeta');
+    const statePath = await tempStatePath();
+    executeCommandMock.mockRejectedValueOnce(new Error('network down'));
+
+    const rows = await collectAuthRefresh({
+      sites: 'zeta',
+      statePath,
+      now: new Date('2026-06-06T12:00:00.000Z'),
+    });
+
+    expect(rows).toEqual([
+      { site: 'zeta', status: 'error', last_touched_at: '', next_refresh_at: '', error: 'network down' },
+    ]);
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    expect(state.sites.zeta).toMatchObject({
+      last_attempt_at: '2026-06-06T12:00:00.000Z',
+      last_status: 'error',
+    });
+    expect(state.sites.zeta.last_touched_at).toBeUndefined();
   });
 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,3 +1,6 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { Command, InvalidArgumentError, Option } from 'commander';
 import { AuthRequiredError, CliError, getErrorMessage } from '../errors.js';
@@ -14,6 +17,10 @@ import { render as renderOutput } from '../output.js';
 
 type AuthStatus = 'logged_in' | 'not_logged_in' | 'unknown' | 'error';
 type AuthStatusMode = 'quick' | 'full';
+type AuthRefreshStatus = 'refreshed' | 'touched' | 'not_logged_in' | 'skipped' | 'unsupported' | 'error';
+
+const AUTH_REFRESH_STATE_VERSION = 1;
+const AUTH_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export interface AuthStatusRow {
   site: string;
@@ -33,6 +40,35 @@ interface AuthStatusOptions {
   profile?: string;
 }
 
+export interface AuthRefreshRow {
+  site: string;
+  status: AuthRefreshStatus;
+  last_touched_at: string;
+  next_refresh_at: string;
+  error: string;
+}
+
+interface AuthRefreshOptions {
+  sites?: string;
+  all?: boolean;
+  concurrency?: string | number;
+  timeout?: string | number;
+  profile?: string;
+  statePath?: string;
+  now?: Date;
+}
+
+interface AuthRefreshSiteState {
+  last_touched_at?: string;
+  last_attempt_at?: string;
+  last_status?: AuthRefreshStatus;
+}
+
+interface AuthRefreshState {
+  version: number;
+  sites: Record<string, AuthRefreshSiteState>;
+}
+
 function parsePositiveInt(raw: string | number | undefined, label: string, fallback: number): number {
   if (raw === undefined || raw === null || raw === '') return fallback;
   const parsed = Number(raw);
@@ -46,6 +82,47 @@ function parseSiteFilter(raw: string | undefined): Set<string> | null {
   if (!raw || !raw.trim()) return null;
   const sites = raw.split(',').map(site => site.trim()).filter(Boolean);
   return sites.length > 0 ? new Set(sites) : null;
+}
+
+function defaultAuthRefreshStatePath(): string {
+  return join(homedir(), '.opencli', 'auth-refresh.json');
+}
+
+function emptyAuthRefreshState(): AuthRefreshState {
+  return { version: AUTH_REFRESH_STATE_VERSION, sites: {} };
+}
+
+async function loadAuthRefreshState(statePath: string): Promise<AuthRefreshState> {
+  try {
+    const parsed = JSON.parse(await readFile(statePath, 'utf8')) as Partial<AuthRefreshState>;
+    if (parsed && parsed.version === AUTH_REFRESH_STATE_VERSION && parsed.sites && typeof parsed.sites === 'object') {
+      return { version: AUTH_REFRESH_STATE_VERSION, sites: parsed.sites as Record<string, AuthRefreshSiteState> };
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  return emptyAuthRefreshState();
+}
+
+async function saveAuthRefreshState(statePath: string, state: AuthRefreshState): Promise<void> {
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+function lastTouchedMs(entry: AuthRefreshSiteState | undefined): number | null {
+  if (!entry?.last_touched_at) return null;
+  const parsed = Date.parse(entry.last_touched_at);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isRefreshThrottled(entry: AuthRefreshSiteState | undefined, now: Date): boolean {
+  const touched = lastTouchedMs(entry);
+  return touched !== null && now.getTime() - touched < AUTH_REFRESH_INTERVAL_MS;
+}
+
+function nextRefreshAt(entry: AuthRefreshSiteState | undefined): string {
+  const touched = lastTouchedMs(entry);
+  return touched === null ? '' : new Date(touched + AUTH_REFRESH_INTERVAL_MS).toISOString();
 }
 
 function authWhoamiCommands(): CliCommand[] {
@@ -72,7 +149,7 @@ function withTimeoutArg(cmd: CliCommand, timeoutSeconds: number): CliCommand {
     ...cmd,
     args: hasTimeout
       ? cmd.args
-      : [...cmd.args, { name: 'timeout', type: 'int', default: timeoutSeconds, help: 'Per-site auth status timeout in seconds' }],
+      : [...cmd.args, { name: 'timeout', type: 'int', default: timeoutSeconds, help: 'Per-site auth command timeout in seconds' }],
   };
 }
 
@@ -131,6 +208,48 @@ function rowForError(site: string, checked: AuthStatusMode, error: unknown): Aut
     logged_in: '',
     identity: '',
     checked,
+    error: code ? `${code}: ${message}` : message,
+  };
+}
+
+function refreshCommand(cmd: CliCommand, timeoutSeconds: number): BrowserCliCommand | null {
+  if (cmd.browser !== true) return null;
+  const refreshFunc = cmd.authStatus?.refresh ?? cmd.func;
+  if (typeof refreshFunc !== 'function') return null;
+  return withTimeoutArg({
+    ...cmd,
+    func: refreshFunc,
+    navigateBefore: false,
+    siteSession: 'persistent',
+    defaultWindowMode: 'background',
+  }, timeoutSeconds) as BrowserCliCommand;
+}
+
+function normalizeRefreshStatus(result: unknown): 'refreshed' | 'touched' {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    const row = result as Record<string, unknown>;
+    if (row.status === 'refreshed' || row.refreshed === true) return 'refreshed';
+  }
+  return 'touched';
+}
+
+function refreshRowForError(site: string, entry: AuthRefreshSiteState | undefined, error: unknown): AuthRefreshRow {
+  if (error instanceof AuthRequiredError) {
+    return {
+      site,
+      status: 'not_logged_in',
+      last_touched_at: entry?.last_touched_at ?? '',
+      next_refresh_at: nextRefreshAt(entry),
+      error: '',
+    };
+  }
+  const code = error instanceof CliError ? error.code : '';
+  const message = getErrorMessage(error);
+  return {
+    site,
+    status: 'error',
+    last_touched_at: entry?.last_touched_at ?? '',
+    next_refresh_at: nextRefreshAt(entry),
     error: code ? `${code}: ${message}` : message,
   };
 }
@@ -199,6 +318,66 @@ async function runFull(cmd: CliCommand, opts: { timeoutSeconds: number; profile?
   }
 }
 
+async function runRefresh(cmd: CliCommand, opts: {
+  timeoutSeconds: number;
+  profile?: string;
+  now: Date;
+  state: AuthRefreshState;
+  force: boolean;
+}): Promise<AuthRefreshRow> {
+  const existing = opts.state.sites[cmd.site];
+  if (!opts.force && isRefreshThrottled(existing, opts.now)) {
+    return {
+      site: cmd.site,
+      status: 'skipped',
+      last_touched_at: existing?.last_touched_at ?? '',
+      next_refresh_at: nextRefreshAt(existing),
+      error: '',
+    };
+  }
+
+  const attemptAt = opts.now.toISOString();
+  const loaded = await loadLazyCommand(cmd);
+  const refreshCmd = refreshCommand(loaded, opts.timeoutSeconds);
+  if (!refreshCmd) {
+    opts.state.sites[cmd.site] = { ...existing, last_attempt_at: attemptAt, last_status: 'unsupported' };
+    return {
+      site: cmd.site,
+      status: 'unsupported',
+      last_touched_at: existing?.last_touched_at ?? '',
+      next_refresh_at: nextRefreshAt(existing),
+      error: 'refresh probe is not available for this site',
+    };
+  }
+
+  try {
+    const result = await executeCommand(refreshCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
+      siteSession: 'persistent',
+      keepTab: 'true',
+      windowMode: 'background',
+      ...(opts.profile ? { profile: opts.profile } : {}),
+    });
+    const status = normalizeRefreshStatus(result);
+    opts.state.sites[cmd.site] = {
+      ...existing,
+      last_attempt_at: attemptAt,
+      last_touched_at: attemptAt,
+      last_status: status,
+    };
+    return {
+      site: cmd.site,
+      status,
+      last_touched_at: attemptAt,
+      next_refresh_at: new Date(opts.now.getTime() + AUTH_REFRESH_INTERVAL_MS).toISOString(),
+      error: '',
+    };
+  } catch (error) {
+    const status: AuthRefreshStatus = error instanceof AuthRequiredError ? 'not_logged_in' : 'error';
+    opts.state.sites[cmd.site] = { ...existing, last_attempt_at: attemptAt, last_status: status };
+    return refreshRowForError(cmd.site, existing, error);
+  }
+}
+
 async function mapConcurrent<T, R>(
   items: T[],
   concurrency: number,
@@ -239,6 +418,26 @@ export async function collectAuthStatus(options: AuthStatusOptions): Promise<Aut
     : rows.filter(row => row.status === normalizedOnly);
 }
 
+export async function collectAuthRefresh(options: AuthRefreshOptions): Promise<AuthRefreshRow[]> {
+  const selectedSites = parseSiteFilter(options.sites);
+  const concurrency = parsePositiveInt(options.concurrency, '--concurrency', 3);
+  const timeoutSeconds = parsePositiveInt(options.timeout, '--timeout', 20);
+  const statePath = options.statePath ?? defaultAuthRefreshStatePath();
+  const now = options.now ?? new Date();
+  const state = await loadAuthRefreshState(statePath);
+
+  const commands = authWhoamiCommands().filter(cmd => !selectedSites || selectedSites.has(cmd.site));
+  const rows = await mapConcurrent(commands, concurrency, cmd => runRefresh(cmd, {
+    timeoutSeconds,
+    profile: options.profile,
+    now,
+    state,
+    force: options.all === true,
+  }));
+  await saveAuthRefreshState(statePath, state);
+  return rows;
+}
+
 export function registerAuthCommands(program: Command): Command {
   const auth = program
     .command('auth')
@@ -270,6 +469,33 @@ export function registerAuthCommands(program: Command): Command {
         columns: ['site', 'status', 'identity', 'checked', 'error'],
         title: 'opencli/auth status',
         source: opts.full ? 'full whoami probe' : 'quick auth check',
+      });
+    });
+
+  const refresh = auth
+    .command('refresh')
+    .description('Touch logged-in site sessions to keep browser auth fresh')
+    .option('--site <sites>', 'Comma-separated site names to refresh, e.g. github,claude')
+    .option('--all', 'Ignore the 24h refresh throttle and force every selected site', false)
+    .option('--concurrency <n>', 'Maximum sites to refresh at once')
+    .option('--timeout <seconds>', 'Per-site timeout in seconds')
+    .option('-f, --format <fmt>', 'Output format: table, plain, json, yaml, md, csv', 'table')
+    .action(async (opts) => {
+      const globals = typeof refresh.optsWithGlobals === 'function' ? refresh.optsWithGlobals() as Record<string, unknown> : {};
+      const rows = await collectAuthRefresh({
+        sites: opts.site,
+        all: opts.all === true,
+        concurrency: opts.concurrency,
+        timeout: opts.timeout,
+        profile: typeof globals.profile === 'string' && globals.profile.trim() ? globals.profile.trim() : undefined,
+      });
+      const fmt = typeof opts.format === 'string' ? opts.format : 'table';
+      renderOutput(rows, {
+        fmt,
+        fmtExplicit: refresh.getOptionValueSource('format') === 'cli',
+        columns: ['site', 'status', 'last_touched_at', 'next_refresh_at', 'error'],
+        title: 'opencli/auth refresh',
+        source: opts.all ? 'forced persistent touch' : 'persistent touch with 24h throttle',
       });
     });
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -214,8 +214,23 @@ function rowForError(site: string, checked: AuthStatusMode, error: unknown): Aut
 
 function refreshCommand(cmd: CliCommand, timeoutSeconds: number): BrowserCliCommand | null {
   if (cmd.browser !== true) return null;
-  const refreshFunc = cmd.authStatus?.refresh ?? cmd.func;
-  if (typeof refreshFunc !== 'function') return null;
+  let refreshFunc = cmd.authStatus?.refresh;
+  if (typeof refreshFunc !== 'function') {
+    const quickCheck = cmd.authStatus?.quickCheck;
+    if (typeof quickCheck !== 'function' || !cmd.domain) return null;
+    const refreshUrl = cmd.domain.startsWith('http://') || cmd.domain.startsWith('https://')
+      ? cmd.domain
+      : `https://${cmd.domain}`;
+    refreshFunc = async (page, kwargs, debug) => {
+      await page.goto(refreshUrl);
+      await page.wait(1);
+      const loggedIn = normalizeQuickResult(await quickCheck(page, kwargs, debug));
+      if (loggedIn !== true) {
+        throw new AuthRequiredError(cmd.domain ?? cmd.site, `Auth refresh quickCheck failed for ${cmd.site}`);
+      }
+      return { status: 'touched' };
+    };
+  }
   return withTimeoutArg({
     ...cmd,
     func: refreshFunc,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -31,6 +31,7 @@ export type SiteSessionMode = 'ephemeral' | 'persistent';
 
 export interface AuthStatusMetadata {
   quickCheck?: BrowserCommandFunc;
+  refresh?: BrowserCommandFunc;
 }
 
 interface BaseCliCommand {


### PR DESCRIPTION
## Summary
- add top-level `opencli auth refresh` with `--site`, `--all`, concurrency, timeout, and structured output
- run refresh probes in persistent site sessions/background windows so session rotation is retained
- persist local throttle state in `~/.opencli/auth-refresh.json`; only `touched`/`refreshed` update `last_touched_at`, while `not_logged_in`/`error` only update `last_attempt_at`
- extend auth metadata with optional adapter `refresh(page, kwargs)` hook; fallback reuses existing whoami/touch path

## Semantics
- default refresh respects a hidden 24h throttle per site
- `--site github,claude` limits the selected sites and still respects throttle
- `--all` forces selected sites and bypasses throttle
- no daemon scheduler, no auto-login, no credential/MFA/CAPTCHA automation, no cookie/token values returned

## Validation
- `npx tsc --noEmit`
- `npx vitest run --project unit src/commands/auth.test.ts`
- clean-HOME `npx vitest run --project unit src/commands/auth.test.ts src/cli.test.ts src/registry.test.ts` (194 passed)
- clean-HOME `npm test` (5060 passed, 1 skipped)
- `npm run build`
- `git diff --check`
- clean-HOME throttled smoke: `node dist/src/main.js auth refresh --site github -f json` returned `skipped` without browser dispatch