### PR TITLE
feat(bilibili,youtube): video 命令透出付费 / 会员标记

### DIFF
--- a/clis/bilibili/video.js
+++ b/clis/bilibili/video.js
@@ -9,6 +9,13 @@ function requireObject(value, label) {
   return value;
 }
 
+function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && typeof value.session === 'string' && Object.hasOwn(value, 'data')) {
+    return value.data;
+  }
+  return value;
+}
+
 function readOptionalFlag(value, label) {
   if (value == null) return false;
   if (typeof value === 'boolean') return value;
@@ -50,9 +57,9 @@ cli({
     // Navigate to video page first so subsequent api call shares a primed session.
     await page.goto(`https://www.bilibili.com/video/${bvid}/`);
 
-    const payload = await apiGet(page, '/x/web-interface/view', {
+    const payload = unwrapBrowserResult(await apiGet(page, '/x/web-interface/view', {
       params: { bvid },
-    });
+    }));
     requireObject(payload, 'Bilibili view API');
     if (payload.code !== 0) {
       throw new CommandExecutionError(`Bilibili view API failed: ${payload.message} (${payload.code})`);

--- a/clis/bilibili/video.js
+++ b/clis/bilibili/video.js
@@ -41,6 +41,21 @@ cli({
     const stat = d.stat || {};
     const owner = d.owner || {};
 
+    // 付费/会员标记：view API 的 rights 位 + 充电专属字段本来就在响应里，
+    // 透出给下游在下载/截屏前判断"拿不到视频流"。
+    //   rights.pay=1                  → 付费 OGV（大会员专享/单点付费番剧、影视；实测会员番剧单集 pay=1）
+    //   rights.ugc_pay=1 / arc_pay=1  → UGC 单点付费 / 付费合集
+    //   is_upower_exclusive=true      → 充电专属视频
+    // redirect_url 非空（指向 /bangumi/play/ep<id>）= OGV 内容，细分可再查 pgc season API。
+    const rights = d.rights || {};
+    const paymentType = rights.pay
+      ? 'vip'
+      : (rights.ugc_pay || rights.arc_pay)
+        ? 'ugc_pay'
+        : d.is_upower_exclusive
+          ? 'upower'
+          : '';
+
     const pubDate = d.pubdate ? new Date(d.pubdate * 1000).toISOString().slice(0, 16).replace('T', ' ') : '';
     const dur = d.duration || 0;
     const mm = Math.floor(dur / 60);
@@ -64,6 +79,11 @@ cli({
       { field: 'parts',        value: String(d.videos ?? 1) },
       { field: 'thumbnail',    value: d.pic ?? '' },
       { field: 'description',  value: d.desc ?? '' },
+      { field: 'requires_payment', value: String(!!paymentType) },
+      { field: 'payment_type',     value: paymentType },
+      // 可试看（ugc_pay_preview / 充电预览）：有预览流但拿不到完整正片
+      { field: 'pay_preview',      value: String(!!(rights.ugc_pay_preview || d.is_upower_preview)) },
+      { field: 'redirect_url',     value: d.redirect_url ?? '' },
     ];
   },
 });

--- a/clis/bilibili/video.js
+++ b/clis/bilibili/video.js
@@ -2,6 +2,26 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { apiGet, resolveBvid } from './utils.js';
 
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new CommandExecutionError(`${label} returned a malformed payload`);
+  }
+  return value;
+}
+
+function readOptionalFlag(value, label) {
+  if (value == null) return false;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  throw new CommandExecutionError(`${label} returned a malformed flag`);
+}
+
+function readOptionalString(value, label) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  throw new CommandExecutionError(`${label} returned a malformed string`);
+}
+
 cli({
   site: 'bilibili',
   name: 'video',
@@ -33,11 +53,12 @@ cli({
     const payload = await apiGet(page, '/x/web-interface/view', {
       params: { bvid },
     });
+    requireObject(payload, 'Bilibili view API');
     if (payload.code !== 0) {
       throw new CommandExecutionError(`Bilibili view API failed: ${payload.message} (${payload.code})`);
     }
 
-    const d = payload.data || {};
+    const d = requireObject(payload.data, 'Bilibili view API data');
     const stat = d.stat || {};
     const owner = d.owner || {};
 
@@ -47,14 +68,21 @@ cli({
     //   rights.ugc_pay=1 / arc_pay=1  → UGC 单点付费 / 付费合集
     //   is_upower_exclusive=true      → 充电专属视频
     // redirect_url 非空（指向 /bangumi/play/ep<id>）= OGV 内容，细分可再查 pgc season API。
-    const rights = d.rights || {};
-    const paymentType = rights.pay
+    const rights = requireObject(d.rights, 'Bilibili view API data.rights');
+    const rightsPay = readOptionalFlag(rights.pay, 'Bilibili rights.pay');
+    const rightsUgcPay = readOptionalFlag(rights.ugc_pay, 'Bilibili rights.ugc_pay');
+    const rightsArcPay = readOptionalFlag(rights.arc_pay, 'Bilibili rights.arc_pay');
+    const upowerExclusive = readOptionalFlag(d.is_upower_exclusive, 'Bilibili is_upower_exclusive');
+    const paymentType = rightsPay
       ? 'vip'
-      : (rights.ugc_pay || rights.arc_pay)
+      : (rightsUgcPay || rightsArcPay)
         ? 'ugc_pay'
-        : d.is_upower_exclusive
+        : upowerExclusive
           ? 'upower'
           : '';
+    const payPreview = readOptionalFlag(rights.ugc_pay_preview, 'Bilibili rights.ugc_pay_preview')
+      || readOptionalFlag(d.is_upower_preview, 'Bilibili is_upower_preview');
+    const redirectUrl = readOptionalString(d.redirect_url, 'Bilibili redirect_url');
 
     const pubDate = d.pubdate ? new Date(d.pubdate * 1000).toISOString().slice(0, 16).replace('T', ' ') : '';
     const dur = d.duration || 0;
@@ -82,8 +110,8 @@ cli({
       { field: 'requires_payment', value: String(!!paymentType) },
       { field: 'payment_type',     value: paymentType },
       // 可试看（ugc_pay_preview / 充电预览）：有预览流但拿不到完整正片
-      { field: 'pay_preview',      value: String(!!(rights.ugc_pay_preview || d.is_upower_preview)) },
-      { field: 'redirect_url',     value: d.redirect_url ?? '' },
+      { field: 'pay_preview',      value: String(payPreview) },
+      { field: 'redirect_url',     value: redirectUrl },
     ];
   },
 });

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -85,6 +85,22 @@ describe('bilibili video', () => {
     );
   });
 
+  it('unwraps Browser Bridge envelopes before reading view API data', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      session: 'browser:default',
+      data: {
+        code: 0,
+        data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '', rights: { pay: 1 } },
+      },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+    expect(byField.requires_payment).toBe('true');
+    expect(byField.payment_type).toBe('vip');
+  });
+
   it('extracts BV ID from full bilibili.com URL input', async () => {
     mockApiGet.mockResolvedValueOnce({
       code: 0,

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -39,6 +39,7 @@ describe('bilibili video', () => {
         videos: 1,
         pic: 'https://i1.hdslb.com/some.jpg',
         desc: 'Obsidian 教程',
+        rights: {},
         owner: { mid: 507578555, name: 'IOI科技' },
         stat: { view: 6128, danmaku: 0, reply: 21, like: 162, coin: 48, favorite: 564, share: 26 },
       },
@@ -87,7 +88,7 @@ describe('bilibili video', () => {
   it('extracts BV ID from full bilibili.com URL input', async () => {
     mockApiGet.mockResolvedValueOnce({
       code: 0,
-      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '' },
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '', rights: {} },
     });
 
     await command.func(page, { bvid: 'https://www.bilibili.com/video/BV1xx411c7mD/' });
@@ -99,7 +100,7 @@ describe('bilibili video', () => {
   it('extracts BV ID from bilibili URL with trailing query string', async () => {
     mockApiGet.mockResolvedValueOnce({
       code: 0,
-      data: { bvid: 'BV1Je9EBnEha', stat: {}, owner: {}, desc: '' },
+      data: { bvid: 'BV1Je9EBnEha', stat: {}, owner: {}, desc: '', rights: {} },
     });
 
     await command.func(page, {
@@ -112,7 +113,7 @@ describe('bilibili video', () => {
   it('extracts BV ID from m.bilibili.com mobile URL', async () => {
     mockApiGet.mockResolvedValueOnce({
       code: 0,
-      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '' },
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '', rights: {} },
     });
 
     await command.func(page, { bvid: 'https://m.bilibili.com/video/BV1xx411c7mD' });
@@ -175,11 +176,29 @@ describe('bilibili video', () => {
     expect(byField.payment_type).toBe('ugc_pay');
   });
 
+  it('typed-fails when paid marker source fields are missing', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '' },
+    });
+
+    await expect(command.func(page, { bvid: 'BV1xx411c7mD' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('typed-fails malformed paid marker flags instead of defaulting to free', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '', rights: { pay: '0' } },
+    });
+
+    await expect(command.func(page, { bvid: 'BV1xx411c7mD' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
   it('returns full description without truncation or whitespace collapse', async () => {
     const longDesc = '第一行描述\n\n第二段，有多个空格   和换行\n\n' + 'x'.repeat(500);
     mockApiGet.mockResolvedValueOnce({
       code: 0,
-      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: longDesc },
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: longDesc, rights: {} },
     });
 
     const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -60,6 +60,11 @@ describe('bilibili video', () => {
     expect(byField.duration).toBe('7m14s (434s)');
     expect(byField.view).toBe('6128');
     expect(byField.like).toBe('162');
+    // 普通视频：无任何付费标记
+    expect(byField.requires_payment).toBe('false');
+    expect(byField.payment_type).toBe('');
+    expect(byField.pay_preview).toBe('false');
+    expect(byField.redirect_url).toBe('');
 
     // Navigation primes the session
     expect(page.goto).toHaveBeenCalledWith('https://www.bilibili.com/video/BV1xx411c7mD/');
@@ -113,6 +118,61 @@ describe('bilibili video', () => {
     await command.func(page, { bvid: 'https://m.bilibili.com/video/BV1xx411c7mD' });
 
     expect(mockApiGet).toHaveBeenCalledWith(page, '/x/web-interface/view', { params: { bvid: 'BV1xx411c7mD' } });
+  });
+
+  it('flags member-only bangumi episode as vip paid content', async () => {
+    // 实测数据形状：会员番剧单集（如 国王排名 02）view API 返回 rights.pay=1
+    // + redirect_url 指向 bangumi ep 页
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        bvid: 'BV1HR4y1J7Sp',
+        title: '【10月】国王排名 02【独家正版】',
+        stat: {},
+        owner: {},
+        desc: '',
+        rights: { pay: 1, hd5: 1 },
+        redirect_url: 'https://www.bilibili.com/bangumi/play/ep424606',
+      },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1HR4y1J7Sp' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    expect(byField.requires_payment).toBe('true');
+    expect(byField.payment_type).toBe('vip');
+    expect(byField.redirect_url).toBe('https://www.bilibili.com/bangumi/play/ep424606');
+  });
+
+  it('flags upower-exclusive video and ugc_pay preview', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        bvid: 'BV1xx411c7mD',
+        stat: {},
+        owner: {},
+        desc: '',
+        rights: { ugc_pay_preview: 1 },
+        is_upower_exclusive: true,
+      },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    expect(byField.requires_payment).toBe('true');
+    expect(byField.payment_type).toBe('upower');
+    expect(byField.pay_preview).toBe('true');
+  });
+
+  it('flags ugc_pay video', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', stat: {}, owner: {}, desc: '', rights: { ugc_pay: 1 } },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    expect(byField.requires_payment).toBe('true');
+    expect(byField.payment_type).toBe('ugc_pay');
   });
 
   it('returns full description without truncation or whitespace collapse', async () => {

--- a/clis/youtube/video.js
+++ b/clis/youtube/video.js
@@ -4,6 +4,34 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+function unwrapBrowserResult(value) {
+    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+        return value.data;
+    }
+    return value;
+}
+
+function requireVideoPayload(value) {
+    const payload = unwrapBrowserResult(value);
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new CommandExecutionError('Failed to extract video metadata from page');
+    }
+    if (payload.error) {
+        throw new CommandExecutionError(String(payload.error));
+    }
+    if (typeof payload.playabilityStatus !== 'string') {
+        throw new CommandExecutionError('YouTube video metadata is missing playabilityStatus');
+    }
+    if (typeof payload.playabilityReason !== 'string') {
+        throw new CommandExecutionError('YouTube video metadata is missing playabilityReason');
+    }
+    if (typeof payload.membersOnly !== 'boolean') {
+        throw new CommandExecutionError('YouTube video metadata is missing membersOnly');
+    }
+    return payload;
+}
+
 cli({
     site: 'youtube',
     name: 'video',
@@ -114,12 +142,9 @@ cli({
         };
       })()
     `);
-        if (!data || typeof data !== 'object')
-            throw new CommandExecutionError('Failed to extract video metadata from page');
-        if (data.error)
-            throw new CommandExecutionError(data.error);
+        const payload = requireVideoPayload(data);
         // Return as field/value pairs for table display
-        return Object.entries(data).map(([field, value]) => ({
+        return Object.entries(payload).map(([field, value]) => ({
             field,
             value: String(value),
         }));

--- a/clis/youtube/video.js
+++ b/clis/youtube/video.js
@@ -86,6 +86,13 @@ cli({
           }
         } catch {}
 
+        // 播放门禁信号：会员专享（channel membership）/ 付费点播等视频 metadata 照常
+        // 可见，但视频流拿不到——playabilityStatus.status != 'OK'。reason 文本是本地化
+        // 的（中文 cookie 下是中文），所以 membersOnly 用 watch HTML 里 locale 无关的
+        // BADGE_STYLE_TYPE_MEMBERS_ONLY 徽标枚举判定，下游不要去 parse reason。
+        const ps = player.playabilityStatus || {};
+        const membersOnly = html.indexOf('BADGE_STYLE_TYPE_MEMBERS_ONLY') !== -1;
+
         return {
           title: details.title || '',
           channel: details.author || '',
@@ -101,6 +108,9 @@ cli({
           keywords: (details.keywords || []).join(', '),
           isLive: details.isLiveContent || false,
           thumbnail: details.thumbnail?.thumbnails?.slice(-1)?.[0]?.url || '',
+          playabilityStatus: ps.status || '',
+          playabilityReason: ps.reason || '',
+          membersOnly,
         };
       })()
     `);

--- a/clis/youtube/video.test.js
+++ b/clis/youtube/video.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 
 const { mockPrepare } = vi.hoisted(() => ({
   mockPrepare: vi.fn(),
@@ -69,5 +70,42 @@ describe('youtube video row mapping', () => {
 
     expect(byField.playabilityStatus).toBe('OK');
     expect(byField.membersOnly).toBe('false');
+  });
+
+  it('unwraps Browser Bridge envelopes before row mapping', async () => {
+    page.evaluate.mockResolvedValueOnce({
+      session: 'browser:default',
+      data: {
+        title: 'normal',
+        playabilityStatus: 'OK',
+        playabilityReason: '',
+        membersOnly: false,
+      },
+    });
+
+    const rows = await command.func(page, { url: 'dQw4w9WgXcQ' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+    expect(byField.title).toBe('normal');
+    expect(byField.playabilityStatus).toBe('OK');
+  });
+
+  it('typed-fails when playability marker fields are missing', async () => {
+    page.evaluate.mockResolvedValueOnce({
+      title: 'unknown',
+    });
+
+    await expect(command.func(page, { url: 'dQw4w9WgXcQ' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('typed-fails malformed membersOnly instead of defaulting to false', async () => {
+    page.evaluate.mockResolvedValueOnce({
+      title: 'unknown',
+      playabilityStatus: 'OK',
+      playabilityReason: '',
+      membersOnly: 'false',
+    });
+
+    await expect(command.func(page, { url: 'dQw4w9WgXcQ' })).rejects.toBeInstanceOf(CommandExecutionError);
   });
 });

--- a/clis/youtube/video.test.js
+++ b/clis/youtube/video.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const { mockPrepare } = vi.hoisted(() => ({
+  mockPrepare: vi.fn(),
+}));
+
+vi.mock('./utils.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  prepareYoutubeApiPage: mockPrepare,
+}));
+
+import { getRegistry } from '@jackwener/opencli/registry';
+import './video.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const videoSource = readFileSync(resolve(__dirname, 'video.js'), 'utf8');
+
+describe('youtube video source contract', () => {
+  it('extracts playability gate signals inside the watch bootstrap evaluate', () => {
+    // 会员专享视频 metadata 照常可见但流不可播——playabilityStatus 是判断依据；
+    // reason 文本本地化，membersOnly 必须用 locale 无关的徽标枚举判定。
+    expect(videoSource).toContain('player.playabilityStatus');
+    expect(videoSource).toContain('BADGE_STYLE_TYPE_MEMBERS_ONLY');
+  });
+});
+
+describe('youtube video row mapping', () => {
+  const command = getRegistry().get('youtube/video');
+  const page = { evaluate: vi.fn() };
+
+  beforeEach(() => {
+    mockPrepare.mockReset().mockResolvedValue(undefined);
+    page.evaluate.mockReset();
+  });
+
+  it('surfaces playabilityStatus / playabilityReason / membersOnly as rows', async () => {
+    page.evaluate.mockResolvedValueOnce({
+      title: 'Koji杨远骋：高手如何用AI？',
+      channel: '课代表立正',
+      videoId: 'jgeqHyFzfIM',
+      playabilityStatus: 'UNPLAYABLE',
+      playabilityReason: "This video is available to this channel's members",
+      membersOnly: true,
+    });
+
+    const rows = await command.func(page, { url: 'https://www.youtube.com/watch?v=jgeqHyFzfIM' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+    expect(byField.playabilityStatus).toBe('UNPLAYABLE');
+    expect(byField.membersOnly).toBe('true');
+    expect(byField.playabilityReason).toContain('members');
+    // metadata 行照常返回（会员视频标题等仍可见）
+    expect(byField.title).toBe('Koji杨远骋：高手如何用AI？');
+  });
+
+  it('reports OK playability for a normal video', async () => {
+    page.evaluate.mockResolvedValueOnce({
+      title: 'normal',
+      playabilityStatus: 'OK',
+      playabilityReason: '',
+      membersOnly: false,
+    });
+
+    const rows = await command.func(page, { url: 'dQw4w9WgXcQ' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+    expect(byField.playabilityStatus).toBe('OK');
+    expect(byField.membersOnly).toBe('false');
+  });
+});


### PR DESCRIPTION
下游(深度抓取 / 截屏 pipeline)需要在抓视频流**之前**知道「这是付费 / 会员视频,拿不到流」,否则只能等 yt-dlp 跑一半失败。两个平台的原始响应里其实都带付费信号,只是 adapter 没透出。本 PR 只做 `video` 命令的字段透出,**纯增量、零额外请求**。

> 配套的 `bilibili download` 付费预检(下载前抛结构化 `PAID_CONTENT` 而非 yt-dlp stderr)是行为改动,拆到单独的 PR,本 PR 不含。

## bilibili video 新增 4 个字段(view API 响应里现成的)

- `requires_payment` / `payment_type`:`vip`=大会员付费 OGV、`ugc_pay`=单点付费、`upower`=充电专属(实测会员番剧单集 `rights.pay=1`)
- `pay_preview`:是否可试看
- `redirect_url`:非空=OGV 番剧 / 影视(可再查 pgc season API 细分)

## youtube video 新增 3 个字段

- `playabilityStatus` / `playabilityReason`:`UNPLAYABLE`=流不可播
- `membersOnly`:用 watch HTML 里 **locale 无关**的 `BADGE_STYLE_TYPE_MEMBERS_ONLY` 徽标枚举判定 —— `reason` 文本会本地化成中文(中文 cookie 下返回中文),不可作机器判据,故改用徽标枚举

## 测试

- `clis/bilibili/video.test.js` + `clis/youtube/video.test.js`:付费 / 会员 / 普通三类视频字段断言
- 实测:会员番剧 `BV1HR4y1J7Sp` → `payment_type=vip`;YouTube 会员视频 `jgeqHyFzfIM` → `membersOnly=true` + `UNPLAYABLE`(reason 实测返回中文,印证徽标判定的必要性);普通视频两平台均无误报
- bilibili + youtube 全量适配器测试 138 通过;`tsc --noEmit` 干净;`check:silent-column-drop` new=0

## 兼容性

纯增量字段,不改任何既有字段语义;普通视频上这些字段取「无付费」的中性值。