### PR TITLE
fix(pipeline/sort): order numbers numerically instead of lexically

### DIFF
--- a/src/pipeline/steps/transform.ts
+++ b/src/pipeline/steps/transform.ts
@@ -53,6 +53,19 @@ export async function stepFilter(_page: IPage | null, params: unknown, data: unk
   return data.filter((item, i) => evalExpr(String(params), { args, item, index: i }));
 }
 
+/**
+ * Returns `value` when it is a real, finite number-typed value, else null.
+ * Strings are intentionally NOT coerced: parsing them would (a) make the sort
+ * comparator non-transitive (violating Array.sort's strict-weak-ordering) and
+ * (b) revert the maintainer's intentional natural-sort default for strings
+ * (PR #306). Adapters that want numeric ordering coerce the field with
+ * `Number(...)` upstream (e.g. clis/binance/{gainers,losers}.js), producing a
+ * genuine number for this branch.
+ */
+function toFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 export async function stepSort(_page: IPage | null, params: unknown, data: unknown, _args: Record<string, unknown>): Promise<unknown> {
   if (!Array.isArray(data)) return data;
   const key = isRecord(params) ? String(params.by ?? '') : String(params);
@@ -60,7 +73,18 @@ export async function stepSort(_page: IPage | null, params: unknown, data: unkno
   return [...data].sort((a, b) => {
     const left = isRecord(a) ? a[key] : undefined;
     const right = isRecord(b) ? b[key] : undefined;
-    const cmp = String(left ?? '').localeCompare(String(right ?? ''), undefined, { numeric: true });
+    const leftNum = toFiniteNumber(left);
+    const rightNum = toFiniteNumber(right);
+    // Total, transitive order with explicit group precedence so the comparator
+    // honors Array.sort's strict-weak-ordering contract:
+    //   1. both real numbers     -> numeric compare (fixes negatives/decimals)
+    //   2. exactly one number    -> numbers sort before non-numbers
+    //   3. neither a number      -> natural-sort strings (PR #306 default)
+    let cmp: number;
+    if (leftNum !== null && rightNum !== null) cmp = leftNum - rightNum;
+    else if (leftNum !== null) cmp = -1;
+    else if (rightNum !== null) cmp = 1;
+    else cmp = String(left ?? '').localeCompare(String(right ?? ''), undefined, { numeric: true });
     return reverse ? -cmp : cmp;
   });
 }

--- a/src/pipeline/transform.test.ts
+++ b/src/pipeline/transform.test.ts
@@ -137,6 +137,53 @@ describe('stepSort', () => {
     const result = await stepSort(null, { by: 'value', order: 'asc' }, data, {});
     expect((result as typeof data).map((r) => r.name)).toEqual(['B', 'C', 'A']);
   });
+
+  it('orders negative numbers (real numbers) numerically, not lexically', async () => {
+    const data = [{ v: 3 }, { v: -5 }, { v: -10 }];
+    const result = await stepSort(null, 'v', data, {});
+    expect((result as typeof data).map((r) => r.v)).toEqual([-10, -5, 3]);
+  });
+
+  it('orders decimal numbers (real numbers) numerically', async () => {
+    const data = [{ v: 1.9 }, { v: 1.25 }, { v: 1.5 }];
+    const result = await stepSort(null, 'v', data, {});
+    expect((result as typeof data).map((r) => r.v)).toEqual([1.25, 1.5, 1.9]);
+  });
+
+  it('orders negative numbers (real numbers) numerically when descending', async () => {
+    const data = [{ v: -10 }, { v: 3 }, { v: -5 }];
+    const result = await stepSort(null, { by: 'v', order: 'desc' }, data, {});
+    expect((result as typeof data).map((r) => r.v)).toEqual([3, -5, -10]);
+  });
+
+  it('produces a permutation-independent order for mixed number/string values (transitivity)', async () => {
+    // Group precedence: real numbers (ascending) sort before non-number values,
+    // which then natural-sort among themselves. The output must be identical
+    // regardless of input order, which it cannot be if the comparator is
+    // non-transitive (e.g. coercing strings to numbers).
+    const expected = [-10, -1, 2, 50, 'apple', 'banana'];
+    const permutations = [
+      [{ v: 'banana' }, { v: 2 }, { v: -10 }, { v: 'apple' }, { v: 50 }, { v: -1 }],
+      [{ v: 50 }, { v: 'apple' }, { v: -1 }, { v: -10 }, { v: 'banana' }, { v: 2 }],
+      [{ v: -1 }, { v: -10 }, { v: 'banana' }, { v: 50 }, { v: 2 }, { v: 'apple' }],
+    ];
+    for (const data of permutations) {
+      const result = await stepSort(null, 'v', data, {});
+      expect((result as typeof data).map((r) => r.v)).toEqual(expected);
+    }
+  });
+
+  it('reverses the mixed number/string order under desc (numbers still grouped together)', async () => {
+    const data = [{ v: 'banana' }, { v: 2 }, { v: -10 }, { v: 'apple' }, { v: 50 }];
+    const result = await stepSort(null, { by: 'v', order: 'desc' }, data, {});
+    expect((result as typeof data).map((r) => r.v)).toEqual(['banana', 'apple', 50, 2, -10]);
+  });
+
+  it('falls back to string comparison for non-numeric values', async () => {
+    const data = [{ v: 'banana' }, { v: 'apple' }, { v: 'cherry' }];
+    const result = await stepSort(null, 'v', data, {});
+    expect((result as typeof data).map((r) => r.v)).toEqual(['apple', 'banana', 'cherry']);
+  });
 });
 
 describe('stepLimit', () => {


### PR DESCRIPTION
## Problem

The pipeline `sort` step compared every value with `localeCompare(..., { numeric: true })` — a natural sort. That mis-orders fields that hold **real numbers**: `-10` sorts after `-5`, and `1.25` sorts after `1.5`. Adapters that build a numeric sort key (e.g. Binance gainers/losers) got wrong rankings for negative/decimal values.

The first attempt at a fix made things worse: it coerced numeric **strings** to numbers inside the comparator. That had two failure modes:
1. **Non-transitive comparator** — mixing string-coerced numbers with plain strings violates `Array.sort`'s strict-weak-ordering contract, so results became input-order-dependent (undefined behavior).
2. **Silent regression of PR #306** — the maintainer intentionally chose natural-sort for string-encoded numbers (commit `e573f3fc`, test "sorts string-encoded numbers naturally by default"). String coercion silently reverted that decision.

## Root cause

`src/pipeline/steps/transform.ts` — `stepSort` comparator (around line 73): a single `localeCompare(..., { numeric: true })` applied uniformly, with no numeric path for real number-typed values. The intermediate fix's `toFiniteNumber` additionally parsed strings (`Number(value)`), introducing the non-transitivity and the PR #306 regression.

## Fix

Compare numerically **only when both values are real numbers**; preserve the intentional natural-sort default (PR #306) for strings.

- `toFiniteNumber(value)` returns a number only when `typeof value === 'number' && Number.isFinite(value)`, else `null`. Strings are never parsed.
- The comparator is now a **total, transitive order** with explicit group precedence:
  1. both real numbers → numeric (`left - right`) — fixes negatives/decimals;
  2. exactly one real number → numbers sort before non-numbers (`-1` / `+1`);
  3. neither → existing `localeCompare(String(left ?? ''), String(right ?? ''), undefined, { numeric: true })` — natural-sort strings.
- The `reverse` flag is applied once at the end (`reverse ? -cmp : cmp`), so `order: 'desc'` fully reverses the total order, including the number-vs-string grouping.

**Transitivity guarantee:** because the three groups are disjoint and each branch is itself a consistent order (numeric subtraction; fixed cross-group sign; localeCompare), the comparator defines a strict weak ordering — output is permutation-independent. This is asserted directly in the tests (same array, three input permutations, identical output).

## Affected adapters (real-world win)

`clis/binance/losers.js` and `clis/binance/gainers.js` build `sort_change: '${{ Number(item.priceChangePercent) }}'` — a genuine number-typed field (the pipeline `render` returns the raw `evalExpr` result for a single full-expression template, not a stringified one) — then `{ sort: { by: 'sort_change' } }` (losers, asc) and `{ sort: { by: 'sort_change', order: 'desc' } }` (gainers). 24h price changes include negatives, so these now rank correctly (previously `-10%` sorted after `-5%`). String-keyed sorts elsewhere keep the natural-sort behavior unchanged.

## Tests

`src/pipeline/transform.test.ts` (where the `stepSort` tests live; there is **no** `src/pipeline/steps/transform.test.ts`):
- negatives as real numbers `[3,-5,-10]` asc → `[-10,-5,3]`;
- decimals as real numbers `[1.9,1.25,1.5]` asc → `[1.25,1.5,1.9]`;
- negatives desc → `[3,-5,-10]`;
- **transitivity/permutation-independence**: a mixed number+string array sorted under 3 input permutations yields the identical output `[-10,-1,2,50,'apple','banana']`;
- desc mixed → `['banana','apple',50,2,-10]` (numbers stay grouped);
- non-numeric string fallback unchanged;
- the existing PR #306 "sorts string-encoded numbers naturally by default" test is untouched and still passes.

`npx tsc --noEmit` passes. `npx vitest run src/pipeline/transform.test.ts` → 25/25. Full suite (`npm test`) → 464 files / 5067 tests passed, 1 skipped.