### PR TITLE
fix(plugin): tolerate plugin directories removed mid-scan

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -202,7 +202,20 @@ export async function discoverPlugins(): Promise<void> {
  * Unlike discoverClisFromFs, this does NOT expect nested site subdirectories.
  */
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
-  const files = await fs.promises.readdir(dir);
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(dir);
+  } catch (err) {
+    // The directory can disappear between the parent scan and this read
+    // (e.g. a concurrent `opencli plugin remove`). Mirror the broken-symlink
+    // handling in isDiscoverablePluginDir: treat a vanished directory as
+    // "no plugin here" rather than letting startup crash.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      log.warn(`Failed to scan plugin directory ${dir}: ${getErrorMessage(err)}`);
+    }
+    return;
+  }
   const fileSet = new Set(files);
   await Promise.all(files.map(async (file) => {
     const filePath = path.join(dir, file);

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -204,6 +204,33 @@ browser: false
     await expect(discoverPlugins()).resolves.not.toThrow();
     expect(getRegistry().get('__test-plugin-broken__/hello')).toBeUndefined();
   });
+
+  it('tolerates a plugin directory removed mid-scan without throwing', async () => {
+    // Reproduces the race where a plugin directory is listed by the parent
+    // scan but removed (e.g. a concurrent `opencli plugin remove`) before its
+    // contents are read, so the inner readdir rejects with ENOENT.
+    await fs.promises.mkdir(testPluginDir, { recursive: true });
+    const realReaddir = fs.promises.readdir.bind(fs.promises);
+    // fs.promises.readdir is overloaded; type the mock loosely and delegate
+    // to the real implementation for every path except the vanished one.
+    const spy = vi
+      .spyOn(fs.promises, 'readdir')
+      .mockImplementation(((p: fs.PathLike, options?: unknown): Promise<unknown> => {
+        if (String(p) === testPluginDir) {
+          const err = new Error(
+            `ENOENT: no such file or directory, scandir '${p}'`,
+          ) as NodeJS.ErrnoException;
+          err.code = 'ENOENT';
+          return Promise.reject(err);
+        }
+        return realReaddir(p, options as Parameters<typeof realReaddir>[1]);
+      }) as typeof fs.promises.readdir);
+    try {
+      await expect(discoverPlugins()).resolves.not.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe('executeCommand', () => {


### PR DESCRIPTION
## Problem

`discoverPlugins()` lists `~/.opencli/plugins/` and then reads each entry's contents in `discoverPluginDir()`. If a plugin directory is removed **between** the parent listing and the inner `readdir()` — e.g. a concurrent `opencli plugin remove`, or a half-removed plugin — the inner `readdir()` rejects with `ENOENT`.

Because `discoverPlugins()` runs on the **main startup path** (`src/main.ts`, plus three call sites in `src/cli.ts`), that unhandled rejection crashes CLI startup rather than being skipped.

`isDiscoverablePluginDir()` already swallows the analogous case for a vanished **symlink** target (`ENOENT`/`ENOTDIR`), but the directory read in `discoverPluginDir()` is unguarded.

## Fix

Extend the same `ENOENT`/`ENOTDIR` handling to the directory read, so a directory that disappears mid-scan is treated as "no plugin here" instead of an unhandled rejection. Other (unexpected) errors still surface via `log.warn`, matching the existing pattern in the same file.

```ts
let files: string[];
try {
  files = await fs.promises.readdir(dir);
} catch (err) {
  const code = (err as NodeJS.ErrnoException).code;
  if (code !== 'ENOENT' && code !== 'ENOTDIR') {
    log.warn(`Failed to scan plugin directory ${dir}: ${getErrorMessage(err)}`);
  }
  return;
}
```

## De-flakes the unit suite

This also fixes an intermittent failure of `discoverPlugins > handles non-existent plugins directory gracefully`. The plugin unit tests share the **real** `~/.opencli/plugins/` (`PLUGINS_DIR` derives from `os.homedir()` with no override), so a directory created and removed by `plugin.test.ts` can race the scan in `engine.test.ts` and surface this exact `ENOENT`:

```
AssertionError: promise rejected "Error: ENOENT ... scandir
'~/.opencli/plugins/__test-local-plugin__'" instead of resolving
 ❯ discoverPluginDir src/discovery.ts
 ❯ discoverPlugins src/discovery.ts
```

## Test

Adds a deterministic regression test that stubs the inner `readdir` to reject with `ENOENT` and asserts `discoverPlugins()` still resolves. Verified red→green: it fails on `main` (unhandled `ENOENT`) and passes with the fix.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full unit/extension/adapter gate green (514 files, 5345 passed, 1 skipped)