### PR TITLE
fix(chatgpt): stabilize response extraction against virtual scrolling

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -6,7 +6,7 @@ import {
     currentChatGPTUrl,
     ensureChatGPTComposer,
     ensureOnChatGPT,
-    getChatGPTResponsePairKeys,
+    getChatGPTResponsePairCounts,
     getVisibleMessages,
     normalizeBooleanFlag,
     openChatGPTConversation,
@@ -100,7 +100,7 @@ export const askCommand = cli({
 
         const baselineMessages = await getVisibleMessages(page);
         const baseline = baselineMessages.length;
-        const baselinePairKeys = new Set(getChatGPTResponsePairKeys(baselineMessages, prompt));
+        const baselinePairCounts = getChatGPTResponsePairCounts(baselineMessages, prompt);
         const sent = await sendChatGPTMessage(page, prompt);
         if (!sent) {
             throw new CommandExecutionError('Failed to send message to ChatGPT', `Open ${CHATGPT_URL} and verify the composer is ready.`);
@@ -111,7 +111,7 @@ export const askCommand = cli({
             return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response: '' }];
         }
         const response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
-            baselinePairKeys,
+            baselinePairCounts,
             conversationUrl,
         });
         return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response }];

--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -6,7 +6,8 @@ import {
     currentChatGPTUrl,
     ensureChatGPTComposer,
     ensureOnChatGPT,
-    getBubbleCount,
+    getChatGPTResponsePairKeys,
+    getVisibleMessages,
     normalizeBooleanFlag,
     openChatGPTConversation,
     requireNonEmptyPrompt,
@@ -97,7 +98,9 @@ export const askCommand = cli({
             await page.wait(3);
         }
 
-        const baseline = await getBubbleCount(page);
+        const baselineMessages = await getVisibleMessages(page);
+        const baseline = baselineMessages.length;
+        const baselinePairKeys = new Set(getChatGPTResponsePairKeys(baselineMessages, prompt));
         const sent = await sendChatGPTMessage(page, prompt);
         if (!sent) {
             throw new CommandExecutionError('Failed to send message to ChatGPT', `Open ${CHATGPT_URL} and verify the composer is ready.`);
@@ -107,7 +110,10 @@ export const askCommand = cli({
         if (!shouldWait) {
             return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response: '' }];
         }
-        const response = await waitForChatGPTResponse(page, baseline, prompt, timeout);
+        const response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
+            baselinePairKeys,
+            conversationUrl,
+        });
         return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response }];
     },
 });

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -611,7 +611,7 @@ export async function sendChatGPTMessage(page, text) {
     `)), 'chatgpt composer readiness');
 
     if (!typeResult.ready) return false;
-    
+
     // Use page.type() which is Playwright's native method
     try {
         if (page.nativeType) {
@@ -636,7 +636,7 @@ export async function sendChatGPTMessage(page, text) {
             })()
         `);
     }
-    
+
     let sent = null;
     for (let attempt = 0; attempt < 20; attempt += 1) {
         await page.wait(0.5);
@@ -676,7 +676,7 @@ export async function sendChatGPTMessage(page, text) {
     if (!sent?.sendBtnFound) {
         return false;
     }
-    
+
     await page.evaluate(`
         (() => {
             const isVisible = (el) => {
@@ -847,6 +847,11 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
     let lastText = '';
     let stableCount = 0;
 
+    const clean = (str) => String(str || '')
+        .replace(/[*_`#\-+>!\[\]()]/g, '')
+        .replace(/\s+/g, '')
+        .toLowerCase();
+
     while (Date.now() - startTime < timeoutSeconds * 1000) {
         await page.wait(3);
         if (await isGenerating(page)) {
@@ -855,10 +860,21 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
         }
 
         const messages = await getVisibleMessages(page);
-        const newMessages = messages.slice(Math.max(0, baselineCount));
-        const assistant = [...newMessages].reverse().find((m) => m.Role === 'Assistant')
-            || [...messages].reverse().find((m) => m.Role === 'Assistant');
-        const candidate = String(assistant?.Text || '').trim();
+        const lastUser = [...messages].reverse().find((m) => m.Role === 'User');
+        const lastAssistant = [...messages].reverse().find((m) => m.Role === 'Assistant');
+
+        if (!lastUser || !lastAssistant) continue;
+
+        const isPromptVisible = clean(lastUser.Text) === clean(prompt)
+            || clean(lastUser.Text).includes(clean(prompt))
+            || clean(prompt).includes(clean(lastUser.Text));
+        
+        const hasAssistantResponded = isPromptVisible
+            && messages.indexOf(lastAssistant) > messages.indexOf(lastUser);
+
+        if (!hasAssistantResponded) continue;
+
+        const candidate = String(lastAssistant.Text || '').trim();
         if (!candidate || candidate === String(prompt || '').trim()) continue;
 
         if (candidate === lastText) {
@@ -941,11 +957,11 @@ async function extractConversationLinks(page) {
         return rows;
     })()`)), 'chatgpt conversation link extraction');
     return items.map((item, index) => ({
-            Index: index + 1,
-            Id: String(item?.Id || ''),
-            Title: String(item?.Title || '(untitled)').trim() || '(untitled)',
-            Url: String(item?.Url || ''),
-        })).filter((item) => item.Id);
+        Index: index + 1,
+        Id: String(item?.Id || ''),
+        Title: String(item?.Title || '(untitled)').trim() || '(untitled)',
+        Url: String(item?.Url || ''),
+    })).filter((item) => item.Id);
 }
 
 function imageMimeFromPath(filePath) {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -842,39 +842,76 @@ export async function getBubbleCount(page) {
     return messages.length;
 }
 
-export async function waitForChatGPTResponse(page, baselineCount, prompt, timeoutSeconds) {
-    const startTime = Date.now();
-    let lastText = '';
-    let stableCount = 0;
-
-    const clean = (str) => String(str || '')
+function cleanPromptText(str) {
+    return String(str || '')
         .replace(/[*_`#\-+>!\[\]()]/g, '')
         .replace(/\s+/g, '')
         .toLowerCase();
+}
+
+function responsePairKey(user, assistant) {
+    return JSON.stringify([
+        cleanPromptText(user?.Text),
+        String(assistant?.Text || '').trim(),
+    ]);
+}
+
+export function getChatGPTResponsePairKeys(messages, prompt) {
+    const promptKey = cleanPromptText(prompt);
+    if (!promptKey) return [];
+    const keys = [];
+    for (let index = 0; index < messages.length; index += 1) {
+        const user = messages[index];
+        if (user?.Role !== 'User' || cleanPromptText(user.Text) !== promptKey) continue;
+        const assistant = messages.slice(index + 1).find((message) => message?.Role === 'Assistant');
+        if (!assistant || !String(assistant.Text || '').trim()) continue;
+        keys.push(responsePairKey(user, assistant));
+    }
+    return keys;
+}
+
+function findLatestNewAssistantResponse(messages, prompt, baselinePairKeys) {
+    const promptKey = cleanPromptText(prompt);
+    if (!promptKey) return '';
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const user = messages[index];
+        if (user?.Role !== 'User' || cleanPromptText(user.Text) !== promptKey) continue;
+        const assistantIndex = messages.findIndex((message, candidateIndex) => (
+            candidateIndex > index
+            && message?.Role === 'Assistant'
+            && String(message.Text || '').trim()
+        ));
+        if (assistantIndex < 0) continue;
+        const assistant = messages[assistantIndex];
+        if (baselinePairKeys.has(responsePairKey(user, assistant))) continue;
+        return String(assistant.Text || '').trim();
+    }
+    return '';
+}
+
+export async function waitForChatGPTResponse(page, baselineCount, prompt, timeoutSeconds, options = {}) {
+    const startTime = Date.now();
+    let lastText = '';
+    let stableCount = 0;
+    const baselinePairKeys = new Set(options.baselinePairKeys || []);
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {
         await page.wait(3);
+        if (options.conversationUrl) {
+            const currentUrl = await currentChatGPTUrl(page);
+            if (currentUrl && !isSameChatGPTConversation(currentUrl, options.conversationUrl)) {
+                throw new CommandExecutionError(
+                    `ChatGPT navigated away from the target conversation (${options.conversationUrl}); current URL is ${currentUrl}`,
+                );
+            }
+        }
         if (await isGenerating(page)) {
             stableCount = 0;
             continue;
         }
 
         const messages = await getVisibleMessages(page);
-        const lastUser = [...messages].reverse().find((m) => m.Role === 'User');
-        const lastAssistant = [...messages].reverse().find((m) => m.Role === 'Assistant');
-
-        if (!lastUser || !lastAssistant) continue;
-
-        const isPromptVisible = clean(lastUser.Text) === clean(prompt)
-            || clean(lastUser.Text).includes(clean(prompt))
-            || clean(prompt).includes(clean(lastUser.Text));
-        
-        const hasAssistantResponded = isPromptVisible
-            && messages.indexOf(lastAssistant) > messages.indexOf(lastUser);
-
-        if (!hasAssistantResponded) continue;
-
-        const candidate = String(lastAssistant.Text || '').trim();
+        const candidate = findLatestNewAssistantResponse(messages, prompt, baselinePairKeys);
         if (!candidate || candidate === String(prompt || '').trim()) continue;
 
         if (candidate === lastText) {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -844,9 +844,8 @@ export async function getBubbleCount(page) {
 
 function cleanPromptText(str) {
     return String(str || '')
-        .replace(/[*_`#\-+>!\[\]()]/g, '')
-        .replace(/\s+/g, '')
-        .toLowerCase();
+        .replace(/\s+/g, ' ')
+        .trim();
 }
 
 function responsePairKey(user, assistant) {
@@ -870,9 +869,23 @@ export function getChatGPTResponsePairKeys(messages, prompt) {
     return keys;
 }
 
-function findLatestNewAssistantResponse(messages, prompt, baselinePairKeys) {
+export function getChatGPTResponsePairCounts(messages, prompt) {
+    const counts = new Map();
+    for (const key of getChatGPTResponsePairKeys(messages, prompt)) {
+        counts.set(key, (counts.get(key) || 0) + 1);
+    }
+    return counts;
+}
+
+function normalizeBaselinePairCounts(options) {
+    if (options.baselinePairCounts instanceof Map) return options.baselinePairCounts;
+    return new Map(Array.from(options.baselinePairKeys || []).map((key) => [key, 1]));
+}
+
+function findLatestNewAssistantResponse(messages, prompt, baselinePairCounts) {
     const promptKey = cleanPromptText(prompt);
     if (!promptKey) return '';
+    const currentPairCounts = getChatGPTResponsePairCounts(messages, prompt);
     for (let index = messages.length - 1; index >= 0; index -= 1) {
         const user = messages[index];
         if (user?.Role !== 'User' || cleanPromptText(user.Text) !== promptKey) continue;
@@ -883,7 +896,8 @@ function findLatestNewAssistantResponse(messages, prompt, baselinePairKeys) {
         ));
         if (assistantIndex < 0) continue;
         const assistant = messages[assistantIndex];
-        if (baselinePairKeys.has(responsePairKey(user, assistant))) continue;
+        const key = responsePairKey(user, assistant);
+        if ((currentPairCounts.get(key) || 0) <= (baselinePairCounts.get(key) || 0)) continue;
         return String(assistant.Text || '').trim();
     }
     return '';
@@ -893,7 +907,7 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
     const startTime = Date.now();
     let lastText = '';
     let stableCount = 0;
-    const baselinePairKeys = new Set(options.baselinePairKeys || []);
+    const baselinePairCounts = normalizeBaselinePairCounts(options);
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {
         await page.wait(3);
@@ -911,7 +925,7 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
         }
 
         const messages = await getVisibleMessages(page);
-        const candidate = findLatestNewAssistantResponse(messages, prompt, baselinePairKeys);
+        const candidate = findLatestNewAssistantResponse(messages, prompt, baselinePairCounts);
         if (!candidate || candidate === String(prompt || '').trim()) continue;
 
         if (candidate === lastText) {

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages } from './utils.js';
+import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairKeys, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
 
 const tempDirs = [];
 
@@ -257,6 +257,107 @@ describe('chatgpt detail completion state', () => {
             Generating: false,
             StableSeconds: 0,
         });
+    });
+});
+
+describe('chatgpt ask response extraction boundary', () => {
+    function createResponseWaitPage(messageSets, { url = 'https://chatgpt.com/c/demo' } = {}) {
+        let messageIndex = 0;
+        return {
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                if (script === 'window.location.href') return Promise.resolve(url);
+                if (script.includes('Stop generating') || script.includes('Thinking')) {
+                    return Promise.resolve(false);
+                }
+                if (script.includes('data-message-author-role')) {
+                    const messages = messageSets[Math.min(messageIndex, messageSets.length - 1)] ?? [];
+                    messageIndex += 1;
+                    return Promise.resolve(messages.map((message) => ({
+                        role: message.Role,
+                        text: message.Text,
+                        html: message.Text,
+                    })));
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+    }
+
+    function mockAdvancingClock(stepMs = 1000) {
+        let now = 0;
+        vi.spyOn(Date, 'now').mockImplementation(() => {
+            now += stepMs;
+            return now;
+        });
+    }
+
+    it('does not return a stale baseline assistant pair for repeated prompts', async () => {
+        mockAdvancingClock();
+        const baselineMessages = [
+            { Role: 'User', Text: 'repeat this prompt' },
+            { Role: 'Assistant', Text: 'old answer' },
+        ];
+        const page = createResponseWaitPage([
+            baselineMessages,
+            baselineMessages,
+            baselineMessages,
+        ]);
+
+        await expect(waitForChatGPTResponse(page, baselineMessages.length, 'repeat this prompt', 4, {
+            baselinePairKeys: new Set(getChatGPTResponsePairKeys(baselineMessages, 'repeat this prompt')),
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).rejects.toThrow(/chatgpt ask timed out/);
+    });
+
+    it('requires an exact normalized user prompt match instead of substring matching', async () => {
+        mockAdvancingClock();
+        const staleMessages = [
+            { Role: 'User', Text: 'write a short story' },
+            { Role: 'Assistant', Text: 'old answer' },
+        ];
+        const page = createResponseWaitPage([
+            staleMessages,
+            staleMessages,
+            staleMessages,
+        ]);
+
+        await expect(waitForChatGPTResponse(page, 0, 'short', 4, {
+            baselinePairKeys: new Set(),
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).rejects.toThrow(/chatgpt ask timed out/);
+    });
+
+    it('returns a stable assistant response for the new prompt pair', async () => {
+        mockAdvancingClock();
+        const baselineMessages = [
+            { Role: 'User', Text: 'repeat this prompt' },
+            { Role: 'Assistant', Text: 'old answer' },
+        ];
+        const newMessages = [
+            ...baselineMessages,
+            { Role: 'User', Text: 'repeat this prompt' },
+            { Role: 'Assistant', Text: 'new answer' },
+        ];
+        const page = createResponseWaitPage([
+            newMessages,
+            newMessages,
+            newMessages,
+        ]);
+
+        await expect(waitForChatGPTResponse(page, baselineMessages.length, 'repeat this prompt', 10, {
+            baselinePairKeys: new Set(getChatGPTResponsePairKeys(baselineMessages, 'repeat this prompt')),
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).resolves.toBe('new answer');
+    });
+
+    it('fails closed when the browser drifts to another conversation while waiting', async () => {
+        mockAdvancingClock();
+        const page = createResponseWaitPage([], { url: 'https://chatgpt.com/c/other' });
+
+        await expect(waitForChatGPTResponse(page, 0, 'hello', 4, {
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).rejects.toThrow(/navigated away from the target conversation/);
     });
 });
 

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -396,7 +396,7 @@ describe('chatgpt send selectors', () => {
 });
 
 describe('chatgpt generated image detection', () => {
-    function createDomPage(html, setup = () => {}) {
+    function createDomPage(html, setup = () => { }) {
         const dom = new JSDOM(html, {
             url: 'https://chatgpt.com/c/demo',
             runScripts: 'outside-only',

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairKeys, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
+import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairCounts, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
 
 const tempDirs = [];
 
@@ -305,7 +305,7 @@ describe('chatgpt ask response extraction boundary', () => {
         ]);
 
         await expect(waitForChatGPTResponse(page, baselineMessages.length, 'repeat this prompt', 4, {
-            baselinePairKeys: new Set(getChatGPTResponsePairKeys(baselineMessages, 'repeat this prompt')),
+            baselinePairCounts: getChatGPTResponsePairCounts(baselineMessages, 'repeat this prompt'),
             conversationUrl: 'https://chatgpt.com/c/demo',
         })).rejects.toThrow(/chatgpt ask timed out/);
     });
@@ -328,6 +328,24 @@ describe('chatgpt ask response extraction boundary', () => {
         })).rejects.toThrow(/chatgpt ask timed out/);
     });
 
+    it('does not collapse punctuation-distinct prompts into the requested prompt', async () => {
+        mockAdvancingClock();
+        const staleMessages = [
+            { Role: 'User', Text: 'what now?' },
+            { Role: 'Assistant', Text: 'old answer' },
+        ];
+        const page = createResponseWaitPage([
+            staleMessages,
+            staleMessages,
+            staleMessages,
+        ]);
+
+        await expect(waitForChatGPTResponse(page, 0, 'what now!', 4, {
+            baselinePairCounts: getChatGPTResponsePairCounts([], 'what now!'),
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).rejects.toThrow(/chatgpt ask timed out/);
+    });
+
     it('returns a stable assistant response for the new prompt pair', async () => {
         mockAdvancingClock();
         const baselineMessages = [
@@ -346,9 +364,32 @@ describe('chatgpt ask response extraction boundary', () => {
         ]);
 
         await expect(waitForChatGPTResponse(page, baselineMessages.length, 'repeat this prompt', 10, {
-            baselinePairKeys: new Set(getChatGPTResponsePairKeys(baselineMessages, 'repeat this prompt')),
+            baselinePairCounts: getChatGPTResponsePairCounts(baselineMessages, 'repeat this prompt'),
             conversationUrl: 'https://chatgpt.com/c/demo',
         })).resolves.toBe('new answer');
+    });
+
+    it('accepts a repeated prompt when the new response text matches a visible baseline answer', async () => {
+        mockAdvancingClock();
+        const baselineMessages = [
+            { Role: 'User', Text: 'repeat this prompt' },
+            { Role: 'Assistant', Text: 'same answer' },
+        ];
+        const newMessages = [
+            ...baselineMessages,
+            { Role: 'User', Text: 'repeat this prompt' },
+            { Role: 'Assistant', Text: 'same answer' },
+        ];
+        const page = createResponseWaitPage([
+            newMessages,
+            newMessages,
+            newMessages,
+        ]);
+
+        await expect(waitForChatGPTResponse(page, baselineMessages.length, 'repeat this prompt', 10, {
+            baselinePairCounts: getChatGPTResponsePairCounts(baselineMessages, 'repeat this prompt'),
+            conversationUrl: 'https://chatgpt.com/c/demo',
+        })).resolves.toBe('same answer');
     });
 
     it('fails closed when the browser drifts to another conversation while waiting', async () => {


### PR DESCRIPTION
## Description

This PR resolves non-deterministic and stale response extraction in the ChatGPT CLI adapter caused by DOM virtual scrolling and prompt race conditions.

### The Problem
1. **Virtual Scrolling**: In long conversations, ChatGPT unmounts old message bubbles from the top of the DOM. This causes absolute `baselineCount` indexes to point to wrong offsets, leading to empty slices and timeouts.
2. **Stale Fallback**: When waiting for a response, the adapter previously fell back to searching the entire visible message history, which immediately matched and returned the *previous* turn's assistant answer before the new one started generating.

### Changes
1. **Relative DOM Index Tracking**: Replaced index-based slicing with index relative comparison. It retrieves the latest `lastUser` and `lastAssistant` bubbles from the DOM.
2. **Prompt-Presence Verification**: Normalizes text (ignoring markdown formatting and whitespace for language-agnostic compatibility) and checks if the prompt is visible.
3. **Sequence Lock**: Validates that the latest assistant bubble physically appears *after* the verified user prompt bubble (`messages.indexOf(lastAssistant) > messages.indexOf(lastUser)`) before capturing and waiting for the generation to stabilize.

Related issue: #1907

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

## Screenshots / Output
```json
[
  {
    "conversationId": "6a28e5f3-ad4c-83ec-b8e4-a28616066ddb",
    "conversationUrl": "https://chatgpt.com/c/6a28e5f3-ad4c-83ec-b8e4-a28616066ddb",
    "tool": "",
    "response": "200"
  }
]
