### PR TITLE
fix(doctor): surface cached extension version when disconnected to detect version mismatch

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,7 +9,7 @@ import { BrowserBridge } from './browser/index.js';
 import { getDaemonHealth } from './browser/daemon-client.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
-import { getCachedLatestExtensionVersion } from './update-check.js';
+import { getCachedLatestExtensionVersion, getCachedExtensionVersion } from './update-check.js';
 import type { BrowserProfileStatus } from './browser/daemon-client.js';
 import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
@@ -152,6 +152,20 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
         '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
         '  3. Click "Load unpacked" → select the extension folder',
       );
+    }
+    // When extension is disconnected, check cached version from last successful handshake.
+    // Chrome Web Store auto-upgrades can leave the extension at a version that the npm
+    // CLI can't talk to — this surfaces the version mismatch instead of staying silent.
+    if (opts.cliVersion) {
+      const cachedExtVersion = getCachedExtensionVersion();
+      if (cachedExtVersion) {
+        issues.push(
+          `Extension was previously connected at v${cachedExtVersion} but is now unreachable. ` +
+          `CLI is v${opts.cliVersion}. This may indicate a version mismatch from Chrome Web Store auto-upgrade.\n` +
+          '  Try: npm install -g @jackwener/opencli && opencli daemon restart\n' +
+          '  Then restart Chrome to reload the extension service worker.',
+        );
+      }
     }
   }
   if (extensionConnected && !extensionVersion) {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -222,11 +222,21 @@ export function recordExtensionVersion(version: string): void {
 }
 
 /**
- * Get the cached latest extension version (if available).
+ * Get the cached latest extension version from GitHub Releases (if available).
  * Used by `opencli doctor` to report extension updates.
  */
 export function getCachedLatestExtensionVersion(): string | undefined {
   return _cache?.latestExtensionVersion;
+}
+
+/**
+ * Get the last-seen extension version from the daemon cache.
+ * The daemon writes this on each successful WebSocket hello handshake.
+ * When the extension is disconnected, this is the most recent version
+ * we saw working — useful for detecting version drift.
+ */
+export function getCachedExtensionVersion(): string | undefined {
+  return _cache?.currentExtensionVersion;
 }
 
 export {


### PR DESCRIPTION
## Problem

When the Chrome Web Store auto-upgrades the extension but the npm CLI stays pinned at an older version, the bridge silently breaks. `opencli doctor` shows only "extension not connected" with no indication of a version mismatch — the user (and automated agents) have no way to diagnose the root cause.

### Repro

1. Chrome Web Store auto-updates extension to v1.0.19
2. npm CLI stays at v1.8.0
3. `opencli doctor` → `Extension: not connected` (silent)
4. All `COOKIE` / `INTERCEPT` / `UI` adapters fail with `extension not connected`

The existing compat-range check (lines 168-185 in doctor.ts) correctly detects protocol mismatches when the extension IS connected, but it never runs when the extension is disconnected.

## Fix

Two minimal changes:

1. **`update-check.ts`**: Export `getCachedExtensionVersion()` to read `currentExtensionVersion` from the daemon's shared cache. The daemon already writes this on every successful WebSocket handshake via `recordExtensionVersion()` — we just weren't reading it in the doctor path.

2. **`doctor.ts`**: When the extension is disconnected (`daemonRunning && !extensionConnected`), check the cached extension version. If found, append a version-mismatch hint to the issues list, suggesting `npm install -g` + restart Chrome.

### Example output (before → after)

Before:
```
[OK] Daemon: running on port 19825
[MISSING] Extension: not connected
Issues:
  • Daemon is running but the Chrome/Chromium extension is not connected.
```

After:
```
[OK] Daemon: running on port 19825
[MISSING] Extension: not connected
Issues:
  • Daemon is running but the Chrome/Chromium extension is not connected.
  • Extension was previously connected at v1.0.19 but is now unreachable.
    CLI is v1.8.0. This may indicate a version mismatch from Chrome Web Store auto-upgrade.
    Try: npm install -g @jackwener/opencli && opencli daemon restart
    Then restart Chrome to reload the extension service worker.
```

## Testing

All existing tests pass:
- `src/doctor.test.ts` — 17/17
- Full `npm test --project unit` — 1175 passed, 1 skipped