### PR TITLE
fix(extension): prevent background page throttling by forcing visibi...

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -467,6 +467,7 @@ describe('background tab isolation', () => {
       registerFrameTracking: vi.fn(),
       hasActiveNetworkCapture: vi.fn(() => false),
       detach: vi.fn(async () => {}),
+      ensureAttached: vi.fn(async () => {}),
       waitForDownload,
     }));
 
@@ -503,6 +504,7 @@ describe('background tab isolation', () => {
       registerFrameTracking: vi.fn(),
       hasActiveNetworkCapture: vi.fn(() => false),
       detach: vi.fn(async () => {}),
+      ensureAttached: vi.fn(async () => {}),
       evaluateAsync: vi.fn(async () => 'main-result'),
       evaluateInFrame,
       getFrameTree: vi.fn(async () => ({
@@ -654,6 +656,7 @@ describe('background tab isolation', () => {
       registerListeners: vi.fn(),
       hasActiveNetworkCapture: vi.fn(() => true),
       detach: detachMock,
+      ensureAttached: vi.fn(async () => {}),
     }));
 
     const mod = await import('./background');
@@ -808,6 +811,7 @@ describe('background tab isolation', () => {
     let maxInFlight = 0;
     vi.doMock('./cdp', () => ({
       registerListeners: vi.fn(),
+      ensureAttached: vi.fn(async () => {}),
       evaluateAsync: vi.fn(async (tabId: number, code: string) => {
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
@@ -846,6 +850,7 @@ describe('background tab isolation', () => {
     let maxInFlight = 0;
     vi.doMock('./cdp', () => ({
       registerListeners: vi.fn(),
+      ensureAttached: vi.fn(async () => {}),
       evaluateAsync: vi.fn(async (tabId: number, code: string) => {
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
@@ -2303,6 +2308,7 @@ describe('background tab isolation', () => {
       registerFrameTracking: vi.fn(),
       hasActiveNetworkCapture: vi.fn(() => false),
       detach: vi.fn(async () => {}),
+      ensureAttached: vi.fn(async () => {}),
     }));
 
     const mod = await import('./background');

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1286,6 +1286,49 @@ type ResolvedTab = { tabId: number; tab: chrome.tabs.Tab | null };
  * the Tab object (when available) so callers can skip a redundant chrome.tabs.get().
  */
 async function resolveTab(tabId: number | undefined, leaseKey: string, initialUrl?: string): Promise<ResolvedTab> {
+  const resolved = await resolveTabInternal(tabId, leaseKey, initialUrl);
+
+  if (getWindowMode(leaseKey) === 'foreground' && resolved.tabId !== undefined) {
+    try {
+      if (typeof chrome.tabs?.update === 'function') {
+        await chrome.tabs.update(resolved.tabId, { active: true });
+      }
+      const tab = resolved.tab || (typeof chrome.tabs?.get === 'function' ? await chrome.tabs.get(resolved.tabId) : null);
+      if (tab && typeof tab.windowId === 'number' && typeof chrome.windows?.update === 'function') {
+        let stateUpdate: chrome.windows.UpdateInfo = {};
+        if (typeof chrome.windows?.get === 'function') {
+          try {
+            const win = await chrome.windows.get(tab.windowId);
+            if (win.state === 'minimized') {
+              stateUpdate.state = 'normal';
+            }
+          } catch { /* ignore */ }
+        }
+        await chrome.windows.update(tab.windowId, { focused: true, ...stateUpdate });
+      }
+
+      if (typeof chrome.debugger?.sendCommand === 'function') {
+        try {
+          await executor.ensureAttached(resolved.tabId);
+          await chrome.debugger.sendCommand({ tabId: resolved.tabId }, 'Emulation.setPageVisibilityState', {
+            visibilityState: 'visible',
+          });
+          await chrome.debugger.sendCommand({ tabId: resolved.tabId }, 'Emulation.setFocusEmulationEnabled', {
+            enabled: true,
+          });
+        } catch (cdpErr) {
+          console.warn(`[opencli] Failed to set CDP visibility/focus emulation: ${cdpErr}`);
+        }
+      }
+    } catch (err) {
+      console.warn(`[opencli] Failed to focus tab/window: ${err}`);
+    }
+  }
+
+  return resolved;
+}
+
+async function resolveTabInternal(tabId: number | undefined, leaseKey: string, initialUrl?: string): Promise<ResolvedTab> {
   const existingSession = automationSessions.get(leaseKey);
   // Even when an explicit tabId is provided, validate it is still debuggable.
   if (tabId !== undefined) {

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -153,6 +153,17 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
   } catch {
     // Some pages may not need explicit enable
   }
+
+  try {
+    await chrome.debugger.sendCommand({ tabId }, 'Emulation.setPageVisibilityState', {
+      visibilityState: 'visible',
+    });
+    await chrome.debugger.sendCommand({ tabId }, 'Emulation.setFocusEmulationEnabled', {
+      enabled: true,
+    });
+  } catch {
+    // Best effort
+  }
 }
 
 export async function evaluate(tabId: number, expression: string, aggressiveRetry: boolean = false): Promise<unknown> {


### PR DESCRIPTION
## Description

This PR fixes CLI command timeouts (like `ask`) that occur when the automation browser window runs in the background, is minimized, or loses screen focus. Under these conditions, Chrome's Blink engine aggressively throttles timers and suspends DOM rendering.

### Changes
1. **Window Restoring**: In `background.ts` (`resolveTab`), if the browser window state is `minimized`, it forces the window state back to `normal` and brings it to the foreground with `focused: true`.
2. **CDP Emulation**: In `cdp.ts` (`ensureAttached`), it uses the Chrome DevTools Protocol (CDP) to call `Emulation.setPageVisibilityState({ visibilityState: 'visible' })` and `Emulation.setFocusEmulationEnabled({ enabled: true })`. This convinces Blink that the page remains active, fully rendering, and focused.

Related issue: #1908 

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

## Screenshots / Output
<!-- No screenshots necessary -->
