### PR TITLE
chore(build): regenerate cli-manifest.json to sync siteSession (#1462)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -343,7 +343,8 @@
     "type": "js",
     "modulePath": "12306/auth.js",
     "sourceFile": "12306/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "1688",
@@ -557,7 +558,8 @@
     "type": "js",
     "modulePath": "1688/auth.js",
     "sourceFile": "1688/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "1point3acres",
@@ -943,7 +945,8 @@
     "type": "js",
     "modulePath": "1point3acres/auth.js",
     "sourceFile": "1point3acres/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "36kr",
@@ -1645,7 +1648,8 @@
     "type": "js",
     "modulePath": "amazon/auth.js",
     "sourceFile": "amazon/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "antigravity",
@@ -2998,7 +3002,8 @@
     "type": "js",
     "modulePath": "band/auth.js",
     "sourceFile": "band/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "barchart",
@@ -5701,7 +5706,8 @@
     "type": "js",
     "modulePath": "boss/auth.js",
     "sourceFile": "boss/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "brave",
@@ -5906,7 +5912,8 @@
     "type": "js",
     "modulePath": "chaoxing/auth.js",
     "sourceFile": "chaoxing/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt",
@@ -6309,7 +6316,8 @@
     "type": "js",
     "modulePath": "chatgpt/auth.js",
     "sourceFile": "chatgpt/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "chatgpt-app",
@@ -7098,7 +7106,8 @@
     "type": "js",
     "modulePath": "claude/auth.js",
     "sourceFile": "claude/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "cnki",
@@ -8349,7 +8358,8 @@
     "type": "js",
     "modulePath": "coupang/auth.js",
     "sourceFile": "coupang/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "crates",
@@ -8681,7 +8691,8 @@
     "type": "js",
     "modulePath": "ctrip/auth.js",
     "sourceFile": "ctrip/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "cursor",
@@ -9380,7 +9391,8 @@
     "type": "js",
     "modulePath": "deepseek/auth.js",
     "sourceFile": "deepseek/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "defillama",
@@ -9768,7 +9780,8 @@
     "type": "js",
     "modulePath": "dianping/auth.js",
     "sourceFile": "dianping/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "dictionary",
@@ -10539,7 +10552,8 @@
     "type": "js",
     "modulePath": "douban/auth.js",
     "sourceFile": "douban/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao",
@@ -10835,7 +10849,8 @@
     "type": "js",
     "modulePath": "doubao/auth.js",
     "sourceFile": "doubao/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "doubao-app",
@@ -12729,7 +12744,8 @@
     "type": "js",
     "modulePath": "facebook/auth.js",
     "sourceFile": "facebook/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "flathub",
@@ -12901,7 +12917,8 @@
     "type": "js",
     "modulePath": "flomo/auth.js",
     "sourceFile": "flomo/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",
@@ -13263,7 +13280,8 @@
     "type": "js",
     "modulePath": "gemini/auth.js",
     "sourceFile": "gemini/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "geogebra",
@@ -13675,7 +13693,8 @@
     "type": "js",
     "modulePath": "gitee/auth.js",
     "sourceFile": "gitee/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "github",
@@ -14721,7 +14740,8 @@
     "type": "js",
     "modulePath": "grok/auth.js",
     "sourceFile": "grok/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "hackernews",
@@ -15312,7 +15332,8 @@
     "type": "js",
     "modulePath": "hf/auth.js",
     "sourceFile": "hf/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "homebrew",
@@ -15771,7 +15792,8 @@
     "type": "js",
     "modulePath": "hupu/auth.js",
     "sourceFile": "hupu/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "imdb",
@@ -16819,7 +16841,8 @@
     "type": "js",
     "modulePath": "instagram/auth.js",
     "sourceFile": "instagram/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "jd",
@@ -17068,7 +17091,8 @@
     "type": "js",
     "modulePath": "jd/auth.js",
     "sourceFile": "jd/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "jianyu",
@@ -17201,7 +17225,8 @@
     "type": "js",
     "modulePath": "jianyu/auth.js",
     "sourceFile": "jianyu/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "jike",
@@ -17573,7 +17598,8 @@
     "type": "js",
     "modulePath": "jike/auth.js",
     "sourceFile": "jike/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "jimeng",
@@ -17713,7 +17739,8 @@
     "type": "js",
     "modulePath": "jimeng/auth.js",
     "sourceFile": "jimeng/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "jimeng",
@@ -18054,7 +18081,8 @@
     "type": "js",
     "modulePath": "ke/auth.js",
     "sourceFile": "ke/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "ke",
@@ -19123,7 +19151,8 @@
     "type": "js",
     "modulePath": "kimi/auth.js",
     "sourceFile": "kimi/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "lesswrong",
@@ -20611,7 +20640,8 @@
     "type": "js",
     "modulePath": "linkedin/auth.js",
     "sourceFile": "linkedin/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "linkedin-learning",
@@ -20770,7 +20800,8 @@
     "type": "js",
     "modulePath": "linkedin-learning/auth.js",
     "sourceFile": "linkedin-learning/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "linux-do",
@@ -21154,7 +21185,8 @@
     "type": "js",
     "modulePath": "linux-do/auth.js",
     "sourceFile": "linux-do/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "lobsters",
@@ -21561,7 +21593,8 @@
     "type": "js",
     "modulePath": "maimai/auth.js",
     "sourceFile": "maimai/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "manus",
@@ -21764,7 +21797,8 @@
     "type": "js",
     "modulePath": "manus/auth.js",
     "sourceFile": "manus/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "maven",
@@ -22805,7 +22839,8 @@
     "type": "js",
     "modulePath": "notebooklm/auth.js",
     "sourceFile": "notebooklm/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "notebooklm",
@@ -23411,7 +23446,8 @@
     "type": "js",
     "modulePath": "nowcoder/auth.js",
     "sourceFile": "nowcoder/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "npm",
@@ -25024,7 +25060,8 @@
     "type": "js",
     "modulePath": "pixiv/auth.js",
     "sourceFile": "pixiv/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "powerchina",
@@ -25111,7 +25148,8 @@
     "type": "js",
     "modulePath": "powerchina/auth.js",
     "sourceFile": "powerchina/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "producthunt",
@@ -26627,7 +26665,8 @@
     "type": "js",
     "modulePath": "quark/auth.js",
     "sourceFile": "quark/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "qwen",
@@ -26976,7 +27015,8 @@
     "type": "js",
     "modulePath": "qwen/auth.js",
     "sourceFile": "qwen/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "reddit",
@@ -28054,7 +28094,8 @@
     "type": "js",
     "modulePath": "rednote/auth.js",
     "sourceFile": "rednote/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "rest-countries",
@@ -28278,7 +28319,8 @@
     "type": "js",
     "modulePath": "reuters/auth.js",
     "sourceFile": "reuters/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "rfc",
@@ -31423,7 +31465,8 @@
     "type": "js",
     "modulePath": "suno/auth.js",
     "sourceFile": "suno/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "taobao",
@@ -31658,7 +31701,8 @@
     "type": "js",
     "modulePath": "taobao/auth.js",
     "sourceFile": "taobao/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "tdx",
@@ -32454,7 +32498,8 @@
     "type": "js",
     "modulePath": "tiktok/auth.js",
     "sourceFile": "tiktok/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "toutiao",
@@ -32567,7 +32612,8 @@
     "type": "js",
     "modulePath": "toutiao/auth.js",
     "sourceFile": "toutiao/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "trae-cn",
@@ -35956,7 +36002,8 @@
     "type": "js",
     "modulePath": "upwork/auth.js",
     "sourceFile": "upwork/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "v2ex",
@@ -36319,7 +36366,8 @@
     "type": "js",
     "modulePath": "v2ex/auth.js",
     "sourceFile": "v2ex/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "wanfang",
@@ -36567,7 +36615,8 @@
     "type": "js",
     "modulePath": "wechat-channels/auth.js",
     "sourceFile": "wechat-channels/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -37003,7 +37052,8 @@
     "type": "js",
     "modulePath": "weibo/auth.js",
     "sourceFile": "weibo/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weixin",
@@ -37551,7 +37601,8 @@
     "type": "js",
     "modulePath": "weread/auth.js",
     "sourceFile": "weread/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weread-official",
@@ -38662,7 +38713,8 @@
     "type": "js",
     "modulePath": "xianyu/auth.js",
     "sourceFile": "xianyu/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaoe",
@@ -38850,7 +38902,8 @@
     "type": "js",
     "modulePath": "xiaoe/auth.js",
     "sourceFile": "xiaoe/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -40208,7 +40261,8 @@
     "type": "js",
     "modulePath": "xueqiu/auth.js",
     "sourceFile": "xueqiu/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yahoo",
@@ -41419,7 +41473,8 @@
     "type": "js",
     "modulePath": "youtube/auth.js",
     "sourceFile": "youtube/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "yuanbao",
@@ -41672,7 +41727,8 @@
     "type": "js",
     "modulePath": "yuanbao/auth.js",
     "sourceFile": "yuanbao/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "zhihu",
@@ -42308,7 +42364,8 @@
     "type": "js",
     "modulePath": "zhihu/auth.js",
     "sourceFile": "zhihu/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "zlibrary",
@@ -42612,6 +42669,7 @@
     "type": "js",
     "modulePath": "zsxq/auth.js",
     "sourceFile": "zsxq/auth.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   }
 ]


### PR DESCRIPTION
## Problem

`main`'s CI is red on the `build (ubuntu-latest)` job:

```
::error::cli-manifest.json is out of sync with the source. Run 'npm run build' and commit the result.
```

## Root cause

#1462 (`467fdd0b`, "rename site browser reuse to persistent sessions") added the `siteSession` field to the manifest generator — `src/build-manifest.ts:129`:

```ts
siteSession: cmd.siteSession,
```

…but `cli-manifest.json` was never regenerated, so the committed manifest lacks `siteSession` on the affected adapter commands. The `build (ubuntu-latest)` job runs `npm run build` and fails if the regenerated `cli-manifest.json` differs from the committed one — which it now does on `main` and therefore on every PR branched off it.

## Fix

Ran `npm run build-manifest`. The result is a **deterministic** 116/58-line diff that **only** adds the missing `"siteSession": "persistent"` fields to the affected commands — no reordering, no other field changes. Regenerating twice produces an identical file.

This restores `main` (and any PR based on it) to a green manifest-sync check.

Happy to close if you'd rather regenerate it yourself — just flagging that the gate is currently red for everyone branching off `main`.
