### PR TITLE
fix(execution): keep mtime entry so daemon hot-reload busts the cache

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -110,8 +110,12 @@ async function runCommand(
         const stat = fs.statSync(modulePath);
         const prevMtime = _moduleMtimes.get(modulePath);
         if (prevMtime !== undefined && stat.mtimeMs !== prevMtime) {
+          // Drop only the load promise — keep the mtime entry. The
+          // cache-buster gate below keys off `_moduleMtimes.has(...)`;
+          // deleting it here makes the re-import fall back to the bare
+          // URL, so Node's ESM loader returns the already-cached (stale)
+          // module instead of the edited one — defeating hot-reload.
           _loadedModules.delete(modulePath);
-          _moduleMtimes.delete(modulePath);
         }
       } catch { /* file may have been deleted; let import below handle it */ }
     }


### PR DESCRIPTION
## Problem

In daemon mode, `runCommand()` hot-reloads a user adapter (under `~/.opencli/clis/`) when its file mtime changes. The cache-buster gate keys off `_moduleMtimes.has(modulePath)`:

```ts
const importUrl = _moduleMtimes.has(modulePath) ? `${url}?t=${Date.now()}` : url;
```

When the mtime entry is present, the import URL gets a `?t=<now>` query so Node's ESM loader re-evaluates the edited file.

But the invalidation block deleted **both** maps:

```ts
if (prevMtime !== undefined && stat.mtimeMs !== prevMtime) {
  _loadedModules.delete(modulePath);
  _moduleMtimes.delete(modulePath);   // ← removes the cache-bust signal
}
```

With the mtime entry gone, the gate sees `has() === false` on the very next block and imports the **bare** `url` — which Node's ESM loader resolves to the **already-cached (stale)** module. So editing a user adapter while the daemon is alive silently keeps running the old code, defeating the documented hot-reload (`// Track mtime of loaded user adapter files for hot-reload in daemon mode.`).

## Fix

Drop only the load promise on invalidation; keep the mtime entry so the re-import is cache-busted:

```ts
if (prevMtime !== undefined && stat.mtimeMs !== prevMtime) {
  _loadedModules.delete(modulePath);
}
```

On reload, `_moduleMtimes.has(modulePath)` is now `true` → the import URL gets `?t=<now>` → Node re-evaluates the edited file. (After a successful (re)load the success handler refreshes the stored mtime, so the next unchanged run is a no-op as before.)

## Why no unit test

The daemon runs under **native Node ESM**, where `import('file://…?t=N')` busts the per-URL module cache — that's the exact mechanism this fix relies on. vitest's module runner caches by file path and ignores the query string, so the cache-bust path can't be faithfully reproduced in-suite (verified empirically: a re-import probe stays stale under vitest even with the fix, because vite-node never re-evaluates the queried URL). The change itself is a one-line invalidation fix; the inline comment documents the invariant.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full gate green (514 files, 5344 passed, 1 skipped)