### PR TITLE
fix(verify): resolve smoke test dir one level up from builtin clis

### DIFF
--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for src/verify.ts.
+ *
+ * Focus: smoke-test directory resolution. `builtinClis` is `<packageRoot>/clis`
+ * (see src/main.ts), so the package root — and thus `<packageRoot>/tests/smoke` —
+ * must be reached by going a SINGLE level up from `builtinClis`, not two.
+ */
+
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSpawn } = vi.hoisted(() => ({ mockSpawn: vi.fn() }));
+
+vi.mock('node:child_process', () => ({ spawn: mockSpawn }));
+
+import { verifyClis } from './verify.js';
+
+/** A fake child process that immediately closes with the given exit code. */
+function fakeChild(code: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter;
+    cwd?: string;
+  };
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => child.emit('close', code));
+  return child;
+}
+
+describe('verify.ts smoke-test path resolution', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects tests/smoke under the package root and runs vitest there', async () => {
+    // Lay out <tmp>/clis (builtinClis) and <tmp>/tests/smoke so that resolving a
+    // single '..' from builtinClis reaches the package root that owns tests/smoke.
+    const pkgRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-verify-'));
+    tmpDirs.push(pkgRoot);
+    const builtinClis = path.join(pkgRoot, 'clis');
+    fs.mkdirSync(builtinClis, { recursive: true });
+    fs.mkdirSync(path.join(pkgRoot, 'tests', 'smoke'), { recursive: true });
+
+    let spawnCwd: string | undefined;
+    mockSpawn.mockImplementation((_cmd: string, _args: string[], opts: { cwd?: string }) => {
+      spawnCwd = opts?.cwd;
+      return fakeChild(0);
+    });
+
+    const report = await verifyClis({ builtinClis, userClis: builtinClis, smoke: true });
+
+    // The smoke dir was found, so vitest was actually spawned at the package root —
+    // not short-circuited as the old dead-feature "unavailable" path.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(spawnCwd).toBe(path.resolve(pkgRoot));
+    expect(report.smoke?.executed).toBe(true);
+    expect(report.smoke?.ok).toBe(true);
+    expect(report.smoke?.summary).not.toContain('unavailable');
+  });
+
+  it('reports smoke tests unavailable when no tests/smoke dir exists', async () => {
+    const pkgRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-verify-'));
+    tmpDirs.push(pkgRoot);
+    const builtinClis = path.join(pkgRoot, 'clis');
+    fs.mkdirSync(builtinClis, { recursive: true });
+
+    const report = await verifyClis({ builtinClis, userClis: builtinClis, smoke: true });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(report.smoke?.executed).toBe(false);
+    expect(report.smoke?.summary).toContain('unavailable');
+  });
+});

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,9 +1,10 @@
 /**
- * Verification: runs validation and optional smoke test.
+ * Verification: runs validation and an optional smoke test.
  *
- * The smoke test is intentionally kept as a stub — full browser-based
- * smoke testing requires a running browser session and is better suited
- * to the `opencli test` command or CI pipelines.
+ * The smoke test runs `vitest run tests/smoke/` from the package root when that
+ * directory is present (repo/dev/CI checkouts). It reports "unavailable" when the
+ * directory is absent — notably in published npm installs, since `tests/` is not
+ * listed in package.json "files".
  */
 
 import { validateClisWithTarget, renderValidationReport, type ValidationReport } from './validate.js';
@@ -47,7 +48,10 @@ export function renderVerifyReport(report: VerifyReport): string {
 }
 
 async function runSmokeTests(builtinClis: string): Promise<NonNullable<VerifyReport['smoke']>> {
-  const projectRoot = path.resolve(builtinClis, '..', '..');
+  // builtinClis is `<packageRoot>/clis` (see src/main.ts: BUILTIN_CLIS =
+  // path.join(findPackageRoot(__filename), 'clis')), so the package root that
+  // owns tests/smoke is a single level up.
+  const projectRoot = path.resolve(builtinClis, '..');
   const smokeDir = path.join(projectRoot, 'tests', 'smoke');
 
   if (!fs.existsSync(smokeDir)) {


### PR DESCRIPTION
## Problem

`opencli verify --smoke` never ran the smoke suite. Even with `tests/smoke/` present in a repo/dev checkout, the command always reported "Smoke tests are unavailable in this package/environment." The `--smoke` flag was effectively a dead feature.

## Root cause

`src/verify.ts` `runSmokeTests()` computed the project root as `path.resolve(builtinClis, '..', '..')` — two levels up. But `builtinClis` is already `<packageRoot>/clis` (see `src/main.ts:30`: `const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis')`). Two `..` therefore landed one directory *above* the package root, so `path.join(projectRoot, 'tests', 'smoke')` never existed and the code always fell into the "unavailable" short-circuit.

## Fix

`src/verify.ts` — resolve a single `..` to reach the package root:

```ts
const projectRoot = path.resolve(builtinClis, '..');
```

The fix is inlined directly in `runSmokeTests` (no extra exported helper). The stale module doc comment that described smoke testing as an intentional "stub" was refreshed to describe the actual behavior.

## Scope (honest)

This only affects **repo / dev / CI** usage. `tests/` is **not** listed in `package.json` "files" (`["dist/src/", "clis/", "cli-manifest.json", "scripts/", "README.md", "LICENSE"]`), so end users installing the published npm package have no `tests/smoke` directory and will still correctly get "unavailable". Actually shipping smoke tests to end users would additionally require adding `tests/smoke` (and a way to resolve a vitest binary in an installed package) to the published "files" — **out of scope** for this fix, which is solely the path-resolution bug.

## Tests

`src/verify.test.ts` adds two behavioral integration cases (`spawn` mocked via `vi.mock('node:child_process')`):

1. With a temp layout `<tmp>/clis` (as `builtinClis`) + `<tmp>/tests/smoke`, `verifyClis({ smoke: true })` detects the dir and spawns vitest at the package root — asserts `spawn` called once with `cwd === <tmp>` and `report.smoke.executed === true`.
2. With no `tests/smoke`, it reports "unavailable" and does **not** spawn.

Gate: `npx vitest run src/verify.test.ts` → 2 passed; `npx tsc --noEmit` → clean.