### PR TITLE
fix(plugin): allow uninstalling a plugin whose symlink target was removed

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -532,6 +532,27 @@ describe('uninstallPlugin', () => {
   it('throws for non-existent plugin', () => {
     expect(() => uninstallPlugin('__nonexistent__')).toThrow('not installed');
   });
+
+  it('removes a dangling symlink (monorepo target deleted) instead of refusing', () => {
+    const linkName = '__test-uninstall-dangling__';
+    const link = path.join(PLUGINS_DIR, linkName);
+    fs.mkdirSync(PLUGINS_DIR, { recursive: true });
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-dangling-'));
+    try { fs.rmSync(link, { force: true }); } catch {}
+    fs.symlinkSync(target, link, 'dir');
+    fs.rmSync(target, { recursive: true, force: true }); // now dangling
+
+    try {
+      // existsSync follows the link → false, but the dead link is still there.
+      expect(fs.existsSync(link)).toBe(false);
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+
+      expect(() => uninstallPlugin(linkName)).not.toThrow();
+      expect(() => fs.lstatSync(link)).toThrow(); // dead link removed
+    } finally {
+      try { fs.rmSync(link, { force: true }); } catch {}
+    }
+  });
 });
 
 describe('updatePlugin', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1044,7 +1044,12 @@ function updateStandaloneLockEntry(
  */
 export function uninstallPlugin(name: string): void {
   const targetDir = path.join(PLUGINS_DIR, name);
-  if (!fs.existsSync(targetDir)) {
+  // Use lstat (pathExistsSync), not existsSync: a monorepo sub-plugin whose
+  // symlink target was removed is a *dangling* link. existsSync follows the
+  // link and reports false, so uninstall would throw "not installed" and the
+  // user could never remove a plugin that `plugin list` still shows. The
+  // symlink branch below unlinks the dead link correctly.
+  if (!pathExistsSync(targetDir)) {
     throw new Error(`Plugin "${name}" is not installed.`);
   }
 


### PR DESCRIPTION
## Problem

`uninstallPlugin()` gates on `fs.existsSync(targetDir)`, which **follows** symlinks.

A monorepo sub-plugin installs as a symlink `~/.opencli/plugins/<name>` → `~/.opencli/monorepos/<repo>`. If that target is later removed (a manual delete, a failed/rolled-back update, a disk issue), the link **dangles**. `existsSync` then reports `false`, so `uninstallPlugin` throws `Plugin "<name>" is not installed.` — yet `plugin list` (which uses `lstat` via `isSymlinkSync`) still shows it.

Net result: the plugin is permanently stuck — **visible in `list`, unremovable via `uninstall`**.

## Fix

Use the lstat-based `pathExistsSync` (already defined in this file) instead of `existsSync`:

```ts
if (!pathExistsSync(targetDir)) {
  throw new Error(`Plugin "${name}" is not installed.`);
}
```

`lstat` does not follow the link, so a dangling symlink passes the guard and reaches the existing symlink branch (`if (isSymlinkSync(targetDir)) fs.unlinkSync(targetDir)`), which removes the dead link and cleans up the lock entry. A genuinely absent path still throws "not installed" (`lstat` raises `ENOENT`).

`updatePlugin` has the same `existsSync` guard, but a dangling link can't be updated anyway — left as-is to keep this change scoped to the uninstall path, where the user is actively cleaning up.

## Test

Adds a regression test: create a plugin symlink, delete its target so the link dangles, and assert `uninstallPlugin` removes it without throwing (and the dead link is gone). The existing "throws for non-existent plugin" test stays green. Verified red→green.

## Checks

- `npx tsc --noEmit` — clean
- `npm test` — full gate green