### PR TITLE
fix(linkedin): preserve safe-send and public job details

### DIFF
--- a/clis/linkedin/job-detail.js
+++ b/clis/linkedin/job-detail.js
@@ -16,6 +16,14 @@ function normalizeJobUrl(value) {
   return `https://www.linkedin.com/jobs/search/?currentJobId=${match[1]}`;
 }
 
+function normalizePublicJobUrl(value) {
+  const url = assertSafeLinkedinUrl(value, 'job-url');
+  const parsed = new URL(url);
+  const match = parsed.pathname.match(/^\/jobs\/view\/(?:[^/]+-)?(\d+)/) || parsed.search.match(/[?&]currentJobId=(\d+)/);
+  if (!match) throw new ArgumentError('job-url must be a https://www.linkedin.com/jobs/view/<id> URL');
+  return `https://www.linkedin.com/jobs/view/${match[1]}`;
+}
+
 function decodeLinkedinRedirect(url) {
   if (!url) return '';
   try {
@@ -25,10 +33,86 @@ function decodeLinkedinRedirect(url) {
   return normalizeHttpUrl(url);
 }
 
+function stripHtml(value) {
+  return normalizeWhitespace(String(value || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:p|li|div|section|article|h[1-6])>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'"));
+}
+
+function trimPublicDescription(value) {
+  const text = normalizeWhitespace(value);
+  const marker = text.search(/\b(?:We're looking|We are looking|About the role|About The Role|Job description|Job Description|Responsibilities|Qualifications)\b/);
+  if (marker > 0 && /use ai|sign in|tailor my resume|email or phone/i.test(text.slice(0, marker))) {
+    return normalizeWhitespace(text.slice(marker));
+  }
+  return text;
+}
+
+function extractPublicDescriptionFromHtml(html) {
+  const text = String(html || '');
+  for (const match of text.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)) {
+    try {
+      const payload = JSON.parse(match[1] || '{}');
+      const items = Array.isArray(payload) ? payload : [payload];
+      for (const item of items) {
+        const description = trimPublicDescription(stripHtml(item?.description || item?.jobDescription || ''));
+        if (description.length > 40) return description;
+      }
+    } catch {}
+  }
+  const plain = stripHtml(text);
+  const reportIndex = plain.search(/\bReport this job\b/i);
+  const start = reportIndex >= 0 ? reportIndex + plain.match(/\bReport this job\b/i)[0].length : plain.search(/\b(?:We're looking|About the role|Job description|Responsibilities)\b/i);
+  if (start < 0) return '';
+  const rest = plain.slice(start);
+  const endMatch = rest.search(/\b(?:Show more|Show less|Seniority level|Employment type|Job function|Industries|Similar jobs|People also viewed)\b/i);
+  const chunk = trimPublicDescription(rest.slice(0, endMatch > 0 ? endMatch : 5000));
+  return chunk.length > 40 ? chunk : '';
+}
+
+async function fetchPublicJobDescription(url) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    });
+    if (!response.ok) return '';
+    return extractPublicDescriptionFromHtml(await response.text());
+  } catch {
+    return '';
+  }
+}
+
 function buildExtractionScript() {
   return String.raw`(() => {
     const clean = (s) => String(s || '').replace(/[\u00a0\u202f]+/g, ' ').replace(/\s+/g, ' ').trim();
     const readRenderedDescription = () => {
+      const readJsonLd = () => {
+        const scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        for (const script of scripts) {
+          let payload;
+          try { payload = JSON.parse(script.textContent || '{}'); } catch { continue; }
+          const items = Array.isArray(payload) ? payload : [payload];
+          for (const item of items) {
+            const value = clean(item?.description || item?.jobDescription || '');
+            if (value.length > 40) return value.replace(/<[^>]+>/g, ' ');
+          }
+        }
+        return '';
+      };
+      const jsonLd = readJsonLd();
+      if (jsonLd) return clean(jsonLd);
       const expanders = Array.from(document.querySelectorAll('button, a'))
         .filter((el) => /\b(show more|see more|more)\b/i.test(clean(el.innerText || el.textContent || el.getAttribute('aria-label') || '')));
       for (const expander of expanders.slice(0, 3)) {
@@ -47,6 +131,14 @@ function buildExtractionScript() {
       for (const candidate of candidates) {
         const value = clean(candidate.innerText || candidate.textContent || '');
         if (value && value.length > 40 && !/^show more$/i.test(value)) return value.replace(/^About the job\s*/i, '');
+      }
+      const lines = (document.body?.innerText || '').split(/\n+/).map(clean).filter(Boolean);
+      const reportIndex = lines.findIndex((line) => /^report this job$/i.test(line));
+      const startIndex = reportIndex >= 0 ? reportIndex + 1 : lines.findIndex((line) => /^we'?re looking|^about the role|^job description|^responsibilities/i.test(line));
+      if (startIndex >= 0) {
+        const endIndex = lines.findIndex((line, index) => index > startIndex && /^(show more|show less|seniority level|employment type|job function|industries|similar jobs|people also viewed)$/i.test(line));
+        const chunk = lines.slice(startIndex, endIndex > startIndex ? endIndex : startIndex + 80).join(' ');
+        if (chunk.length > 40) return chunk;
       }
       return '';
     };
@@ -151,17 +243,34 @@ cli({
   columns: ['title', 'company', 'location', 'workplace_type', 'job_type', 'applicants', 'listed', 'apply_url', 'company_url', 'url', 'description'],
   func: async (page, args) => {
     if (!page) throw new CommandExecutionError('Browser session required for linkedin job-detail');
-    const jobUrl = normalizeJobUrl(args['job-url']);
-    await page.goto(jobUrl);
+    const publicJobUrl = normalizePublicJobUrl(args['job-url']);
+    await page.goto(publicJobUrl);
     await page.wait(4);
-    await assertLinkedInAuthenticated(page, 'LinkedIn job-detail');
-    const row = unwrapEvaluateResult(await page.evaluate(buildExtractionScript()));
+    let row = unwrapEvaluateResult(await page.evaluate(buildExtractionScript()));
+    let publicDescription = '';
+    if (!normalizeWhitespace(row?.description)) {
+      publicDescription = await fetchPublicJobDescription(publicJobUrl);
+      if (publicDescription) row = { ...row, description: publicDescription };
+    }
+    if (!normalizeWhitespace(row?.title) || !normalizeWhitespace(row?.description)) {
+      const jobUrl = normalizeJobUrl(args['job-url']);
+      await page.goto(jobUrl);
+      await page.wait(4);
+      await assertLinkedInAuthenticated(page, 'LinkedIn job-detail');
+      const authenticatedRow = unwrapEvaluateResult(await page.evaluate(buildExtractionScript()));
+      row = {
+        ...authenticatedRow,
+        description: normalizeWhitespace(authenticatedRow?.description) || normalizeWhitespace(row?.description) || publicDescription,
+      };
+    }
     return [normalizeDetail(row)];
   },
 });
 
 export const __test__ = {
   normalizeJobUrl,
+  normalizePublicJobUrl,
   decodeLinkedinRedirect,
+  extractPublicDescriptionFromHtml,
   normalizeDetail,
 };

--- a/clis/linkedin/job-detail.test.js
+++ b/clis/linkedin/job-detail.test.js
@@ -3,7 +3,13 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './job-detail.js';
 
-const { normalizeJobUrl, decodeLinkedinRedirect, normalizeDetail } = await import('./job-detail.js').then((m) => m.__test__);
+const {
+  normalizeJobUrl,
+  normalizePublicJobUrl,
+  decodeLinkedinRedirect,
+  extractPublicDescriptionFromHtml,
+  normalizeDetail,
+} = await import('./job-detail.js').then((m) => m.__test__);
 
 describe('linkedin job-detail adapter', () => {
   const command = getRegistry().get('linkedin/job-detail');
@@ -19,6 +25,12 @@ describe('linkedin job-detail adapter', () => {
     expect(normalizeJobUrl('https://www.linkedin.com/jobs/view/123456?x=1')).toBe('https://www.linkedin.com/jobs/search/?currentJobId=123456');
   });
 
+  it('normalizes public LinkedIn job urls', () => {
+    expect(normalizePublicJobUrl('https://www.linkedin.com/jobs/view/123456?x=1')).toBe('https://www.linkedin.com/jobs/view/123456');
+    expect(normalizePublicJobUrl('https://www.linkedin.com/jobs/view/senior-engineer-at-acme-123456')).toBe('https://www.linkedin.com/jobs/view/123456');
+    expect(normalizePublicJobUrl('https://www.linkedin.com/jobs/search/?currentJobId=123456')).toBe('https://www.linkedin.com/jobs/view/123456');
+  });
+
   it('rejects non-job URLs', () => {
     expect(() => normalizeJobUrl('https://www.linkedin.com/feed/')).toThrow(ArgumentError);
     expect(() => normalizeJobUrl('https://example.com/jobs/view/1')).toThrow(ArgumentError);
@@ -28,6 +40,20 @@ describe('linkedin job-detail adapter', () => {
     expect(decodeLinkedinRedirect('https://www.linkedin.com/redir/redirect/?url=https%3A%2F%2Fexample.com%2Fapply')).toBe('https://example.com/apply');
     expect(decodeLinkedinRedirect('https://www.linkedin.com/redir/redirect/?url=javascript%3Aalert(1)')).toBe('');
     expect(decodeLinkedinRedirect('javascript:alert(1)')).toBe('');
+  });
+
+  it('extracts public job descriptions from LinkedIn HTML', () => {
+    expect(extractPublicDescriptionFromHtml(`
+      <html><body>
+        <div>Report this job</div>
+        <p>We're looking for Next.js Developers.</p>
+        <ul><li>Build web applications using Next.js and React.</li></ul>
+        <h3>Seniority level</h3>
+      </body></html>
+    `)).toBe("We're looking for Next.js Developers. Build web applications using Next.js and React.");
+    expect(extractPublicDescriptionFromHtml(`
+      <script type="application/ld+json">{"description":"<p>Design and build coding benchmarks for AI models.</p>"}</script>
+    `)).toBe('Design and build coding benchmarks for AI models.');
   });
 
   it('requires stable title in extracted detail', () => {

--- a/clis/linkedin/safe-send.js
+++ b/clis/linkedin/safe-send.js
@@ -53,6 +53,10 @@ function textContainsNormalized(haystack, needle) {
   return !n || h.includes(n);
 }
 
+function hasLineBreaks(value) {
+  return /\r|\n/.test(String(value ?? ''));
+}
+
 function selectBestHeaderName(headerNames, expectedName) {
   const expected = normalizeName(expectedName);
   const names = (Array.isArray(headerNames) ? headerNames : [])
@@ -104,6 +108,12 @@ function assessThreadSafety(probe, expected) {
 function requireStringArg(args, key, label = key) {
   const value = normalizeWhitespace(args[key]);
   if (!value) throw new ArgumentError(`${label} is required`);
+  return value;
+}
+
+function requireRawStringArg(args, key, label = key) {
+  const value = String(args[key] ?? '');
+  if (!normalizeWhitespace(value)) throw new ArgumentError(`${label} is required`);
   return value;
 }
 
@@ -198,6 +208,78 @@ function buildReadComposerScript() {
   })()`;
 }
 
+function buildFillComposerMultilineScript(message) {
+  return `(() => {
+    const marker = '__OPENCLI_LINKEDIN_FILL_COMPOSER_MULTILINE__';
+    void marker;
+    const message = ${JSON.stringify(String(message ?? ''))};
+    const normalize = (s) => String(s || '').replace(/[\\u00a0\\u202f]/g, ' ').replace(/\\s+/g, ' ').trim();
+    const composer = Array.from(document.querySelectorAll('[contenteditable="true"][role="textbox"], div.msg-form__contenteditable[contenteditable="true"], [aria-label*="Write a message" i]'))
+      .find((el) => !el.closest('[aria-hidden="true"]') && el.offsetParent !== null);
+    if (!composer) return { ok: false, error: 'composer_not_found', composerText: '', method: '' };
+
+    const setDomMultiline = () => {
+      composer.innerHTML = '';
+      const normalized = message.replace(/\\r\\n/g, '\\n').replace(/\\r/g, '\\n');
+      const lines = normalized.split('\\n');
+      lines.forEach((line, index) => {
+        if (index > 0) composer.appendChild(document.createElement('br'));
+        if (line) composer.appendChild(document.createTextNode(line));
+      });
+      composer.dispatchEvent(new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        inputType: 'insertFromPaste',
+        data: message,
+      }));
+      composer.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertFromPaste',
+        data: message,
+      }));
+      return { method: 'dom_multiline' };
+    };
+
+    composer.focus();
+    composer.innerHTML = '';
+    composer.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward', data: null }));
+
+    let method = 'dom_multiline';
+    try {
+      if (typeof DataTransfer !== 'undefined' && typeof ClipboardEvent !== 'undefined') {
+        const data = new DataTransfer();
+        data.setData('text/plain', message);
+        const paste = new ClipboardEvent('paste', {
+          clipboardData: data,
+          bubbles: true,
+          cancelable: true,
+        });
+        composer.dispatchEvent(paste);
+        method = 'paste_event';
+      }
+    } catch {
+      method = 'dom_multiline';
+    }
+
+    if (normalize(composer.innerText || composer.textContent) !== normalize(message)) {
+      method = setDomMultiline().method;
+    }
+
+    const brCount = composer.querySelectorAll('br').length;
+    const childBlockCount = Array.from(composer.children).filter((el) => {
+      const tag = String(el.tagName || '').toLowerCase();
+      return tag === 'br' || tag === 'div' || tag === 'p';
+    }).length;
+
+    return {
+      ok: normalize(composer.innerText || composer.textContent) === normalize(message),
+      composerText: composer.innerText || composer.textContent || '',
+      method,
+      renderedBreaks: brCount + childBlockCount,
+    };
+  })()`;
+}
+
 function buildClickSendScript() {
   return String.raw`(() => {
     const marker = '__OPENCLI_LINKEDIN_CLICK_SEND__';
@@ -224,6 +306,24 @@ async function probeThread(page) {
   };
 }
 
+async function fillComposer(page, message) {
+  if (!hasLineBreaks(message)) {
+    await page.insertText(message);
+    return { method: 'insert_text', renderedBreaks: 0 };
+  }
+
+  const result = unwrapEvaluateResult(await page.evaluate(buildFillComposerMultilineScript(message)));
+  if (result?.ok) {
+    return {
+      method: result.method || 'dom_multiline',
+      renderedBreaks: Number(result.renderedBreaks || 0),
+    };
+  }
+
+  await page.insertText(message);
+  return { method: 'insert_text_fallback', renderedBreaks: 0 };
+}
+
 cli({
   site: 'linkedin',
   name: 'safe-send',
@@ -247,7 +347,7 @@ cli({
 
     const threadUrl = requireLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'), '--thread-url');
     const expectedName = requireStringArg(args, 'expected-name', '--expected-name');
-    const message = requireStringArg(args, 'message', '--message');
+    const message = requireRawStringArg(args, 'message', '--message');
 
     await page.goto('https://www.linkedin.com/messaging/');
     await page.wait(4);
@@ -308,7 +408,7 @@ cli({
     const focus = unwrapEvaluateResult(await page.evaluate(buildFocusComposerScript()));
     if (!focus?.ok) throw new CommandExecutionError(`LinkedIn safe-send blocked: ${focus?.error || 'composer_focus_failed'}`);
 
-    await page.insertText(message);
+    await fillComposer(page, message);
     await page.wait(0.6 + Math.random() * 0.8);
 
     const composer = unwrapEvaluateResult(await page.evaluate(buildReadComposerScript()));
@@ -353,5 +453,8 @@ export const __test__ = {
   normalizeName,
   canonicalizeLinkedInThreadUrl,
   hashText,
+  hasLineBreaks,
+  requireRawStringArg,
+  buildFillComposerMultilineScript,
   assessThreadSafety,
 };

--- a/clis/linkedin/safe-send.test.js
+++ b/clis/linkedin/safe-send.test.js
@@ -8,6 +8,9 @@ const {
   normalizeName,
   canonicalizeLinkedInThreadUrl,
   hashText,
+  hasLineBreaks,
+  requireRawStringArg,
+  buildFillComposerMultilineScript,
   assessThreadSafety,
 } = await import('./safe-send.js').then((m) => m.__test__);
 
@@ -20,6 +23,11 @@ function makeFakePage(probe) {
       const text = String(script);
       if (text.includes('__OPENCLI_LINKEDIN_PROBE__')) return probe;
       if (text.includes('__OPENCLI_LINKEDIN_FOCUS_COMPOSER__')) return { ok: true, composerText: '' };
+      if (text.includes('__OPENCLI_LINKEDIN_FILL_COMPOSER_MULTILINE__')) {
+        const match = text.match(/const message = (.*?);\n/);
+        composerText = match ? JSON.parse(match[1]) : composerText;
+        return { ok: true, composerText, method: 'dom_multiline', renderedBreaks: 2 };
+      }
       if (text.includes('__OPENCLI_LINKEDIN_READ_COMPOSER__')) return { ok: true, composerText };
       if (text.includes('__OPENCLI_LINKEDIN_CLICK_SEND__')) return { ok: true, sent: true };
       return undefined;
@@ -36,6 +44,26 @@ describe('linkedin safe-send helpers', () => {
   it('normalizes whitespace and LinkedIn names for exact-ish comparisons', () => {
     expect(normalizeWhitespace('  Lokesh\n\tRamesh  ')).toBe('Lokesh Ramesh');
     expect(normalizeName('Lokesh Ramesh • 1st')).toBe('lokesh ramesh');
+  });
+
+  it('detects multiline messages without treating wrapped single-line text as multiline', () => {
+    expect(hasLineBreaks('hello\nworld')).toBe(true);
+    expect(hasLineBreaks('hello\r\nworld')).toBe(true);
+    expect(hasLineBreaks('hello world')).toBe(false);
+  });
+
+  it('validates required message arguments without stripping intentional formatting', () => {
+    expect(requireRawStringArg({ message: 'Hi\n\n- one' }, 'message', '--message')).toBe('Hi\n\n- one');
+    expect(() => requireRawStringArg({ message: ' \n\t ' }, 'message', '--message')).toThrow(ArgumentError);
+  });
+
+  it('builds a LinkedIn-specific multiline composer script with paste and DOM fallback markers', () => {
+    const script = buildFillComposerMultilineScript('Hi\n\n- one\n- two');
+
+    expect(script).toContain('__OPENCLI_LINKEDIN_FILL_COMPOSER_MULTILINE__');
+    expect(script).toContain('ClipboardEvent');
+    expect(script).toContain('dom_multiline');
+    expect(script).toContain('insertFromPaste');
   });
 
   it('canonicalizes thread URLs while dropping query and hash noise', () => {
@@ -200,5 +228,28 @@ describe('linkedin safe-send command', () => {
     expect(rows[0]).toMatchObject({ status: 'sent', recipient: 'Lokesh Ramesh', reason: 'verified' });
     expect(page.insertText).toHaveBeenCalledWith('both, but starting hands on');
     expect(page.pressKey).not.toHaveBeenCalled();
+  });
+
+  it('fills multiline messages through the LinkedIn composer helper before sending', async () => {
+    const command = getRegistry().get('linkedin/safe-send');
+    const page = makeFakePage({
+      url: 'https://www.linkedin.com/messaging/thread/lokesh/',
+      headerNames: ['Lokesh Ramesh'],
+      bodyText: 'Lokesh Ramesh\nprovider doc follow ups',
+      composerFound: true,
+      searchFailure: false,
+    });
+
+    const message = 'Hi Lokesh\n\n- first point\n- second point';
+    const rows = await command.func(page, {
+      'thread-url': 'https://www.linkedin.com/messaging/thread/lokesh/',
+      'expected-name': 'Lokesh Ramesh',
+      message,
+      send: true,
+    });
+
+    expect(rows[0]).toMatchObject({ status: 'sent', recipient: 'Lokesh Ramesh', reason: 'verified' });
+    expect(page.insertText).not.toHaveBeenCalled();
+    expect(page.evaluate).toHaveBeenCalledWith(expect.stringContaining('__OPENCLI_LINKEDIN_FILL_COMPOSER_MULTILINE__'));
   });
 });


### PR DESCRIPTION
## Description

Refresh the remaining LinkedIn improvements on one clean branch.

This branch now carries the two LinkedIn deltas that were still worth preserving on top of current `main`:

- preserve multiline formatting in `linkedin safe-send`
- improve `linkedin job-detail` by reading public job descriptions before falling back to the authenticated job view

The older LinkedIn side branches were reviewed against current `main` and were not merged wholesale because they were older alternate implementations of command surfaces that already exist upstream.

Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

What changed:

1. `opencli linkedin safe-send`
- preserve intentional newlines when filling multiline messages
- keep existing dry-run and verification guardrails intact

2. `opencli linkedin job-detail`
- normalize public `/jobs/view/<id>` URLs directly
- try public description extraction first from page JSON-LD / rendered HTML
- fall back to authenticated `currentJobId` job view only when the public page is incomplete

PR replacement notes:

- supersedes `#1817`
- absorbs the remaining clean LinkedIn public-JD improvement from the mixed local branch line

Checks run:

- `npx tsc --noEmit`
- `npm run build`
- `git diff --exit-code -- cli-manifest.json`
- `node scripts/check-silent-column-drop.mjs`
- `node scripts/check-typed-error-lint.mjs`
- `npx vitest run clis/linkedin/safe-send.test.js clis/linkedin/job-detail.test.js --reporter=verbose`
