### PR TITLE
fix(download): match video platforms on host boundary, not substring

### DIFF
--- a/src/download/index.test.ts
+++ b/src/download/index.test.ts
@@ -3,7 +3,7 @@ import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { exportCookiesToNetscape, formatCookieHeader, httpDownload, resolveRedirectUrl } from './index.js';
+import { detectContentType, exportCookiesToNetscape, formatCookieHeader, httpDownload, requiresYtdlp, resolveRedirectUrl } from './index.js';
 
 const servers: http.Server[] = [];
 const tempDirs: string[] = [];
@@ -159,5 +159,42 @@ describe('download helpers', { retry: process.platform === 'win32' ? 2 : 0 }, ()
     const mode = fs.statSync(cookiesPath).mode & 0o777;
     expect(mode).toBe(0o600);
     expect(fs.readFileSync(cookiesPath, 'utf8')).toContain('sid\tsecret');
+  });
+});
+
+describe('video-platform host detection', () => {
+  it('matches real video-platform hosts (host or subdomain)', () => {
+    for (const url of [
+      'https://www.youtube.com/watch?v=abc',
+      'https://youtu.be/abc',
+      'https://m.bilibili.com/video/BV1xx',
+      'https://twitter.com/u/status/1',
+      'https://x.com/u/status/1',
+      'https://www.tiktok.com/@u/video/1',
+      'https://vimeo.com/12345',
+      'https://www.twitch.tv/u',
+    ]) {
+      expect(requiresYtdlp(url)).toBe(true);
+      expect(detectContentType(url)).toBe('video');
+    }
+  });
+
+  it('does not match hosts that merely end with a token or carry it in the path', () => {
+    // netflix.com / max.com / phoenix.com all *contain* the substring "x.com";
+    // the path-only token "youtu.be-guide" must not match either.
+    for (const url of [
+      'https://netflix.com/watch/123',
+      'https://www.phoenix.com/a.zip',
+      'https://max.com/movie',
+      'https://cdn.site.com/youtu.be-guide.bin',
+      'https://notx.com/a',
+    ]) {
+      expect(requiresYtdlp(url)).toBe(false);
+      expect(detectContentType(url)).not.toBe('video');
+    }
+  });
+
+  it('returns false for an unparseable URL instead of throwing', () => {
+    expect(requiresYtdlp('not a url')).toBe(false);
   });
 });

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -46,6 +46,26 @@ const VIDEO_PLATFORM_DOMAINS = [
   'x.com', 'tiktok.com', 'vimeo.com', 'twitch.tv',
 ];
 
+/**
+ * Whether a URL's host is a known video platform.
+ *
+ * Matches on the parsed hostname with a domain boundary (exact host or a
+ * subdomain) rather than a raw substring of the whole URL. A plain
+ * `url.includes('x.com')` wrongly classifies `netflix.com`, `max.com`, etc.
+ * (and any URL whose path merely contains a token like `youtu.be`) as a
+ * video platform, routing ordinary files to yt-dlp and mislabelling content
+ * types. Mirrors the host-boundary check used in execution.ts.
+ */
+function isVideoPlatformUrl(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return VIDEO_PLATFORM_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`));
+}
+
 const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.ico', '.bmp', '.avif']);
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.avi', '.mov', '.mkv', '.flv', '.m3u8', '.ts']);
 const DOC_EXTENSIONS = new Set(['.html', '.htm', '.json', '.xml', '.txt', '.md', '.markdown']);
@@ -60,12 +80,11 @@ export function detectContentType(url: string, contentType?: string): 'image' | 
     if (contentType.startsWith('text/') || contentType.includes('json') || contentType.includes('xml')) return 'document';
   }
 
-  const urlLower = url.toLowerCase();
   const ext = path.extname(new URL(url).pathname).toLowerCase();
 
   if (IMAGE_EXTENSIONS.has(ext)) return 'image';
   if (VIDEO_EXTENSIONS.has(ext)) return 'video';
-  if (VIDEO_PLATFORM_DOMAINS.some(d => urlLower.includes(d))) return 'video';
+  if (isVideoPlatformUrl(url)) return 'video';
   if (DOC_EXTENSIONS.has(ext)) return 'document';
   return 'binary';
 }
@@ -74,8 +93,7 @@ export function detectContentType(url: string, contentType?: string): 'image' | 
  * Check if URL requires yt-dlp for download.
  */
 export function requiresYtdlp(url: string): boolean {
-  const urlLower = url.toLowerCase();
-  return VIDEO_PLATFORM_DOMAINS.some(d => urlLower.includes(d));
+  return isVideoPlatformUrl(url);
 }
 
 /**


### PR DESCRIPTION
## Problem

`requiresYtdlp()` and `detectContentType()` classify video-platform URLs with a raw substring test against the whole lowercased URL:

```ts
VIDEO_PLATFORM_DOMAINS.some(d => url.toLowerCase().includes(d))
```

`VIDEO_PLATFORM_DOMAINS` contains short tokens like `x.com` and `youtu.be`, so the test fires for:

- any host that merely **ends in** a token — `netflix.com`, `max.com`, `phoenix.com` all contain the substring `x.com`;
- any URL whose **path/query** contains a token — `https://cdn.site.com/youtu.be-guide.bin`.

```
requiresYtdlp('https://netflix.com/watch/123')          // → true  (wrong)
requiresYtdlp('https://max.com/movie')                  // → true  (wrong)
detectContentType('https://www.phoenix.com/a.zip')      // → 'video' (wrong)
```

Consequences: a matching URL is force-routed through `ytdlpDownload` instead of `httpDownload` (so an ordinary file on any `*x.com` host is handed to yt-dlp, which errors or fetches the wrong thing), and `detectContentType` mislabels documents/images as `video`. `example.com` happens to be safe (doesn't contain `x.com`), which masked the bug in practice.

## Fix

Match on the parsed **hostname** with a domain boundary (exact host or subdomain) via a small `isVideoPlatformUrl()` helper — the same host-boundary check already used by `urlMatchesDomain` in `execution.ts`:

```ts
function isVideoPlatformUrl(url: string): boolean {
  let host: string;
  try { host = new URL(url).hostname.toLowerCase(); } catch { return false; }
  return VIDEO_PLATFORM_DOMAINS.some(d => host === d || host.endsWith(`.${d}`));
}
```

All real cases (`youtube.com/watch`, `youtu.be/abc`, `m.bilibili.com`, `twitter.com`, `x.com`) still match; the false positives no longer do, and an unparseable URL returns `false` instead of throwing.

## Test

Adds `video-platform host detection` tests covering the positive set, the false positives (`netflix.com` / `max.com` / `phoenix.com` / path-only token), and the unparseable-URL case. Verified red→green — the false-positive test fails on `main` and passes with the fix.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full gate green (514 files, 5347 passed, 1 skipped)