### PR TITLE
fix(tiktok): restore following list auth context

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -30046,7 +30046,8 @@
     "type": "js",
     "modulePath": "tiktok/following.js",
     "sourceFile": "tiktok/following.js",
-    "navigateBefore": "https://www.tiktok.com"
+    "navigateBefore": "https://www.tiktok.com",
+    "siteSession": "persistent"
   },
   {
     "site": "tiktok",

--- a/clis/tiktok/following.js
+++ b/clis/tiktok/following.js
@@ -61,8 +61,14 @@ function buildFollowingScript(limit) {
     return found;
   }
 
+  function findViewerSecUidFromAppContext() {
+    const scope = window.__$UNIVERSAL_DATA$__?.__DEFAULT_SCOPE__;
+    const appUser = scope?.['webapp.app-context']?.user;
+    return String(appUser?.secUid || appUser?.sec_uid || '').trim();
+  }
+
   const universal = findUniversalData();
-  let viewerSecUid = findViewerSecUid(universal);
+  let viewerSecUid = findViewerSecUid(universal) || findViewerSecUidFromAppContext();
   const msToken = getCookie('msToken');
 
   if (!viewerSecUid) {
@@ -150,6 +156,7 @@ export const followingCommand = cli({
     domain: 'www.tiktok.com',
     strategy: Strategy.COOKIE,
     browser: true,
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Number of accounts (max ${MAX_LIMIT})` },
     ],


### PR DESCRIPTION
## Summary
- Restore TikTok following viewer secUid extraction from the current `window.__$UNIVERSAL_DATA$__.__DEFAULT_SCOPE__['webapp.app-context'].user` app context.
- Default `tiktok/following` to a persistent site session so COOKIE/page-context state survives between navigation and API calls.
- Rebuild `cli-manifest.json`.

## Original Failure
`tiktok/following` could report `AUTH_REQUIRED` or return no data even when Chrome was logged into TikTok.

TikTok no longer exposes the viewer secUid through the old warm universal data shape used by the adapter. The current page exposes it under `webapp.app-context` inside `__$UNIVERSAL_DATA$__`.

## Verification
- `npx tsx src/main.ts validate tiktok/following`
- `npm run test:adapter -- tiktok`
- `npx tsx src/main.ts tiktok following --limit 3 -f json`
