### PR TITLE
fix(discovery): recognize shared make*Command factory adapters at runtime

### DIFF
--- a/src/discovery.test.ts
+++ b/src/discovery.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { PLUGIN_MODULE_PATTERN } from './discovery.js';
+
+describe('PLUGIN_MODULE_PATTERN', () => {
+  it('matches adapters authored via shared make<Pascal>Command factories', () => {
+    // clis/cursor/status.js shape — no direct cli()/lifecycle call.
+    expect(PLUGIN_MODULE_PATTERN.test(`export const c = makeStatusCommand('x','y')`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`export const c = makeScreenshotCommand('x', 'y');`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`export const c = makeNewCommand('x', 'y');`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`export const c = makeDumpCommand('x');`)).toBe(true);
+  });
+
+  it('still matches direct cli() registrations', () => {
+    expect(PLUGIN_MODULE_PATTERN.test(`export const c = cli({ site: 's', name: 'n', access: 'read' });`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`cli (`)).toBe(true);
+  });
+
+  it('still matches site-auth and lifecycle hook registrations', () => {
+    expect(PLUGIN_MODULE_PATTERN.test(`registerSiteAuthCommands('site', opts)`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`onStartup(async () => {})`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`onBeforeExecute(() => {})`)).toBe(true);
+    expect(PLUGIN_MODULE_PATTERN.test(`onAfterExecute(() => {})`)).toBe(true);
+  });
+
+  it('does not match helper / type-only modules', () => {
+    expect(PLUGIN_MODULE_PATTERN.test(`export function helper() { return 'noop'; }`)).toBe(false);
+    // A lowercase factory name must not be treated as a command source.
+    expect(PLUGIN_MODULE_PATTERN.test(`export const x = makething();`)).toBe(false);
+  });
+});

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -24,8 +24,13 @@ export const USER_OPENCLI_DIR = path.join(os.homedir(), '.opencli');
 export const USER_CLIS_DIR = path.join(USER_OPENCLI_DIR, 'clis');
 /** Plugins directory: ~/.opencli/plugins/ */
 export const PLUGINS_DIR = path.join(USER_OPENCLI_DIR, 'plugins');
-/** Matches files that register commands via cli() or lifecycle hooks */
-const PLUGIN_MODULE_PATTERN = /\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/;
+/**
+ * Matches files that register commands via cli(), shared make<Pascal>Command
+ * factories (clis/_shared/), or lifecycle hooks. Must stay in sync with
+ * build-manifest's CLI_MODULE_PATTERN — otherwise factory-authored adapters
+ * land in the manifest but are silently dropped by the runtime scanner.
+ */
+export const PLUGIN_MODULE_PATTERN = /\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(|\bmake[A-Z]\w*Command\s*\(/;
 
 function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
   if (!rawStrategy) return fallback;


### PR DESCRIPTION
## Problem

A user/plugin adapter authored with the documented shared factories — e.g. `export const c = makeStatusCommand('x', 'y')` (the exact shape of built-ins like `clis/cursor/status.js`) — is silently un-loaded at runtime. It compiles into the manifest fine (so built-ins work via the fast path), but a plugin or `~/.opencli/clis` adapter that relies on the filesystem scanner never registers, with no error or warning.

## Root cause

`src/discovery.ts:31` — `PLUGIN_MODULE_PATTERN` is the regex the runtime scanner uses (via `isCliModule` → `discoverClisFromFs` / `discoverPluginDir`) to decide whether a `.js` file is a command module worth importing:

```
/\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/
```

The build-time scanner in `src/build-manifest.ts:47` (`CLI_MODULE_PATTERN`) covers the same surface **plus** the factory token `\bmake[A-Z]\w*Command\s*\(`:

```
/\bcli\s*\(|\bregisterSiteAuthCommands\s*\(|\bmake[A-Z]\w*Command\s*\(/
```

Factory-authored adapters (`makeStatusCommand` / `makeScreenshotCommand` / `makeNewCommand` / `makeDumpCommand` in `clis/_shared/desktop-commands.js`) contain no top-level `cli(` / lifecycle call, so they match build-manifest but **not** discovery. The two patterns had drifted.

## Fix

Add `|\bmake[A-Z]\w*Command\s*\(` to discovery's `PLUGIN_MODULE_PATTERN` so it matches build-manifest. One-token, behavior-preserving change:

- Behavior unchanged for adapters that call `cli(`, `registerSiteAuthCommands(`, or any lifecycle hook (`onStartup`/`onBeforeExecute`/`onAfterExecute`) — those tokens are untouched.
- Behavior unchanged for helper/type-only modules — a lowercase `makething()` still does not match (the `[A-Z]` after `make` and the `Command(` suffix are required).

Alternative (not implemented): hoist a single shared `CLI_MODULE_PATTERN` constant imported by both `discovery.ts` and `build-manifest.ts`, so the runtime and build-time scanners can never drift again. Left as a follow-up to keep this fix surgical.

## Tests

- New co-located `src/discovery.test.ts` asserts `PLUGIN_MODULE_PATTERN` matches each factory shape (`makeStatusCommand`/`makeScreenshotCommand`/`makeNewCommand`/`makeDumpCommand`), still matches `cli(`, `registerSiteAuthCommands(`, and the lifecycle hooks, and still rejects helper/type-only modules. `PLUGIN_MODULE_PATTERN` is now exported (minimal) for this assertion.
- `npx tsc --noEmit` passes.
- `npx vitest run src/discovery.test.ts src/build-manifest.test.ts` → 17 passed.