### PR TITLE
feat(twitter): 读命令暴露 media_posters[]（视频/动图静帧 poster）

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -32148,7 +32148,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
@@ -32209,7 +32210,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
@@ -32554,7 +32556,8 @@
       "created_at",
       "url",
       "has_media",
-      "media_urls"
+      "media_urls",
+      "media_posters"
     ],
     "type": "js",
     "modulePath": "twitter/likes.js",
@@ -32862,6 +32865,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -33293,6 +33297,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -33342,6 +33347,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -33398,6 +33404,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "card",
       "quoted_tweet"
     ],
@@ -33477,6 +33484,7 @@
       "url",
       "has_media",
       "media_urls",
+      "media_posters",
       "quoted_tweet"
     ],
     "type": "js",

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -129,7 +129,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the folder by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const folderId = String(kwargs['folder-id'] || '').trim();
         if (!folderId || !FOLDER_ID_PATTERN.test(folderId)) {

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -99,6 +99,7 @@ describe('twitter bookmark-folder timeline parser', () => {
                 url: 'https://x.com/alice/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
             },
         ]);
         expect(nextCursor).toBe('NEXT_CURSOR');

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -112,7 +112,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const cookies = await page.getCookies({ url: 'https://x.com' });

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -28,6 +28,7 @@ describe('twitter bookmarks parser', () => {
             url: 'https://x.com/alice/status/1',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -148,7 +148,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of liked tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the liked tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls'],
+    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const rawUsername = String(kwargs.username ?? '').trim();

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -124,7 +124,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -33,6 +33,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/bob/status/99',
             has_media: false,
             media_urls: [],
+            media_posters: [],
             card: null,
             quoted_tweet: null,
         });
@@ -72,6 +73,7 @@ describe('twitter list-tweets parser', () => {
             url: 'https://x.com/alice/status/499',
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/x.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/x.jpg'],
         });
     });
 

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -275,7 +275,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -79,6 +79,7 @@ describe('twitter search command', () => {
                 url: 'https://x.com/i/status/1',
                 has_media: false,
                 media_urls: [],
+                media_posters: [],
                 card: null,
                 quoted_tweet: null,
             },

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -278,25 +278,39 @@ export async function resolveTwitterQueryId(page, operationName, fallbackId) {
  * back to `entities.media` when the extended form is missing. For videos and
  * animated GIFs, returns the mp4 variant URL; for photos, returns
  * `media_url_https`.
+ *
+ * Also returns `media_posters`, index-aligned 1:1 with `media_urls`: the still
+ * preview image for each item. For videos / animated GIFs this is the
+ * `media_url_https` thumbnail (otherwise discarded in favour of the mp4 URL);
+ * for photos it equals the photo URL itself. Each entry is a non-null string —
+ * it falls back to the media URL if a thumbnail is somehow absent, preserving
+ * alignment.
  */
 export function extractMedia(legacy) {
     const media = legacy?.extended_entities?.media || legacy?.entities?.media;
     if (!Array.isArray(media) || media.length === 0) {
-        return { has_media: false, media_urls: [] };
+        return { has_media: false, media_urls: [], media_posters: [] };
     }
     const urls = [];
+    const posters = [];
     for (const m of media) {
         if (!m) continue;
         if (m.type === 'video' || m.type === 'animated_gif') {
             const variants = m.video_info?.variants || [];
             const mp4 = variants.find((v) => v?.content_type === 'video/mp4');
             const url = mp4?.url || m.media_url_https;
-            if (url) urls.push(url);
+            if (url) {
+                urls.push(url);
+                posters.push(m.media_url_https || url);
+            }
         } else {
-            if (m.media_url_https) urls.push(m.media_url_https);
+            if (m.media_url_https) {
+                urls.push(m.media_url_https);
+                posters.push(m.media_url_https);
+            }
         }
     }
-    return { has_media: urls.length > 0, media_urls: urls };
+    return { has_media: urls.length > 0, media_urls: urls, media_posters: posters };
 }
 
 /**
@@ -435,6 +449,7 @@ export function extractQuotedTweet(tweet) {
         url: `https://x.com/${qScreenName}/status/${qTw.rest_id}`,
         has_media: qMedia.has_media,
         media_urls: qMedia.media_urls,
+        media_posters: qMedia.media_posters,
     };
     if (qCard) out.card = qCard;
     return out;

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -259,11 +259,12 @@ describe('twitter buildTwitterArticleScopeSource', () => {
 
 describe('twitter extractMedia', () => {
     it('returns false + empty list when legacy has no media', () => {
-        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [] });
-        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [] });
+        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [], media_posters: [] });
+        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [], media_posters: [] });
         expect(extractMedia({ extended_entities: { media: [] } })).toEqual({
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -278,6 +279,11 @@ describe('twitter extractMedia', () => {
         });
         expect(result.has_media).toBe(true);
         expect(result.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        // For photos the poster equals the photo URL itself.
+        expect(result.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);
@@ -314,6 +320,14 @@ describe('twitter extractMedia', () => {
             'https://video.twimg.com/x.mp4',
             'https://video.twimg.com/g.mp4',
         ]);
+        // The previously-discarded video_info thumbnails are now exposed as
+        // posters, index-aligned with media_urls and distinct from the mp4 URLs.
+        expect(result.media_posters).toEqual([
+            'https://pbs.twimg.com/media/thumb.jpg',
+            'https://pbs.twimg.com/tweet_video_thumb/g.jpg',
+        ]);
+        expect(result.media_posters[0]).not.toBe(result.media_urls[0]);
+        expect(result.media_posters[1]).not.toBe(result.media_urls[1]);
     });
 
     it('falls back to media_url_https when no mp4 variant is available', () => {
@@ -331,6 +345,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/thumb.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/thumb.jpg'],
         });
     });
 
@@ -345,6 +360,7 @@ describe('twitter extractMedia', () => {
         expect(result).toEqual({
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/c.jpg'],
+            media_posters: ['https://pbs.twimg.com/media/c.jpg'],
         });
     });
 });
@@ -626,6 +642,7 @@ describe('twitter extractQuotedTweet', () => {
             url: 'https://x.com/alice/status/2040254679301718161',
             has_media: false,
             media_urls: [],
+            media_posters: [],
         });
     });
 
@@ -651,6 +668,10 @@ describe('twitter extractQuotedTweet', () => {
         const q = extractQuotedTweet(tweet);
         expect(q.has_media).toBe(true);
         expect(q.media_urls).toEqual([
+            'https://pbs.twimg.com/media/a.jpg',
+            'https://pbs.twimg.com/media/b.jpg',
+        ]);
+        expect(q.media_posters).toEqual([
             'https://pbs.twimg.com/media/a.jpg',
             'https://pbs.twimg.com/media/b.jpg',
         ]);

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -113,7 +113,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/thread.test.js
+++ b/clis/twitter/thread.test.js
@@ -5,7 +5,7 @@ import { __test__ } from './thread.js';
 describe('twitter thread parser', () => {
     it('extracts author bio from tweet user entity', () => {
         const command = getRegistry().get('twitter/thread');
-        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet']);
+        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet']);
         const result = __test__.parseTweetDetail({
             data: {
                 threaded_conversation_with_injections_v2: {

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -156,7 +156,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -227,7 +227,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the chronological ordering.' },
     ],
-    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet'],
+    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
         const rawUsername = String(kwargs.username ?? '').trim();

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -6,7 +6,7 @@ import { __test__ } from './tweets.js';
 describe('twitter tweets helpers', () => {
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'quoted_tweet']);
+        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet']);
     });
 
     it('makes the username argument optional so it can default to the logged-in user', () => {


### PR DESCRIPTION
> 本 PR 与 #1890(API 错误/queryId 健壮性)同从原 #1875 拆分而来,按单一关注点分成「字段增强」与「健壮性」两个独立 PR。本 PR 只含 `media_posters` 这一个新字段。

为 Twitter 读命令补充 `media_posters[]` 字段,与 `media_urls` 索引 1:1 对齐,提供每条媒体的静帧预览图。

## 动机

`media_urls` 对视频 / 动图返回的是 mp4 URL,丢弃了原本可用的 `media_url_https` 缩略图。下游消费者想渲染「视频静帧预览 + 播放按钮」时,只能拿到 mp4 地址,没有 poster 帧,要么额外抓取要么放弃预览。

## 改动

`clis/twitter/shared.js` 的 `extractMedia()` 增加返回 `media_posters[]`:

- **视频 / 动图**:poster 取 `media_url_https`(那张原本被 mp4 URL 取代而丢弃的缩略图),没有时回退到媒体 URL 本身,保证非空且对齐
- **照片**:poster 等于照片 URL 本身

`extractQuotedTweet()` 也透传被引用推文的 `media_posters`。

8 个读命令 columns 暴露该列:timeline / search / thread / tweets / likes / list-tweets / bookmarks / bookmark-folder。

## 测试

- `extractMedia`:照片 poster = 照片 URL、视频/动图 poster = 缩略图且与 mp4 URL 不同、无 mp4 变体时回退、空媒体返回空数组
- `extractQuotedTweet`:被引用推文 media_posters 透传
- twitter 全量:**35 文件 / 392 用例通过**;`tsc --noEmit` 干净;`npm run build` 干净

## 兼容性

纯增量字段 / 列,不改任何既有字段语义。`media_posters` 与 `media_urls` 等长,消费者可按下标配对。