### PR TITLE
feat(cli): expose bundled opencli skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "files": [
     "dist/src/",
     "clis/",
+    "skills/opencli-*/**",
     "cli-manifest.json",
     "scripts/",
     "README.md",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,9 +17,10 @@ import { render as renderOutput } from './output.js';
 import { PKG_VERSION } from './version.js';
 import { printCompletionScript } from './completion.js';
 import { loadExternalClis, executeExternalCli, installExternalCli, registerExternalCli, isBinaryInstalled, formatExternalCliLabel } from './external.js';
+import { listOpenCliSkills, readOpenCliSkill } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
-import { EXIT_CODES, getErrorMessage, BrowserConnectError } from './errors.js';
+import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
 import { buildFindJs, buildSemanticFindJs, isFindError, type FindResult, type FindError, type SemanticFindOptions } from './browser/find.js';
@@ -795,6 +796,49 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       const r = await verifyClis({ builtinClis: BUILTIN_CLIS, userClis: USER_CLIS, target, smoke: opts.smoke });
       console.log(renderVerifyReport(r));
       process.exitCode = r.ok ? EXIT_CODES.SUCCESS : EXIT_CODES.GENERIC_ERROR;
+    });
+
+  const skillsCmd = program
+    .command('skills')
+    .description('Read bundled OpenCLI skills');
+
+  skillsCmd
+    .command('list')
+    .description('List bundled opencli-* skills')
+    .option('-f, --format <fmt>', 'Output format: table, json, yaml, md, csv', 'table')
+    .action((opts) => {
+      const rows = listOpenCliSkills();
+      renderOutput(rows, {
+        fmt: opts.format,
+        fmtExplicit: !!opts.format,
+        columns: ['name', 'description', 'version', 'path'],
+        title: 'opencli/skills/list',
+        source: 'opencli skills list',
+      });
+    });
+
+  skillsCmd
+    .command('read')
+    .description("Print an opencli-* skill's SKILL.md or reference file")
+    .argument('<skill>', 'Skill name, or skill/path like opencli-browser/references/foo.md')
+    .argument('[path]', 'Path under the skill directory')
+    .option('--json', 'Output a JSON envelope instead of raw markdown', false)
+    .action((skill: string, skillPath: string | undefined, opts) => {
+      let result: ReturnType<typeof readOpenCliSkill>;
+      try {
+        result = readOpenCliSkill(skill, skillPath ?? '');
+      } catch (err) {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        if (err instanceof CliError && err.hint) console.error(`Hint: ${err.hint}`);
+        process.exitCode = err instanceof CliError ? err.exitCode : EXIT_CODES.GENERIC_ERROR;
+        return;
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      process.stdout.write(result.content);
+      if (!result.content.endsWith('\n')) process.stdout.write('\n');
     });
 
   const authCmd = registerAuthCommands(program);

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -1,0 +1,78 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from './errors.js';
+import { listOpenCliSkills, readOpenCliSkill } from './skills.js';
+
+function makePackageRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-skills-'));
+  fs.mkdirSync(path.join(root, 'skills', 'opencli-browser', 'references'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'skills', 'opencli-autofix'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'skills', 'smart-search'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'package.json'), '{"name":"@jackwener/opencli"}\n');
+  fs.writeFileSync(path.join(root, 'skills', 'opencli-browser', 'SKILL.md'), [
+    '---',
+    'name: opencli-browser',
+    'description: Browser control skill',
+    'version: 1.2.3',
+    '---',
+    '',
+    '# Browser',
+    '',
+    'Body.',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(root, 'skills', 'opencli-browser', 'references', 'targets.md'), '# Targets\n');
+  fs.writeFileSync(path.join(root, 'skills', 'opencli-autofix', 'SKILL.md'), [
+    '---',
+    'name: opencli-autofix',
+    'description: Fix adapters: keep scope narrow',
+    '---',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(root, 'skills', 'smart-search', 'SKILL.md'), [
+    '---',
+    'name: smart-search',
+    'description: Search skill',
+    '---',
+    '',
+  ].join('\n'));
+  return root;
+}
+
+describe('opencli skills content', () => {
+  it('lists only opencli-prefixed skills', () => {
+    const root = makePackageRoot();
+
+    expect(listOpenCliSkills(root).map((skill) => skill.name)).toEqual([
+      'opencli-autofix',
+      'opencli-browser',
+    ]);
+    expect(listOpenCliSkills(root).find((skill) => skill.name === 'opencli-autofix')?.description)
+      .toBe('Fix adapters: keep scope narrow');
+  });
+
+  it('reads a skill SKILL.md and reference file', () => {
+    const root = makePackageRoot();
+
+    expect(readOpenCliSkill('opencli-browser', '', root)).toMatchObject({
+      skill: 'opencli-browser',
+      path: 'SKILL.md',
+    });
+    expect(readOpenCliSkill('opencli-browser/references/targets.md', '', root)).toMatchObject({
+      skill: 'opencli-browser',
+      path: 'references/targets.md',
+      content: '# Targets\n',
+    });
+    expect(readOpenCliSkill('opencli-browser', 'references/targets.md', root).content).toBe('# Targets\n');
+  });
+
+  it('rejects non-opencli skills and path traversal', () => {
+    const root = makePackageRoot();
+
+    expect(() => readOpenCliSkill('smart-search', '', root)).toThrow(ArgumentError);
+    expect(() => readOpenCliSkill('opencli-browser/../smart-search/SKILL.md', '', root)).toThrow(ArgumentError);
+    expect(() => readOpenCliSkill('opencli-browser', '../../package.json', root)).toThrow(ArgumentError);
+  });
+});

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,0 +1,153 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+import { ArgumentError } from './errors.js';
+import { findPackageRoot } from './package-paths.js';
+
+const MODULE_FILE = fileURLToPath(import.meta.url);
+
+export interface OpenCliSkillInfo {
+  name: string;
+  description: string;
+  version: string;
+  path: string;
+}
+
+export interface OpenCliSkillReadResult {
+  skill: string;
+  path: string;
+  content: string;
+}
+
+interface SkillFrontmatter {
+  name?: unknown;
+  description?: unknown;
+  version?: unknown;
+}
+
+export function getSkillsRoot(packageRoot: string = findPackageRoot(MODULE_FILE)): string {
+  return path.join(packageRoot, 'skills');
+}
+
+export function listOpenCliSkills(packageRoot?: string): OpenCliSkillInfo[] {
+  const skillsRoot = getSkillsRoot(packageRoot);
+  if (!fs.existsSync(skillsRoot)) return [];
+
+  return fs.readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('opencli-'))
+    .map((entry) => readSkillInfo(skillsRoot, entry.name))
+    .filter((entry): entry is OpenCliSkillInfo => entry !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function readOpenCliSkill(target: string, relpath = '', packageRoot?: string): OpenCliSkillReadResult {
+  const { name, pathInSkill } = parseSkillTarget(target, relpath);
+  if (!name.startsWith('opencli-')) {
+    throw new ArgumentError(`Unknown OpenCLI skill: ${name}`, 'Run "opencli skills list" to see available OpenCLI skills.');
+  }
+
+  const skillsRoot = getSkillsRoot(packageRoot);
+  const skillRoot = path.join(skillsRoot, name);
+  if (!isDirectory(skillRoot) || !fs.existsSync(path.join(skillRoot, 'SKILL.md'))) {
+    throw new ArgumentError(`Unknown OpenCLI skill: ${name}`, 'Run "opencli skills list" to see available OpenCLI skills.');
+  }
+
+  const relativePath = normalizeSkillPath(pathInSkill || 'SKILL.md');
+  const absolutePath = path.resolve(skillRoot, relativePath);
+  const relativeToRoot = path.relative(skillRoot, absolutePath);
+  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+    throw new ArgumentError(`Invalid skill path: ${relativePath}`, 'Skill paths must stay inside the selected OpenCLI skill.');
+  }
+  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    throw new ArgumentError(`Skill file not found: ${name}/${relativePath}`, 'Run "opencli skills list <skill>" is not supported yet; read SKILL.md or a known references/... file.');
+  }
+
+  return {
+    skill: name,
+    path: relativePath,
+    content: fs.readFileSync(absolutePath, 'utf8'),
+  };
+}
+
+function readSkillInfo(skillsRoot: string, name: string): OpenCliSkillInfo | null {
+  const skillMdPath = path.join(skillsRoot, name, 'SKILL.md');
+  if (!fs.existsSync(skillMdPath)) return null;
+  const content = fs.readFileSync(skillMdPath, 'utf8');
+  const fm = parseFrontmatter(content);
+  return {
+    name: typeof fm.name === 'string' && fm.name ? fm.name : name,
+    description: typeof fm.description === 'string' ? fm.description : firstBodyParagraph(content),
+    version: typeof fm.version === 'string' || typeof fm.version === 'number' ? String(fm.version) : '',
+    path: `${name}/SKILL.md`,
+  };
+}
+
+function parseSkillTarget(target: string, relpath: string): { name: string; pathInSkill: string } {
+  const normalizedTarget = normalizeSkillPath(target);
+  if (relpath) {
+    return { name: normalizedTarget, pathInSkill: relpath };
+  }
+  const slash = normalizedTarget.indexOf('/');
+  if (slash === -1) {
+    return { name: normalizedTarget, pathInSkill: '' };
+  }
+  return {
+    name: normalizedTarget.slice(0, slash),
+    pathInSkill: normalizedTarget.slice(slash + 1),
+  };
+}
+
+function normalizeSkillPath(raw: string): string {
+  const normalized = raw.trim().replace(/\\/g, '/');
+  if (!normalized || normalized.includes('\0')) {
+    throw new ArgumentError('Skill path must be non-empty.');
+  }
+  if (normalized.startsWith('/') || normalized.split('/').some((part) => part === '..')) {
+    throw new ArgumentError(`Invalid skill path: ${raw}`, 'Use a path relative to an OpenCLI skill directory.');
+  }
+  return path.posix.normalize(normalized);
+}
+
+function parseFrontmatter(content: string): SkillFrontmatter {
+  if (!content.startsWith('---\n')) return {};
+  const end = content.indexOf('\n---', 4);
+  if (end < 0) return {};
+  try {
+    const parsed = yaml.load(content.slice(4, end));
+    return parsed && typeof parsed === 'object' ? parsed as SkillFrontmatter : {};
+  } catch {
+    return parseLooseFrontmatter(content.slice(4, end));
+  }
+}
+
+function parseLooseFrontmatter(raw: string): SkillFrontmatter {
+  const out: Record<string, string> = {};
+  for (const line of raw.split('\n')) {
+    const match = /^([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, value] = match;
+    if (!['name', 'description', 'version'].includes(key)) continue;
+    out[key] = value.trim().replace(/^['"]|['"]$/g, '');
+  }
+  return out;
+}
+
+function firstBodyParagraph(content: string): string {
+  const body = content.startsWith('---\n')
+    ? content.slice(Math.max(content.indexOf('\n---', 4) + 4, 0))
+    : content;
+  const paragraph = body
+    .split(/\n\s*\n/)
+    .map((part) => part.replace(/^#+\s*/gm, '').trim())
+    .find(Boolean);
+  return paragraph ?? '';
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add `opencli skills list/read` for bundled `opencli-*` skills
- read `SKILL.md` and reference files from the package `skills/` directory with traversal/non-opencli guards
- include only `skills/opencli-*/**` in the npm package so Browser Bridge bundled OpenCLI carries matching skills

## Validation
- `npm test -- --run src/skills.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `node dist/src/main.js skills list -f json`
- `node dist/src/main.js skills read opencli-browser --json | head -40`
- `node dist/src/main.js skills read smart-search` exits 2 with friendly error
- `node dist/src/main.js skills read opencli-browser ../../package.json` exits 2 with friendly error
- `npm pack --json --dry-run` confirms 23 `skills/opencli-*` files included and 0 `skills/smart-search` files
- `git diff --check`

Note: I also ran `npm test -- --run src/skills.test.ts src/cli.test.ts` earlier; `src/skills.test.ts` passed, while `src/cli.test.ts` showed existing unrelated browser tab/context expectation failures on `origin/main`.
