### PR TITLE
fix(launcher): don't kill the user's app on non-darwin platforms

### DIFF
--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ElectronAppEntry } from './electron-apps.js';
-import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
+import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveElectronEndpoint, resolveExecutableCandidates } from './launcher.js';
 
 interface MockChildProcess {
   once: ReturnType<typeof vi.fn>;
@@ -31,12 +31,59 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
 }));
 
+vi.mock('./electron-apps.js', () => ({
+  getElectronApp: vi.fn(),
+}));
+
+vi.mock('./tui.js', () => ({
+  confirmPrompt: vi.fn(() => Promise.resolve(true)),
+}));
+
 const cp = vi.mocked(await import('node:child_process'));
+const electronApps = vi.mocked(await import('./electron-apps.js'));
 
 describe('probeCDP', () => {
   it('returns false when CDP endpoint is unreachable', async () => {
     const result = await probeCDP(59999, 500);
     expect(result).toBe(false);
+  });
+});
+
+describe('resolveElectronEndpoint', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    cp.execFileSync.mockReset();
+    electronApps.getElectronApp.mockReset();
+  });
+
+  it('degrades gracefully on non-darwin without killing the running app', async () => {
+    // Auto-launch (process detect → kill → discover → relaunch) is macOS-only:
+    // discoverAppPath resolves a path on darwin alone. On other platforms
+    // resolveElectronEndpoint must NOT enter the kill branch, which would
+    // pkill the user's app and then fail at discoverAppPath (returns null),
+    // leaving the app dead with a misleading "not installed" error.
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    // Port 59999 has no listener, so probeCDP resolves false (see above).
+    electronApps.getElectronApp.mockReturnValue({
+      port: 59999,
+      processName: 'TestApp',
+      displayName: 'TestApp',
+    } as ElectronAppEntry);
+
+    const err = await resolveElectronEndpoint('testapp').then(
+      () => { throw new Error('expected resolveElectronEndpoint to reject'); },
+      (e) => e as { message: string; hint?: string },
+    );
+    // Graceful degradation: the "not reachable" guard message + a linux
+    // auto-launch hint, NOT the destructive "Could not find ... on this
+    // machine" error that follows a kill.
+    expect(err.message).toMatch(/is not reachable on CDP port/);
+    expect(err.message).not.toMatch(/Could not find/);
+    expect(err.hint).toMatch(/Auto-launch is not yet supported on linux/);
+    // The destructive pkill path must never run on a non-darwin platform.
+    expect(cp.execFileSync).not.toHaveBeenCalledWith('pkill', expect.anything(), expect.anything());
   });
 });
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -225,8 +225,14 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
     return endpoint;
   }
 
-  // Step 2: Running without CDP? (process detection requires Unix tools)
-  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  // Step 2: Running without CDP? Auto-launch (process detect → kill →
+  // discover → relaunch) is only implemented for macOS — discoverAppPath
+  // resolves a path on darwin alone. On every other platform we must NOT
+  // enter the kill branch below: doing so would pkill the user's running
+  // app and then fail at discoverAppPath (which returns null), leaving the
+  // app dead with a misleading "not installed" error. Degrade gracefully
+  // with a manual-launch hint instead.
+  if (process.platform !== 'darwin') {
     throw new CommandExecutionError(
       `${label} is not reachable on CDP port ${port}.`,
       `Auto-launch is not yet supported on ${process.platform}.\n` +


### PR DESCRIPTION
## Problem

`resolveElectronEndpoint()` gates its auto-launch flow with:

```ts
if (process.platform !== 'darwin' && process.platform !== 'linux') { ...graceful... }
```

so **Linux falls through** into the process-detect → confirm → **kill** → discover → relaunch path. But `discoverAppPath()` resolves an app path on **macOS only** — it hard-returns `null` on every other platform.

The result on Linux, when an Electron app (Cursor, Codex, ChatGPT-app, …) is running *without* CDP:

1. `detectProcess()` finds it (pgrep works on Linux),
2. the user confirms "restart with debug port?",
3. `killProcess()` **pkills the running app** (pkill works on Linux),
4. `discoverAppPath()` returns `null` (non-darwin),
5. the function throws **`Could not find <app> on this machine. Install <app>…`**

So the user's app is killed and never relaunched, behind a misleading "not installed" error — strictly worse than not running the command. The kill branch is reachable on a platform where the subsequent launch path can never succeed.

## Fix

Gate the kill/relaunch path on `darwin` alone:

```ts
if (process.platform !== 'darwin') { ...graceful... }
```

Every non-macOS platform now takes the existing graceful branch (manual-launch hint + `OPENCLI_CDP_ENDPOINT`) **before any kill** — the same degradation already applied to Windows. This drops Linux *auto-launch* (which never worked, since `discoverAppPath` is macOS-only) rather than killing the app and failing; a real Linux `discoverAppPath` implementation can re-enable it later.

## Test

Adds a `resolveElectronEndpoint` regression test: on a non-darwin platform with an app that isn't reachable on CDP, it asserts the call rejects with the graceful "not reachable / auto-launch not supported" error (not the destructive "Could not find …" path) **and that `pkill` is never invoked**. Verified red→green — it fails on `main` (the app is pkilled, wrong error) and passes with the fix.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full gate green (514 files, 5345 passed, 1 skipped)