### PR TITLE
fix(external): set non-zero exit code when an external CLI is killed by a signal

### DIFF
--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
@@ -22,7 +23,15 @@ vi.mock('node:os', async () => {
   };
 });
 
-import { formatExternalCliLabel, installExternalCli, parseCommand, type ExternalCliConfig } from './external.js';
+import {
+  executeExternalCli,
+  formatExternalCliLabel,
+  installExternalCli,
+  parseCommand,
+  type ExternalCliConfig,
+} from './external.js';
+
+const mockSpawnSync = vi.mocked(spawnSync);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -144,5 +153,63 @@ describe('installExternalCli', () => {
 
     expect(installExternalCli(cli)).toBe(false);
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('executeExternalCli', () => {
+  const registry: ExternalCliConfig[] = [{ name: 'gh', binary: 'gh' }];
+  let previousExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+    mockExecFileSync.mockReset();
+    mockPlatform.mockReturnValue('darwin');
+    previousExitCode = process.exitCode;
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+  });
+
+  it('mirrors the child exit status', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('')); // isBinaryInstalled -> true
+    mockSpawnSync.mockReturnValue({ status: 3, signal: null } as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('gh', ['repo', 'list'], registry);
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('reports a non-zero exit code when the child is signal-killed without the parent receiving it', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('')); // isBinaryInstalled -> true
+    // SIGKILL is delivered to the child PID (OOM-killer, `kill -9 <pid>`, etc.)
+    // without reaching the parent, so this branch is genuinely exercised.
+    mockSpawnSync.mockReturnValue({ status: null, signal: 'SIGKILL' } as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('gh', ['repo', 'list'], registry);
+
+    expect(process.exitCode).toBe(137); // 128 + SIGKILL(9)
+  });
+
+  it('maps SIGINT to the curated INTERRUPTED exit code', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('')); // isBinaryInstalled -> true
+    mockSpawnSync.mockReturnValue({ status: null, signal: 'SIGINT' } as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('gh', ['repo', 'list'], registry);
+
+    expect(process.exitCode).toBe(130); // EXIT_CODES.INTERRUPTED
+  });
+
+  it('falls back to GENERIC_ERROR for signals missing from os.constants', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('')); // isBinaryInstalled -> true
+    mockSpawnSync.mockReturnValue({
+      status: null,
+      signal: 'SIGNOPE' as NodeJS.Signals,
+    } as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('gh', ['repo', 'list'], registry);
+
+    expect(process.exitCode).toBe(1); // EXIT_CODES.GENERIC_ERROR
   });
 });

--- a/src/external.ts
+++ b/src/external.ts
@@ -206,6 +206,19 @@ export function executeExternalCli(name: string, args: string[], preloaded?: Ext
   
   if (result.status !== null) {
     process.exitCode = result.status;
+  } else if (result.signal) {
+    // Terminated by a signal (e.g. OOM-killer SIGKILL, or an operator/script
+    // killing the child PID): spawnSync leaves status null, so mirror the POSIX
+    // convention of 128 + signal number instead of falsely reporting success.
+    // Reuse the curated SIGINT constant; fall back to GENERIC_ERROR for signals
+    // missing from the os.constants table.
+    const sig = result.signal;
+    process.exitCode =
+      sig === 'SIGINT'
+        ? EXIT_CODES.INTERRUPTED
+        : os.constants.signals[sig]
+          ? 128 + os.constants.signals[sig]
+          : EXIT_CODES.GENERIC_ERROR;
   }
 }
 


### PR DESCRIPTION
## Problem

When an external CLI launched by `executeExternalCli` is terminated by a signal, opencli exits `0` — falsely reporting success even though the child never ran to completion. A script that pipes opencli's exit code into `&&`/`set -e`, or CI gating on it, treats the failed run as a pass.

This is genuinely reachable whenever a signal reaches only the child PID, not opencli's process group: the kernel OOM-killer sending `SIGKILL` to a memory-hungry child, or an operator/supervisor doing `kill <child-pid>` / `kill -9 <child-pid>`. In those cases the parent keeps running and reaches the exit-code logic with a dead child.

(Note: terminal Ctrl-C is *not* the motivating case — there is no `process.on('SIGINT')` handler in this path, so a group-delivered SIGINT kills the parent before this branch runs. The framing here is limited to signals that hit the child alone.)

## Root cause

`src/external.ts:200-214` (`executeExternalCli`). `spawnSync` returns `{ status: null, signal: '<NAME>' }` when the child is killed by a signal. The only exit-code assignment was guarded by `if (result.status !== null)`, so the signal case fell through and `process.exitCode` stayed at its default `0`.

## Fix

Add an `else if (result.signal)` branch mapping the signal to a non-zero code using the POSIX `128 + signal number` convention:

```ts
const sig = result.signal;
process.exitCode =
  sig === 'SIGINT'
    ? EXIT_CODES.INTERRUPTED                     // 130, curated constant
    : os.constants.signals[sig]
      ? 128 + os.constants.signals[sig]          // e.g. SIGKILL -> 137
      : EXIT_CODES.GENERIC_ERROR;                // unknown signal -> 1
```

- Reuses the curated `EXIT_CODES.INTERRUPTED` (`src/errors.ts:35`, =130) for SIGINT instead of re-deriving `128 + os.constants.signals['SIGINT']`, keeping the exit-code table the single source of truth.
- Falls back to `EXIT_CODES.GENERIC_ERROR` for any signal name absent from `os.constants.signals`, so an unmapped signal can never silently produce a `0` exit.

## Tests

`src/external.test.ts` — new `executeExternalCli` suite (`npx vitest run src/external.test.ts`, 14 tests pass):

- `mirrors the child exit status` — status 3 -> exitCode 3.
- `reports a non-zero exit code when the child is signal-killed ...` — the realistic child-only kill, `SIGKILL` -> 137 (128+9).
- `maps SIGINT to the curated INTERRUPTED exit code` — `SIGINT` -> 130, asserting the constant is reused.
- `falls back to GENERIC_ERROR for signals missing from os.constants` — `SIGNOPE` -> 1.

Each case captures and restores `process.exitCode` (afterEach) to match the surrounding tests. `node:os` is partially mocked with `importActual`, so `os.constants.signals` resolves real numbers (137/130 are computed, not hard-coded into the source).

## Scope

Surgical: one new branch in `executeExternalCli` plus its tests. No change to the `result.status` or `result.error` paths, the install flow, or the exit-code table.

Gate: `npx tsc --noEmit` clean; `npx vitest run src/external.test.ts` passes (14/14).