### PR TITLE
fix(xiaohongshu/download): pick highest-res video master across codecs (h264-only capped at 720p)

### DIFF
--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -151,9 +151,24 @@ export function buildDownloadExtractJs(noteId) {
                 const fullUrl = vUrl.startsWith('http') ? vUrl : 'https://sns-video-bd.xhscdn.com/' + vUrl;
                 pushMedia('video', fullUrl);
               }
-              const streams = video.media?.stream?.h264 || [];
-              for (const stream of streams) {
-                if (stream.masterUrl) pushMedia('video', stream.masterUrl);
+              // xiaohongshu publishes each video under several codecs
+              // (h264 + h265/hevc, occasionally h266/av1). The 1080p/2K
+              // rendition is frequently carried ONLY by h265, so reading the
+              // h264 list alone silently caps downloads at 720p. Pick the
+              // highest-resolution master across every codec (ties broken by
+              // bitrate, which keeps the more compatible h264 at equal size).
+              const codecStreams = video.media?.stream || {};
+              const allStreams = [
+                ...(codecStreams.h264 || []),
+                ...(codecStreams.h265 || []),
+                ...(codecStreams.h266 || []),
+                ...(codecStreams.av1 || []),
+              ].filter(s => s && s.masterUrl);
+              if (allStreams.length) {
+                const best = allStreams.slice().sort((a, b) =>
+                  (b.height || 0) - (a.height || 0)
+                  || (b.videoBitrate || 0) - (a.videoBitrate || 0))[0];
+                if (best.masterUrl) pushMedia('video', best.masterUrl);
               }
             }
           }

--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -155,20 +155,23 @@ export function buildDownloadExtractJs(noteId) {
               // (h264 + h265/hevc, occasionally h266/av1). The 1080p/2K
               // rendition is frequently carried ONLY by h265, so reading the
               // h264 list alone silently caps downloads at 720p. Pick the
-              // highest-resolution master across every codec (ties broken by
-              // bitrate, which keeps the more compatible h264 at equal size).
+              // highest-resolution master across every codec; at equal
+              // resolution prefer the most compatible codec (h264 > h265 >
+              // h266 > av1), and only then the higher bitrate.
               const codecStreams = video.media?.stream || {};
-              const allStreams = [
-                ...(codecStreams.h264 || []),
-                ...(codecStreams.h265 || []),
-                ...(codecStreams.h266 || []),
-                ...(codecStreams.av1 || []),
-              ].filter(s => s && s.masterUrl);
+              const codecPreference = ['h264', 'h265', 'h266', 'av1'];
+              const allStreams = [];
+              codecPreference.forEach((codec, rank) => {
+                (codecStreams[codec] || []).forEach(s => {
+                  if (s && s.masterUrl) allStreams.push({ stream: s, rank });
+                });
+              });
               if (allStreams.length) {
                 const best = allStreams.slice().sort((a, b) =>
-                  (b.height || 0) - (a.height || 0)
-                  || (b.videoBitrate || 0) - (a.videoBitrate || 0))[0];
-                if (best.masterUrl) pushMedia('video', best.masterUrl);
+                  (b.stream.height || 0) - (a.stream.height || 0)
+                  || a.rank - b.rank
+                  || (b.stream.videoBitrate || 0) - (a.stream.videoBitrate || 0))[0];
+                if (best.stream.masterUrl) pushMedia('video', best.stream.masterUrl);
               }
             }
           }

--- a/clis/xiaohongshu/download.test.js
+++ b/clis/xiaohongshu/download.test.js
@@ -313,4 +313,76 @@ describe('xiaohongshu download buildDownloadExtractJs carousel ordering (JSDOM)'
         expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/test.mp4']);
         expect(result.media.map((m) => m.type)).toEqual(['video', 'image']);
     });
+
+    it('picks the highest-resolution master across codecs (1080p h265 over 720p h264)', () => {
+        // Modern xiaohongshu video notes expose no origin url; the 1080p rendition
+        // is carried only by h265, so an h264-only read silently capped at 720p.
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            video: {
+                                media: {
+                                    stream: {
+                                        h264: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h264-720.mp4', height: 1280, width: 720, videoBitrate: 1205288 }],
+                                        h265: [
+                                            { masterUrl: 'https://sns-video-bd.xhscdn.com/h265-720.mp4', height: 1280, width: 720, videoBitrate: 933371 },
+                                            { masterUrl: 'https://sns-video-bd.xhscdn.com/h265-1080.mp4', height: 1920, width: 1080, videoBitrate: 1054537 },
+                                        ],
+                                        h266: [],
+                                        av1: [],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
+        expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/h265-1080.mp4']);
+    });
+
+    it('falls back to an h264-only stream when no higher-codec rendition exists', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            video: { media: { stream: { h264: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/only-h264.mp4', height: 1280, videoBitrate: 1200000 }] } } },
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
+        expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/only-h264.mp4']);
+    });
+
+    it('prefers the more compatible h264 master when resolutions tie', () => {
+        const initialState = {
+            note: {
+                noteDetailMap: {
+                    '69f9716c000000003601f90e': {
+                        note: {
+                            video: {
+                                media: {
+                                    stream: {
+                                        h264: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h264-1080.mp4', height: 1920, width: 1080, videoBitrate: 2000000 }],
+                                        h265: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h265-1080.mp4', height: 1920, width: 1080, videoBitrate: 1400000 }],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = runExtract({ initialState });
+        const videos = result.media.filter((m) => m.type === 'video').map((m) => m.url);
+        expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/h264-1080.mp4']);
+    });
 });

--- a/clis/xiaohongshu/download.test.js
+++ b/clis/xiaohongshu/download.test.js
@@ -362,7 +362,11 @@ describe('xiaohongshu download buildDownloadExtractJs carousel ordering (JSDOM)'
         expect(videos).toEqual(['https://sns-video-bd.xhscdn.com/only-h264.mp4']);
     });
 
-    it('prefers the more compatible h264 master when resolutions tie', () => {
+    it('prefers the more compatible h264 master at equal resolution, even when h265 has the higher bitrate', () => {
+        // Locks in explicit codec preference: at equal resolution the tie-break
+        // is codec rank (h264 > h265 > h266 > av1), NOT bitrate. Here h265
+        // carries the higher bitrate yet h264 must still win — this would fail
+        // under a bitrate-only tie-break.
         const initialState = {
             note: {
                 noteDetailMap: {
@@ -371,8 +375,8 @@ describe('xiaohongshu download buildDownloadExtractJs carousel ordering (JSDOM)'
                             video: {
                                 media: {
                                     stream: {
-                                        h264: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h264-1080.mp4', height: 1920, width: 1080, videoBitrate: 2000000 }],
-                                        h265: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h265-1080.mp4', height: 1920, width: 1080, videoBitrate: 1400000 }],
+                                        h264: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h264-1080.mp4', height: 1920, width: 1080, videoBitrate: 1400000 }],
+                                        h265: [{ masterUrl: 'https://sns-video-bd.xhscdn.com/h265-1080.mp4', height: 1920, width: 1080, videoBitrate: 2000000 }],
                                     },
                                 },
                             },


### PR DESCRIPTION
## What

xiaohongshu (and `rednote`, which reuses the same extractor) video downloads were silently capped at **720p**.

`buildDownloadExtractJs` read only `video.media.stream.h264`. But on modern xiaohongshu video notes the origin url is absent — `video.url` / `video.originVideoKey` / `video.consumer.originVideoKey` are all `null` — and the higher-resolution rendition is published **only under `h265`**. So the h264-only fallback dropped it and the user got 720p.

## Evidence (live notes, all `origin=null`)

| note id | h264 (read before) | h265 (ignored before) |
|---|---|---|
| `67d1824d…` | 720p | 1080p |
| `6a1554fb…` | 720p | 1440p |
| `6a2521e9…` | 720p | 1080p |
| 风景短片 | 720p | **2160p (4K)** |

The selected h265 master downloads as a complete, valid mp4 (ffprobe-confirmed `hevc 3840×2160` on the 4K note).

## Fix

Pick the highest-resolution `masterUrl` across all codecs (`h264/h265/h266/av1`), breaking ties by bitrate so the more compatible h264 is kept at equal resolution. Origin-url behavior is unchanged.

## Tests

- 3 new JSDOM cases in `download.test.js`: 1080p h265 chosen over 720p h264; h264-only fallback still works; equal-resolution tie prefers h264.
- `vitest run clis/xiaohongshu/` → **184 passed**.
- `check:silent-column-drop` and `check:typed-error-lint` gates: no new violations.
