### PR TITLE
fix(cli): accept browser `--window` placed after the subcommand (#1850)

### DIFF
--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -116,6 +116,35 @@ describe('rewriteBrowserArgv', () => {
     ]);
   });
 
+  it('hoists a trailing parent `--window` option to before the subcommand (#1850)', () => {
+    // The natural placement (after the subcommand + its args) must work the same
+    // as the parent-slot placement.
+    expect(rewriteBrowserArgv(['browser', 'work', 'open', 'https://x.com', '--window', 'background'])).toEqual([
+      'browser', '--session', 'work', '--window', 'background', 'open', 'https://x.com',
+    ]);
+    expect(rewriteBrowserArgv(['browser', 'work', 'state', '--window', 'foreground'])).toEqual([
+      'browser', '--session', 'work', '--window', 'foreground', 'state',
+    ]);
+  });
+
+  it('hoists the `--window=<mode>` long form too (#1850)', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'open', 'https://x.com', '--window=background'])).toEqual([
+      'browser', '--session', 'work', '--window=background', 'open', 'https://x.com',
+    ]);
+  });
+
+  it('leaves an already-parent-slot `--window` untouched (#1850)', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', '--window', 'background', 'open', 'https://x.com'])).toEqual([
+      'browser', '--session', 'work', '--window', 'background', 'open', 'https://x.com',
+    ]);
+  });
+
+  it('hoists `--window` alongside a leading root --profile flag (#1850)', () => {
+    expect(rewriteBrowserArgv(['--profile', 'work', 'browser', 'mercury', 'open', 'https://x.com', '--window', 'background'])).toEqual([
+      '--profile', 'work', 'browser', '--session', 'mercury', '--window', 'background', 'open', 'https://x.com',
+    ]);
+  });
+
   it('leaves argv alone when the root command is not `browser`, even if `browser` appears later', () => {
     // The first browser keyword does NOT win — it must be at the root.
     expect(rewriteBrowserArgv(['twitter', 'browser', 'work', 'state'])).toEqual([

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -116,7 +116,41 @@ export function rewriteBrowserArgv(argv: readonly string[]): string[] {
   if (BROWSER_SUBCOMMAND_NAMES.has(next)) return result;
   // Splice in --session <name> in place of the positional.
   result.splice(sessionIdx, 1, '--session', next);
+  // `--window` is a parent (`browser`) option, so commander only accepts it
+  // *before* the leaf subcommand. Users naturally write it at the end
+  // (`browser work open <url> --window background`); hoist such a trailing
+  // occurrence to the parent option slot so the obvious placement works. (#1850)
+  hoistParentWindowOption(result, sessionIdx + 2);
   return result;
+}
+
+/**
+ * Move a `--window <mode>` / `--window=<mode>` that appears after the browser
+ * subcommand to the parent option slot (just before the subcommand), so
+ * `browser <session> <subcommand> ... --window <mode>` parses the same as the
+ * already-working `browser <session> --window <mode> <subcommand> ...`. Mutates
+ * `argv` in place; only the first occurrence is hoisted. Stops at `--`.
+ */
+function hoistParentWindowOption(argv: string[], fromIndex: number): void {
+  const subIdx = argv.findIndex((tok, idx) => idx >= fromIndex && BROWSER_SUBCOMMAND_NAMES.has(tok));
+  if (subIdx === -1) return;
+  for (let k = subIdx + 1; k < argv.length; k += 1) {
+    const tok = argv[k];
+    if (tok === '--') return;
+    if (tok === '--window') {
+      const value = argv[k + 1];
+      const removed = value !== undefined && !value.startsWith('-')
+        ? argv.splice(k, 2)
+        : argv.splice(k, 1);
+      argv.splice(subIdx, 0, ...removed);
+      return;
+    }
+    if (tok.startsWith('--window=')) {
+      const removed = argv.splice(k, 1);
+      argv.splice(subIdx, 0, ...removed);
+      return;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## What

`opencli browser <session> <subcommand> ... --window <mode>` fails with `error: unknown option '--window'` (#1850).

`--window` is registered on the `browser` **parent** command, so commander only accepts it *before* the leaf subcommand:

- ✅ `opencli browser work --window background open https://x.com`
- ❌ `opencli browser work open https://x.com --window background` ← the obvious placement

## Fix

`rewriteBrowserArgv` (the existing `browser <session> <subcommand>` argv preprocessor) now hoists a trailing `--window <mode>` / `--window=<mode>` to the parent option slot, so both placements parse identically. argv without `--window` is unchanged; only the first occurrence is hoisted; the scan stops at `--`.

## Tests / verification

- 4 new `rewriteBrowserArgv` cases: trailing form, `=` form, already-in-slot no-op, and with a leading `--profile`. `vitest run src/cli-argv-preprocess.test.ts` → **32 passed**.
- Live: `opencli browser <session> open https://example.com --window background` now opens the page (previously errored with `unknown option '--window'`).

Fixes #1850
