### PR TITLE
fix(daemon-client): don't retry a profile_required 409 as a duplicate id

### DIFF
--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -222,6 +222,31 @@ describe('daemon-client', () => {
     expect(ids[0]).not.toBe(ids[1]);
   });
 
+  it('sendCommand surfaces a profile_required 409 immediately instead of retrying', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({
+        id: 'server',
+        ok: false,
+        errorCode: 'profile_required',
+        error: 'Multiple Browser Bridge profiles are connected; choose one with --profile.',
+        errorHint: 'Run opencli profile list, then use opencli --profile <name> ...',
+      }),
+    } as Response);
+
+    // The profile_required 409 is not a duplicate-id collision: it must throw
+    // the actionable error on the first attempt, not loop until "max retries
+    // exhausted".
+    await expect(sendCommand('exec', { code: '1 + 1' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: 'profile_required',
+      hint: 'Run opencli profile list, then use opencli --profile <name> ...',
+    } satisfies Partial<BrowserCommandError>);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('sendCommand does not retry command_result_unknown even when the message looks transient', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue({

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -201,8 +201,13 @@ async function sendCommandRaw(
         if (result.errorCode === 'command_result_unknown') {
           throw new BrowserCommandError(result.error ?? 'Browser command result is unknown', result.errorCode, result.errorHint);
         }
-        const isDuplicateCommandId = res.status === 409
-          || (result.error ?? '').includes('Duplicate command id');
+        // Only retry the genuine duplicate-id 409, which always carries this
+        // message. A bare `res.status === 409` also matches the daemon's
+        // `profile_required` 409 (multiple Browser Bridge profiles connected),
+        // which is NOT retryable — retrying it silently burns every attempt and
+        // then throws the opaque "max retries exhausted", discarding the
+        // actionable errorCode/hint that tells the user to pass --profile.
+        const isDuplicateCommandId = (result.error ?? '').includes('Duplicate command id');
         if (isDuplicateCommandId && attempt < maxRetries) {
           continue;
         }


### PR DESCRIPTION
## Problem

`sendCommand()` treats **any** HTTP 409 as a retryable duplicate-command-id collision:

```ts
const isDuplicateCommandId = res.status === 409
  || (result.error ?? '').includes('Duplicate command id');
if (isDuplicateCommandId && attempt < maxRetries) { continue; }
```

But the daemon emits `409` for **two** distinct conditions:

1. genuine duplicate id — `"Duplicate command id already pending; retry"` (retryable with a fresh id), and
2. `profile_required` — `"Multiple Browser Bridge profiles are connected; choose one with --profile."` with `errorCode: 'profile_required'` (**not** retryable; the user must pick a profile).

When multiple Browser Bridge profiles are connected and none is selected, the bare `res.status === 409` makes the client silently re-POST up to `maxRetries` times — every attempt returns the same 409 — then throw the opaque **`sendCommand: max retries exhausted`**, discarding the `BrowserCommandError` `code` (`profile_required`) and `hint` that tell the user exactly what to do (`--profile`).

## Fix

Gate the retry on the duplicate-id **message** alone — the duplicate-id 409 always carries that exact text (`daemon.ts`):

```ts
const isDuplicateCommandId = (result.error ?? '').includes('Duplicate command id');
```

The `profile_required` 409 (no such text, `classifyBrowserError` → non-retryable) now falls through to `throw new BrowserCommandError(result.error, result.errorCode, result.errorHint)`, surfacing the actionable message + code on the **first** attempt.

## Test

Adds a test asserting a `profile_required` 409 rejects with a `BrowserCommandError` (`code: 'profile_required'`, hint preserved) and that `fetch` is called **once** (no retry loop). The existing "retries with a new id when daemon reports a duplicate pending id" test — which sends the duplicate-id message — stays green. Verified red→green.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full gate green