### PR TITLE
fix(gemini): expand "More tools" submenu to reach Deep Research

### DIFF
--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -779,7 +779,8 @@ function openGeminiToolsMenuScript() {
 function selectGeminiToolScript(labels) {
     const labelsJson = JSON.stringify(labels);
     return `
-    ((targetLabels) => {
+    (async () => {
+      const targetLabels = ${labelsJson};
       const isDisabled = (el) => {
         if (!(el instanceof HTMLElement)) return true;
         if ('disabled' in el && el.disabled) return true;
@@ -810,39 +811,69 @@ function selectGeminiToolScript(labels) {
       const lowered = normalized.map((label) => label.toLowerCase());
       if (lowered.length === 0) return '';
 
-      const menuSelectors = [
-        '[role="menu"]',
-        '[role="listbox"]',
-        '[aria-label*="tool" i]',
-        '[aria-label*="mode" i]',
-        '[aria-modal="true"]',
-      ];
-      const menuRoots = Array.from(document.querySelectorAll(menuSelectors.join(','))).filter(isVisible);
-      if (menuRoots.length === 0) return '';
-      const seen = new Set();
+      const findAndClickInVisibleMenus = () => {
+        const menuSelectors = [
+          '[role="menu"]',
+          '[role="listbox"]',
+          '[aria-label*="tool" i]',
+          '[aria-label*="mode" i]',
+          '[aria-modal="true"]',
+        ];
+        const menuRoots = Array.from(document.querySelectorAll(menuSelectors.join(','))).filter(isVisible);
+        if (menuRoots.length === 0) return '';
+        const seen = new Set();
 
-      for (const root of menuRoots) {
-        const candidates = Array.from(root.querySelectorAll('button, [role="menuitem"], [role="option"], [role="button"], a, li'));
-        for (const node of candidates) {
-          if (seen.has(node)) continue;
-          seen.add(node);
-          if (!isInteractable(node)) continue;
-          const text = (node.textContent || '').trim().toLowerCase();
-          const aria = (node.getAttribute('aria-label') || '').trim().toLowerCase();
-          if (!text && !aria) continue;
-          const combined = \`\${text} \${aria}\`.trim();
-          for (let index = 0; index < lowered.length; index += 1) {
-            const label = lowered[index];
-            if (label && combined.includes(label)) {
-              if (node instanceof HTMLElement) node.click();
-              return normalized[index];
+        for (const root of menuRoots) {
+          const candidates = Array.from(root.querySelectorAll('button, [role="menuitem"], [role="option"], [role="button"], a, li'));
+          for (const node of candidates) {
+            if (seen.has(node)) continue;
+            seen.add(node);
+            if (!isInteractable(node)) continue;
+            const text = (node.textContent || '').trim().toLowerCase();
+            const aria = (node.getAttribute('aria-label') || '').trim().toLowerCase();
+            if (!text && !aria) continue;
+            const combined = \`\${text} \${aria}\`.trim();
+            for (let index = 0; index < lowered.length; index += 1) {
+              const label = lowered[index];
+              if (label && combined.includes(label)) {
+                if (node instanceof HTMLElement) node.click();
+                return normalized[index];
+              }
             }
           }
         }
+        return '';
+      };
+
+      let match = findAndClickInVisibleMenus();
+      if (match) return match;
+
+      // Gemini hides some tools (e.g. Deep Research) behind a "More tools" / "更多工具"
+      // submenu. Expand any such expander inside an already-open menu and retry once.
+      const moreToolsTokens = ['more tools', '更多工具'];
+      const openMenus = Array.from(document.querySelectorAll('[role="menu"], [role="listbox"], [aria-modal="true"]')).filter(isVisible);
+      let expanded = false;
+      for (const menu of openMenus) {
+        const expandables = Array.from(menu.querySelectorAll('button, [role="button"], [role="menuitem"]')).filter(isInteractable);
+        const more = expandables.find((node) => {
+          const text = (node.textContent || '').trim().toLowerCase();
+          const aria = (node.getAttribute('aria-label') || '').trim().toLowerCase();
+          return moreToolsTokens.some((token) => (text && text.includes(token)) || (aria && aria.includes(token)));
+        });
+        if (more instanceof HTMLElement) {
+          more.click();
+          expanded = true;
+          break;
+        }
+      }
+      if (expanded) {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        match = findAndClickInVisibleMenus();
+        if (match) return match;
       }
 
       return '';
-    })(${labelsJson})
+    })()
   `;
 }
 function clickGeminiConfirmButtonScript(labels) {


### PR DESCRIPTION
## Summary

Gemini's Web UI moved **Deep Research** behind a `更多工具` / `More tools` submenu inside the tools menu. `selectGeminiToolScript` only scanned already-visible menu roots, so `opencli gemini deep-research` returned `tool-not-found`.

After the first scan misses, look for a "More tools" expander button inside any open menu, click it, wait for the submenu to render, and rescan once. Tools in the first-level menu still match on the first pass, so canvas/image/video adapters are unaffected.

The script changes from a sync IIFE to an async IIFE; callers already `await page.evaluate(...)`, so this is compatible.

## Reproduction

```
$ opencli gemini deep-research "<prompt>"
status: tool-not-found
url: https://gemini.google.com/app
```

## Root cause

UI structure on `https://gemini.google.com/app`:

1. Click `上传和工具` (aria-label="上传和工具") → opens first menu: `上传文件`, `从云端硬盘添加`, `制作图片`, `制作视频`, `Canvas`, `更多工具`.
2. Click `更多工具` (aria-label="更多工具") → opens submenu: `Deep Research`, `制作音乐`, `学习辅导`, ...

`openGeminiToolsMenu` only opens the first-level menu. `selectGeminiToolScript` searched only visible `[role=menu]` / `[role=listbox]` roots and never expanded the `更多工具` submenu.

Confirmed via `opencli browser` inspection of the live page.

## Verification

```
$ opencli gemini deep-research "test" --timeout 20
status: started
url: https://gemini.google.com/app/dc7728bdd2612061
```

Status flipped from `tool-not-found` → `started`.

```
$ npx vitest run clis/gemini/utils.test.js clis/gemini/deep-research.test.js
PASS (38) FAIL (0)
```

## Notes

- Did not add a unit test: the adapter test suite uses mock-page style without a DOM environment, and the regression is behavioral (submenu expansion), which an e2e test would cover better. Happy to add one if maintainers prefer.
- No CHANGELOG update — didn't see one in the repo; let me know if it should be touched.

Fixes #1941