### PR TITLE
fix(gemini): isolate concurrent image generations via chat-id anchoring

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13172,7 +13172,7 @@
     "modulePath": "gemini/image.js",
     "sourceFile": "gemini/image.js",
     "navigateBefore": false,
-    "siteSession": "persistent"
+    "siteSession": "ephemeral"
   },
   {
     "site": "gemini",

--- a/clis/gemini/image.js
+++ b/clis/gemini/image.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { GEMINI_DOMAIN, exportGeminiImages, getGeminiVisibleImageUrls, sendGeminiMessage, startNewGeminiChat, waitForGeminiImages } from './utils.js';
+import { GEMINI_APP_URL, GEMINI_DOMAIN, exportGeminiImages, getGeminiVisibleImageUrls, sendGeminiMessage, startNewGeminiChat, waitForGeminiConversationId, waitForGeminiImages } from './utils.js';
 function extFromMime(mime) {
     if (mime.includes('png'))
         return '.png';
@@ -18,6 +18,14 @@ function normalizeBooleanFlag(value) {
         return value;
     const normalized = String(value ?? '').trim().toLowerCase();
     return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+function expandHome(value) {
+    const raw = String(value ?? '');
+    if (raw === '~')
+        return os.homedir();
+    if (raw.startsWith('~/'))
+        return path.join(os.homedir(), raw.slice(2));
+    return raw;
 }
 function displayPath(filePath) {
     const home = os.homedir();
@@ -52,7 +60,13 @@ export const imageCommand = cli({
     domain: GEMINI_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
-    siteSession: 'persistent',
+    // Ephemeral so concurrent `gemini image` processes each get an isolated
+    // tab/chat instead of fighting over one shared `site:gemini` tab. Combined
+    // with the chat-id anchoring below, every run grabs the image from its own
+    // conversation. Note: Gemini's backend serializes image generation per
+    // account, so truly simultaneous launches still collide (one stalls) —
+    // stagger concurrent runs by ~20-30s to let each generation land cleanly.
+    siteSession: 'ephemeral',
     navigateBefore: false,
     defaultFormat: 'plain',
     args: [
@@ -68,31 +82,33 @@ export const imageCommand = cli({
         const prompt = kwargs.prompt;
         const ratio = normalizeRatio(String(kwargs.rt ?? '1:1'));
         const style = String(kwargs.st ?? '').trim();
-        const outputDir = kwargs.op || path.join(os.homedir(), 'tmp', 'gemini-images');
+        const outputDir = expandHome(kwargs.op || path.join(os.homedir(), 'tmp', 'gemini-images'));
         const timeout = kwargs.timeout;
         if (!Number.isInteger(timeout) || timeout < 1) {
             throw new ArgumentError('--timeout must be a positive integer (seconds)');
         }
-        const startFresh = true;
         const skipDownloadRaw = kwargs.sd;
         const skipDownload = skipDownloadRaw === '' || skipDownloadRaw === true || normalizeBooleanFlag(skipDownloadRaw);
         const effectivePrompt = buildImagePrompt(prompt, {
             ratio,
             style: style || undefined,
         });
-        if (startFresh)
-            await startNewGeminiChat(page);
+        await startNewGeminiChat(page);
         const beforeUrls = await getGeminiVisibleImageUrls(page);
         await sendGeminiMessage(page, effectivePrompt);
-        const urls = await waitForGeminiImages(page, beforeUrls, timeout);
-        const link = await currentGeminiLink(page);
+        // Anchor every subsequent image scan to the chat this generation created
+        // so a concurrent `gemini image` run can't swap the visible chat out from
+        // under us and make us grab its image.
+        const conversationId = await waitForGeminiConversationId(page, Math.min(30, timeout));
+        const urls = await waitForGeminiImages(page, beforeUrls, timeout, conversationId);
+        const link = conversationId ? `${GEMINI_APP_URL}/${conversationId}` : await currentGeminiLink(page);
         if (!urls.length) {
             return [{ status: '⚠️ no-images', file: '📁 -', link: `🔗 ${link}` }];
         }
         if (skipDownload) {
             return [{ status: '🎨 generated', file: '📁 -', link: `🔗 ${link}` }];
         }
-        const assets = await exportGeminiImages(page, urls);
+        const assets = await exportGeminiImages(page, urls, conversationId);
         if (!assets.length) {
             return [{ status: '⚠️ export-failed', file: '📁 -', link: `🔗 ${link}` }];
         }
@@ -109,3 +125,4 @@ export const imageCommand = cli({
         return results;
     },
 });
+export const __test__ = { expandHome };

--- a/clis/gemini/image.test.js
+++ b/clis/gemini/image.test.js
@@ -1,0 +1,21 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './image.js';
+
+const { expandHome } = __test__;
+
+describe('expandHome', () => {
+    it('expands a bare ~ to the home directory', () => {
+        expect(expandHome('~')).toBe(os.homedir());
+    });
+    it('expands a ~/ prefix to the home directory', () => {
+        expect(expandHome('~/tmp/gemini-images')).toBe(path.join(os.homedir(), 'tmp', 'gemini-images'));
+    });
+    it('leaves absolute paths untouched', () => {
+        expect(expandHome('/tmp/out')).toBe('/tmp/out');
+    });
+    it('leaves a leading ~user (not ~/) untouched', () => {
+        expect(expandHome('~someone/dir')).toBe('~someone/dir');
+    });
+});

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -126,6 +126,21 @@ export function parseGeminiConversationUrl(value) {
         return null;
     }
 }
+export function parseGeminiConversationId(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw)
+        return null;
+    try {
+        const url = new URL(raw);
+        if (url.hostname !== GEMINI_DOMAIN && !url.hostname.endsWith(`.${GEMINI_DOMAIN}`))
+            return null;
+        const match = url.pathname.match(/^\/app\/([^/]+)\/?$/);
+        return match ? match[1] : null;
+    }
+    catch {
+        return null;
+    }
+}
 export function normalizeGeminiTitle(value) {
     return value.replace(/\s+/g, ' ').trim().toLowerCase();
 }
@@ -1040,6 +1055,26 @@ export async function getCurrentGeminiUrl(page) {
         return url;
     return GEMINI_APP_URL;
 }
+export async function waitForGeminiConversationId(page, timeoutSeconds) {
+    const maxPolls = Math.max(1, Math.ceil(timeoutSeconds));
+    for (let index = 0; index < maxPolls; index += 1) {
+        const url = await page.evaluate(currentUrlScript()).catch(() => '');
+        const id = parseGeminiConversationId(url);
+        if (id)
+            return id;
+        await page.wait(1);
+    }
+    return null;
+}
+export async function ensureGeminiConversation(page, conversationId) {
+    if (!conversationId)
+        return;
+    const url = await page.evaluate(currentUrlScript()).catch(() => '');
+    if (parseGeminiConversationId(url) === conversationId)
+        return;
+    await page.goto(`${GEMINI_APP_URL}/${conversationId}`, { waitUntil: 'load', settleMs: 2500 });
+    await page.wait(1);
+}
 export async function openGeminiToolsMenu(page) {
     await ensureGeminiPage(page);
     const opened = await page.evaluate(openGeminiToolsMenuScript());
@@ -1786,8 +1821,11 @@ export const __test__ = {
     submitComposerScript,
     insertComposerTextFallbackScript,
 };
-export async function getGeminiVisibleImageUrls(page) {
-    await ensureGeminiPage(page);
+export async function getGeminiVisibleImageUrls(page, conversationId) {
+    if (conversationId)
+        await ensureGeminiConversation(page, conversationId);
+    else
+        await ensureGeminiPage(page);
     return await page.evaluate(`
     (() => {
       const isVisible = (el) => {
@@ -1798,7 +1836,28 @@ export async function getGeminiVisibleImageUrls(page) {
         return rect.width > 32 && rect.height > 32;
       };
 
-      const imgs = Array.from(document.querySelectorAll('main img')).filter((img) => img instanceof HTMLImageElement && isVisible(img));
+      const collect = (root) => Array.from(root.querySelectorAll('img'))
+        .filter((img) => img instanceof HTMLImageElement && isVisible(img));
+
+      // Prefer the latest response turn so we don't pick up images from an
+      // earlier turn. Gemini's DOM varies, so fall back to the whole main
+      // region whenever the scoped turn yields nothing (never regress to zero).
+      const main = document.querySelector('main') || document.body;
+      const turnSelectors = [
+        '[class*="conversation-turn"]',
+        '[class*="response-container"]',
+        '[class*="model-response"]',
+        '[class*="message"]',
+      ];
+      let imgs = [];
+      for (const selector of turnSelectors) {
+        const nodes = Array.from(document.querySelectorAll('main ' + selector)).filter(isVisible);
+        if (nodes.length) {
+          const scoped = collect(nodes[nodes.length - 1]);
+          if (scoped.length) { imgs = scoped; break; }
+        }
+      }
+      if (!imgs.length) imgs = collect(main);
       const urls = [];
       const seen = new Set();
 
@@ -1818,7 +1877,7 @@ export async function getGeminiVisibleImageUrls(page) {
     })()
   `);
 }
-export async function waitForGeminiImages(page, beforeUrls, timeoutSeconds) {
+export async function waitForGeminiImages(page, beforeUrls, timeoutSeconds, conversationId) {
     const beforeSet = new Set(beforeUrls);
     const pollIntervalSeconds = 3;
     const maxPolls = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));
@@ -1826,7 +1885,7 @@ export async function waitForGeminiImages(page, beforeUrls, timeoutSeconds) {
     let stableCount = 0;
     for (let index = 0; index < maxPolls; index += 1) {
         await page.wait(index === 0 ? 2 : pollIntervalSeconds);
-        const urls = (await getGeminiVisibleImageUrls(page)).filter((url) => !beforeSet.has(url));
+        const urls = (await getGeminiVisibleImageUrls(page, conversationId)).filter((url) => !beforeSet.has(url));
         if (urls.length === 0)
             continue;
         const key = urls.join('\n');
@@ -1842,8 +1901,11 @@ export async function waitForGeminiImages(page, beforeUrls, timeoutSeconds) {
     }
     return lastUrls;
 }
-export async function exportGeminiImages(page, urls) {
-    await ensureGeminiPage(page);
+export async function exportGeminiImages(page, urls, conversationId) {
+    if (conversationId)
+        await ensureGeminiConversation(page, conversationId);
+    else
+        await ensureGeminiPage(page);
     const urlsJson = JSON.stringify(urls);
     return await page.evaluate(`
     (async (targetUrls) => {

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
+import { __test__, collectGeminiTranscriptAdditions, ensureGeminiConversation, getGeminiConversationList, getGeminiPageState, getGeminiVisibleImageUrls, getGeminiVisibleTurns, parseGeminiConversationId, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, waitForGeminiConversationId, } from './utils.js';
 function createPageMock() {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -60,6 +60,58 @@ describe('collectGeminiTranscriptAdditions', () => {
         const before = ['baseline'];
         const current = ['baseline', '关于“请只回复：OK”，这里是解释。'];
         expect(collectGeminiTranscriptAdditions(before, current, prompt)).toBe('关于“请只回复：OK”，这里是解释。');
+    });
+});
+describe('gemini image chat-id anchoring', () => {
+    it('parseGeminiConversationId extracts the id only from a /app/<id> url', () => {
+        expect(parseGeminiConversationId('https://gemini.google.com/app/abc123')).toBe('abc123');
+        expect(parseGeminiConversationId('https://gemini.google.com/app/abc123/')).toBe('abc123');
+        expect(parseGeminiConversationId('https://gemini.google.com/app')).toBeNull();
+        expect(parseGeminiConversationId('https://example.com/app/abc123')).toBeNull();
+        expect(parseGeminiConversationId('')).toBeNull();
+    });
+    it('waitForGeminiConversationId polls the url until a conversation id is assigned', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce('https://gemini.google.com/app/conv-xyz');
+        const id = await waitForGeminiConversationId(page, 5);
+        expect(id).toBe('conv-xyz');
+    });
+    it('waitForGeminiConversationId returns null when no id appears before timeout', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        evaluate.mockResolvedValue('https://gemini.google.com/app');
+        const id = await waitForGeminiConversationId(page, 2);
+        expect(id).toBeNull();
+    });
+    it('ensureGeminiConversation navigates back when the page drifted to another chat', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        const goto = vi.mocked(page.goto);
+        evaluate.mockResolvedValueOnce('https://gemini.google.com/app/other-chat');
+        await ensureGeminiConversation(page, 'mine');
+        expect(goto).toHaveBeenCalledWith('https://gemini.google.com/app/mine', expect.anything());
+    });
+    it('ensureGeminiConversation does not navigate when already on the target chat', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        const goto = vi.mocked(page.goto);
+        evaluate.mockResolvedValueOnce('https://gemini.google.com/app/mine');
+        await ensureGeminiConversation(page, 'mine');
+        expect(goto).not.toHaveBeenCalled();
+    });
+    it('getGeminiVisibleImageUrls re-anchors to the owning conversation before scanning', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        const goto = vi.mocked(page.goto);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app/other')
+            .mockResolvedValueOnce(['blob:img1']);
+        const urls = await getGeminiVisibleImageUrls(page, 'mine');
+        expect(goto).toHaveBeenCalledWith('https://gemini.google.com/app/mine', expect.anything());
+        expect(urls).toEqual(['blob:img1']);
     });
 });
 describe('gemini send strategy', () => {


### PR DESCRIPTION
## Problem

Concurrent `gemini image` runs shared one `site:gemini` tab. A second run could navigate that tab to its own chat while the first was still scanning, so the first run would grab the *wrong* image (the other run's output).

## Fix

- **Ephemeral site session** for the image command — each run gets an isolated tab/chat instead of fighting over the shared `site:gemini` tab.
- **Chat-id anchoring** — capture the conversation id the generation creates (`waitForGeminiConversationId`), then re-anchor (`ensureGeminiConversation`) before every image scan / wait / export so a parallel run can't swap the visible chat out from under us. The returned link is derived from that id too.
- **Scoped image scan** — prefer the latest response turn when collecting visible image URLs, with a fallback to the whole `main` region so it never regresses to zero.
- **`~` expansion** for `--op` so `~/foo` resolves to the home directory.

> Note: Gemini's backend serializes image generation per account, so truly simultaneous launches can still collide (one stalls). Stagger concurrent runs by ~20–30s for clean landings. This is documented inline.

## Manifest

`cli-manifest.json` is regenerated from source. Besides the `gemini/image` entry flipping to `ephemeral`, the bulk of the diff is the COOKIE/auth default `siteSession: persistent` being brought back in sync after drift — the committed manifest was stale. The CI manifest-drift gate (`git diff --exit-code -- cli-manifest.json` after `npm run build`) requires this.

## Tests

- New `clis/gemini/image.test.js` covering `expandHome`.
- New cases in `clis/gemini/utils.test.js` for `parseGeminiConversationId`, `waitForGeminiConversationId`, `ensureGeminiConversation`, and conversation re-anchoring in `getGeminiVisibleImageUrls`.
- `npx tsc --noEmit` clean; gemini suites pass (36/36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)