### PR TITLE
fix: bypass proxy for loopback daemon requests

### DIFF
--- a/src/node-network.test.ts
+++ b/src/node-network.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { decideProxy, hasProxyEnv } from './node-network.js';
+const nativeFetchMock = vi.hoisted(() => vi.fn());
+const undiciFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('undici', () => ({
+  Agent: class Agent {},
+  EnvHttpProxyAgent: class EnvHttpProxyAgent {},
+  fetch: undiciFetchMock,
+}));
+
+vi.stubGlobal('fetch', nativeFetchMock);
+
+const { decideProxy, fetchWithNodeNetwork, hasProxyEnv } = await import('./node-network.js');
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  nativeFetchMock.mockReset();
+  undiciFetchMock.mockReset();
+});
 
 describe('node network proxy decisions', () => {
   it('detects common proxy env variables', () => {
@@ -89,5 +106,20 @@ describe('node network proxy decisions', () => {
       mode: 'proxy',
       proxyUrl: 'socks5://127.0.0.1:1080',
     });
+  });
+
+  it('uses native fetch for loopback URLs even when proxy env vars exist', async () => {
+    const response = new Response('direct');
+    nativeFetchMock.mockResolvedValue(response);
+    undiciFetchMock.mockResolvedValue(new Response('proxied'));
+
+    vi.stubEnv('HTTP_PROXY', 'http://127.0.0.1:7897');
+    vi.stubEnv('HTTPS_PROXY', 'http://127.0.0.1:7897');
+
+    const result = await fetchWithNodeNetwork('http://127.0.0.1:19825/status');
+
+    expect(result).toBe(response);
+    expect(nativeFetchMock).toHaveBeenCalledTimes(1);
+    expect(undiciFetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/node-network.ts
+++ b/src/node-network.ts
@@ -187,13 +187,16 @@ export function decideProxy(url: URL, env: NodeJS.ProcessEnv = process.env): Pro
 
 export function getDispatcherForUrl(url: URL, env: NodeJS.ProcessEnv = process.env): Dispatcher {
   const config = resolveProxyConfig(env);
+  if (config.noProxyEntries.some((entry) => matchesNoProxyEntry(url, entry))) {
+    return directDispatcher;
+  }
   if (!config.httpProxy && !config.httpsProxy) return directDispatcher;
   return createProxyDispatcher(config);
 }
 
 export async function fetchWithNodeNetwork(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
   const url = resolveUrl(input);
-  if (!url || !hasProxyEnv()) {
+  if (!url || !hasProxyEnv() || decideProxy(url).mode === 'direct') {
     return nativeFetch(input, init);
   }
 


### PR DESCRIPTION
## Description

Fix `opencli` daemon connectivity when a system-wide proxy is enabled.

`opencli` was routing localhost traffic through the proxy layer, which prevented the CLI from reaching its local daemon on `127.0.0.1:19825`. This change makes loopback URLs bypass proxy dispatch and adds a regression test to cover the behavior.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

`opencli doctor` after the fix:

```text
opencli v1.8.3 doctor (node v20.20.2)

[OK] Daemon: running on port 19825 (v1.8.3)
[OK] Extension: connected (v1.0.19)

Profiles:
  • jaje896r: connected v1.0.19
[OK] Connectivity: connected in 0.3s

Everything looks good!