### PR TITLE
[codex] Add targeted Discord read navigation

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9872,7 +9872,10 @@
     "columns": [
       "Index",
       "Channel",
-      "Type"
+      "Type",
+      "guild_id",
+      "channel_id",
+      "url"
     ],
     "type": "js",
     "modulePath": "discord-app/channels.js",
@@ -9907,6 +9910,52 @@
   },
   {
     "site": "discord-app",
+    "name": "goto",
+    "description": "Open a Discord channel by id/name/url without sending messages",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "guild",
+        "type": "str",
+        "required": false,
+        "help": "Guild/server id or visible name"
+      },
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "Channel id or visible name"
+      },
+      {
+        "name": "url",
+        "type": "str",
+        "required": false,
+        "help": "Discord channel URL"
+      },
+      {
+        "name": "timeout",
+        "type": "str",
+        "required": false,
+        "help": "Seconds to wait for Discord to show the route (default: 8)",
+        "default": "8"
+      }
+    ],
+    "columns": [
+      "Status",
+      "guild_id",
+      "channel_id",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "discord-app/goto.js",
+    "sourceFile": "discord-app/goto.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "discord-app",
     "name": "members",
     "description": "List online members in the current Discord channel",
     "access": "read",
@@ -9927,7 +9976,7 @@
   {
     "site": "discord-app",
     "name": "read",
-    "description": "Read recent messages from the active Discord channel",
+    "description": "Read recent messages from the active or targeted Discord channel",
     "access": "read",
     "domain": "localhost",
     "strategy": "ui",
@@ -9936,15 +9985,35 @@
       {
         "name": "count",
         "type": "str",
-        "default": "20",
         "required": false,
-        "help": "Number of messages to read (default: 20)"
+        "help": "Number of messages to read (default: 20)",
+        "default": "20"
+      },
+      {
+        "name": "guild",
+        "type": "str",
+        "required": false,
+        "help": "Guild/server id or visible name for targeted reads"
+      },
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "Channel id or visible name for targeted reads"
+      },
+      {
+        "name": "url",
+        "type": "str",
+        "required": false,
+        "help": "Discord channel URL to open before reading"
       }
     ],
     "columns": [
       "Author",
       "Time",
-      "Message"
+      "Message",
+      "channel_id",
+      "message_id"
     ],
     "type": "js",
     "modulePath": "discord-app/read.js",
@@ -10014,7 +10083,9 @@
     "args": [],
     "columns": [
       "Index",
-      "Server"
+      "Server",
+      "guild_id",
+      "url"
     ],
     "type": "js",
     "modulePath": "discord-app/servers.js",
@@ -10038,6 +10109,110 @@
     "type": "js",
     "modulePath": "discord-app/status.js",
     "sourceFile": "discord-app/status.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "discord-app",
+    "name": "thread-read",
+    "description": "Read recent messages from a Discord thread/post by id or URL",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "thread",
+        "type": "str",
+        "required": false,
+        "help": "Thread/post id, or a full Discord thread/post URL"
+      },
+      {
+        "name": "count",
+        "type": "str",
+        "required": false,
+        "help": "Number of messages to read (default: 20)",
+        "default": "20"
+      },
+      {
+        "name": "guild",
+        "type": "str",
+        "required": false,
+        "help": "Parent guild/server id or visible name"
+      },
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "Parent forum/channel id or visible name"
+      },
+      {
+        "name": "url",
+        "type": "str",
+        "required": false,
+        "help": "Discord thread/post URL"
+      }
+    ],
+    "columns": [
+      "Author",
+      "Time",
+      "Message",
+      "channel_id",
+      "message_id"
+    ],
+    "type": "js",
+    "modulePath": "discord-app/thread-read.js",
+    "sourceFile": "discord-app/thread-read.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "discord-app",
+    "name": "threads",
+    "description": "List visible Discord forum/thread posts in the active or targeted channel",
+    "access": "read",
+    "domain": "localhost",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "str",
+        "required": false,
+        "help": "Maximum thread/post cards to return (default: 30)",
+        "default": "30"
+      },
+      {
+        "name": "guild",
+        "type": "str",
+        "required": false,
+        "help": "Guild/server id or visible name for targeted thread listing"
+      },
+      {
+        "name": "channel",
+        "type": "str",
+        "required": false,
+        "help": "Forum/channel id or visible name for targeted thread listing"
+      },
+      {
+        "name": "url",
+        "type": "str",
+        "required": false,
+        "help": "Discord forum/channel URL to open before listing threads"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Thread",
+      "Author",
+      "Updated",
+      "Preview",
+      "guild_id",
+      "channel_id",
+      "thread_id",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "discord-app/threads.js",
+    "sourceFile": "discord-app/threads.js",
     "navigateBefore": true
   },
   {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9938,9 +9938,9 @@
       {
         "name": "timeout",
         "type": "str",
+        "default": "8",
         "required": false,
-        "help": "Seconds to wait for Discord to show the route (default: 8)",
-        "default": "8"
+        "help": "Seconds to wait for Discord to show the route (default: 8)"
       }
     ],
     "columns": [
@@ -9985,9 +9985,9 @@
       {
         "name": "count",
         "type": "str",
+        "default": "20",
         "required": false,
-        "help": "Number of messages to read (default: 20)",
-        "default": "20"
+        "help": "Number of messages to read (default: 20)"
       },
       {
         "name": "guild",
@@ -10129,9 +10129,9 @@
       {
         "name": "count",
         "type": "str",
+        "default": "20",
         "required": false,
-        "help": "Number of messages to read (default: 20)",
-        "default": "20"
+        "help": "Number of messages to read (default: 20)"
       },
       {
         "name": "guild",
@@ -10176,9 +10176,9 @@
       {
         "name": "limit",
         "type": "str",
+        "default": "30",
         "required": false,
-        "help": "Maximum thread/post cards to return (default: 30)",
-        "default": "30"
+        "help": "Maximum thread/post cards to return (default: 30)"
       },
       {
         "name": "guild",

--- a/clis/discord-app/channels.js
+++ b/clis/discord-app/channels.js
@@ -1,4 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { listDiscordChannels } from './utils.js';
+
 export const channelsCommand = cli({
     site: 'discord-app',
     name: 'channels',
@@ -8,51 +10,16 @@ export const channelsCommand = cli({
     strategy: Strategy.UI,
     browser: true,
     args: [],
-    columns: ['Index', 'Channel', 'Type'],
+    columns: ['Index', 'Channel', 'Type', 'guild_id', 'channel_id', 'url'],
     func: async (page) => {
-        const channels = await page.evaluate(`
-      (function() {
-        const results = [];
-
-        // Discord channel links: <a> tags with href like /channels/GUILD/CHANNEL
-        const links = document.querySelectorAll('a[href*="/channels/"][data-list-item-id^="channels___"]');
-
-        links.forEach(function(el) {
-          var label = el.getAttribute('aria-label') || '';
-          if (!label) return;
-
-          // Skip categories
-          if (/[（(]category[）)]/i.test(label)) return;
-
-          // Strip any leading status prefix before the first comma (e.g. "unread, ", locale-agnostic)
-          var commaIdx = label.search(/[,，]/);
-          var cleaned = commaIdx !== -1 ? label.slice(commaIdx + 1).trimStart() : label;
-
-          // Extract name and type from "name (type)" or "name（type）"
-          var m = cleaned.match(/^(.+?)\s*[（(](.+?)[）)]\s*$/);
-          // If no type annotation found, skip — real channels always have "(Type channel)" in aria-label
-          if (!m) return;
-          var name = m[1].trim();
-          var rawType = m[2].toLowerCase();
-
-          // Discord channel names are ASCII-only; skip placeholder entries (e.g. locked channels)
-          if (!name || !/^[\x20-\x7E]+$/.test(name)) return;
-
-          var type = 'Text';
-          if (rawType.includes('voice')) type = 'Voice';
-          else if (rawType.includes('forum')) type = 'Forum';
-          else if (rawType.includes('announcement')) type = 'Announcement';
-          else if (rawType.includes('stage')) type = 'Stage';
-
-          results.push({ Index: results.length + 1, Channel: name, Type: type });
-        });
-
-        return results;
-      })()
-    `);
+        const channels = await listDiscordChannels(page);
         if (channels.length === 0) {
-            return [{ Index: 0, Channel: 'No channels found', Type: '—' }];
+            return [{ Index: 0, Channel: 'No channels found', Type: '—', guild_id: '', channel_id: '', url: '' }];
         }
         return channels;
     },
 });
+
+export const __test__ = {
+    channelsCommand,
+};

--- a/clis/discord-app/channels.js
+++ b/clis/discord-app/channels.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { listDiscordChannels } from './utils.js';
 
 export const channelsCommand = cli({
@@ -14,7 +15,7 @@ export const channelsCommand = cli({
     func: async (page) => {
         const channels = await listDiscordChannels(page);
         if (channels.length === 0) {
-            return [{ Index: 0, Channel: 'No channels found', Type: '—', guild_id: '', channel_id: '', url: '' }];
+            throw new EmptyResultError('discord-app channels', 'No Discord channels were found in the current server sidebar.');
         }
         return channels;
     },

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -12,6 +12,9 @@ import {
     buildDiscordChannelUrl,
     buildListChannelsScript,
     buildListThreadsScript,
+    listDiscordChannels,
+    listDiscordServers,
+    listDiscordThreads,
     parseDiscordChannelUrl,
     resolveDiscordChannelTarget,
 } from './utils.js';
@@ -142,6 +145,32 @@ describe('discord-app command registration', () => {
             expect(cmd.browser).toBe(true);
             expect(cmd.domain).toBe('localhost');
         }
+    });
+});
+
+describe('discord-app list row validation', () => {
+    it('typed-fails channel rows missing stable channel identity', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue([{ Channel: 'general', guild_id: '111', url: 'https://discord.com/channels/111/222' }]),
+        };
+
+        await expect(listDiscordChannels(page)).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('typed-fails server rows missing stable guild identity', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue([{ Server: 'OpenCLI', url: 'https://discord.com/channels/111' }]),
+        };
+
+        await expect(listDiscordServers(page)).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('typed-fails thread rows missing stable thread identity', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue([{ Thread: 'release', guild_id: '111', channel_id: '333', url: 'https://discord.com/channels/111/333/555' }]),
+        };
+
+        await expect(listDiscordThreads(page, 10)).rejects.toThrow(CommandExecutionError);
     });
 });
 

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './channels.js';
+import './goto.js';
+import './read.js';
+import './servers.js';
+import './thread-read.js';
+import './threads.js';
+import {
+    buildDiscordChannelUrl,
+    buildListChannelsScript,
+    buildListThreadsScript,
+    parseDiscordChannelUrl,
+    resolveDiscordChannelTarget,
+} from './utils.js';
+
+function runDomScript(html, script, url = 'https://discord.com/channels/111/222') {
+    const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+    return dom.window.eval(script);
+}
+
+function createRoutePage({ route, rows = [] }) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (script) => {
+            if (script.includes('__opencliDiscordRouteState')) {
+                return {
+                    url: route.url,
+                    route: {
+                        guild_id: route.guild_id,
+                        channel_id: route.channel_id,
+                        thread_id: route.thread_id || '',
+                    },
+                    has_messages: true,
+                    has_threads: false,
+                    has_header: true,
+                };
+            }
+            if (script.includes('__opencliDiscordReadMessages')) return rows;
+            throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+        }),
+    };
+}
+
+describe('discord-app url helpers', () => {
+    it('parses and builds channel and thread URLs', () => {
+        expect(parseDiscordChannelUrl('https://discord.com/channels/111/222')).toEqual({
+            guild_id: '111',
+            channel_id: '222',
+            url: 'https://discord.com/channels/111/222',
+        });
+        expect(parseDiscordChannelUrl('/channels/111/222/333')).toEqual({
+            guild_id: '111',
+            channel_id: '222',
+            thread_id: '333',
+            url: 'https://discord.com/channels/111/222/333',
+        });
+        expect(buildDiscordChannelUrl({ guildId: '111', channelId: '222', threadId: '333' }))
+            .toBe('https://discord.com/channels/111/222/333');
+    });
+
+    it('rejects non-Discord URLs', () => {
+        expect(parseDiscordChannelUrl('https://example.com/channels/111/222')).toBeNull();
+        expect(parseDiscordChannelUrl('javascript:alert(1)')).toBeNull();
+    });
+});
+
+describe('discord-app DOM extraction scripts', () => {
+    it('lists channel metadata from stable Discord channel links', () => {
+        const rows = runDomScript(`
+          <nav>
+            <a data-list-item-id="channels___222" href="/channels/111/222" aria-label="unread, general (text channel)">general</a>
+            <a data-list-item-id="channels___333" href="/channels/111/333" aria-label="support（forum channel）">support</a>
+            <a data-list-item-id="channels___444" href="/channels/111/444" aria-label="Ops (Voice channel)">Ops</a>
+            <a data-list-item-id="channels___cat" href="/channels/111/555" aria-label="Info (category)">Info</a>
+          </nav>
+        `, buildListChannelsScript());
+
+        expect(rows).toEqual([
+            {
+                Index: 1,
+                Channel: 'general',
+                Type: 'Text',
+                guild_id: '111',
+                channel_id: '222',
+                url: 'https://discord.com/channels/111/222',
+            },
+            {
+                Index: 2,
+                Channel: 'support',
+                Type: 'Forum',
+                guild_id: '111',
+                channel_id: '333',
+                url: 'https://discord.com/channels/111/333',
+            },
+            {
+                Index: 3,
+                Channel: 'Ops',
+                Type: 'Voice',
+                guild_id: '111',
+                channel_id: '444',
+                url: 'https://discord.com/channels/111/444',
+            },
+        ]);
+    });
+
+    it('lists visible forum/thread cards with thread ids', () => {
+        const rows = runDomScript(`
+          <main>
+            <article class="mainCard_abc">
+              <a href="/channels/111/333/555" aria-label="Release planning"></a>
+              <h3 class="title_abc">Release planning</h3>
+              <span class="username_abc">Alex</span>
+              <time datetime="2026-06-15T01:02:03.000Z">today</time>
+              <p>Discuss launch blockers</p>
+            </article>
+          </main>
+        `, buildListThreadsScript(10));
+
+        expect(rows).toEqual([expect.objectContaining({
+            Index: 1,
+            Thread: 'Release planning',
+            Author: 'Alex',
+            Updated: '2026-06-15T01:02:03.000Z',
+            guild_id: '111',
+            channel_id: '333',
+            thread_id: '555',
+            url: 'https://discord.com/channels/111/333/555',
+        })]);
+    });
+});
+
+describe('discord-app command registration', () => {
+    it('registers read-only navigation and thread commands', () => {
+        for (const name of ['channels', 'goto', 'read', 'servers', 'threads', 'thread-read']) {
+            const cmd = getRegistry().get(`discord-app/${name}`);
+            expect(cmd, `discord-app/${name}`).toBeDefined();
+            expect(cmd.access).toBe('read');
+            expect(cmd.browser).toBe(true);
+            expect(cmd.domain).toBe('localhost');
+        }
+    });
+});
+
+describe('discord-app targeted reads', () => {
+    it('read --url navigates once before scraping messages', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' },
+            rows: [{ Author: 'Ada', Time: '2026-06-15T00:00:00.000Z', Message: 'hello', channel_id: '222', message_id: '999' }],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .resolves.toEqual([{ Author: 'Ada', Time: '2026-06-15T00:00:00.000Z', Message: 'hello', channel_id: '222', message_id: '999' }]);
+
+        expect(page.goto).toHaveBeenCalledTimes(1);
+        expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/222', { waitUntil: 'none', settleMs: 1000 });
+    });
+
+    it('goto builds numeric guild/channel routes without reading channel DOM', async () => {
+        const cmd = getRegistry().get('discord-app/goto');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' },
+        });
+
+        await expect(cmd.func(page, { guild: '111', channel: '222' })).resolves.toEqual([{
+            Status: 'Opened',
+            guild_id: '111',
+            channel_id: '222',
+            url: 'https://discord.com/channels/111/222',
+        }]);
+        expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/222', { waitUntil: 'none', settleMs: 1000 });
+    });
+
+    it('resolves visible channel names from the current sidebar', async () => {
+        const page = {
+            evaluate: vi.fn(async (script) => {
+                if (script.includes('__opencliDiscordListChannels')) {
+                    return [{ Channel: 'general', guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' }];
+                }
+                throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+            }),
+        };
+
+        await expect(resolveDiscordChannelTarget(page, { channel: 'general' }, { required: true })).resolves.toEqual({
+            guild_id: '111',
+            channel_id: '222',
+            url: 'https://discord.com/channels/111/222',
+        });
+    });
+
+    it('thread-read navigates to a thread URL and then reads messages', async () => {
+        const cmd = getRegistry().get('discord-app/thread-read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '333', thread_id: '555', url: 'https://discord.com/channels/111/333/555' },
+            rows: [{ Author: 'Grace', Time: '', Message: 'thread message', channel_id: '555', message_id: '777' }],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/333/555', count: '1' }))
+            .resolves.toEqual([{ Author: 'Grace', Time: '', Message: 'thread message', channel_id: '555', message_id: '777' }]);
+        expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/333/555', { waitUntil: 'none', settleMs: 1000 });
+    });
+});

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -159,6 +159,37 @@ describe('discord-app targeted reads', () => {
         expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/222', { waitUntil: 'none', settleMs: 1000 });
     });
 
+    it('read --url waits for the message list after route navigation', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        let routeStateCalls = 0;
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                if (script.includes('__opencliDiscordRouteState')) {
+                    routeStateCalls += 1;
+                    return {
+                        url: 'https://discord.com/channels/111/222',
+                        route: { guild_id: '111', channel_id: '222', thread_id: '' },
+                        has_messages: routeStateCalls >= 3,
+                        has_threads: false,
+                        has_header: true,
+                    };
+                }
+                if (script.includes('__opencliDiscordReadMessages')) {
+                    return [{ Author: 'Ada', Time: '', Message: 'hydrated', channel_id: '222', message_id: '999' }];
+                }
+                throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+            }),
+        };
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .resolves.toEqual([{ Author: 'Ada', Time: '', Message: 'hydrated', channel_id: '222', message_id: '999' }]);
+
+        expect(page.wait).toHaveBeenCalledWith(0.5);
+        expect(routeStateCalls).toBeGreaterThanOrEqual(2);
+    });
+
     it('goto builds numeric guild/channel routes without reading channel DOM', async () => {
         const cmd = getRegistry().get('discord-app/goto');
         const page = createRoutePage({

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './channels.js';
 import './goto.js';
@@ -159,6 +160,83 @@ describe('discord-app targeted reads', () => {
         expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/222', { waitUntil: 'none', settleMs: 1000 });
     });
 
+    it('read --url rejects stale messages from another channel after navigation', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' },
+            rows: [{ Author: 'Ada', Time: '', Message: 'stale', channel_id: '999', message_id: '123' }],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+
+    it('read --url rejects message rows without channel_id proof after navigation', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' },
+            rows: [{ Author: 'Ada', Time: '', Message: 'unbound', message_id: '123' }],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+
+    it('read --url throws EmptyResultError instead of a success-shaped empty row', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '222', url: 'https://discord.com/channels/111/222' },
+            rows: [],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .rejects.toThrow(EmptyResultError);
+    });
+
+    it('read fails typed when browser extraction returns malformed message rows', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                if (script.includes('__opencliDiscordRouteState')) {
+                    return { url: 'https://discord.com/channels/111/222', route: { guild_id: '111', channel_id: '222', thread_id: '' }, has_messages: true };
+                }
+                if (script.includes('__opencliDiscordReadMessages')) return { rows: [] };
+                throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+            }),
+        };
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+
+    it('read unwraps Browser Bridge evaluate envelopes before shape validation', async () => {
+        const cmd = getRegistry().get('discord-app/read');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                if (script.includes('__opencliDiscordRouteState')) {
+                    return {
+                        session: 'site:discord-app',
+                        data: { url: 'https://discord.com/channels/111/222', route: { guild_id: '111', channel_id: '222', thread_id: '' }, has_messages: true },
+                    };
+                }
+                if (script.includes('__opencliDiscordReadMessages')) {
+                    return {
+                        session: 'site:discord-app',
+                        data: [{ Author: 'Ada', Time: '', Message: 'wrapped', channel_id: '222', message_id: '999' }],
+                    };
+                }
+                throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+            }),
+        };
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/222', count: '1' }))
+            .resolves.toEqual([{ Author: 'Ada', Time: '', Message: 'wrapped', channel_id: '222', message_id: '999' }]);
+    });
+
     it('read --url waits for the message list after route navigation', async () => {
         const cmd = getRegistry().get('discord-app/read');
         let routeStateCalls = 0;
@@ -232,5 +310,16 @@ describe('discord-app targeted reads', () => {
         await expect(cmd.func(page, { url: 'https://discord.com/channels/111/333/555', count: '1' }))
             .resolves.toEqual([{ Author: 'Grace', Time: '', Message: 'thread message', channel_id: '555', message_id: '777' }]);
         expect(page.goto).toHaveBeenCalledWith('https://discord.com/channels/111/333/555', { waitUntil: 'none', settleMs: 1000 });
+    });
+
+    it('thread-read rejects messages from the parent channel instead of the requested thread', async () => {
+        const cmd = getRegistry().get('discord-app/thread-read');
+        const page = createRoutePage({
+            route: { guild_id: '111', channel_id: '333', thread_id: '555', url: 'https://discord.com/channels/111/333/555' },
+            rows: [{ Author: 'Grace', Time: '', Message: 'parent message', channel_id: '333', message_id: '777' }],
+        });
+
+        await expect(cmd.func(page, { url: 'https://discord.com/channels/111/333/555', count: '1' }))
+            .rejects.toThrow(CommandExecutionError);
     });
 });

--- a/clis/discord-app/goto.js
+++ b/clis/discord-app/goto.js
@@ -1,0 +1,38 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    navigateToDiscordTarget,
+    parsePositiveInt,
+    resolveDiscordChannelTarget,
+} from './utils.js';
+
+export const gotoCommand = cli({
+    site: 'discord-app',
+    name: 'goto',
+    access: 'read',
+    description: 'Open a Discord channel by id/name/url without sending messages',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'guild', required: false, help: 'Guild/server id or visible name' },
+        { name: 'channel', required: false, help: 'Channel id or visible name' },
+        { name: 'url', required: false, help: 'Discord channel URL' },
+        { name: 'timeout', required: false, default: '8', help: 'Seconds to wait for Discord to show the route (default: 8)' },
+    ],
+    columns: ['Status', 'guild_id', 'channel_id', 'url'],
+    func: async (page, kwargs) => {
+        const timeoutSeconds = parsePositiveInt(kwargs.timeout, 8, 'timeout');
+        const target = await resolveDiscordChannelTarget(page, kwargs, { required: true });
+        await navigateToDiscordTarget(page, target, { timeoutMs: timeoutSeconds * 1000 });
+        return [{
+            Status: 'Opened',
+            guild_id: target.guild_id,
+            channel_id: target.channel_id,
+            url: target.url,
+        }];
+    },
+});
+
+export const __test__ = {
+    gotoCommand,
+};

--- a/clis/discord-app/read.js
+++ b/clis/discord-app/read.js
@@ -1,46 +1,36 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    maybeNavigateToDiscordChannel,
+    parsePositiveInt,
+    readDiscordMessages,
+} from './utils.js';
+
 export const readCommand = cli({
     site: 'discord-app',
     name: 'read',
     access: 'read',
-    description: 'Read recent messages from the active Discord channel',
+    description: 'Read recent messages from the active or targeted Discord channel',
     domain: 'localhost',
     strategy: Strategy.UI,
     browser: true,
     args: [
         { name: 'count', required: false, help: 'Number of messages to read (default: 20)', default: '20' },
+        { name: 'guild', required: false, help: 'Guild/server id or visible name for targeted reads' },
+        { name: 'channel', required: false, help: 'Channel id or visible name for targeted reads' },
+        { name: 'url', required: false, help: 'Discord channel URL to open before reading' },
     ],
-    columns: ['Author', 'Time', 'Message'],
+    columns: ['Author', 'Time', 'Message', 'channel_id', 'message_id'],
     func: async (page, kwargs) => {
-        const count = parseInt(kwargs.count, 10) || 20;
-        const messages = await page.evaluate(`
-      (function(limit) {
-        const results = [];
-        // Discord renders messages in list items with id starting with "chat-messages-"
-        const msgNodes = document.querySelectorAll('[id^="chat-messages-"] > div, [class*="messageListItem"]');
-        
-        const slice = Array.from(msgNodes).slice(-limit);
-        
-        slice.forEach(node => {
-          const authorEl = node.querySelector('[class*="username"], [class*="headerText"] span');
-          const timeEl = node.querySelector('time');
-          const contentEl = node.querySelector('[id^="message-content-"], [class*="messageContent"]');
-          
-          if (contentEl) {
-            results.push({
-              Author: authorEl ? authorEl.textContent.trim() : '—',
-              Time: timeEl ? timeEl.getAttribute('datetime') || timeEl.textContent.trim() : '',
-              Message: (contentEl.textContent || '').trim().substring(0, 300),
-            });
-          }
-        });
-        
-        return results;
-      })(${count})
-    `);
+        const count = parsePositiveInt(kwargs.count, 20, 'count');
+        await maybeNavigateToDiscordChannel(page, kwargs);
+        const messages = await readDiscordMessages(page, count);
         if (messages.length === 0) {
             return [{ Author: 'System', Time: '', Message: 'No messages found in the current channel.' }];
         }
         return messages;
     },
 });
+
+export const __test__ = {
+    readCommand,
+};

--- a/clis/discord-app/read.js
+++ b/clis/discord-app/read.js
@@ -22,7 +22,7 @@ export const readCommand = cli({
     columns: ['Author', 'Time', 'Message', 'channel_id', 'message_id'],
     func: async (page, kwargs) => {
         const count = parsePositiveInt(kwargs.count, 20, 'count');
-        await maybeNavigateToDiscordChannel(page, kwargs);
+        await maybeNavigateToDiscordChannel(page, kwargs, { waitForContent: 'messages' });
         const messages = await readDiscordMessages(page, count);
         if (messages.length === 0) {
             return [{ Author: 'System', Time: '', Message: 'No messages found in the current channel.' }];

--- a/clis/discord-app/read.js
+++ b/clis/discord-app/read.js
@@ -1,5 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
+    assertDiscordMessageRowsBelongToTarget,
     maybeNavigateToDiscordChannel,
     parsePositiveInt,
     readDiscordMessages,
@@ -22,10 +24,14 @@ export const readCommand = cli({
     columns: ['Author', 'Time', 'Message', 'channel_id', 'message_id'],
     func: async (page, kwargs) => {
         const count = parsePositiveInt(kwargs.count, 20, 'count');
-        await maybeNavigateToDiscordChannel(page, kwargs, { waitForContent: 'messages' });
-        const messages = await readDiscordMessages(page, count);
+        const target = await maybeNavigateToDiscordChannel(page, kwargs, { waitForContent: 'messages' });
+        const messages = assertDiscordMessageRowsBelongToTarget(
+            await readDiscordMessages(page, count),
+            target,
+            'Discord channel read',
+        );
         if (messages.length === 0) {
-            return [{ Author: 'System', Time: '', Message: 'No messages found in the current channel.' }];
+            throw new EmptyResultError('discord-app read', 'No messages were found in the selected Discord channel.');
         }
         return messages;
     },

--- a/clis/discord-app/servers.js
+++ b/clis/discord-app/servers.js
@@ -1,4 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { listDiscordServers } from './utils.js';
+
 export const serversCommand = cli({
     site: 'discord-app',
     name: 'servers',
@@ -8,30 +10,16 @@ export const serversCommand = cli({
     strategy: Strategy.UI,
     browser: true,
     args: [],
-    columns: ['Index', 'Server'],
+    columns: ['Index', 'Server', 'guild_id', 'url'],
     func: async (page) => {
-        const servers = await page.evaluate(`
-      (function() {
-        const results = [];
-        // Discord guild icons in the sidebar
-        const items = document.querySelectorAll('[data-list-item-id*="guildsnav___"], [class*="listItem_"]');
-        
-        items.forEach((item, i) => {
-          const nameAttr = item.querySelector('[data-dnd-name]');
-          const ariaLabel = item.getAttribute('aria-label') || (item.querySelector('[aria-label]') || {}).getAttribute?.('aria-label');
-          const name = nameAttr ? nameAttr.getAttribute('data-dnd-name') : (ariaLabel || (item.textContent || '').trim());
-          
-          if (name && name.length > 0) {
-            results.push({ Index: i + 1, Server: name.substring(0, 80) });
-          }
-        });
-        
-        return results;
-      })()
-    `);
+        const servers = await listDiscordServers(page);
         if (servers.length === 0) {
-            return [{ Index: 0, Server: 'No servers found' }];
+            return [{ Index: 0, Server: 'No servers found', guild_id: '', url: '' }];
         }
         return servers;
     },
 });
+
+export const __test__ = {
+    serversCommand,
+};

--- a/clis/discord-app/servers.js
+++ b/clis/discord-app/servers.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import { listDiscordServers } from './utils.js';
 
 export const serversCommand = cli({
@@ -14,7 +15,7 @@ export const serversCommand = cli({
     func: async (page) => {
         const servers = await listDiscordServers(page);
         if (servers.length === 0) {
-            return [{ Index: 0, Server: 'No servers found', guild_id: '', url: '' }];
+            throw new EmptyResultError('discord-app servers', 'No Discord servers were found in the sidebar.');
         }
         return servers;
     },

--- a/clis/discord-app/thread-read.js
+++ b/clis/discord-app/thread-read.js
@@ -1,0 +1,39 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    navigateToDiscordTarget,
+    parsePositiveInt,
+    readDiscordMessages,
+    resolveDiscordThreadTarget,
+} from './utils.js';
+
+export const threadReadCommand = cli({
+    site: 'discord-app',
+    name: 'thread-read',
+    access: 'read',
+    description: 'Read recent messages from a Discord thread/post by id or URL',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'thread', required: false, help: 'Thread/post id, or a full Discord thread/post URL' },
+        { name: 'count', required: false, default: '20', help: 'Number of messages to read (default: 20)' },
+        { name: 'guild', required: false, help: 'Parent guild/server id or visible name' },
+        { name: 'channel', required: false, help: 'Parent forum/channel id or visible name' },
+        { name: 'url', required: false, help: 'Discord thread/post URL' },
+    ],
+    columns: ['Author', 'Time', 'Message', 'channel_id', 'message_id'],
+    func: async (page, kwargs) => {
+        const count = parsePositiveInt(kwargs.count, 20, 'count');
+        const target = await resolveDiscordThreadTarget(page, kwargs);
+        await navigateToDiscordTarget(page, target);
+        const rows = await readDiscordMessages(page, count);
+        if (rows.length === 0) {
+            return [{ Author: 'System', Time: '', Message: 'No messages found in the selected thread.', channel_id: target.channel_id, message_id: '' }];
+        }
+        return rows;
+    },
+});
+
+export const __test__ = {
+    threadReadCommand,
+};

--- a/clis/discord-app/thread-read.js
+++ b/clis/discord-app/thread-read.js
@@ -1,5 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
+    assertDiscordMessageRowsBelongToTarget,
     navigateToDiscordTarget,
     parsePositiveInt,
     readDiscordMessages,
@@ -26,9 +28,13 @@ export const threadReadCommand = cli({
         const count = parsePositiveInt(kwargs.count, 20, 'count');
         const target = await resolveDiscordThreadTarget(page, kwargs);
         await navigateToDiscordTarget(page, target, { waitForContent: 'messages' });
-        const rows = await readDiscordMessages(page, count);
+        const rows = assertDiscordMessageRowsBelongToTarget(
+            await readDiscordMessages(page, count),
+            target,
+            'Discord thread read',
+        );
         if (rows.length === 0) {
-            return [{ Author: 'System', Time: '', Message: 'No messages found in the selected thread.', channel_id: target.channel_id, message_id: '' }];
+            throw new EmptyResultError('discord-app thread-read', 'No messages were found in the selected Discord thread.');
         }
         return rows;
     },

--- a/clis/discord-app/thread-read.js
+++ b/clis/discord-app/thread-read.js
@@ -25,7 +25,7 @@ export const threadReadCommand = cli({
     func: async (page, kwargs) => {
         const count = parsePositiveInt(kwargs.count, 20, 'count');
         const target = await resolveDiscordThreadTarget(page, kwargs);
-        await navigateToDiscordTarget(page, target);
+        await navigateToDiscordTarget(page, target, { waitForContent: 'messages' });
         const rows = await readDiscordMessages(page, count);
         if (rows.length === 0) {
             return [{ Author: 'System', Time: '', Message: 'No messages found in the selected thread.', channel_id: target.channel_id, message_id: '' }];

--- a/clis/discord-app/threads.js
+++ b/clis/discord-app/threads.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     listDiscordThreads,
     maybeNavigateToDiscordChannel,
@@ -25,17 +26,7 @@ export const threadsCommand = cli({
         await maybeNavigateToDiscordChannel(page, kwargs, { waitForContent: 'threads', contentTimeoutMs: 3000 });
         const rows = await listDiscordThreads(page, limit);
         if (rows.length === 0) {
-            return [{
-                Index: 0,
-                Thread: 'No visible forum/thread posts found',
-                Author: '',
-                Updated: '',
-                Preview: 'Open a Forum channel or pass --url/--guild/--channel for one.',
-                guild_id: '',
-                channel_id: '',
-                thread_id: '',
-                url: '',
-            }];
+            throw new EmptyResultError('discord-app threads', 'No visible forum/thread posts were found in the selected Discord channel.');
         }
         return rows;
     },

--- a/clis/discord-app/threads.js
+++ b/clis/discord-app/threads.js
@@ -1,0 +1,46 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    listDiscordThreads,
+    maybeNavigateToDiscordChannel,
+    parsePositiveInt,
+} from './utils.js';
+
+export const threadsCommand = cli({
+    site: 'discord-app',
+    name: 'threads',
+    access: 'read',
+    description: 'List visible Discord forum/thread posts in the active or targeted channel',
+    domain: 'localhost',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'limit', required: false, default: '30', help: 'Maximum thread/post cards to return (default: 30)' },
+        { name: 'guild', required: false, help: 'Guild/server id or visible name for targeted thread listing' },
+        { name: 'channel', required: false, help: 'Forum/channel id or visible name for targeted thread listing' },
+        { name: 'url', required: false, help: 'Discord forum/channel URL to open before listing threads' },
+    ],
+    columns: ['Index', 'Thread', 'Author', 'Updated', 'Preview', 'guild_id', 'channel_id', 'thread_id', 'url'],
+    func: async (page, kwargs) => {
+        const limit = parsePositiveInt(kwargs.limit, 30, 'limit');
+        await maybeNavigateToDiscordChannel(page, kwargs);
+        const rows = await listDiscordThreads(page, limit);
+        if (rows.length === 0) {
+            return [{
+                Index: 0,
+                Thread: 'No visible forum/thread posts found',
+                Author: '',
+                Updated: '',
+                Preview: 'Open a Forum channel or pass --url/--guild/--channel for one.',
+                guild_id: '',
+                channel_id: '',
+                thread_id: '',
+                url: '',
+            }];
+        }
+        return rows;
+    },
+});
+
+export const __test__ = {
+    threadsCommand,
+};

--- a/clis/discord-app/threads.js
+++ b/clis/discord-app/threads.js
@@ -22,7 +22,7 @@ export const threadsCommand = cli({
     columns: ['Index', 'Thread', 'Author', 'Updated', 'Preview', 'guild_id', 'channel_id', 'thread_id', 'url'],
     func: async (page, kwargs) => {
         const limit = parsePositiveInt(kwargs.limit, 30, 'limit');
-        await maybeNavigateToDiscordChannel(page, kwargs);
+        await maybeNavigateToDiscordChannel(page, kwargs, { waitForContent: 'threads', contentTimeoutMs: 3000 });
         const rows = await listDiscordThreads(page, limit);
         if (rows.length === 0) {
             return [{

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -1,0 +1,511 @@
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+const DISCORD_HOSTS = new Set(['discord.com', 'canary.discord.com', 'ptb.discord.com']);
+const DISCORD_ORIGIN = 'https://discord.com';
+const CHANNEL_ID_RE = /^\d{3,}$/;
+
+function stringArg(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+export function isDiscordSnowflake(value) {
+    return CHANNEL_ID_RE.test(String(value || '').trim());
+}
+
+export function normalizeDiscordName(value) {
+    return String(value || '')
+        .trim()
+        .replace(/^#/, '')
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}
+
+export function parseDiscordChannelUrl(raw) {
+    const value = stringArg(raw);
+    if (!value) return null;
+
+    let url;
+    try {
+        url = new URL(value, DISCORD_ORIGIN);
+    } catch {
+        return null;
+    }
+
+    if (!DISCORD_HOSTS.has(url.hostname)) return null;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts[0] !== 'channels' || parts.length < 3) return null;
+
+    const guildId = decodeURIComponent(parts[1] || '');
+    const channelId = decodeURIComponent(parts[2] || '');
+    const threadId = parts[3] ? decodeURIComponent(parts[3]) : undefined;
+    if (!guildId || !channelId) return null;
+
+    return {
+        guild_id: guildId,
+        channel_id: channelId,
+        ...(threadId ? { thread_id: threadId } : {}),
+        url: buildDiscordChannelUrl({ guildId, channelId, threadId }),
+    };
+}
+
+export function buildDiscordChannelUrl({ guildId, channelId, threadId }) {
+    if (!guildId || !channelId) {
+        throw new ArgumentError('Discord channel navigation requires both guild_id and channel_id.');
+    }
+    const base = `${DISCORD_ORIGIN}/channels/${encodeURIComponent(String(guildId))}/${encodeURIComponent(String(channelId))}`;
+    return threadId ? `${base}/${encodeURIComponent(String(threadId))}` : base;
+}
+
+export function parsePositiveInt(value, fallback, label) {
+    if (value === undefined || value === null || value === '') return fallback;
+    const raw = String(value).trim();
+    if (!/^\d+$/.test(raw)) {
+        throw new ArgumentError(`--${label} must be a positive integer.`);
+    }
+    const parsed = parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new ArgumentError(`--${label} must be a positive integer.`);
+    }
+    return parsed;
+}
+
+export function hasDiscordChannelTarget(kwargs = {}) {
+    return Boolean(stringArg(kwargs.url) || stringArg(kwargs.guild) || stringArg(kwargs.channel));
+}
+
+export function buildListChannelsScript() {
+    return `
+      (function __opencliDiscordListChannels() {
+        function parseRoute(raw) {
+          try {
+            var url = new URL(raw, 'https://discord.com');
+            var parts = url.pathname.split('/').filter(Boolean);
+            if (parts[0] !== 'channels' || parts.length < 3) return null;
+            return { guild_id: parts[1], channel_id: parts[2], thread_id: parts[3] || '' };
+          } catch (_) {
+            return null;
+          }
+        }
+
+        function absUrl(path) {
+          try { return new URL(path, 'https://discord.com').href; } catch (_) { return ''; }
+        }
+
+        function cleanChannelLabel(label) {
+          var cleaned = String(label || '').trim();
+          var commaIdx = cleaned.search(/[,，]/);
+          if (commaIdx !== -1) cleaned = cleaned.slice(commaIdx + 1).trimStart();
+          return cleaned;
+        }
+
+        function inferType(label, el) {
+          var raw = String(label || '').toLowerCase();
+          var id = String(el.getAttribute('data-list-item-id') || '').toLowerCase();
+          if (raw.indexOf('voice') !== -1 || id.indexOf('voice') !== -1) return 'Voice';
+          if (raw.indexOf('forum') !== -1 || id.indexOf('forum') !== -1) return 'Forum';
+          if (raw.indexOf('announcement') !== -1 || raw.indexOf('news') !== -1 || id.indexOf('announcement') !== -1) return 'Announcement';
+          if (raw.indexOf('stage') !== -1 || id.indexOf('stage') !== -1) return 'Stage';
+          return 'Text';
+        }
+
+        function channelName(label, el) {
+          var cleaned = cleanChannelLabel(label);
+          var m = cleaned.match(/^(.+?)\\s*[（(](.+?)[）)]\\s*$/);
+          if (m) return m[1].trim();
+          var ariaName = el.getAttribute('aria-label') || '';
+          if (ariaName && ariaName !== label) return cleanChannelLabel(ariaName).replace(/\\s*[（(].*?[）)]\\s*$/, '').trim();
+          var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+          return text.replace(/\\s*[（(].*?[）)]\\s*$/, '').trim();
+        }
+
+        var links = Array.from(document.querySelectorAll('a[href*="/channels/"]'));
+        var seen = new Set();
+        var rows = [];
+        links.forEach(function(el) {
+          var href = el.getAttribute('href') || '';
+          var route = parseRoute(href);
+          if (!route || route.thread_id || !route.channel_id || route.channel_id === '@me') return;
+          var key = route.guild_id + '/' + route.channel_id;
+          if (seen.has(key)) return;
+
+          var label = el.getAttribute('aria-label') || el.getAttribute('title') || '';
+          var cleaned = cleanChannelLabel(label);
+          if (/[（(]\\s*category\\s*[）)]/i.test(cleaned)) return;
+
+          var name = channelName(cleaned, el);
+          if (!name) return;
+
+          var type = inferType(cleaned, el);
+          rows.push({
+            Index: rows.length + 1,
+            Channel: name,
+            Type: type,
+            guild_id: route.guild_id,
+            channel_id: route.channel_id,
+            url: absUrl('/channels/' + route.guild_id + '/' + route.channel_id)
+          });
+          seen.add(key);
+        });
+
+        return rows;
+      })()
+    `;
+}
+
+export function buildListServersScript() {
+    return `
+      (function __opencliDiscordListServers() {
+        function parseGuildId(raw) {
+          try {
+            var url = new URL(raw, 'https://discord.com');
+            var parts = url.pathname.split('/').filter(Boolean);
+            if (parts[0] !== 'channels' || parts.length !== 2 || !parts[1] || parts[1] === '@me') return '';
+            return parts[1];
+          } catch (_) {
+            return '';
+          }
+        }
+
+        var rows = [];
+        var seen = new Set();
+        var items = Array.from(document.querySelectorAll('a[href^="/channels/"], [data-list-item-id*="guildsnav___"], [class*="listItem_"]'));
+        items.forEach(function(item) {
+          var link = item.matches && item.matches('a[href^="/channels/"]') ? item : item.querySelector && item.querySelector('a[href^="/channels/"]');
+          var href = link ? link.getAttribute('href') || '' : '';
+          var guildId = parseGuildId(href);
+          if (!guildId || seen.has(guildId)) return;
+
+          var named = item.querySelector && item.querySelector('[data-dnd-name]');
+          var name = named ? named.getAttribute('data-dnd-name') : '';
+          if (!name) name = item.getAttribute && item.getAttribute('aria-label') || '';
+          if (!name && link) name = link.getAttribute('aria-label') || link.getAttribute('title') || '';
+          name = String(name || '').replace(/\\s+/g, ' ').trim();
+          if (!name || /^direct messages$/i.test(name)) return;
+
+          rows.push({
+            Index: rows.length + 1,
+            Server: name.slice(0, 80),
+            guild_id: guildId,
+            url: 'https://discord.com/channels/' + guildId
+          });
+          seen.add(guildId);
+        });
+
+        return rows;
+      })()
+    `;
+}
+
+export function buildReadMessagesScript(count) {
+    const limit = Math.max(1, parseInt(String(count), 10) || 20);
+    return `
+      (function __opencliDiscordReadMessages(limit) {
+        function textOf(el) { return el ? String(el.textContent || '').replace(/\\s+/g, ' ').trim() : ''; }
+        function routeOfMessage(node) {
+          var id = node && node.getAttribute ? node.getAttribute('id') || '' : '';
+          var match = id.match(/^chat-messages-(\\d+)-(\\d+)/);
+          return match ? { channel_id: match[1], message_id: match[2] } : {};
+        }
+
+        var results = [];
+        var nodes = Array.from(document.querySelectorAll('[id^="chat-messages-"], [class*="messageListItem"]'));
+        var seen = new Set();
+
+        nodes.forEach(function(node) {
+          var route = routeOfMessage(node);
+          var contentEl = node.querySelector('[id^="message-content-"], [class*="messageContent"]');
+          if (!contentEl) return;
+
+          var key = route.message_id || textOf(contentEl);
+          if (!key || seen.has(key)) return;
+          seen.add(key);
+
+          var authorEl = node.querySelector('[class*="username"], [class*="headerText"] span, h3 span');
+          var timeEl = node.querySelector('time');
+          results.push({
+            Author: textOf(authorEl) || '—',
+            Time: timeEl ? (timeEl.getAttribute('datetime') || textOf(timeEl)) : '',
+            Message: textOf(contentEl).slice(0, 300),
+            ...(route.channel_id ? { channel_id: route.channel_id } : {}),
+            ...(route.message_id ? { message_id: route.message_id } : {})
+          });
+        });
+
+        return results.slice(-limit);
+      })(${limit})
+    `;
+}
+
+export function buildListThreadsScript(limit) {
+    const max = Math.max(1, parseInt(String(limit), 10) || 30);
+    return `
+      (function __opencliDiscordListThreads(limit) {
+        function parseRoute(raw) {
+          try {
+            var url = new URL(raw, 'https://discord.com');
+            var parts = url.pathname.split('/').filter(Boolean);
+            if (parts[0] !== 'channels' || parts.length < 4) return null;
+            return { guild_id: parts[1], channel_id: parts[2], thread_id: parts[3], url: 'https://discord.com/channels/' + parts[1] + '/' + parts[2] + '/' + parts[3] };
+          } catch (_) {
+            return null;
+          }
+        }
+
+        function clean(text) {
+          return String(text || '').replace(/\\s+/g, ' ').trim();
+        }
+
+        function firstUsefulLine(text) {
+          var lines = String(text || '').split(/\\n+/).map(clean).filter(Boolean);
+          return lines.find(function(line) {
+            return !/^(new|unread|locked|pinned|thread|post)$/i.test(line);
+          }) || '';
+        }
+
+        var rows = [];
+        var seen = new Set();
+        var links = Array.from(document.querySelectorAll('a[href*="/channels/"]'));
+        links.forEach(function(link) {
+          if (link.closest('[id^="chat-messages-"], [class*="messageListItem"]')) return;
+          var route = parseRoute(link.getAttribute('href') || '');
+          if (!route || seen.has(route.thread_id)) return;
+          var card = link.closest('[role="listitem"], li, article, [class*="container_"], [class*="card_"], [class*="mainCard_"]') || link;
+          var label = clean(link.getAttribute('aria-label') || link.getAttribute('title') || '');
+          var titleEl = card.querySelector('[class*="title"], [class*="name"], h3, h2, strong');
+          var title = clean(titleEl && titleEl.textContent) || label || firstUsefulLine(card.textContent);
+          if (!title) return;
+          var authorEl = card.querySelector('[class*="username"], [class*="author"], [class*="user"]');
+          var timeEl = card.querySelector('time');
+          rows.push({
+            Index: rows.length + 1,
+            Thread: title.slice(0, 140),
+            Author: clean(authorEl && authorEl.textContent),
+            Updated: timeEl ? (timeEl.getAttribute('datetime') || clean(timeEl.textContent)) : '',
+            Preview: firstUsefulLine(card.textContent).slice(0, 240),
+            guild_id: route.guild_id,
+            channel_id: route.channel_id,
+            thread_id: route.thread_id,
+            url: route.url
+          });
+          seen.add(route.thread_id);
+        });
+
+        return rows.slice(0, limit);
+      })(${max})
+    `;
+}
+
+export function buildRouteStateScript() {
+    return `
+      (function __opencliDiscordRouteState() {
+        function parseRoute(raw) {
+          try {
+            var url = new URL(raw, 'https://discord.com');
+            var parts = url.pathname.split('/').filter(Boolean);
+            if (parts[0] !== 'channels' || parts.length < 3) return null;
+            return { guild_id: parts[1], channel_id: parts[2], thread_id: parts[3] || '' };
+          } catch (_) {
+            return null;
+          }
+        }
+        return {
+          url: window.location.href,
+          title: document.title,
+          route: parseRoute(window.location.href),
+          has_messages: !!document.querySelector('[id^="chat-messages-"], [class*="messageListItem"]'),
+          has_threads: !!document.querySelector('a[href*="/channels/"][href*="/"]'),
+          has_header: !!document.querySelector('[class*="title"], [aria-label*="Channel"], [aria-label*="频道"]')
+        };
+      })()
+    `;
+}
+
+async function getCurrentDiscordRoute(page) {
+    const state = await page.evaluate(buildRouteStateScript());
+    if (state && state.route) return state.route;
+    const url = typeof state?.url === 'string' ? state.url : '';
+    return parseDiscordChannelUrl(url);
+}
+
+export async function listDiscordChannels(page) {
+    const rows = await page.evaluate(buildListChannelsScript());
+    return Array.isArray(rows) ? rows : [];
+}
+
+export async function listDiscordServers(page) {
+    const rows = await page.evaluate(buildListServersScript());
+    return Array.isArray(rows) ? rows : [];
+}
+
+function rowMatchesChannel(row, channel) {
+    if (!channel) return false;
+    if (String(row.channel_id || '') === channel) return true;
+    return normalizeDiscordName(row.Channel) === normalizeDiscordName(channel);
+}
+
+function rowMatchesGuild(row, guild) {
+    if (!guild) return true;
+    return String(row.guild_id || '') === guild || normalizeDiscordName(row.Server) === normalizeDiscordName(guild);
+}
+
+export async function resolveDiscordChannelTarget(page, kwargs = {}, options = {}) {
+    const urlArg = stringArg(kwargs.url);
+    if (urlArg) {
+        const parsed = parseDiscordChannelUrl(urlArg);
+        if (!parsed || parsed.thread_id) {
+            throw new ArgumentError('--url must be a Discord channel URL like https://discord.com/channels/<guild_id>/<channel_id>.');
+        }
+        return parsed;
+    }
+
+    const guildArg = stringArg(kwargs.guild);
+    const channelArg = stringArg(kwargs.channel);
+    if (!guildArg && !channelArg) {
+        if (options.required) {
+            throw new ArgumentError('Pass --url or --guild/--channel to choose a Discord channel.');
+        }
+        return null;
+    }
+    if (!channelArg) {
+        throw new ArgumentError('Pass --channel with --guild, or use --url.');
+    }
+
+    let guildId = guildArg;
+    if (guildArg && !isDiscordSnowflake(guildArg) && guildArg !== '@me') {
+        const server = (await listDiscordServers(page)).find((row) => rowMatchesGuild(row, guildArg));
+        if (server?.guild_id) guildId = String(server.guild_id);
+    }
+
+    if (guildId && isDiscordSnowflake(guildId) && isDiscordSnowflake(channelArg)) {
+        return {
+            guild_id: guildId,
+            channel_id: channelArg,
+            url: buildDiscordChannelUrl({ guildId, channelId: channelArg }),
+        };
+    }
+
+    const channels = await listDiscordChannels(page);
+    const match = channels.find((row) => rowMatchesGuild(row, guildId) && rowMatchesChannel(row, channelArg));
+    if (match) {
+        return {
+            guild_id: String(match.guild_id),
+            channel_id: String(match.channel_id),
+            url: String(match.url || buildDiscordChannelUrl({ guildId: match.guild_id, channelId: match.channel_id })),
+        };
+    }
+
+    if (!guildId && isDiscordSnowflake(channelArg)) {
+        const route = await getCurrentDiscordRoute(page);
+        if (route?.guild_id) {
+            return {
+                guild_id: route.guild_id,
+                channel_id: channelArg,
+                url: buildDiscordChannelUrl({ guildId: route.guild_id, channelId: channelArg }),
+            };
+        }
+    }
+
+    throw new ArgumentError(
+        `Could not resolve Discord channel "${channelArg}".`,
+        'Use "opencli discord-app channels -f json" and retry with --url or numeric --guild/--channel ids.',
+    );
+}
+
+export async function waitForDiscordRoute(page, target, options = {}) {
+    const timeoutMs = options.timeoutMs ?? 8000;
+    const intervalSeconds = options.intervalSeconds ?? 0.5;
+    const started = Date.now();
+    let lastState = null;
+
+    while (Date.now() - started <= timeoutMs) {
+        lastState = await page.evaluate(buildRouteStateScript());
+        const route = lastState?.route;
+        if (route && String(route.guild_id) === String(target.guild_id) && String(route.channel_id) === String(target.channel_id)) {
+            if (!target.thread_id || String(route.thread_id || '') === String(target.thread_id)) {
+                return lastState;
+            }
+        }
+        await page.wait(intervalSeconds);
+    }
+
+    throw new CommandExecutionError(
+        'Discord did not finish navigating to the requested channel.',
+        `Last observed URL: ${lastState?.url || 'unknown'}`,
+    );
+}
+
+export async function navigateToDiscordTarget(page, target, options = {}) {
+    await page.goto(target.url, { waitUntil: 'none', settleMs: options.settleMs ?? 1000 });
+    return waitForDiscordRoute(page, target, options);
+}
+
+export async function maybeNavigateToDiscordChannel(page, kwargs = {}, options = {}) {
+    if (!hasDiscordChannelTarget(kwargs)) return null;
+    const target = await resolveDiscordChannelTarget(page, kwargs, { required: true });
+    await navigateToDiscordTarget(page, target, options);
+    return target;
+}
+
+export async function readDiscordMessages(page, count) {
+    const rows = await page.evaluate(buildReadMessagesScript(count));
+    return Array.isArray(rows) ? rows : [];
+}
+
+export async function listDiscordThreads(page, limit) {
+    const rows = await page.evaluate(buildListThreadsScript(limit));
+    return Array.isArray(rows) ? rows : [];
+}
+
+export async function resolveDiscordThreadTarget(page, kwargs = {}) {
+    const urlArg = stringArg(kwargs.url);
+    if (urlArg) {
+        const parsed = parseDiscordChannelUrl(urlArg);
+        if (!parsed || !parsed.thread_id) {
+            throw new ArgumentError('--url must be a Discord thread/post URL like https://discord.com/channels/<guild_id>/<channel_id>/<thread_id>.');
+        }
+        return parsed;
+    }
+
+    const threadArg = stringArg(kwargs.thread);
+    if (!threadArg) {
+        throw new ArgumentError('Pass --thread <thread_id> or --url <thread_url>.');
+    }
+
+    const parsedThreadUrl = parseDiscordChannelUrl(threadArg);
+    if (parsedThreadUrl?.thread_id) return parsedThreadUrl;
+
+    const channelTarget = hasDiscordChannelTarget(kwargs)
+        ? await resolveDiscordChannelTarget(page, kwargs, { required: true })
+        : null;
+    if (channelTarget) {
+        return {
+            guild_id: channelTarget.guild_id,
+            channel_id: channelTarget.channel_id,
+            thread_id: threadArg,
+            url: buildDiscordChannelUrl({
+                guildId: channelTarget.guild_id,
+                channelId: channelTarget.channel_id,
+                threadId: threadArg,
+            }),
+        };
+    }
+
+    const current = await getCurrentDiscordRoute(page);
+    if (current?.guild_id && current?.channel_id) {
+        return {
+            guild_id: current.guild_id,
+            channel_id: current.channel_id,
+            thread_id: threadArg,
+            url: buildDiscordChannelUrl({
+                guildId: current.guild_id,
+                channelId: current.channel_id,
+                threadId: threadArg,
+            }),
+        };
+    }
+
+    throw new ArgumentError(
+        `Could not resolve Discord thread "${threadArg}".`,
+        'Open the parent forum/channel first, or pass --guild and --channel ids with --thread.',
+    );
+}

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -434,9 +434,32 @@ export async function waitForDiscordRoute(page, target, options = {}) {
     );
 }
 
+export async function waitForDiscordContent(page, kind = 'messages', options = {}) {
+    const timeoutMs = options.timeoutMs ?? 5000;
+    const intervalSeconds = options.intervalSeconds ?? 0.5;
+    const started = Date.now();
+    let lastState = null;
+
+    while (Date.now() - started <= timeoutMs) {
+        lastState = await page.evaluate(buildRouteStateScript());
+        if (kind === 'messages' && lastState?.has_messages) return lastState;
+        if (kind === 'threads' && lastState?.has_threads) return lastState;
+        await page.wait(intervalSeconds);
+    }
+
+    return lastState;
+}
+
 export async function navigateToDiscordTarget(page, target, options = {}) {
     await page.goto(target.url, { waitUntil: 'none', settleMs: options.settleMs ?? 1000 });
-    return waitForDiscordRoute(page, target, options);
+    const state = await waitForDiscordRoute(page, target, options);
+    if (options.waitForContent === 'messages' || options.waitForContent === 'threads') {
+        return waitForDiscordContent(page, options.waitForContent, {
+            timeoutMs: options.contentTimeoutMs ?? 5000,
+            intervalSeconds: options.intervalSeconds ?? 0.5,
+        });
+    }
+    return state;
 }
 
 export async function maybeNavigateToDiscordChannel(page, kwargs = {}, options = {}) {

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -8,6 +8,29 @@ function stringArg(value) {
     return typeof value === 'string' && value.trim() ? value.trim() : '';
 }
 
+export function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}
+
+function requireObjectEvaluateResult(payload, context) {
+    const value = unwrapEvaluateResult(payload);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new CommandExecutionError(`${context} returned malformed browser output.`);
+    }
+    return value;
+}
+
+function requireArrayEvaluateResult(payload, context) {
+    const value = unwrapEvaluateResult(payload);
+    if (!Array.isArray(value)) {
+        throw new CommandExecutionError(`${context} returned malformed browser output.`);
+    }
+    return value;
+}
+
 export function isDiscordSnowflake(value) {
     return CHANNEL_ID_RE.test(String(value || '').trim());
 }
@@ -321,20 +344,18 @@ export function buildRouteStateScript() {
 }
 
 async function getCurrentDiscordRoute(page) {
-    const state = await page.evaluate(buildRouteStateScript());
+    const state = requireObjectEvaluateResult(await page.evaluate(buildRouteStateScript()), 'Discord route state');
     if (state && state.route) return state.route;
     const url = typeof state?.url === 'string' ? state.url : '';
     return parseDiscordChannelUrl(url);
 }
 
 export async function listDiscordChannels(page) {
-    const rows = await page.evaluate(buildListChannelsScript());
-    return Array.isArray(rows) ? rows : [];
+    return requireArrayEvaluateResult(await page.evaluate(buildListChannelsScript()), 'Discord channel list');
 }
 
 export async function listDiscordServers(page) {
-    const rows = await page.evaluate(buildListServersScript());
-    return Array.isArray(rows) ? rows : [];
+    return requireArrayEvaluateResult(await page.evaluate(buildListServersScript()), 'Discord server list');
 }
 
 function rowMatchesChannel(row, channel) {
@@ -418,7 +439,7 @@ export async function waitForDiscordRoute(page, target, options = {}) {
     let lastState = null;
 
     while (Date.now() - started <= timeoutMs) {
-        lastState = await page.evaluate(buildRouteStateScript());
+        lastState = requireObjectEvaluateResult(await page.evaluate(buildRouteStateScript()), 'Discord route state');
         const route = lastState?.route;
         if (route && String(route.guild_id) === String(target.guild_id) && String(route.channel_id) === String(target.channel_id)) {
             if (!target.thread_id || String(route.thread_id || '') === String(target.thread_id)) {
@@ -441,7 +462,7 @@ export async function waitForDiscordContent(page, kind = 'messages', options = {
     let lastState = null;
 
     while (Date.now() - started <= timeoutMs) {
-        lastState = await page.evaluate(buildRouteStateScript());
+        lastState = requireObjectEvaluateResult(await page.evaluate(buildRouteStateScript()), 'Discord route state');
         if (kind === 'messages' && lastState?.has_messages) return lastState;
         if (kind === 'threads' && lastState?.has_threads) return lastState;
         await page.wait(intervalSeconds);
@@ -470,13 +491,38 @@ export async function maybeNavigateToDiscordChannel(page, kwargs = {}, options =
 }
 
 export async function readDiscordMessages(page, count) {
-    const rows = await page.evaluate(buildReadMessagesScript(count));
-    return Array.isArray(rows) ? rows : [];
+    return requireArrayEvaluateResult(await page.evaluate(buildReadMessagesScript(count)), 'Discord message list');
 }
 
 export async function listDiscordThreads(page, limit) {
-    const rows = await page.evaluate(buildListThreadsScript(limit));
-    return Array.isArray(rows) ? rows : [];
+    return requireArrayEvaluateResult(await page.evaluate(buildListThreadsScript(limit)), 'Discord thread list');
+}
+
+export function assertDiscordMessageRowsBelongToTarget(rows, target, context = 'Discord read') {
+    if (!target) return rows;
+    const expectedChannelId = String(target.thread_id || target.channel_id || '');
+    if (!expectedChannelId) {
+        throw new CommandExecutionError(`${context} target is missing a stable channel/thread id.`);
+    }
+    for (const row of rows) {
+        if (!row || typeof row !== 'object' || Array.isArray(row)) {
+            throw new CommandExecutionError(`${context} returned malformed message rows.`);
+        }
+        const actualChannelId = row.channel_id == null || row.channel_id === '' ? '' : String(row.channel_id);
+        if (!actualChannelId) {
+            throw new CommandExecutionError(
+                `${context} could not verify returned message target.`,
+                `Expected channel/thread id ${expectedChannelId}, but the message row did not include channel_id.`,
+            );
+        }
+        if (actualChannelId && actualChannelId !== expectedChannelId) {
+            throw new CommandExecutionError(
+                `${context} returned messages from the wrong Discord target.`,
+                `Expected channel/thread id ${expectedChannelId}, saw ${actualChannelId}.`,
+            );
+        }
+    }
+    return rows;
 }
 
 export async function resolveDiscordThreadTarget(page, kwargs = {}) {

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -31,6 +31,24 @@ function requireArrayEvaluateResult(payload, context) {
     return value;
 }
 
+function requireNonEmptyRowField(row, field, context, index) {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+        throw new CommandExecutionError(`${context} returned malformed row ${index + 1}.`);
+    }
+    const value = String(row[field] || '').trim();
+    if (!value) {
+        throw new CommandExecutionError(`${context} row ${index + 1} is missing ${field}.`);
+    }
+    return value;
+}
+
+function requireRowsWithFields(rows, fields, context) {
+    rows.forEach((row, index) => {
+        fields.forEach((field) => requireNonEmptyRowField(row, field, context, index));
+    });
+    return rows;
+}
+
 export function isDiscordSnowflake(value) {
     return CHANNEL_ID_RE.test(String(value || '').trim());
 }
@@ -351,11 +369,19 @@ async function getCurrentDiscordRoute(page) {
 }
 
 export async function listDiscordChannels(page) {
-    return requireArrayEvaluateResult(await page.evaluate(buildListChannelsScript()), 'Discord channel list');
+    return requireRowsWithFields(
+        requireArrayEvaluateResult(await page.evaluate(buildListChannelsScript()), 'Discord channel list'),
+        ['Channel', 'guild_id', 'channel_id', 'url'],
+        'Discord channel list',
+    );
 }
 
 export async function listDiscordServers(page) {
-    return requireArrayEvaluateResult(await page.evaluate(buildListServersScript()), 'Discord server list');
+    return requireRowsWithFields(
+        requireArrayEvaluateResult(await page.evaluate(buildListServersScript()), 'Discord server list'),
+        ['Server', 'guild_id', 'url'],
+        'Discord server list',
+    );
 }
 
 function rowMatchesChannel(row, channel) {
@@ -495,7 +521,11 @@ export async function readDiscordMessages(page, count) {
 }
 
 export async function listDiscordThreads(page, limit) {
-    return requireArrayEvaluateResult(await page.evaluate(buildListThreadsScript(limit)), 'Discord thread list');
+    return requireRowsWithFields(
+        requireArrayEvaluateResult(await page.evaluate(buildListThreadsScript(limit)), 'Discord thread list'),
+        ['Thread', 'guild_id', 'channel_id', 'thread_id', 'url'],
+        'Discord thread list',
+    );
 }
 
 export function assertDiscordMessageRowsBelongToTarget(rows, target, context = 'Discord read') {

--- a/docs/adapters/desktop/discord.md
+++ b/docs/adapters/desktop/discord.md
@@ -22,8 +22,44 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9232"
 | `opencli discord-app status` | Check CDP connection |
 | `opencli discord-app send "message"` | Send a message in the active channel |
 | `opencli discord-app read` | Read recent messages |
-| `opencli discord-app channels` | List channels in the current server |
-| `opencli discord-app servers` | List all joined servers |
+| `opencli discord-app channels` | List channels in the current server, including `guild_id`, `channel_id`, and `url` |
+| `opencli discord-app servers` | List visible joined servers, including `guild_id` and `url` |
+| `opencli discord-app goto` | Open a channel by id/name/url without sending messages |
+| `opencli discord-app threads` | List visible forum/thread posts in a channel |
+| `opencli discord-app thread-read` | Read a forum/thread post by id or URL |
 | `opencli discord-app search "query"` | Search messages (Cmd+F) |
 | `opencli discord-app members` | List online members |
 | `opencli discord-app delete MESSAGE_ID` | Delete a message by its ID |
+
+## Read-only channel targeting
+
+```bash
+# Get stable channel ids/URLs from the currently open server.
+opencli discord-app channels -f json
+
+# Open one channel without clicking the UI.
+opencli discord-app goto --url https://discord.com/channels/<guild_id>/<channel_id>
+opencli discord-app goto --guild <guild_id> --channel <channel_id>
+
+# Read after navigating internally. Omitting the target keeps the old behavior:
+# read the currently active channel.
+opencli discord-app read --url https://discord.com/channels/<guild_id>/<channel_id> --count 20 -f json
+opencli discord-app read --guild <guild_id> --channel <channel_id> --count 20 -f json
+```
+
+Passing numeric IDs or a channel URL is the most stable mode. Name lookup is
+best-effort for channels visible in the current Discord sidebar.
+
+Opening a channel through Discord's own route can update Discord's normal
+client-side read/unread state, just like manually opening the channel.
+
+## Forum and thread-style channels
+
+```bash
+# List visible forum/thread post cards from the active or targeted channel.
+opencli discord-app threads --url https://discord.com/channels/<guild_id>/<forum_channel_id> -f json
+
+# Read a selected post/thread.
+opencli discord-app thread-read --url https://discord.com/channels/<guild_id>/<forum_channel_id>/<thread_id> --count 20 -f json
+opencli discord-app thread-read --guild <guild_id> --channel <forum_channel_id> --thread <thread_id> --count 20 -f json
+```

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -174,6 +174,6 @@ Run `opencli list` for the live registry.
 | **[ChatGPT App](./desktop/chatgpt-app.md)** | Automate ChatGPT macOS app    | `status` `new` `send` `read` `ask` `model`                                                                  |
 | **[ChatWise](./desktop/chatwise.md)**       | Multi-LLM client              | `status` `new` `send` `read` `ask` `model` `history` `export` `screenshot`                                  |
 | **[Qoder](./desktop/qoder.md)**             | Control Qoder IDE             | `status` `new` `history` `send` `ask` `read` `search` `settings` `knowledge` `marketplace` `credits` `view-all` `add-workspace` `account` `more-actions` `prompt-enhance` `open-editor` `sidebar-toggle` `open-panel` |
-| **[Discord](./desktop/discord.md)**         | Desktop messages & channels   | `status` `send` `read` `channels` `servers` `search` `members`                                              |
+| **[Discord](./desktop/discord.md)**         | Desktop messages & channels   | `status` `send` `read` `channels` `servers` `goto` `threads` `thread-read` `search` `members`               |
 | **[Doubao App](./desktop/doubao-app.md)**   | Doubao AI desktop app via CDP | `status` `new` `send` `read` `ask` `screenshot` `dump`                                                      |
 | **[Trae SOLO](./desktop/trae-solo.md)**      | Trae SOLO desktop state       | `status` `history` `model` `mode` `automation-list` `skill-*` `state-*` `task-fs-*`                         |


### PR DESCRIPTION
## Description

Adds read-only Discord desktop navigation and thread/forum support for issue #1950.

This PR extends the existing `discord-app` adapter so agents can discover stable channel metadata, open a target channel by URL or ids, read from a targeted channel, list visible forum/thread posts, and read a selected thread/post without using send/delete style write actions.

Related issue: #1950

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [x] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Validation performed locally:

- `node --check` for all new/modified Discord adapter JS files
- `git diff --cached --check`
- `node -e "JSON.parse(require('fs').readFileSync('cli-manifest.json','utf8'))"`
- Low-frequency read-only CDP smoke test against a locally running Discord debug port:
  - Discord target was reachable
  - channel extraction returned 14 channels with metadata fields
  - recent-message extraction returned the expected row shape

I could not run the full Vitest adapter suite in this local environment because the checkout has no `node_modules` and the shell PATH had no system `node`, `npm`, `npx`, or `bun`. I used the bundled Codex Node runtime for syntax and JSON checks instead.
