### PR TITLE
fix(linkedin): support Connect under "More" menu and scope invites to the profile owner

### DIFF
--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -126,9 +126,19 @@ function assessProfileSafety(probe, expectedName, expectedProfileUrl) {
     return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
 }
 
-function buildProfileProbeScript() {
+function buildProfileProbeScript(expectedName = '') {
     return String.raw`(() => {
     const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
+    const expectedName = ${JSON.stringify(expectedName)};
+    const normalizeName = (s) => clean(s)
+      .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
+      .replace(/\s+LinkedIn.*$/i, '')
+      .replace(/\b(p\.?eng\.?|cpa|mba|ph\.?d\.?)\b/ig, '')
+      .replace(/[^\p{L}\p{N}\s.'-]+/gu, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+    const tokens = (s) => normalizeName(s).replace(/[.'-]+/g, ' ').split(/\s+/).map((t) => t.trim()).filter((t) => t.length >= 2);
     const text = document.body ? (document.body.innerText || '') : '';
     const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
       || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
@@ -143,28 +153,50 @@ function buildProfileProbeScript() {
     const name = clean(heading?.innerText || heading?.textContent || '') || titleName;
     const buttons = Array.from(document.querySelectorAll('button, [role="button"], a')).filter((el) => el.offsetParent !== null);
     const buttonLabels = buttons.map((button) => clean(button.innerText || button.textContent || button.getAttribute('aria-label'))).filter(Boolean);
-    const lowerLabels = buttonLabels.map((label) => label.toLowerCase());
-    const pending = lowerLabels.some((label) => label === 'pending' || label.includes('pending'));
-    const connectAvailable = lowerLabels.some((label) => label === 'connect' || label.startsWith('connect ') || label.includes(' invite '));
+    const expectedTokens = tokens(expectedName || name);
+    const ariaLabel = (el) => clean(el?.getAttribute('aria-label') || '');
+    const textLabel = (el) => clean(el?.innerText || el?.textContent || '');
+    const labelOf = (el) => clean(textLabel(el) || ariaLabel(el));
+    const namesOwner = (el) => {
+      const label = ariaLabel(el).toLowerCase();
+      return expectedTokens.length >= 1 && expectedTokens.every((token) => label.includes(token));
+    };
+    const topCard = main?.querySelector('.pv-top-card, [class*="top-card"]')
+      || heading?.closest?.('section, .ph5, [class*="top-card"]')
+      || main;
+    const ownerAction = buttons.find((el) => namesOwner(el) && /^(invite|connect|follow|message|more|pending)\b/i.test(ariaLabel(el)));
+    const ownerScope = ownerAction
+      ? (ownerAction.closest('[class*="profile-actions"], [class*="pvs-profile-actions"], .pv-top-card, .ph5, section') || ownerAction.parentElement || topCard)
+      : topCard;
+    const scopedButtons = Array.from(ownerScope?.querySelectorAll?.('button, [role="button"], a') || []).filter((el) => el.offsetParent !== null);
+    const ownerButtons = Array.from(new Set([...buttons.filter(namesOwner), ...scopedButtons]));
+    const lowerOwnerLabels = ownerButtons.map((button) => labelOf(button).toLowerCase()).filter(Boolean);
+    const pending = lowerOwnerLabels.some((label) => label === 'pending' || label.includes('pending'));
+    const connectAvailable = ownerButtons.some((el) => {
+      const label = labelOf(el).toLowerCase();
+      const aria = ariaLabel(el).toLowerCase();
+      return label === 'connect'
+        || label.startsWith('connect ')
+        || (/invite .* to connect/i.test(aria) && namesOwner(el));
+    });
     // When "Follow" is the primary action, Connect is tucked inside the "More" actions
     // menu rather than shown as a top-level button. Note the menu's presence so the safety
     // check can treat the profile as connectable; the send step opens the menu and confirms.
-    const moreAvailable = lowerLabels.some((label) => label === 'more' || label.startsWith('more '));
+    const moreAvailable = lowerOwnerLabels.some((label) => label === 'more' || label.startsWith('more '));
     // A visible "Message" button is NOT proof of an existing connection: LinkedIn shows
     // Message on many 2nd/3rd-degree profiles (open profiles, Premium, recruiter) right
     // next to a real "Connect" button. The reliable signal for a 1st-degree connection is
     // the degree badge ("1st degree connection") in the top card. Scope to the top card so
     // the "People also viewed" sidebar (which lists other members' degrees) cannot bleed in,
     // and never call it connected when a Connect affordance is present.
-    const topCard = main?.querySelector('.pv-top-card, [class*="top-card"], section') || main;
     const topCardRaw = clean(topCard?.textContent || '');
     const firstDegreeBadge = /\b1st degree connection\b/i.test(topCardRaw);
     const alreadyConnected = !connectAvailable && firstDegreeBadge;
     // The Connect control is an <a> linking to LinkedIn's invitation route
     // (/preload/custom-invite/?vanityName=...). Capture it so the sender can
     // navigate straight to the invite dialog.
-    const connectAnchor = buttons.find((el) => el.tagName === 'A'
-      && /^connect$/i.test(clean(el.innerText || el.textContent || el.getAttribute('aria-label'))));
+    const connectAnchor = ownerButtons.find((el) => el.tagName === 'A'
+      && (/^connect$/i.test(labelOf(el)) || (/invite .* to connect/i.test(ariaLabel(el)) && namesOwner(el))));
     const connectHref = connectAnchor ? (connectAnchor.getAttribute('href') || '') : '';
     return {
       url: location.href,
@@ -363,8 +395,8 @@ function buildOpenConnectDialogScript(expectedName) {
   })()`;
 }
 
-async function probeProfile(page) {
-    return unwrapEvaluateResult(await page.evaluate(buildProfileProbeScript()));
+async function probeProfile(page, expectedName = '') {
+    return unwrapEvaluateResult(await page.evaluate(buildProfileProbeScript(expectedName)));
 }
 
 cli({
@@ -390,7 +422,7 @@ cli({
 
         await page.goto(profileUrl);
         await page.wait(6);
-        let probe = await probeProfile(page);
+        let probe = await probeProfile(page, expectedName);
         // The name resolves early (from document.title), but the profile action
         // buttons (Connect / Message / Pending) render later. Keep probing until
         // the action state has resolved, not merely until the name is visible.
@@ -399,7 +431,7 @@ cli({
                 && (probe.connectAvailable || probe.alreadyConnected || probe.pending || probe.moreAvailable);
             if (resolved) break;
             await page.wait(2);
-            probe = await probeProfile(page);
+            probe = await probeProfile(page, expectedName);
         }
         const safety = assessProfileSafety(probe, expectedName, profileUrl);
         if (safety.blockReason === 'auth_required') {
@@ -487,5 +519,6 @@ export const __test__ = {
     unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
+    buildProfileProbeScript,
     buildSentInvitationsProbeScript,
 };

--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -118,8 +118,12 @@ function assessProfileSafety(probe, expectedName, expectedProfileUrl) {
     }
     if (probe?.alreadyConnected) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'already_connected', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
     if (probe?.pending) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connection_pending', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    if (!probe?.connectAvailable) return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
-    return { ok: true, safety: 'connectable', connectable: true, blockReason: 'verified', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    if (probe?.connectAvailable) return { ok: true, safety: 'connectable', connectable: true, blockReason: 'verified', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    // No top-level Connect, but a "More" actions menu is present and the profile is neither
+    // already-connected nor pending: Connect is almost certainly inside that menu. Treat as
+    // connectable; the send step opens "More" and fails cleanly if Connect truly isn't there.
+    if (probe?.moreAvailable) return { ok: true, safety: 'connectable', connectable: true, blockReason: 'verified_via_more', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
+    return { ok: false, safety: 'routine_non_connectable', connectable: false, blockReason: 'connect_button_not_found', expectedValue: expected, actualValue: actual, observedUrl: actualUrl };
 }
 
 function buildProfileProbeScript() {
@@ -140,9 +144,22 @@ function buildProfileProbeScript() {
     const buttons = Array.from(document.querySelectorAll('button, [role="button"], a')).filter((el) => el.offsetParent !== null);
     const buttonLabels = buttons.map((button) => clean(button.innerText || button.textContent || button.getAttribute('aria-label'))).filter(Boolean);
     const lowerLabels = buttonLabels.map((label) => label.toLowerCase());
-    const alreadyConnected = lowerLabels.some((label) => label === 'message' || label.includes('1st degree connection'));
     const pending = lowerLabels.some((label) => label === 'pending' || label.includes('pending'));
     const connectAvailable = lowerLabels.some((label) => label === 'connect' || label.startsWith('connect ') || label.includes(' invite '));
+    // When "Follow" is the primary action, Connect is tucked inside the "More" actions
+    // menu rather than shown as a top-level button. Note the menu's presence so the safety
+    // check can treat the profile as connectable; the send step opens the menu and confirms.
+    const moreAvailable = lowerLabels.some((label) => label === 'more' || label.startsWith('more '));
+    // A visible "Message" button is NOT proof of an existing connection: LinkedIn shows
+    // Message on many 2nd/3rd-degree profiles (open profiles, Premium, recruiter) right
+    // next to a real "Connect" button. The reliable signal for a 1st-degree connection is
+    // the degree badge ("1st degree connection") in the top card. Scope to the top card so
+    // the "People also viewed" sidebar (which lists other members' degrees) cannot bleed in,
+    // and never call it connected when a Connect affordance is present.
+    const topCard = main?.querySelector('.pv-top-card, [class*="top-card"], section') || main;
+    const topCardRaw = clean(topCard?.textContent || '');
+    const firstDegreeBadge = /\b1st degree connection\b/i.test(topCardRaw);
+    const alreadyConnected = !connectAvailable && firstDegreeBadge;
     // The Connect control is an <a> linking to LinkedIn's invitation route
     // (/preload/custom-invite/?vanityName=...). Capture it so the sender can
     // navigate straight to the invite dialog.
@@ -157,6 +174,7 @@ function buildProfileProbeScript() {
       alreadyConnected,
       pending,
       connectAvailable,
+      moreAvailable,
       connectHref,
       buttonLabels: buttonLabels.slice(0, 30),
       bodyText: text,
@@ -288,6 +306,63 @@ function buildInviteScript(note) {
   })()`;
 }
 
+// Opens the connection-invite dialog in-page for profiles where "Connect" is a
+// <button> (not an <a> to /preload/custom-invite/). Connect may be a primary button
+// or hidden inside the "More" actions menu. CRITICAL: a profile page also renders
+// "Connect" buttons for OTHER people (the "People also viewed" / "More profiles for
+// you" sidebar). We must never click those. Every click here is scoped to the profile
+// OWNER, identified by LinkedIn's name-bearing aria-labels ("Invite <Name> to connect",
+// "Message <Name>", "Follow <Name>"). If the owner's control can't be positively
+// identified, fail closed rather than guess.
+function buildOpenConnectDialogScript(expectedName) {
+    return String.raw`(async () => {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const jitter = async (min = 450, max = 1150) => sleep(min + Math.floor(Math.random() * (max - min + 1)));
+    const clean = (s) => String(s || '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+    const visible = (el) => el && el.offsetParent !== null;
+    const expectedName = ${JSON.stringify(expectedName)};
+    const ariaLabel = (el) => clean(el?.getAttribute('aria-label') || '');
+    const textLabel = (el) => clean(el?.innerText || el?.textContent || '');
+    const tokens = (s) => clean(s).toLowerCase().replace(/[.'-]+/g, ' ').split(/\s+/).filter((t) => t.length >= 2);
+    const expTokens = tokens(expectedName);
+    // Require every expected-name token to appear in the control's aria-label, so a
+    // sidebar card's "Invite <OtherName> to connect" can never satisfy this.
+    const namesOwner = (el) => { const al = ariaLabel(el).toLowerCase(); return expTokens.length >= 1 && expTokens.every((t) => al.includes(t)); };
+    const isConnectText = (el) => /^connect$/i.test(textLabel(el));
+    const isOwnerConnect = (el) => /invite .* to connect/i.test(ariaLabel(el)) && namesOwner(el);
+    if (document.querySelector('[role="dialog"]')) return { ok: true, opened: 'already_open' };
+    const all = Array.from(document.querySelectorAll('button, [role="button"], a')).filter(visible);
+    // 1) Primary Connect button whose aria-label names the profile owner.
+    let btn = all.find(isOwnerConnect);
+    // 2) Connect under the owner's "More" menu: find the owner's action bar via a named
+    //    Follow/Message/More/Pending control, open the menu, then pick Connect from THAT
+    //    opened menu only (the dropdown is portaled to the body).
+    if (!btn) {
+      const ownerAction = all.find((el) => namesOwner(el) && /^(follow|message|more|pending|invite)\b/i.test(ariaLabel(el)));
+      const bar = ownerAction
+        ? (ownerAction.closest('[class*="profile-actions"], [class*="pvs-profile-actions"], .pv-top-card, .ph5, section') || ownerAction.parentElement)
+        : null;
+      if (!bar) return { ok: false, reason: 'owner_action_bar_not_found' };
+      const moreBtn = Array.from(bar.querySelectorAll('button, [role="button"]')).filter(visible)
+        .find((el) => { const l = (ariaLabel(el) || textLabel(el)).toLowerCase(); return l === 'more' || l.startsWith('more '); });
+      if (!moreBtn) return { ok: false, reason: 'owner_more_button_not_found' };
+      await jitter();
+      moreBtn.click();
+      await jitter(700, 1300);
+      const menu = Array.from(document.querySelectorAll('[role="menu"], .artdeco-dropdown__content')).filter(visible).pop();
+      const scope = menu || bar;
+      btn = Array.from(scope.querySelectorAll('[role="menuitem"], button, a, div')).filter(visible).find((el) => isOwnerConnect(el) || isConnectText(el));
+    }
+    if (!btn) return { ok: false, reason: 'connect_control_not_found' };
+    await jitter();
+    btn.click();
+    await jitter(1200, 2000);
+    if (document.querySelector('[role="dialog"]')) return { ok: true, opened: 'dialog' };
+    // Some flows fire the invite immediately without a confirmation dialog.
+    return { ok: true, opened: 'no_dialog' };
+  })()`;
+}
+
 async function probeProfile(page) {
     return unwrapEvaluateResult(await page.evaluate(buildProfileProbeScript()));
 }
@@ -321,7 +396,7 @@ cli({
         // the action state has resolved, not merely until the name is visible.
         for (let attempt = 0; attempt < 8; attempt += 1) {
             const resolved = probe?.name
-                && (probe.connectAvailable || probe.alreadyConnected || probe.pending);
+                && (probe.connectAvailable || probe.alreadyConnected || probe.pending || probe.moreAvailable);
             if (resolved) break;
             await page.wait(2);
             probe = await probeProfile(page);
@@ -343,19 +418,34 @@ cli({
             return [{ status: 'connectable_dry_run', recipient: safety.actualValue, reason: safety.blockReason, profile_url: safety.observedUrl, note_chars: note.length, connectable: true }];
         }
         const inviteHref = probe?.connectHref || '';
-        if (!inviteHref) {
-            throw new CommandExecutionError('LinkedIn connect blocked: connect_link_not_found');
+        if (inviteHref) {
+            // Anchor-based Connect: navigate straight to the invitation route, where the
+            // "Add a note?" dialog renders already open.
+            const inviteUrl = canonicalizeLinkedInInviteUrl(inviteHref);
+            if (!inviteUrl) {
+                throw new CommandExecutionError('LinkedIn connect blocked: invalid_connect_link');
+            }
+            await page.goto(inviteUrl);
+            await page.wait(6);
         }
-        const inviteUrl = canonicalizeLinkedInInviteUrl(inviteHref);
-        if (!inviteUrl) {
-            throw new CommandExecutionError('LinkedIn connect blocked: invalid_connect_link');
+        else {
+            // Button-based Connect: no /preload/custom-invite/ anchor exists, so open the
+            // invite dialog in-page by clicking the Connect control (directly or via More).
+            const opened = unwrapEvaluateResult(await page.evaluate(buildOpenConnectDialogScript(expectedName)));
+            if (!opened?.ok) {
+                throw new CommandExecutionError(`LinkedIn connect blocked: ${opened?.reason || 'connect_control_not_found'}`);
+            }
+            await page.wait(3);
         }
-        await page.goto(inviteUrl);
-        await page.wait(6);
         let result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
         if (result?.reason === 'invite_dialog_not_found') {
             await page.wait(5);
             result = unwrapEvaluateResult(await page.evaluate(buildInviteScript(note)));
+        }
+        // A button-based Connect that fired the invite without a confirmation dialog leaves
+        // no dialog to drive; treat it as sent and let the sent-invitations probe verify.
+        if (!result?.ok && result?.reason === 'invite_dialog_not_found' && !inviteHref) {
+            result = { ok: true, status: 'sent', reason: 'invitation_sent_no_dialog' };
         }
         if (!result?.ok) throw new CommandExecutionError(`LinkedIn connect blocked: ${result?.reason || 'send_failed'}`);
         // LinkedIn can take a few seconds after the Send click to materialize the

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -40,6 +40,25 @@ function makeSequentialFakePage(values) {
     };
 }
 
+// Like makeSequentialFakePage, but also answers the in-page "open connect dialog" script
+// (button/More-menu path) with a fixed result, without consuming a sequence slot. The
+// sequence therefore only feeds the profile probe and the sent-invitations probe(s).
+function makeMoreMenuFakePage(values, openResult = { ok: true, opened: 'dialog' }) {
+    let index = 0;
+    return {
+        goto: vi.fn(async () => undefined),
+        wait: vi.fn(async () => undefined),
+        evaluate: vi.fn(async (script) => {
+            const text = String(script);
+            if (text.includes('opened:')) return openResult;
+            if (text.includes('custom-message') || text.includes('invite_dialog_not_found')) return { ok: true, status: 'sent', reason: 'invitation_sent_without_note' };
+            const value = values[Math.min(index, values.length - 1)];
+            index += 1;
+            return value;
+        }),
+    };
+}
+
 describe('linkedin connect helpers', () => {
     it('normalizes names and profile URLs', () => {
         expect(normalizeName('Jane Doe • 2nd degree connection')).toBe('jane doe');
@@ -94,6 +113,18 @@ describe('linkedin connect helpers', () => {
     it('passes only when profile url, name, and connect affordance all match', () => {
         const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/?mini=true', connectAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
         expect(result).toMatchObject({ ok: true, blockReason: 'verified', actualValue: 'Jane Doe', connectable: true });
+    });
+
+    it('treats a present "More" menu as connectable when there is no top-level Connect button', () => {
+        // Follow-primary profiles hide Connect inside the "More" actions menu. The probe
+        // reports moreAvailable; the send step opens the menu and confirms (or fails closed).
+        const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: false, moreAvailable: true }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
+        expect(result).toMatchObject({ ok: true, blockReason: 'verified_via_more', connectable: true });
+    });
+
+    it('still blocks when neither a Connect button nor a More menu is present', () => {
+        const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: false, moreAvailable: false }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
+        expect(result.blockReason).toBe('connect_button_not_found');
     });
 });
 
@@ -209,5 +240,34 @@ describe('linkedin connect command', () => {
         });
         expect(rows[0]).toMatchObject({ status: 'send_unverified', recipient: 'Jane Doe', reason: 'sent_invitation_not_found_after_retries', delivery_verified: false });
         expect(page.evaluate).toHaveBeenCalledTimes(5);
+    });
+
+    it('opens the invite dialog in-page when Connect has no anchor (button/More-menu path) and verifies delivery', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        // Follow-primary profile: no connectHref anchor, but a "More" menu is present.
+        const page = makeMoreMenuFakePage([
+            { name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: false, moreAvailable: true, connectHref: '', buttonLabels: ['Follow', 'Message', 'More'] },
+            { found: true, matchedName: 'Jane Doe', matchedUrl: 'https://www.linkedin.com/in/jane/' },
+        ]);
+        const rows = await command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            send: true,
+        });
+        expect(rows[0]).toMatchObject({ status: 'sent_verified', recipient: 'Jane Doe', reason: 'sent_invitation_verified', delivery_verified: true });
+        expect(page.goto).toHaveBeenCalledWith('https://www.linkedin.com/mynetwork/invitation-manager/sent/');
+    });
+
+    it('fails closed when the owner Connect control cannot be opened from the More menu', async () => {
+        const command = getRegistry().get('linkedin/connect');
+        const page = makeMoreMenuFakePage(
+            [{ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: false, moreAvailable: true, connectHref: '', buttonLabels: ['Follow', 'Message', 'More'] }],
+            { ok: false, reason: 'owner_action_bar_not_found' },
+        );
+        await expect(command.func(page, {
+            'profile-url': 'https://www.linkedin.com/in/jane/',
+            'expected-name': 'Jane Doe',
+            send: true,
+        })).rejects.toThrow('owner_action_bar_not_found');
     });
 });

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './connect.js';
@@ -11,6 +12,7 @@ const {
     unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
+    buildProfileProbeScript,
 } = await import('./connect.js').then((m) => m.__test__);
 
 function makeFakePage(probe, sendResult = { ok: true, status: 'sent', reason: 'connection_request_sent' }) {
@@ -57,6 +59,20 @@ function makeMoreMenuFakePage(values, openResult = { ok: true, opened: 'dialog' 
             return value;
         }),
     };
+}
+
+function evaluateProfileProbe(html, expectedName = 'Jane Doe') {
+    const dom = new JSDOM(html, {
+        url: 'https://www.linkedin.com/in/jane/',
+        runScripts: 'outside-only',
+    });
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'offsetParent', {
+        configurable: true,
+        get() {
+            return this.dataset.hidden === 'true' ? null : dom.window.document.body;
+        },
+    });
+    return dom.window.eval(buildProfileProbeScript(expectedName));
 }
 
 describe('linkedin connect helpers', () => {
@@ -125,6 +141,45 @@ describe('linkedin connect helpers', () => {
     it('still blocks when neither a Connect button nor a More menu is present', () => {
         const result = assessProfileSafety({ name: 'Jane Doe', url: 'https://www.linkedin.com/in/jane/', connectAvailable: false, moreAvailable: false }, 'Jane Doe', 'https://www.linkedin.com/in/jane/');
         expect(result.blockReason).toBe('connect_button_not_found');
+    });
+
+    it('scopes profile action probing to the profile owner instead of sidebar cards', () => {
+        const probe = evaluateProfileProbe(`
+          <main>
+            <section class="pv-top-card">
+              <h1>Jane Doe</h1>
+              <div class="pvs-profile-actions">
+                <button aria-label="Follow Jane Doe">Follow</button>
+                <button aria-label="More actions">More</button>
+              </div>
+            </section>
+            <aside>
+              <a href="/preload/custom-invite/?vanityName=other">Connect</a>
+              <button>More</button>
+            </aside>
+          </main>
+        `);
+        expect(probe.name).toBe('Jane Doe');
+        expect(probe.moreAvailable).toBe(true);
+        expect(probe.connectAvailable).toBe(false);
+        expect(probe.connectHref).toBe('');
+    });
+
+    it('does not treat sidebar Connect as profile-owner connectable when the owner has no action menu', () => {
+        const probe = evaluateProfileProbe(`
+          <main>
+            <section class="pv-top-card">
+              <h1>Jane Doe</h1>
+            </section>
+            <aside>
+              <a href="/preload/custom-invite/?vanityName=other">Connect</a>
+              <button>More</button>
+            </aside>
+          </main>
+        `);
+        expect(probe.connectAvailable).toBe(false);
+        expect(probe.moreAvailable).toBe(false);
+        expect(probe.connectHref).toBe('');
     });
 });
 


### PR DESCRIPTION
## Summary

Makes `linkedin connect` work on profiles where **"Connect" is not a top-level button**, and fixes a profile-state misread. Three related changes to `clis/linkedin/connect.js`, plus tests.

### 1. False-positive `already_connected`
`buildProfileProbeScript` flagged a profile as already connected whenever any visible button was labelled "Message". LinkedIn shows a Message button on many 2nd/3rd-degree profiles (open profiles, Premium, recruiter) right next to a real Connect button, so connectable people were reported as `already_connected` and the request was never sent.

Detection now keys on the **"1st degree connection" badge in the top card** (scoped so the "People also viewed" sidebar cannot bleed in) and never overrides an available Connect affordance.

> Note: PR #1913 independently spotted this same false positive and addresses it with a narrower gate (`alreadyConnected && !connectAvailable`). That gate still blocks the Follow-primary case in §2 below (no top-level Connect → `connectAvailable` is false → still treated as `already_connected`), so this PR takes a more complete approach to the probe. Happy to rebase/reconcile with #1913 whichever way you prefer.

### 2. Connect hidden under the "More" menu
When "Follow" is the primary action, Connect lives inside the "More" actions menu — there is no top-level Connect button and no `/preload/custom-invite/` anchor. These profiles previously failed with `connect_button_not_found` (safety check) or `connect_link_not_found` (send step).

The probe now reports `moreAvailable`; the safety check treats that as connectable (`verified_via_more`); and the send step opens the menu in-page to reach Connect.

### 3. Owner-scoped clicking (safety)
A profile page also renders Connect buttons for **other people** in the "People also viewed" / "More profiles for you" sidebar. The in-page opener only ever clicks a control whose aria-label names the expected profile owner (`Invite <Name> to connect`), or opens that owner's own "More" menu and takes Connect from the menu that opens. If the owner's control cannot be positively identified, it **fails closed** rather than clicking a sidebar card.

## Testing

- `npx tsc --noEmit` — passes
- `npx vitest run clis/linkedin/connect.test.js` — 19 passing (added: `moreAvailable` gate unit test; in-page send path func tests for success and fail-closed)
- Verified end-to-end against live profiles: anchor-based Connect, button-based Connect, and Connect-under-More all send and verify in `/mynetwork/invitation-manager/sent/`; sidebar cards are never invited.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New capability (Connect-under-More support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
