### PR TITLE
feat(gemini): add --thinking flag to select Extended thinking level

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12949,6 +12949,13 @@
         "default": "false",
         "required": false,
         "help": "Start a new chat first (true/false, default: false)"
+      },
+      {
+        "name": "thinking",
+        "type": "str",
+        "default": "false",
+        "required": false,
+        "help": "Switch the thinking level to Extended before asking (true/false, default: false)"
       }
     ],
     "columns": [

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { GEMINI_DOMAIN, readGeminiSnapshot, sendGeminiMessage, startNewGeminiChat, waitForGeminiResponse, waitForGeminiSubmission } from './utils.js';
+import { GEMINI_DOMAIN, readGeminiSnapshot, selectGeminiThinkingLevel, sendGeminiMessage, startNewGeminiChat, waitForGeminiResponse, waitForGeminiSubmission } from './utils.js';
 function normalizeBooleanFlag(value) {
     if (typeof value === 'boolean')
         return value;
@@ -23,6 +23,7 @@ export const askCommand = cli({
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
         { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 60)', default: 60 },
         { name: 'new', required: false, help: 'Start a new chat first (true/false, default: false)', default: 'false' },
+        { name: 'thinking', required: false, help: 'Switch the thinking level to Extended before asking (true/false, default: false)', default: 'false' },
     ],
     columns: ['response'],
     func: async (page, kwargs) => {
@@ -34,6 +35,9 @@ export const askCommand = cli({
         const startFresh = normalizeBooleanFlag(kwargs.new);
         if (startFresh)
             await startNewGeminiChat(page);
+        const enableThinking = normalizeBooleanFlag(kwargs.thinking);
+        if (enableThinking)
+            await selectGeminiThinkingLevel(page, 'Extended');
         const before = await readGeminiSnapshot(page);
         await sendGeminiMessage(page, prompt);
         const submissionStartedAt = Date.now();

--- a/clis/gemini/ask.test.js
+++ b/clis/gemini/ask.test.js
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
     startNewGeminiChat: vi.fn(),
     waitForGeminiSubmission: vi.fn(),
     waitForGeminiResponse: vi.fn(),
+    selectGeminiThinkingLevel: vi.fn(),
 }));
 vi.mock('./utils.js', async () => {
     const actual = await vi.importActual('./utils.js');
@@ -37,6 +38,7 @@ vi.mock('./utils.js', async () => {
         startNewGeminiChat: mocks.startNewGeminiChat,
         waitForGeminiSubmission: mocks.waitForGeminiSubmission,
         waitForGeminiResponse: mocks.waitForGeminiResponse,
+        selectGeminiThinkingLevel: mocks.selectGeminiThinkingLevel,
     };
 });
 import { askCommand } from './ask.js';
@@ -96,5 +98,26 @@ describe('gemini ask orchestration', () => {
         mocks.waitForGeminiResponse.mockResolvedValueOnce('');
         await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
         expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 0);
+    });
+    it('switches the thinking level to Extended before sending when --thinking is enabled', async () => {
+        const page = createPageMock();
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+        await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false', thinking: 'true' });
+        expect(mocks.selectGeminiThinkingLevel).toHaveBeenCalledWith(page, 'Extended');
+        const thinkingOrder = mocks.selectGeminiThinkingLevel.mock.invocationCallOrder[0];
+        const sendOrder = mocks.sendGeminiMessage.mock.invocationCallOrder[0];
+        expect(thinkingOrder).toBeLessThan(sendOrder);
+    });
+    it('does not touch the thinking level when --thinking is not set', async () => {
+        const page = createPageMock();
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+        await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
+        expect(mocks.selectGeminiThinkingLevel).not.toHaveBeenCalled();
     });
 });

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -845,6 +845,63 @@ function selectGeminiToolScript(labels) {
     })(${labelsJson})
   `;
 }
+function geminiModePickerLabelScript() {
+    return `
+    (() => {
+      const picker = Array.from(document.querySelectorAll('button, [role="button"]')).find((node) => (node.getAttribute('aria-label') || '').toLowerCase().includes('open mode picker'));
+      return picker ? (picker.getAttribute('aria-label') || '') : '';
+    })()
+  `;
+}
+function openGeminiModePickerScript() {
+    return `
+    (() => {
+      const picker = Array.from(document.querySelectorAll('button, [role="button"]')).find((node) => (node.getAttribute('aria-label') || '').toLowerCase().includes('open mode picker'));
+      if (!(picker instanceof HTMLElement)) return false;
+      picker.click();
+      return true;
+    })()
+  `;
+}
+function openGeminiThinkingLevelSubmenuScript() {
+    return `
+    (() => {
+      const norm = (value) => (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+      const item = Array.from(document.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="option"]')).find((node) => norm(node.textContent).includes('thinking level'));
+      if (!(item instanceof HTMLElement)) return false;
+      item.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      item.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      item.click();
+      return true;
+    })()
+  `;
+}
+function selectGeminiThinkingOptionScript(level) {
+    const levelJson = JSON.stringify(String(level || ''));
+    return `
+    ((targetLevel) => {
+      const norm = (value) => (value || '').replace(/\\s+/g, ' ').trim();
+      const wanted = norm(targetLevel).toLowerCase();
+      if (!wanted) return '';
+      const items = Array.from(document.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="option"]'));
+      const match = items.find((node) => {
+        const text = norm(node.textContent).toLowerCase();
+        return text === wanted || text.startsWith(wanted + ' ');
+      });
+      if (!(match instanceof HTMLElement)) return '';
+      match.click();
+      return norm(match.textContent);
+    })(${levelJson})
+  `;
+}
+function dismissGeminiMenuScript() {
+    return `
+    (() => {
+      (document.activeElement || document.body).dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+      return true;
+    })()
+  `;
+}
 function clickGeminiConfirmButtonScript(labels) {
     const labelsJson = JSON.stringify(labels);
     return `
@@ -1054,6 +1111,39 @@ export async function selectGeminiTool(page, labels) {
     await openGeminiToolsMenu(page);
     const matched = await page.evaluate(selectGeminiToolScript(labels));
     return typeof matched === 'string' ? matched : '';
+}
+// Switch the composer's thinking level (e.g. "Extended") before sending a
+// prompt. The Gemini 3 mode picker (aria-label "Open mode picker, currently
+// <model>") opens a menu where "Thinking level" is a submenu containing
+// "Standard" / "Extended"; selecting one updates the picker label to
+// "<model> <level>". Idempotent: returns true without touching the UI when the
+// requested level is already active.
+export async function selectGeminiThinkingLevel(page, level = 'Extended') {
+    await ensureGeminiPage(page);
+    const target = String(level || 'Extended');
+    const currentLabel = String((await page.evaluate(geminiModePickerLabelScript())) || '');
+    if (currentLabel.toLowerCase().includes(target.toLowerCase())) {
+        return true;
+    }
+    const opened = await page.evaluate(openGeminiModePickerScript());
+    if (!opened)
+        return false;
+    await page.wait(0.7);
+    // The level options live in a "Thinking level" submenu; try a direct hit
+    // first, then open the submenu and retry.
+    let matched = await page.evaluate(selectGeminiThinkingOptionScript(target));
+    if (!matched) {
+        await page.evaluate(openGeminiThinkingLevelSubmenuScript());
+        await page.wait(0.7);
+        matched = await page.evaluate(selectGeminiThinkingOptionScript(target));
+    }
+    if (matched) {
+        await page.wait(0.5);
+        return true;
+    }
+    // Leave the menu closed if we could not select the level.
+    await page.evaluate(dismissGeminiMenuScript()).catch(() => { });
+    return false;
 }
 export async function waitForGeminiConfirmButton(page, labels, timeoutSeconds) {
     await ensureGeminiPage(page);

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
+import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, selectGeminiThinkingLevel, sendGeminiMessage, } from './utils.js';
 function createPageMock() {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -315,5 +315,37 @@ describe('pickGeminiDeepResearchExportUrl', () => {
             'performance::https://www.google-analytics.com/g/collect?v=2',
         ], 'https://gemini.google.com/app/abc');
         expect(picked).toEqual({ url: '', source: 'none' });
+    });
+});
+describe('selectGeminiThinkingLevel', () => {
+    it('is a no-op when the requested level is already active', async () => {
+        const page = createPageMock();
+        page.evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app') // ensureGeminiPage -> isOnGemini
+            .mockResolvedValueOnce('Open mode picker, currently Flash Extended'); // current label
+        const result = await selectGeminiThinkingLevel(page, 'Extended');
+        expect(result).toBe(true);
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+    });
+    it('opens the picker and selects the level through the Thinking level submenu', async () => {
+        const page = createPageMock();
+        page.evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app') // ensureGeminiPage
+            .mockResolvedValueOnce('Open mode picker, currently Flash') // current label (Standard)
+            .mockResolvedValueOnce(true) // open mode picker
+            .mockResolvedValueOnce('') // direct option hit (submenu not open yet)
+            .mockResolvedValueOnce(true) // open Thinking level submenu
+            .mockResolvedValueOnce('Extended Complex problem solving'); // select option
+        const result = await selectGeminiThinkingLevel(page, 'Extended');
+        expect(result).toBe(true);
+    });
+    it('returns false when the mode picker cannot be opened', async () => {
+        const page = createPageMock();
+        page.evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app') // ensureGeminiPage
+            .mockResolvedValueOnce('') // current label
+            .mockResolvedValueOnce(false); // open mode picker fails
+        const result = await selectGeminiThinkingLevel(page, 'Extended');
+        expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
## What & why

`gemini ask` had no way to control the model's **thinking level**, so prompts that benefit from deeper reasoning always ran at the default ("Standard"). This adds an opt-in `--thinking` flag that switches the composer to **Extended** thinking before sending.

## Changes

- **`clis/gemini/utils.js`** — new exported helper `selectGeminiThinkingLevel(page, level = 'Extended')`. It drives the Gemini 3 mode picker: open the *"Open mode picker"* control → open the *"Thinking level"* submenu → click the requested level. Idempotent: no-ops when the level is already active (matched against the picker's `aria-label`), and dismisses the menu if selection fails.
- **`clis/gemini/ask.js`** — new `--thinking` arg (default `false`). When enabled, the thinking level is set to Extended **before** the prompt is sent. Behavior is unchanged when the flag is omitted.
- **`cli-manifest.json`** — regenerated (adds the new arg).

## UI flow (verified live on gemini.google.com)

The picker button exposes `aria-label="Open mode picker, currently <model>"`. Its menu contains a `"Thinking level"` submenu with `Standard` / `Extended`; selecting Extended updates the label to `"<model> Extended"`.

## Test plan

- `npx vitest run --project adapter clis/gemini/` → **95 passing** (5 new):
  - helper: already-active no-op, submenu selection path, mode-picker-missing failure
  - ask orchestration: selects Extended before sending when enabled; untouched when the flag is absent
- `npx tsc --noEmit` → clean
- Manually verified end-to-end against a logged-in Chrome profile: picker switches to `Flash Extended` before the prompt is sent, and a reasoning prompt returns a correctly-reasoned answer.

## Usage

```bash
opencli gemini ask "tricky reasoning prompt" --thinking true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
