### PR TITLE
fix(plugin): reject unsafe plugin names on install to prevent path traversal

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -8,6 +8,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { PLUGINS_DIR } from './discovery.js';
+import { PluginError } from './errors.js';
 import type { LockEntry } from './plugin.js';
 import * as pluginModule from './plugin.js';
 
@@ -31,6 +32,7 @@ const {
   _parseSource,
   _updateAllPlugins,
   _validatePluginStructure,
+  _assertSafePluginName,
   _writeLockFile,
   _writeLockFileWithFs,
   _isSymlinkSync,
@@ -929,6 +931,63 @@ describe('listPlugins with monorepo metadata', () => {
     expect(found!.monorepoName).toBe('test-mono');
     expect(found!.commands).toContain('hello');
     expect(found!.source).toBe('https://github.com/user/test-mono.git');
+  });
+});
+
+describe('assertSafePluginName', () => {
+  it('accepts conservative plugin names', () => {
+    for (const name of ['github-trending', 'my_tool', 'Plugin.v2', 'a', '__test-mono-sub__']) {
+      expect(() => _assertSafePluginName(name)).not.toThrow();
+    }
+  });
+
+  it('rejects path-traversal and separator-bearing names', () => {
+    for (const name of ['../evil', 'a/b', 'a\\b', '..', '.hidden', '', '/abs/path']) {
+      expect(() => _assertSafePluginName(name)).toThrow(PluginError);
+    }
+  });
+});
+
+describe('installPlugin name sanitization', () => {
+  const traversalEscape = path.join(PLUGINS_DIR, '..', 'evil');
+
+  beforeEach(() => {
+    mockExecFileSync.mockClear();
+    mockExecSync.mockClear();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(traversalEscape, { recursive: true, force: true }); } catch {}
+    vi.clearAllMocks();
+  });
+
+  function mockCloneWithManifestName(maliciousName: string): void {
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'clone') {
+        const cloneDir = String(args[args.length - 1]);
+        fs.mkdirSync(cloneDir, { recursive: true });
+        fs.writeFileSync(path.join(cloneDir, 'hello.js'), 'cli({ site: "test", name: "hello", access: "read" })');
+        fs.writeFileSync(path.join(cloneDir, 'opencli-plugin.json'), JSON.stringify({ name: maliciousName }));
+        return '';
+      }
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return '1234567890abcdef1234567890abcdef12345678\n';
+      }
+      return '';
+    });
+  }
+
+  it('rejects a manifest name containing ".." and writes nothing outside PLUGINS_DIR', () => {
+    mockCloneWithManifestName('../evil');
+
+    expect(() => installPlugin('github:user/opencli-plugin-evil')).toThrow(PluginError);
+    expect(fs.existsSync(traversalEscape)).toBe(false);
+  });
+
+  it('rejects a manifest name containing a path separator', () => {
+    mockCloneWithManifestName('evil/sub');
+
+    expect(() => installPlugin('github:user/opencli-plugin-evil')).toThrow(PluginError);
   });
 });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -430,6 +430,41 @@ export interface ValidationResult {
   errors: string[];
 }
 
+/**
+ * Conservative plugin-name pattern: a leading alphanumeric or underscore
+ * followed by alphanumerics, dots, underscores, or hyphens. Aligns with the
+ * scaffold's naming rules (`plugin-scaffold.ts`) while staying permissive
+ * enough (case-insensitive, leading underscore) not to reject pre-existing
+ * installed names or monorepo sub-plugin keys. A leading `.` is excluded so a
+ * name like `..` can never traverse out of PLUGINS_DIR.
+ */
+const SAFE_PLUGIN_NAME = /^[a-z0-9_][a-z0-9._-]*$/i;
+
+/**
+ * Reject plugin names that could escape PLUGINS_DIR when joined into a
+ * filesystem path. The name often derives from an attacker-controllable
+ * plugin manifest (`name` field or monorepo `plugins` key), so it must be
+ * validated before every `path.join(PLUGINS_DIR, name)` on the install/link
+ * paths. Throws PluginError for empty, absolute, separator-bearing, `..`, or
+ * dot-leading names.
+ */
+function assertSafePluginName(name: string): void {
+  if (
+    !name ||
+    path.isAbsolute(name) ||
+    name.includes('/') ||
+    name.includes('\\') ||
+    name.includes('..') ||
+    name.startsWith('.') ||
+    !SAFE_PLUGIN_NAME.test(name)
+  ) {
+    throw new PluginError(
+      `Unsafe plugin name "${name}".`,
+      'Plugin names must start with a letter or digit and contain only letters, digits, dots, underscores, or hyphens (no path separators or "..").',
+    );
+  }
+}
+
 // ── Lock file helpers ───────────────────────────────────────────────────────
 
 function readLockFileWithWriter(
@@ -664,6 +699,7 @@ function publishMonorepoPlugins(
 
     const commitHash = getCommitHash(repoDir);
     for (const plugin of plugins) {
+      assertSafePluginName(plugin.name);
       const linkPath = path.join(pluginsDir, plugin.name);
       const subDir = resolveRepoContainedPath(repoDir, plugin.subPath);
       tx.track(beginReplaceSymlink(subDir, linkPath));
@@ -734,6 +770,7 @@ function installSinglePlugin(
   manifest: PluginManifest | null,
 ): string {
   const pluginName = manifest?.name ?? name;
+  assertSafePluginName(pluginName);
   const targetDir = path.join(PLUGINS_DIR, pluginName);
 
   if (fs.existsSync(targetDir)) {
@@ -780,6 +817,7 @@ function installLocalPlugin(localPath: string, name: string): string {
   }
 
   const pluginName = manifest?.name ?? name;
+  assertSafePluginName(pluginName);
   const targetDir = path.join(PLUGINS_DIR, pluginName);
 
   if (fs.existsSync(targetDir)) {
@@ -1557,6 +1595,7 @@ export {
   readLockFileWithWriter as _readLockFileWithWriter,
   updateAllPlugins as _updateAllPlugins,
   validatePluginStructure as _validatePluginStructure,
+  assertSafePluginName as _assertSafePluginName,
   writeLockFile as _writeLockFile,
   writeLockFileWithFs as _writeLockFileWithFs,
   isSymlinkSync as _isSymlinkSync,


### PR DESCRIPTION
## Problem

`opencli plugin install` derives the on-disk plugin directory name from the (attacker-controllable) plugin manifest `name` field — or a monorepo `plugins` key — and joins it straight into `PLUGINS_DIR` with no sanitization. A manifest whose `name` is `../evil`, `evil/sub`, or an absolute path escapes `~/.opencli/plugins`, letting an install write or symlink files outside the plugins directory (e.g. `path.join(PLUGINS_DIR, '../evil')` → a sibling of the plugins dir).

This is a filesystem-write / symlink-placement primitive triggered simply by installing a hostile (or compromised) plugin repo.

## Root cause

`src/plugin.ts` joins a name into `PLUGINS_DIR` at three install/link sites without validating it:

- `installSinglePlugin` — `src/plugin.ts:770` (`const pluginName = manifest?.name ?? name; path.join(PLUGINS_DIR, pluginName)`)
- `installLocalPlugin` — `src/plugin.ts:817` (same shape)
- `publishMonorepoPlugins` — `src/plugin.ts:699` (`path.join(pluginsDir, plugin.name)`, where `plugin.name` comes from the monorepo manifest's `plugins` keys)

`readPluginManifest` (`src/plugin-manifest.ts`) does no name validation, and the existing scaffold regex in `src/plugin-scaffold.ts` only guards `plugin create`, never the install path. (Note: sub-plugin *paths* are already contained by `resolveRepoContainedPath`; the gap is the *name*, which becomes the link's basename.)

## Fix

Add `assertSafePluginName(name)` (`src/plugin.ts`) and call it immediately before every `path.join(PLUGINS_DIR, name)` on the install/link paths. It throws `PluginError` for names that are empty, absolute, contain a path separator (`/` or `\`), contain `..`, start with `.`, or fail the conservative pattern `/^[a-z0-9_][a-z0-9._-]*$/i`. The pattern aligns with the scaffold's naming rules but stays case-insensitive and permits a leading underscore so it does not reject any pre-existing valid install name or monorepo sub-plugin key.

`publishMonorepoPlugins` is the shared chokepoint for both install and update link creation, so validating there covers monorepo installs and is defense-in-depth for updates.

Behavior unchanged for currently-valid plugin names: all 96 pre-existing plugin tests still pass, including installs of names like `github-trending`, `hot-digest`, monorepo keys (`alpha`, `beta`), and the `__test-…__` fixtures.

## Tests

`src/plugin.test.ts`:
- `assertSafePluginName` — asserts conservative names (`github-trending`, `my_tool`, `Plugin.v2`, `a`, `__test-mono-sub__`) are accepted and that `../evil`, `a/b`, `a\b`, `..`, `.hidden`, ``, `/abs/path` throw `PluginError`.
- `installPlugin name sanitization` — stubs `git clone` to emit a manifest whose `name` is `../evil` (and one with `/`); asserts `installPlugin` throws `PluginError` and that nothing is created at `path.join(PLUGINS_DIR, '..', 'evil')`.

Gate: `npx tsc --noEmit` (exit 0) and `npx vitest run src/plugin.test.ts src/plugin-manifest.test.ts` (101 passed).

---

This change is scoped strictly to plugin-name sanitization. It is complementary to and independent of the open #1754 (`--ignore-scripts`), which mitigates a different install-time risk (lifecycle-script execution); neither subsumes the other.