### PR TITLE
fix(daemon): don't silently re-execute mutating commands on fetch timeout

### DIFF
--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT } from '../daemon-utils.js';
 import {
   BrowserCommandError,
   fetchDaemonStatus,
@@ -242,5 +243,41 @@ describe('daemon-client', () => {
       hint: 'Inspect state before retrying.',
     } satisfies Partial<BrowserCommandError>);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendCommand does not silently retry a mutating command on fetch AbortError', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+    );
+
+    await expect(sendCommand('exec', { code: 'window.__mutate = true' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: COMMAND_RESULT_UNKNOWN_CODE,
+      hint: COMMAND_RESULT_UNKNOWN_HINT,
+    } satisfies Partial<BrowserCommandError>);
+    // No second dispatch — the command must not be re-POSTed with a fresh id.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendCommand still retries on TypeError (connection refused) since the command never reached the daemon', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_456);
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+      } as Response);
+
+    await expect(sendCommand('exec', { code: '1 + 1' })).resolves.toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const ids = fetchMock.mock.calls.map(([, init]) => {
+      const body = JSON.parse(String(init?.body)) as { id: string };
+      return body.id;
+    });
+    expect(ids[0]).not.toBe(ids[1]);
   });
 });

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -6,6 +6,7 @@
 
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { sleep } from '../utils.js';
+import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT, commandResultUnknownMessage } from '../daemon-utils.js';
 import { classifyBrowserError } from './errors.js';
 import { resolveProfileContextId } from './profile.js';
 
@@ -169,8 +170,12 @@ export async function requestDaemonShutdown(opts?: { timeout?: number }): Promis
  * (sendCommand, sendCommandFull) only shape the return value.
  *
  * Retries up to 4 times:
- * - Network errors (TypeError, AbortError): retry at 500ms
+ * - Connection failures (TypeError, request never reached the daemon): retry at 500ms
  * - Transient browser errors: retry at the delay suggested by classifyBrowserError()
+ *
+ * A fetch AbortError (the 30s request timeout fired after dispatch) is NOT
+ * retried, because the daemon may still be executing the command; re-sending
+ * with a fresh id would double-dispatch it. It surfaces as command_result_unknown.
  */
 async function sendCommandRaw(
   action: DaemonCommand['action'],
@@ -216,9 +221,23 @@ async function sendCommandRaw(
 
       return result;
     } catch (err) {
-      const isNetworkError = err instanceof TypeError
-        || (err instanceof Error && err.name === 'AbortError');
-      if (isNetworkError && attempt < maxRetries) {
+      // A fetch AbortError means our 30s request timeout fired *after* the
+      // request was dispatched — the daemon may still be holding/executing the
+      // command for up to its pending window. Retrying re-POSTs with a fresh id
+      // (generateId() above), which the daemon does not see as a duplicate
+      // (it dedups only by body.id), so the same mutating command would be
+      // dispatched twice. Surface it as an unknown result instead of retrying,
+      // mirroring the command_result_unknown semantics handled above.
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new BrowserCommandError(
+          commandResultUnknownMessage(action),
+          COMMAND_RESULT_UNKNOWN_CODE,
+          COMMAND_RESULT_UNKNOWN_HINT,
+        );
+      }
+      // A TypeError means the request never reached the daemon (e.g. connection
+      // refused), so it is safe to re-send.
+      if (err instanceof TypeError && attempt < maxRetries) {
         await sleep(500);
         continue;
       }


### PR DESCRIPTION
## Problem

The daemon client's retry loop can silently re-execute the *same* mutating browser command (navigate / click / type / `set-file-input` / `insert-text` / `exec`) twice when the 30s client-side request timeout fires while the daemon is still executing the command. For a non-idempotent command this double-dispatch can e.g. submit a form twice, navigate twice, or insert text twice.

## Root cause

`src/browser/daemon-client.ts` `sendCommandRaw`:

- The command id is regenerated on every attempt — `const id = generateId();` (daemon-client.ts:182), inside the retry `for` loop.
- The catch block (daemon-client.ts:218-224 on origin/main) classified **both** a `TypeError` and a fetch `AbortError` as one retryable "network error" and re-sent the command:
  ```ts
  const isNetworkError = err instanceof TypeError
    || (err instanceof Error && err.name === 'AbortError');
  if (isNetworkError && attempt < maxRetries) { await sleep(500); continue; }
  ```

These two failures are not equivalent:
- `TypeError` → the request never reached the daemon (e.g. connection refused), so re-sending is safe.
- `AbortError` → our own 30s request timeout (`requestDaemon(..., { timeout: 30000 })`) aborted the fetch *after* the request was dispatched. The daemon may still be holding the command pending and executing it.

The daemon dedups requests only by `body.id` — `if (pending.has(body.id))` (src/daemon.ts:315, returns `Duplicate command id already pending; retry`). Because the client regenerates the id per attempt, the retry arrives with a *fresh* id, bypasses the duplicate guard, and the daemon dispatches the same command a second time. There is no write/non-idempotent exclusion and no content- or extension-level dedup.

## Fix

Split the single `isNetworkError` condition into two branches (minimal, two-branch change):

- `AbortError` → throw a `BrowserCommandError` with `errorCode: 'command_result_unknown'` and hint `'Inspect state before retrying.'`, instead of retrying. This surfaces the ambiguous in-flight state to the caller rather than blindly re-running a possibly-already-executed mutation.
- `TypeError` → unchanged: still retries at 500ms (the command never reached the daemon).

All other paths are untouched: `maxRetries`, the duplicate-command-id `continue`, and the `classifyBrowserError` transient-retry path. The doc comment above `sendCommandRaw` is updated to match.

This mirrors the maintainer's existing semantics: the daemon already returns `command_result_unknown` with the same `'Inspect state before retrying.'` hint for the post-dispatch-timeout case, and the client already special-cases that response (daemon-client.ts:201) and refuses to retry it (existing test `sendCommand does not retry command_result_unknown even when the message looks transient`). This change extends that same "don't re-run an in-flight mutation" semantic to the *client-side* fetch timeout, which the result-side handling didn't cover.

## Tests

`src/browser/daemon-client.test.ts` (vitest, `fetch` mocked):

1. `sendCommand does not silently retry a mutating command on fetch AbortError` — mock fetch to reject with an `AbortError`; asserts fetch is called exactly once and the call rejects with `BrowserCommandError` code `command_result_unknown` (no second dispatch / no fresh id re-sent).
2. `sendCommand still retries on TypeError (connection refused) since the command never reached the daemon` — mock fetch to reject once with a `TypeError` then resolve ok; asserts 2 calls, the two command ids differ, and it resolves. (Regression guard for the genuine connection-failure retry.)
3. The existing duplicate-command-id retry test and the existing `command_result_unknown` no-retry test remain green.

`npx vitest run src/browser/daemon-client.test.ts` → 15 passed. `npx tsc --noEmit` → clean.

## Scope / honesty

This only triggers when a command stays in-flight longer than the 30s client request timeout (the daemon's pending window is longer), so the practical blast radius is narrow — but for a non-idempotent command the double-execution is a real correctness hazard, and the failure is silent today. The fix is intentionally limited to the `AbortError` branch and preserves all daemon-hiccup resilience for genuine connection failures. No existing issue/PR found for this case.
## Note on the trade-off

A genuine *pre-dispatch* stall that somehow exceeds the 30s client timeout on localhost will now surface `command_result_unknown` instead of being retried. This is the safe direction (it cannot double-execute a mutating command) and is consistent with the `command_result_unknown` semantics already used elsewhere in this client. Connection-refused (`TypeError`, request never reached the daemon) remains retryable.
