### PR TITLE
fix(output): escape pipes and newlines in markdown table cells

### DIFF
--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -59,4 +59,32 @@ describe('output TTY detection', () => {
     expect(out).toBe('# Title\n\nBody');
     expect(out).not.toContain('| markdown |');
   });
+
+  it('escapes pipes and newlines in markdown cells so columns stay aligned', () => {
+    render([{ name: 'a|b', note: 'line1\nline2' }], { fmt: 'md', columns: ['name', 'note'] });
+    const lines = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // Header, separator, one data row.
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('| name | note |');
+    expect(lines[1]).toBe('| --- | --- |');
+    // '|' is escaped to '\|' and the newline becomes '<br>'.
+    expect(lines[2]).toBe('| a\\|b | line1<br>line2 |');
+    // Every row keeps exactly the column count: 3 pipes for 2 columns.
+    for (const line of lines) {
+      expect((line.match(/(?<!\\)\|/g) ?? []).length).toBe(3);
+    }
+  });
+
+  it('keeps columns aligned when a cell value is only a pipe', () => {
+    // Realistic reachable path: e.g. `weread book-search ... --raw -f md` renders
+    // book snippets/titles verbatim, and a snippet can be a literal '|'.
+    render([{ rank: '1', snippet: '|' }], { fmt: 'md', columns: ['rank', 'snippet'] });
+    const lines = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe('| 1 | \\| |');
+    // 2 columns => exactly 3 unescaped delimiters per row; the cell '|' must not add a fourth.
+    for (const line of lines) {
+      expect((line.match(/(?<!\\)\|/g) ?? []).length).toBe(3);
+    }
+  });
 });

--- a/src/output.ts
+++ b/src/output.ts
@@ -121,10 +121,17 @@ function renderMarkdown(data: unknown, opts: RenderOptions): void {
     }
   }
   const columns = resolveColumns(rows, opts);
-  console.log('| ' + columns.join(' | ') + ' |');
+  // Cell values containing '|' or newlines would otherwise add spurious columns
+  // or split the row, breaking the GFM table. Collapse every newline flavour
+  // (CRLF, lone CR, lone LF) into <br> so a stray '\r' can't split the row either.
+  const escapeCell = (v: string): string => v.replace(/\|/g, '\\|').replace(/\r\n|\r|\n/g, '<br>');
+  // The header row is escaped too as defense-in-depth: column names are normally
+  // safe identifiers, but escaping them keeps the table valid even if a caller
+  // passes an arbitrary string as a column key.
+  console.log('| ' + columns.map(escapeCell).join(' | ') + ' |');
   console.log('| ' + columns.map(() => '---').join(' | ') + ' |');
   for (const row of rows) {
-    console.log('| ' + columns.map(c => String((row as Record<string, unknown>)[c] ?? '')).join(' | ') + ' |');
+    console.log('| ' + columns.map(c => escapeCell(String((row as Record<string, unknown>)[c] ?? ''))).join(' | ') + ' |');
   }
 }
 


### PR DESCRIPTION
# fix(output): escape pipes and newlines in markdown table cells

## Problem
`render(..., { fmt: 'md' })` emitted each table cell as raw `String(value)`. A value containing a literal `|` added spurious columns and a `\n` (or a lone `\r`) split the row, corrupting the GFM table so downstream Markdown renderers misaligned every column.

## Root cause
`src/output.ts` — `renderMarkdown()` (the body-row loop, ~line 129 before the fix) joined cells with `| ... |` without escaping the cell content. Both the header row and the data rows were affected.

## Fix
`src/output.ts` `renderMarkdown()` now uses a local `escapeCell` helper (mirroring the escaping already done in `renderCsv`):
- `|` → `\|`
- every newline flavour — CRLF, lone CR, lone LF (`/\r\n|\r|\n/`) → `<br>`, so a stray `\r` can no longer split the row either.

`escapeCell` is applied to both the header row and the body rows. Escaping the header is intentional defense-in-depth: column names are normally safe identifiers, but escaping keeps the table valid even if a caller passes an arbitrary string as a column key. Both points are documented in inline comments.

## Real repro (not theoretical)
`weread book-search <title> <query> --raw -f md` is reachable today. `clis/weread/book-search.js` declares `defaultFormat: 'md'`; with `--raw` it returns the structured `buildRows(...)` objects (columns include `book_title`, `author`, `snippet`). Those values come from `normalizeSearchText()` (`book-search.js:20`), which only collapses whitespace and trims — it does **not** strip `|`. So a book title/author/snippet containing a literal pipe flows straight into a table cell and broke the rendered table before this fix.

## Tests
`src/output.test.ts` (run with `npx vitest run src/output.test.ts` — 8/8 pass):
- Kept the combined pipe + newline case: asserts `a|b` → `a\|b`, `line1\nline2` → `line1<br>line2`, header/separator/data line shape, and exactly 3 unescaped delimiters per row for 2 columns.
- Added a case for a cell whose value is **only** `|` (the most realistic reachable path): asserts the row renders as `| 1 | \| |` and that every line still has exactly 3 unescaped `|` delimiters, i.e. columns stay aligned.

## Scope
Surgical: only `renderMarkdown` cell rendering changed. `renderTable`, `renderCsv`, `renderJson`, `renderYaml`, and `renderPlain` are untouched. The existing single-field markdown passthrough (`{ markdown: '...' }`) is unchanged. `npx tsc --noEmit` passes.