### PR TITLE
fix(deepseek): reject --search in expert mode (UI lacks Search toggle)

### DIFF
--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -95,18 +95,18 @@ export const askCommand = cli({
             throw new CommandExecutionError('Could not enable DeepThink');
         }
 
-        if (wantModel === 'vision' && wantSearch) {
+        if ((wantModel === 'vision' || wantModel === 'expert') && wantSearch) {
             throw new CliError(
                 'ARGUMENT',
-                'DeepSeek vision mode does not support --search.',
-                'Run without --search, or use --model instant/expert for web search.',
+                `DeepSeek ${wantModel} mode does not support --search.`,
+                'Run without --search, or use --model instant for web search.',
                 EXIT_CODES.USAGE_ERROR,
             );
         }
 
-        // Vision mode does not have the search toggle.
+        // Only instant mode has the Search toggle in the DeepSeek UI.
         let searchResult;
-        if (wantModel !== 'vision') {
+        if (wantModel !== 'vision' && wantModel !== 'expert') {
             searchResult = await withRetry(() => setFeature(page, 'Search', wantSearch));
             if (!searchResult?.ok && wantSearch) {
                 throw new CommandExecutionError('Could not enable Search');

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -32,6 +32,16 @@ export const askCommand = cli({
         const timeoutMs = (kwargs.timeout || 120) * 1000;
         const wantThink = parseBoolFlag(kwargs.think);
         const wantSearch = parseBoolFlag(kwargs.search);
+        const wantModel = kwargs.model || 'instant';
+
+        if ((wantModel === 'vision' || wantModel === 'expert') && wantSearch) {
+            throw new CliError(
+                'ARGUMENT',
+                `DeepSeek ${wantModel} mode does not support --search.`,
+                'Run without --search, or use --model instant for web search.',
+                EXIT_CODES.USAGE_ERROR,
+            );
+        }
 
         if (parseBoolFlag(kwargs.new)) {
             await page.goto(DEEPSEEK_URL);
@@ -70,7 +80,6 @@ export const askCommand = cli({
         const inConversation = currentUrl.includes('/a/chat/s/');
         const modelExplicit = kwargs.__opencliOptionSources?.model === 'cli';
 
-        const wantModel = kwargs.model || 'instant';
         if (inConversation && modelExplicit) {
             throw new CliError(
                 'ARGUMENT',
@@ -93,15 +102,6 @@ export const askCommand = cli({
         const thinkResult = await withRetry(() => setFeature(page, 'DeepThink', wantThink));
         if (!thinkResult?.ok && wantThink) {
             throw new CommandExecutionError('Could not enable DeepThink');
-        }
-
-        if ((wantModel === 'vision' || wantModel === 'expert') && wantSearch) {
-            throw new CliError(
-                'ARGUMENT',
-                `DeepSeek ${wantModel} mode does not support --search.`,
-                'Run without --search, or use --model instant for web search.',
-                EXIT_CODES.USAGE_ERROR,
-            );
         }
 
         // Only instant mode has the Search toggle in the DeepSeek UI.

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -302,7 +302,53 @@ describe('deepseek ask conversation resume', () => {
     })).rejects.toMatchObject(new CliError(
       'ARGUMENT',
       'DeepSeek vision mode does not support --search.',
-      'Run without --search, or use --model instant/expert for web search.',
+      'Run without --search, or use --model instant for web search.',
+      EXIT_CODES.USAGE_ERROR,
+    ));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockSendWithFile).not.toHaveBeenCalled();
+  });
+
+  it('skips search toggle in expert mode when search is not requested', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
+    mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockGetBubbleCount.mockResolvedValue(0);
+    mockWaitForResponse.mockResolvedValue('expert reply');
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+
+    const rows = await askCommand.func(page, {
+      prompt: 'analyze',
+      timeout: 120,
+      new: false,
+      model: 'expert',
+      think: false,
+      search: false,
+    });
+
+    expect(rows).toEqual([{ response: 'expert reply' }]);
+    expect(mockSetFeature).toHaveBeenCalledTimes(1);
+    expect(mockSetFeature).toHaveBeenCalledWith(expect.anything(), 'DeepThink', false);
+  });
+
+  it('fails fast instead of silently ignoring --search in expert mode', async () => {
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+
+    await expect(askCommand.func(page, {
+      prompt: 'analyze',
+      timeout: 120,
+      new: false,
+      model: 'expert',
+      think: false,
+      search: true,
+    })).rejects.toMatchObject(new CliError(
+      'ARGUMENT',
+      'DeepSeek expert mode does not support --search.',
+      'Run without --search, or use --model instant for web search.',
       EXIT_CODES.USAGE_ERROR,
     ));
 

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -306,6 +306,10 @@ describe('deepseek ask conversation resume', () => {
       EXIT_CODES.USAGE_ERROR,
     ));
 
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockEnsureOnDeepSeek).not.toHaveBeenCalled();
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSetFeature).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(mockSendWithFile).not.toHaveBeenCalled();
   });
@@ -352,6 +356,10 @@ describe('deepseek ask conversation resume', () => {
       EXIT_CODES.USAGE_ERROR,
     ));
 
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockEnsureOnDeepSeek).not.toHaveBeenCalled();
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSetFeature).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(mockSendWithFile).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Description

Fixes the misleading "Could not enable Search" failure on `opencli deepseek ask --model expert --search true`. The Search toggle only renders in instant mode; expert and vision both lack it. The existing pre-flight already rejected vision + search but left expert to fall through into `setFeature(page, 'Search', true)`, which then failed with a generic `COMMAND_EXEC` after the retries. The fix extends the pre-flight to cover both modes and drops the wrong "or use --model expert" suggestion from the hint string.

Related issue: Closes #1886.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, `--model expert --search true` failed deep inside the retry loop with no explanation of why:

```
$ opencli deepseek ask "test" --model expert --search true --new true
ok: false
error:
  code: COMMAND_EXEC
  message: Could not enable Search
```

After, the pre-flight rejects the unsupported combination up front with the matching ARGUMENT error path the vision case already used:

```
$ opencli deepseek ask "test" --model expert --search true --new true
ok: false
error:
  code: ARGUMENT
  message: DeepSeek expert mode does not support --search.
  help: Run without --search, or use --model instant for web search.
```

Mode compatibility matrix (UI-observed):

| Mode    | DeepThink | Search |
|---------|-----------|--------|
| instant | yes       | yes    |
| expert  | yes       | no     |
| vision  | yes       | no     |

Live (real session, `--site-session persistent --window background`): `expert + search` and `vision + search` both reject with the ARGUMENT pre-flight above; `instant + search` and `expert` (no search) both return a real reply, so the send path is unbroken.

Tests added in `clis/deepseek/ask.test.js` mirror the existing vision fail-fast and skip-toggle pairs for expert. `clis/deepseek/ask.test.js` passes 14 / 14 locally; `npm run check:typed-error-lint` and `npm run check:silent-column-drop` both report `new=0`.
