### PR TITLE
fix(auth): degrade adapter import failures to per-site error rows

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { BrowserCliCommand } from '../registry.js';
+import type { BrowserCliCommand, InternalCliCommand } from '../registry.js';
 
 const executeCommandMock = vi.hoisted(() => vi.fn());
 
@@ -42,6 +42,30 @@ function registerWhoami(site: string, opts: {
 async function tempStatePath(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'opencli-auth-refresh-test-'));
   return join(dir, 'auth-refresh.json');
+}
+
+// Registers a lazy whoami adapter whose module throws at import time, mirroring
+// the manifest registration in discovery.ts (_lazy/_modulePath). loadLazyCommand
+// will `await import(...)` this path and reject — exercising the import-failure path.
+async function registerThrowingLazyWhoami(site: string): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'opencli-auth-lazy-test-'));
+  const modulePath = join(dir, 'boom.mjs');
+  await writeFile(modulePath, "throw new Error('boom');\n", 'utf8');
+  const lazy: InternalCliCommand = {
+    site,
+    name: 'whoami',
+    description: `${site} whoami`,
+    access: 'read',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    domain: `${site}.example.com`,
+    navigateBefore: false,
+    args: [],
+    columns: ['logged_in', 'site', 'username'],
+    _lazy: true,
+    _modulePath: modulePath,
+  };
+  getRegistry().set(`${site}/whoami`, lazy);
 }
 
 beforeEach(() => {
@@ -116,6 +140,20 @@ describe('auth status collection', () => {
     expect(rows).toEqual([
       { site: 'delta', status: 'not_logged_in', logged_in: false, identity: '', checked: 'quick', error: '' },
     ]);
+  });
+
+  it('degrades a lazy adapter that throws on import to a per-site error row without rejecting', async () => {
+    registerWhoami('alpha', { quick: true, quickLoggedIn: true });
+    await registerThrowingLazyWhoami('broken');
+
+    const rows = await collectAuthStatus({ concurrency: 1 });
+
+    const bySite = Object.fromEntries(rows.map(row => [row.site, row]));
+    expect(bySite.alpha).toEqual({
+      site: 'alpha', status: 'logged_in', logged_in: true, identity: '', checked: 'quick', error: '',
+    });
+    expect(bySite.broken).toMatchObject({ site: 'broken', status: 'error', logged_in: '' });
+    expect(bySite.broken?.error).toContain('boom');
   });
 });
 
@@ -293,5 +331,32 @@ describe('auth refresh collection', () => {
       },
     ]);
     expect(executeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('degrades a lazy adapter that throws on import to a per-site error row and still saves state', async () => {
+    registerWhoami('theta', { quick: true, quickLoggedIn: true });
+    await registerThrowingLazyWhoami('broken');
+    const statePath = await tempStatePath();
+    const now = new Date('2026-06-06T12:00:00.000Z');
+
+    const rows = await collectAuthRefresh({ statePath, now, concurrency: 1 });
+
+    const bySite = Object.fromEntries(rows.map(row => [row.site, row]));
+    expect(bySite.theta?.status).toBe('touched');
+    expect(bySite.broken).toMatchObject({ site: 'broken', status: 'error' });
+    expect(bySite.broken?.error).toContain('boom');
+
+    // State file is still written even though one adapter import failed, and the
+    // failing site records its attempt with last_status: 'error' (no last_touched_at).
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    expect(state.sites.theta).toMatchObject({
+      last_touched_at: now.toISOString(),
+      last_status: 'touched',
+    });
+    expect(state.sites.broken).toMatchObject({
+      last_attempt_at: now.toISOString(),
+      last_status: 'error',
+    });
+    expect(state.sites.broken.last_touched_at).toBeUndefined();
   });
 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -270,20 +270,20 @@ function refreshRowForError(site: string, entry: AuthRefreshSiteState | undefine
 }
 
 async function runQuick(cmd: CliCommand, opts: { timeoutSeconds: number; profile?: string }): Promise<AuthStatusRow> {
-  const loaded = await loadLazyCommand(cmd);
-  const quickCmd = quickCheckCommand(loaded, opts.timeoutSeconds);
-  if (!quickCmd) {
-    return {
-      site: cmd.site,
-      status: 'unknown',
-      logged_in: '',
-      identity: '',
-      checked: 'skipped',
-      error: 'quickCheck not implemented; use --full to run whoami',
-    };
-  }
-
   try {
+    const loaded = await loadLazyCommand(cmd);
+    const quickCmd = quickCheckCommand(loaded, opts.timeoutSeconds);
+    if (!quickCmd) {
+      return {
+        site: cmd.site,
+        status: 'unknown',
+        logged_in: '',
+        identity: '',
+        checked: 'skipped',
+        error: 'quickCheck not implemented; use --full to run whoami',
+      };
+    }
+
     const result = await executeCommand(quickCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
       siteSession: 'ephemeral',
       keepTab: 'false',
@@ -311,9 +311,9 @@ async function runQuick(cmd: CliCommand, opts: { timeoutSeconds: number; profile
 }
 
 async function runFull(cmd: CliCommand, opts: { timeoutSeconds: number; profile?: string }): Promise<AuthStatusRow> {
-  const loaded = await loadLazyCommand(cmd);
-  const fullCmd = withTimeoutArg(loaded, opts.timeoutSeconds);
   try {
+    const loaded = await loadLazyCommand(cmd);
+    const fullCmd = withTimeoutArg(loaded, opts.timeoutSeconds);
     const result = await executeCommand(fullCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
       siteSession: 'ephemeral',
       keepTab: 'false',
@@ -352,20 +352,20 @@ async function runRefresh(cmd: CliCommand, opts: {
   }
 
   const attemptAt = opts.now.toISOString();
-  const loaded = await loadLazyCommand(cmd);
-  const refreshCmd = refreshCommand(loaded, opts.timeoutSeconds);
-  if (!refreshCmd) {
-    opts.state.sites[cmd.site] = { ...existing, last_attempt_at: attemptAt, last_status: 'unsupported' };
-    return {
-      site: cmd.site,
-      status: 'unsupported',
-      last_touched_at: existing?.last_touched_at ?? '',
-      next_refresh_at: nextRefreshAt(existing),
-      error: 'refresh probe is not available for this site',
-    };
-  }
-
   try {
+    const loaded = await loadLazyCommand(cmd);
+    const refreshCmd = refreshCommand(loaded, opts.timeoutSeconds);
+    if (!refreshCmd) {
+      opts.state.sites[cmd.site] = { ...existing, last_attempt_at: attemptAt, last_status: 'unsupported' };
+      return {
+        site: cmd.site,
+        status: 'unsupported',
+        last_touched_at: existing?.last_touched_at ?? '',
+        next_refresh_at: nextRefreshAt(existing),
+        error: 'refresh probe is not available for this site',
+      };
+    }
+
     const result = await executeCommand(refreshCmd, { timeout: opts.timeoutSeconds } as CommandArgs, false, {
       siteSession: 'persistent',
       keepTab: 'true',


### PR DESCRIPTION
## Problem

`opencli auth status` and `opencli auth refresh` aggregate results across every registered `whoami` adapter, concurrently, via `mapConcurrent` (which `await Promise.all`s its workers). The whole subsystem is designed to degrade *every* per-site failure into a result row (`rowForError` / `refreshRowForError`) — the "network down" test at `auth.test.ts` proves this is the intended contract.

But one failure mode was not protected: a lazy/manifest-loaded adapter that **throws at import/probe time**. Such an adapter rejects its worker promise, which rejects the `Promise.all` in `mapConcurrent`, which crashes the entire `auth status` / `auth refresh` run — so a single malformed adapter takes down the status of every other site.

## Root cause

In `src/commands/auth.ts`, `loadLazyCommand(cmd)` performs `await import(pathToFileURL(internal._modulePath).href)` for lazy adapters (registered with `_lazy: true` / `_modulePath` at `discovery.ts:139-140`). In all three workers this call — plus the dependent command-shaping — sat **outside** the existing per-site `try`/`catch`:

- `runQuick` — `auth.ts:273` (`loadLazyCommand` + `quickCheckCommand`) was before the `try` at line 286.
- `runFull` — `auth.ts:314` (`loadLazyCommand` + `withTimeoutArg`) was before the `try` at line 316.
- `runRefresh` — `auth.ts:355` (`loadLazyCommand` + `refreshCommand` + the `!refreshCmd` unsupported branch) was before the `try` at line 368.

The `catch` blocks already map failures to error rows, but they could never see an import-time throw because it happened before the `try` was entered.

## Fix

Move `loadLazyCommand()` and its dependent command-shaping (`quickCheckCommand` / `withTimeoutArg` / `refreshCommand`), along with the not-implemented (`!quickCmd`) and unsupported (`!refreshCmd`) early-returns, **inside** the existing per-site `try` in each of the three workers. No signature changes, no new helpers — 3 hunks.

- An adapter that throws at import now degrades to `{ status: 'error', logged_in: '', error: <message> }` (status) / a `status: 'error'` row (refresh), exactly like any other adapter failure, and the aggregate resolves with rows for all other sites.
- `runRefresh`: the throttle/skip check (lines 343-352) intentionally stays *before* the `try` so it is unaffected; the `catch` continues to record `last_attempt_at` / `last_status: 'error'` so refresh state stays consistent and `saveAuthRefreshState` still runs.

## Tests

Added 3 tests to `src/commands/auth.test.ts`. A helper registers a lazy `whoami` adapter (`_lazy: true` + `_modulePath` pointing at a temp `.mjs` whose top-level body does `throw new Error('boom')`), mirroring `discovery.ts` manifest registration:

1. `collectAuthStatus` with one healthy quick-check site + one import-throwing lazy site — asserts it resolves (does not reject) and returns both rows, the bad site as `status: 'error'` / `logged_in: ''` / error containing `boom`, the good site unaffected.
2. `collectAuthRefresh` — same mix; the bad site yields a `status: 'error'` row, the good site is still touched, and the aggregate does not throw.
3. Asserts the state file is still written (`saveAuthRefreshState` ran): the good site records `last_status: 'touched'`, the failing site records `last_attempt_at` / `last_status: 'error'` with no `last_touched_at`.

Verification: `npx tsc --noEmit` clean; `npx vitest run src/commands/auth.test.ts` -> 13 passed. Confirmed the tests fail on the unpatched source (unhandled `boom` rejection) and pass with the fix.

## Scope

Surgical hardening faithful to the module's existing failure-to-row design; only `auth.ts` workers + co-located tests. Edge-case (requires a malformed/throwing adapter module), but currently uncovered, so the per-site error contract silently didn't hold for import failures. No open issue/PR touches this file (only #1879/#1881, both merged).