### PR TITLE
feat(ke): add filters and sort to ershoufang, zufang, xiaoqu & chengjiao

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18458,13 +18458,54 @@
         "type": "str",
         "default": "bj",
         "required": false,
-        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)"
+        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)"
       },
       {
         "name": "district",
         "type": "str",
         "required": false,
-        "help": "区域拼音，如 chaoyang, haidian"
+        "help": "区域拼音，如 chaoyang, haidian, tianhe, xuhui"
+      },
+      {
+        "name": "min-price",
+        "type": "int",
+        "required": false,
+        "help": "最低均价（万/㎡）"
+      },
+      {
+        "name": "max-price",
+        "type": "int",
+        "required": false,
+        "help": "最高均价（万/㎡）"
+      },
+      {
+        "name": "age",
+        "type": "str",
+        "required": false,
+        "help": "楼龄：5/10/15/20 年以内，20+ 为 20 年以上",
+        "choices": [
+          "5",
+          "10",
+          "15",
+          "20",
+          "20+"
+        ]
+      },
+      {
+        "name": "near-subway",
+        "type": "boolean",
+        "required": false,
+        "help": "仅看近地铁小区"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "required": false,
+        "help": "排序：avg-price-asc|desc(小区均价)；不传为默认排序",
+        "choices": [
+          "avg-price-asc",
+          "avg-price-desc"
+        ]
       },
       {
         "name": "limit",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18500,13 +18500,13 @@
         "type": "str",
         "default": "bj",
         "required": false,
-        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)"
+        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)"
       },
       {
         "name": "district",
         "type": "str",
         "required": false,
-        "help": "区域拼音，如 chaoyang, haidian"
+        "help": "区域拼音，如 chaoyang, haidian, pudong"
       },
       {
         "name": "min-price",
@@ -18519,6 +18519,88 @@
         "type": "int",
         "required": false,
         "help": "最高月租（元）"
+      },
+      {
+        "name": "rooms",
+        "type": "int",
+        "required": false,
+        "help": "户型居室数 (1-4)，4 表示四居及以上"
+      },
+      {
+        "name": "rent-type",
+        "type": "str",
+        "required": false,
+        "help": "方式：whole(整租)/shared(合租)",
+        "choices": [
+          "whole",
+          "shared"
+        ]
+      },
+      {
+        "name": "orientation",
+        "type": "str",
+        "required": false,
+        "help": "朝向：south-north(南北)/south(南)/east(东)/north(北)/west(西)",
+        "choices": [
+          "south-north",
+          "south",
+          "east",
+          "north",
+          "west"
+        ]
+      },
+      {
+        "name": "features",
+        "type": "str",
+        "required": false,
+        "help": "特色，逗号分隔多选：near-subway,bag-in,fine,deposit-one,new,certified,anytime-view,vr,owner-rec"
+      },
+      {
+        "name": "lease-term",
+        "type": "str",
+        "required": false,
+        "help": "租期：monthly(月租)/yearly(年租)/min-1month(一个月起租)/1-3months/4-6months",
+        "choices": [
+          "monthly",
+          "yearly",
+          "min-1month",
+          "1-3months",
+          "4-6months"
+        ]
+      },
+      {
+        "name": "floor",
+        "type": "str",
+        "required": false,
+        "help": "楼层：low(低)/mid(中)/high(高)",
+        "choices": [
+          "low",
+          "mid",
+          "high"
+        ]
+      },
+      {
+        "name": "elevator",
+        "type": "str",
+        "required": false,
+        "help": "电梯：yes(有)/no(无)",
+        "choices": [
+          "yes",
+          "no"
+        ]
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "required": false,
+        "help": "排序：newest(最新上架)/rent-asc|desc(租金)/area-asc|desc(面积)",
+        "choices": [
+          "newest",
+          "rent-asc",
+          "rent-desc",
+          "area-asc",
+          "area-desc"
+        ]
       },
       {
         "name": "limit",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18240,13 +18240,13 @@
         "type": "str",
         "default": "bj",
         "required": false,
-        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)"
+        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)"
       },
       {
         "name": "district",
         "type": "str",
         "required": false,
-        "help": "区域拼音，如 chaoyang, haidian, tianhe"
+        "help": "区域拼音，如 chaoyang, haidian, tianhe, xihuqu4"
       },
       {
         "name": "min-price",
@@ -18261,10 +18261,115 @@
         "help": "最高总价（万元）"
       },
       {
+        "name": "min-area",
+        "type": "int",
+        "required": false,
+        "help": "最小建筑面积（㎡）"
+      },
+      {
+        "name": "max-area",
+        "type": "int",
+        "required": false,
+        "help": "最大建筑面积（㎡）"
+      },
+      {
         "name": "rooms",
         "type": "int",
         "required": false,
         "help": "几居室 (1-5)"
+      },
+      {
+        "name": "orientation",
+        "type": "str",
+        "required": false,
+        "help": "朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)",
+        "choices": [
+          "south-north",
+          "south",
+          "east",
+          "north",
+          "west"
+        ]
+      },
+      {
+        "name": "floor",
+        "type": "str",
+        "required": false,
+        "help": "楼层：low(低)/mid(中)/high(高)",
+        "choices": [
+          "low",
+          "mid",
+          "high"
+        ]
+      },
+      {
+        "name": "age",
+        "type": "str",
+        "required": false,
+        "help": "楼龄：5/10/15/20 年以内，20+ 为 20 年以上",
+        "choices": [
+          "5",
+          "10",
+          "15",
+          "20",
+          "20+"
+        ]
+      },
+      {
+        "name": "decoration",
+        "type": "str",
+        "required": false,
+        "help": "装修：fine(精装)/simple(普通)/rough(毛坯)",
+        "choices": [
+          "fine",
+          "simple",
+          "rough"
+        ]
+      },
+      {
+        "name": "elevator",
+        "type": "str",
+        "required": false,
+        "help": "电梯：yes(有)/no(无)",
+        "choices": [
+          "yes",
+          "no"
+        ]
+      },
+      {
+        "name": "features",
+        "type": "str",
+        "required": false,
+        "help": "房源特色，逗号分隔多选：must-see,five-years,two-years,near-subway,vr,new-7d,anytime-view"
+      },
+      {
+        "name": "usage",
+        "type": "str",
+        "required": false,
+        "help": "用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)",
+        "choices": [
+          "residential",
+          "commercial",
+          "villa",
+          "courtyard",
+          "parking",
+          "other"
+        ]
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "required": false,
+        "help": "排序：newest(最新发布)/total-price-asc|desc(总价)/unit-price-asc|desc(单价)/area-asc|desc(面积)",
+        "choices": [
+          "newest",
+          "total-price-asc",
+          "total-price-desc",
+          "unit-price-asc",
+          "unit-price-desc",
+          "area-asc",
+          "area-desc"
+        ]
       },
       {
         "name": "limit",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18196,13 +18196,117 @@
         "type": "str",
         "default": "bj",
         "required": false,
-        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)"
+        "help": "城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)"
       },
       {
         "name": "district",
         "type": "str",
         "required": false,
-        "help": "区域拼音，如 chaoyang, haidian"
+        "help": "区域拼音，如 chaoyang, haidian, xuhui"
+      },
+      {
+        "name": "rooms",
+        "type": "int",
+        "required": false,
+        "help": "几室 (1-5)"
+      },
+      {
+        "name": "min-area",
+        "type": "int",
+        "required": false,
+        "help": "最小建筑面积（㎡）"
+      },
+      {
+        "name": "max-area",
+        "type": "int",
+        "required": false,
+        "help": "最大建筑面积（㎡）"
+      },
+      {
+        "name": "orientation",
+        "type": "str",
+        "required": false,
+        "help": "朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)",
+        "choices": [
+          "south-north",
+          "south",
+          "east",
+          "north",
+          "west"
+        ]
+      },
+      {
+        "name": "floor",
+        "type": "str",
+        "required": false,
+        "help": "楼层：low(低)/mid(中)/high(高)",
+        "choices": [
+          "low",
+          "mid",
+          "high"
+        ]
+      },
+      {
+        "name": "age",
+        "type": "str",
+        "required": false,
+        "help": "楼龄：5/10/15/20 年以内，20+ 为 20 年以上",
+        "choices": [
+          "5",
+          "10",
+          "15",
+          "20",
+          "20+"
+        ]
+      },
+      {
+        "name": "decoration",
+        "type": "str",
+        "required": false,
+        "help": "装修：fine(精装)/simple(普通)/rough(毛坯)",
+        "choices": [
+          "fine",
+          "simple",
+          "rough"
+        ]
+      },
+      {
+        "name": "usage",
+        "type": "str",
+        "required": false,
+        "help": "用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)",
+        "choices": [
+          "residential",
+          "commercial",
+          "villa",
+          "courtyard",
+          "parking",
+          "other"
+        ]
+      },
+      {
+        "name": "elevator",
+        "type": "str",
+        "required": false,
+        "help": "电梯：yes(有)/no(无)",
+        "choices": [
+          "yes",
+          "no"
+        ]
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "required": false,
+        "help": "排序：total-price-asc|desc(总价)/unit-price-asc|desc(房屋单价)/area-asc|desc(面积)",
+        "choices": [
+          "total-price-asc",
+          "total-price-desc",
+          "unit-price-asc",
+          "unit-price-desc",
+          "area-asc",
+          "area-desc"
+        ]
       },
       {
         "name": "limit",

--- a/clis/ke/chengjiao-filters.js
+++ b/clis/ke/chengjiao-filters.js
@@ -1,7 +1,14 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+
 // keyword → Beike code for chengjiao (成交记录). Anchors l3/sf1/de3/lc1 confirmed live on
-// sh.ke.com/chengjiao (Task 1); the rest match ershoufang's already-verified residential
-// codes (same domain + scheme). Verified independently — this module does not import
-// ershoufang's filters.js.
+// sh.ke.com/chengjiao (Task 1). The remaining codes are inherited from ershoufang's
+// already-verified residential scheme on the SAME domain ({city}.ke.com): ORIENTATION,
+// AGE, DECORATION, USAGE, ELEVATOR and SORT. Two of these are worth singling out as
+// inherited-not-independently-confirmed-on-chengjiao (the chengjiao smoke was captcha-blocked):
+//   - ELEVATOR { yes: 'ie2', no: 'ie1' } — note yes=2 (verified on ershoufang, not inverted by mistake).
+//   - SORT 'co{field}{dir}' — these are field+direction codes, NOT positional tab indices, so
+//     chengjiao lacking the 最新发布 tab does not renumber 总价/单价/面积.
+// Verified independently where possible — this module does not import ershoufang's filters.js.
 export const ORIENTATION = {
   'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
 };
@@ -27,7 +34,13 @@ function lookup(table, key) {
   return table[String(key)] || '';
 }
 function roomsCode(rooms) {
-  return present(rooms) ? `l${rooms}` : '';
+  if (!present(rooms)) return '';
+  // chengjiao 房型 is one-based: 一室=l1 .. 五室=l5 (unlike zufang's zero-based l(n-1)).
+  const n = Number(rooms);
+  if (!Number.isInteger(n) || n < 1 || n > 5) {
+    throw new ArgumentError(`--rooms must be an integer 1-5. Received: "${rooms}"`);
+  }
+  return `l${n}`;
 }
 function areaCode(kwargs) {
   const min = kwargs['min-area'];

--- a/clis/ke/chengjiao-filters.js
+++ b/clis/ke/chengjiao-filters.js
@@ -1,0 +1,66 @@
+// keyword → Beike code for chengjiao (成交记录). Anchors l3/sf1/de3/lc1 confirmed live on
+// sh.ke.com/chengjiao (Task 1); the rest match ershoufang's already-verified residential
+// codes (same domain + scheme). Verified independently — this module does not import
+// ershoufang's filters.js.
+export const ORIENTATION = {
+  'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
+};
+export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
+export const ELEVATOR = { yes: 'ie2', no: 'ie1' };
+export const USAGE = {
+  residential: 'sf1', commercial: 'sf2', villa: 'sf3',
+  courtyard: 'sf4', parking: 'sf5', other: 'sf6',
+};
+export const SORT = {
+  'total-price-asc': 'co21', 'total-price-desc': 'co22',
+  'unit-price-asc': 'co41', 'unit-price-desc': 'co42',
+  'area-asc': 'co11', 'area-desc': 'co12',
+};
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function roomsCode(rooms) {
+  return present(rooms) ? `l${rooms}` : '';
+}
+function areaCode(kwargs) {
+  const min = kwargs['min-area'];
+  const max = kwargs['max-area'];
+  if (!present(min) && !present(max)) return '';
+  // max-only needs an explicit min (verified on the ershoufang area endpoint); default to 0.
+  const lo = present(min) ? min : 0;
+  return `ba${lo}ea${present(max) ? max : ''}`;
+}
+
+// Deterministic emit order (mirrors ershoufang's verified order, minus features/price).
+// Beike parses codes by prefix regardless of order, so this is for clean, stable URLs.
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(USAGE, k.usage),
+  (k) => lookup(DECORATION, k.decoration),
+  (k) => lookup(AGE, k.age),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => areaCode(k),
+  (k) => roomsCode(k.rooms),
+];
+
+/**
+ * Build the Beike chengjiao filter/sort code segment for /chengjiao/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildChengjiaoFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}

--- a/clis/ke/chengjiao-filters.test.js
+++ b/clis/ke/chengjiao-filters.test.js
@@ -35,6 +35,11 @@ describe('buildChengjiaoFilterPath — behavior', () => {
     expect(buildChengjiaoFilterPath({ usage: 'villa' })).toBe(USAGE.villa);
     expect(buildChengjiaoFilterPath({ sort: 'total-price-asc' })).toBe(SORT['total-price-asc']);
   });
+  it('rejects out-of-range or non-numeric rooms instead of emitting garbage', () => {
+    expect(() => buildChengjiaoFilterPath({ rooms: 0 })).toThrow(/rooms/);
+    expect(() => buildChengjiaoFilterPath({ rooms: 6 })).toThrow(/rooms/);
+    expect(() => buildChengjiaoFilterPath({ rooms: 'abc' })).toThrow(/rooms/);
+  });
   it('encodes a two-sided area range', () => {
     expect(buildChengjiaoFilterPath({ 'min-area': 70, 'max-area': 90 })).toBe('ba70ea90');
   });

--- a/clis/ke/chengjiao-filters.test.js
+++ b/clis/ke/chengjiao-filters.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildChengjiaoFilterPath,
+  ORIENTATION, FLOOR, AGE, DECORATION, ELEVATOR, USAGE, SORT,
+} from './chengjiao-filters.js';
+
+// Anchors confirmed live on sh.ke.com/chengjiao (Task 1) via URL → document.title:
+// l3→三室, sf1→普通住宅, de3→毛坯房, lc1→低楼层. Remaining codes match ershoufang's
+// already-verified values (same domain + scheme); order is prefix-parsed (order-independent).
+describe('buildChengjiaoFilterPath — confirmed live anchors', () => {
+  it('rooms 3 -> l3 (三室)', () => {
+    expect(buildChengjiaoFilterPath({ rooms: 3 })).toBe('l3');
+  });
+  it('usage residential -> sf1 (普通住宅)', () => {
+    expect(buildChengjiaoFilterPath({ usage: 'residential' })).toBe('sf1');
+  });
+  it('decoration rough -> de3 (毛坯房)', () => {
+    expect(buildChengjiaoFilterPath({ decoration: 'rough' })).toBe('de3');
+  });
+  it('floor low -> lc1 (低楼层)', () => {
+    expect(buildChengjiaoFilterPath({ floor: 'low' })).toBe('lc1');
+  });
+});
+
+describe('buildChengjiaoFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildChengjiaoFilterPath({})).toBe('');
+  });
+  it('maps each single-value enum through its own table', () => {
+    expect(buildChengjiaoFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildChengjiaoFilterPath({ floor: 'high' })).toBe(FLOOR.high);
+    expect(buildChengjiaoFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildChengjiaoFilterPath({ decoration: 'fine' })).toBe(DECORATION.fine);
+    expect(buildChengjiaoFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildChengjiaoFilterPath({ usage: 'villa' })).toBe(USAGE.villa);
+    expect(buildChengjiaoFilterPath({ sort: 'total-price-asc' })).toBe(SORT['total-price-asc']);
+  });
+  it('encodes a two-sided area range', () => {
+    expect(buildChengjiaoFilterPath({ 'min-area': 70, 'max-area': 90 })).toBe('ba70ea90');
+  });
+  it('encodes a lower-bound-only area as ba{min}ea', () => {
+    expect(buildChengjiaoFilterPath({ 'min-area': 70 })).toBe('ba70ea');
+  });
+  it('defaults min to 0 for an upper-bound-only area', () => {
+    expect(buildChengjiaoFilterPath({ 'max-area': 90 })).toBe('ba0ea90');
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildChengjiaoFilterPath({ rooms: 3, decoration: 'rough', sort: 'total-price-asc' });
+    const b = buildChengjiaoFilterPath({ sort: 'total-price-asc', decoration: 'rough', rooms: 3 });
+    expect(a).toBe(b);
+    expect(a).toBe('co21de3l3');
+  });
+});

--- a/clis/ke/chengjiao.js
+++ b/clis/ke/chengjiao.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { cityUrl, gotoKe } from './utils.js';
+import { buildChengjiaoFilterPath } from './chengjiao-filters.js';
 
 cli({
     site: 'ke',
@@ -10,8 +11,18 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)' },
-        { name: 'district', help: '区域拼音，如 chaoyang, haidian' },
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, xuhui' },
+        { name: 'rooms', type: 'int', help: '几室 (1-5)' },
+        { name: 'min-area', type: 'int', help: '最小建筑面积（㎡）' },
+        { name: 'max-area', type: 'int', help: '最大建筑面积（㎡）' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'decoration', choices: ['fine', 'simple', 'rough'], help: '装修：fine(精装)/simple(普通)/rough(毛坯)' },
+        { name: 'usage', choices: ['residential', 'commercial', 'villa', 'courtyard', 'parking', 'other'], help: '用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'sort', choices: ['total-price-asc', 'total-price-desc', 'unit-price-asc', 'unit-price-desc', 'area-asc', 'area-desc'], help: '排序：total-price-asc|desc(总价)/unit-price-asc|desc(房屋单价)/area-asc|desc(面积)' },
         { name: 'limit', type: 'int', default: 20, help: '返回数量' },
     ],
     columns: ['title', 'community', 'layout', 'area', 'deal_price', 'unit_price', 'deal_date'],
@@ -25,7 +36,8 @@ cli({
             path = `/chengjiao/${kwargs.district}/`;
         }
 
-        await gotoKe(page, base + path);
+        const filters = buildChengjiaoFilterPath(kwargs);
+        await gotoKe(page, base + path + (filters ? filters + '/' : ''));
 
         const items = await page.evaluate(`(async () => {
   // chengjiao page uses .listContent li or similar structure

--- a/clis/ke/chengjiao.test.js
+++ b/clis/ke/chengjiao.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './chengjiao.js';
+import { buildChengjiaoFilterPath } from './chengjiao-filters.js';
+
+const cmd = () => getRegistry().get('ke/chengjiao');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/chengjiao command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['rooms', 'min-area', 'max-area', 'orientation', 'floor',
+                      'age', 'decoration', 'usage', 'elevator', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toContain('total-price-desc');
+    // chengjiao sort must NOT offer 'newest'
+    expect(sortArg.choices).not.toContain('newest');
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'xuhui', rooms: 3, decoration: 'rough', limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildChengjiaoFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.ke.com/chengjiao/xuhui/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: no filters, with district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', district: 'haidian', limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/chengjiao/haidian/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: no district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/chengjiao/', expect.anything(),
+    );
+  });
+});

--- a/clis/ke/ershoufang.js
+++ b/clis/ke/ershoufang.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { cityUrl, gotoKe } from './utils.js';
+import { buildErshoufangFilterPath } from './filters.js';
 
 cli({
     site: 'ke',
@@ -10,11 +11,21 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)' },
-        { name: 'district', help: '区域拼音，如 chaoyang, haidian, tianhe' },
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, tianhe, xihuqu4' },
         { name: 'min-price', type: 'int', help: '最低总价（万元）' },
         { name: 'max-price', type: 'int', help: '最高总价（万元）' },
+        { name: 'min-area', type: 'int', help: '最小建筑面积（㎡）' },
+        { name: 'max-area', type: 'int', help: '最大建筑面积（㎡）' },
         { name: 'rooms', type: 'int', help: '几居室 (1-5)' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'decoration', choices: ['fine', 'simple', 'rough'], help: '装修：fine(精装)/simple(普通)/rough(毛坯)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'features', help: '房源特色，逗号分隔多选：must-see,five-years,two-years,near-subway,vr,new-7d,anytime-view' },
+        { name: 'usage', choices: ['residential', 'commercial', 'villa', 'courtyard', 'parking', 'other'], help: '用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)' },
+        { name: 'sort', choices: ['newest', 'total-price-asc', 'total-price-desc', 'unit-price-asc', 'unit-price-desc', 'area-asc', 'area-desc'], help: '排序：newest(最新发布)/total-price-asc|desc(总价)/unit-price-asc|desc(单价)/area-asc|desc(面积)' },
         { name: 'limit', type: 'int', default: 20, help: '返回数量' },
     ],
     columns: ['title', 'community', 'layout', 'area', 'direction', 'total_price', 'unit_price', 'url'],
@@ -28,19 +39,7 @@ cli({
             path = `/ershoufang/${kwargs.district}/`;
         }
 
-        const priceParts = [];
-        if (kwargs['min-price'] || kwargs['max-price']) {
-            const min = kwargs['min-price'] || '';
-            const max = kwargs['max-price'] || '';
-            priceParts.push(`p${min}t${max}`);
-        }
-
-        const roomParts = [];
-        if (kwargs.rooms) {
-            roomParts.push(`l${kwargs.rooms}`);
-        }
-
-        const filters = [...priceParts, ...roomParts].join('');
+        const filters = buildErshoufangFilterPath(kwargs);
         const url = base + path + (filters ? filters + '/' : '');
 
         await gotoKe(page, url);

--- a/clis/ke/ershoufang.test.js
+++ b/clis/ke/ershoufang.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './ershoufang.js';
+
+const cmd = () => getRegistry().get('ke/ershoufang');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    // readPageState + the list scrape both call evaluate; '' state => not blocked
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/ershoufang command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['orientation', 'floor', 'age', 'decoration', 'elevator',
+                      'features', 'usage', 'min-area', 'max-area', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toContain('total-price-desc');
+  });
+
+  it('builds a URL with filters + sort in canonical order', async () => {
+    const page = mockPage();
+    await cmd().func(page, {
+      city: 'hz', district: 'xihuqu4', rooms: 3, decoration: 'rough', sort: 'newest', limit: 10,
+    });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://hz.ke.com/ershoufang/xihuqu4/co32de3l3/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: rooms only', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', rooms: 2, limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/ershoufang/l2/', expect.anything(),
+    );
+  });
+
+  it('no district, no filters', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/ershoufang/', expect.anything(),
+    );
+  });
+});

--- a/clis/ke/filters.js
+++ b/clis/ke/filters.js
@@ -44,7 +44,12 @@ function lookup(table, key) {
 }
 
 function roomsCode(rooms) {
-  return rooms ? `l${rooms}` : '';
+  if (!present(rooms)) return '';
+  const n = Number(rooms);
+  if (!Number.isInteger(n) || n < 1 || n > 5) {
+    throw new ArgumentError(`--rooms must be an integer 1-5. Received: "${rooms}"`);
+  }
+  return `l${n}`;
 }
 
 function priceCode(kwargs) {

--- a/clis/ke/filters.js
+++ b/clis/ke/filters.js
@@ -1,0 +1,101 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+// keyword → Beike URL code. Values confirmed against the live site (Task 1).
+export const ORIENTATION = {
+  'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
+};
+export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
+export const ELEVATOR = { yes: 'ie1', no: 'ie2' };
+// 房源特色 (multi-select). Iteration order here IS the emit order.
+export const FEATURES = {
+  'must-see': 'ng1',
+  'five-years': 'mw1',
+  'two-years': 'mw2',
+  'near-subway': 'nb1',
+  vr: 'vr1',
+  'new-7d': 'nd1',
+  'anytime-view': 'av1',
+};
+export const USAGE = {
+  residential: 'sf1', commercial: 'sf2', villa: 'sf3',
+  courtyard: 'sf4', parking: 'sf5', other: 'sf6',
+};
+export const SORT = {
+  newest: 'co32',
+  'total-price-asc': 'co21',
+  'total-price-desc': 'co22',
+  'unit-price-asc': 'co41',
+  'unit-price-desc': 'co42',
+  'area-asc': 'co51',
+  'area-desc': 'co52',
+};
+
+function lookup(table, key) {
+  if (key === undefined || key === null || key === '') return '';
+  return table[String(key)] || '';
+}
+
+function roomsCode(rooms) {
+  return rooms ? `l${rooms}` : '';
+}
+
+function priceCode(kwargs) {
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!min && !max) return '';
+  return `p${min || ''}t${max || ''}`;
+}
+
+function areaCode(kwargs) {
+  const min = kwargs['min-area'];
+  const max = kwargs['max-area'];
+  if (!min && !max) return '';
+  return `ba${min || ''}ea${max || ''}`;
+}
+
+function featuresCode(raw) {
+  if (!raw) return '';
+  const requested = new Set(
+    String(raw).split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  for (const key of requested) {
+    if (!FEATURES[key]) {
+      throw new ArgumentError(
+        `unknown --features value: "${key}"`,
+        `Allowed: ${Object.keys(FEATURES).join(', ')}`,
+      );
+    }
+  }
+  // emit in table-definition order, not user order
+  return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
+}
+
+// Canonical left-to-right order Beike concatenates prefixes in (confirmed in Task 1).
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => featuresCode(k.features),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(AGE, k.age),
+  (k) => lookup(DECORATION, k.decoration),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => lookup(USAGE, k.usage),
+  (k) => roomsCode(k.rooms),
+  (k) => priceCode(k),
+  (k) => areaCode(k),
+];
+
+/**
+ * Build the Beike filter/sort code segment for /ershoufang/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildErshoufangFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}

--- a/clis/ke/filters.js
+++ b/clis/ke/filters.js
@@ -4,10 +4,10 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const ORIENTATION = {
   'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
 };
-// ⚠️ FLOOR codes are still unverified guesses (left blank during live verification).
+// low=lc1 verified; mid/high (lc2/lc3) inferred from the lc-prefix pattern.
 export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
 export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
-// de3 (rough/毛坯) verified; de1/de2 (精装/普通) still unverified guesses.
+// de1 (精装) and de3 (毛坯) verified; de2 (普通) inferred from the de-prefix pattern.
 export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
 export const ELEVATOR = { yes: 'ie2', no: 'ie1' };
 // 房源特色 (multi-select). Iteration order here IS the emit order.
@@ -74,20 +74,24 @@ function featuresCode(raw) {
   return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
 }
 
-// Canonical left-to-right order Beike concatenates prefixes in.
-// Verified anchors: co < features < elevator < area < rooms < price; co < decoration < rooms
-// (from co32de3l3, de3l3p1, co32mw1ie2ba79ea90l3). The relative positions of
-// orientation/floor/age/usage are inferred from the UI grouping and satisfy every
-// observed constraint; pin them with one more multi-filter URL if needed.
+// Canonical left-to-right order Beike concatenates prefixes in. This linear order
+// satisfies every captured sample:
+//   co32de3l3, de3l3p1, co32mw1ie2ba79ea90l3, sf1de1y1lc1f2
+// i.e. sort < {usage<decoration<age<floor<orientation} < features < elevator < area
+//        < rooms < price.
+// The two sample groups (usage/decoration/age/floor/orientation vs
+// features/elevator/area/rooms) never co-occurred, so their interleaving is one
+// evidence-consistent extension. Beike parses codes by prefix, so order does not affect
+// which filters apply — confirmed by the live smoke.
 const SEGMENT_PRODUCERS = [
   (k) => lookup(SORT, k.sort),
-  (k) => featuresCode(k.features),
-  (k) => lookup(ORIENTATION, k.orientation),
-  (k) => lookup(FLOOR, k.floor),
-  (k) => lookup(AGE, k.age),
-  (k) => lookup(DECORATION, k.decoration),
-  (k) => lookup(ELEVATOR, k.elevator),
   (k) => lookup(USAGE, k.usage),
+  (k) => lookup(DECORATION, k.decoration),
+  (k) => lookup(AGE, k.age),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => featuresCode(k.features),
+  (k) => lookup(ELEVATOR, k.elevator),
   (k) => areaCode(k),
   (k) => roomsCode(k.rooms),
   (k) => priceCode(k),

--- a/clis/ke/filters.js
+++ b/clis/ke/filters.js
@@ -4,23 +4,25 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const ORIENTATION = {
   'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
 };
+// ⚠️ FLOOR codes are still unverified guesses (left blank during live verification).
 export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
 export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+// de3 (rough/毛坯) verified; de1/de2 (精装/普通) still unverified guesses.
 export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
-export const ELEVATOR = { yes: 'ie1', no: 'ie2' };
+export const ELEVATOR = { yes: 'ie2', no: 'ie1' };
 // 房源特色 (multi-select). Iteration order here IS the emit order.
 export const FEATURES = {
-  'must-see': 'ng1',
+  'must-see': 'tt9',
   'five-years': 'mw1',
-  'two-years': 'mw2',
-  'near-subway': 'nb1',
-  vr: 'vr1',
-  'new-7d': 'nd1',
-  'anytime-view': 'av1',
+  'two-years': 'ty1',
+  'near-subway': 'su1',
+  vr: 'tt8',
+  'new-7d': 'tt2',
+  'anytime-view': 'tt4',
 };
 export const USAGE = {
   residential: 'sf1', commercial: 'sf2', villa: 'sf3',
-  courtyard: 'sf4', parking: 'sf5', other: 'sf6',
+  courtyard: 'sf4', parking: 'sf6', other: 'sf5',
 };
 export const SORT = {
   newest: 'co32',
@@ -28,8 +30,8 @@ export const SORT = {
   'total-price-desc': 'co22',
   'unit-price-asc': 'co41',
   'unit-price-desc': 'co42',
-  'area-asc': 'co51',
-  'area-desc': 'co52',
+  'area-asc': 'co11',
+  'area-desc': 'co12',
 };
 
 function lookup(table, key) {
@@ -72,7 +74,11 @@ function featuresCode(raw) {
   return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
 }
 
-// Canonical left-to-right order Beike concatenates prefixes in (confirmed in Task 1).
+// Canonical left-to-right order Beike concatenates prefixes in.
+// Verified anchors: co < features < elevator < area < rooms < price; co < decoration < rooms
+// (from co32de3l3, de3l3p1, co32mw1ie2ba79ea90l3). The relative positions of
+// orientation/floor/age/usage are inferred from the UI grouping and satisfy every
+// observed constraint; pin them with one more multi-filter URL if needed.
 const SEGMENT_PRODUCERS = [
   (k) => lookup(SORT, k.sort),
   (k) => featuresCode(k.features),
@@ -82,9 +88,9 @@ const SEGMENT_PRODUCERS = [
   (k) => lookup(DECORATION, k.decoration),
   (k) => lookup(ELEVATOR, k.elevator),
   (k) => lookup(USAGE, k.usage),
+  (k) => areaCode(k),
   (k) => roomsCode(k.rooms),
   (k) => priceCode(k),
-  (k) => areaCode(k),
 ];
 
 /**

--- a/clis/ke/filters.js
+++ b/clis/ke/filters.js
@@ -34,8 +34,12 @@ export const SORT = {
   'area-desc': 'co12',
 };
 
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+
 function lookup(table, key) {
-  if (key === undefined || key === null || key === '') return '';
+  if (!present(key)) return '';
   return table[String(key)] || '';
 }
 
@@ -53,8 +57,12 @@ function priceCode(kwargs) {
 function areaCode(kwargs) {
   const min = kwargs['min-area'];
   const max = kwargs['max-area'];
-  if (!min && !max) return '';
-  return `ba${min || ''}ea${max || ''}`;
+  if (!present(min) && !present(max)) return '';
+  // Live-verified shapes: ba70ea (=70平以上), ba0ea120 (=120平以下), ba79ea90.
+  // An upper-bound-only query needs an explicit min — `baea120` is ignored by Beike,
+  // so default the lower bound to 0 when only --max-area is given.
+  const lo = present(min) ? min : 0;
+  return `ba${lo}ea${present(max) ? max : ''}`;
 }
 
 function featuresCode(raw) {

--- a/clis/ke/filters.test.js
+++ b/clis/ke/filters.test.js
@@ -13,6 +13,11 @@ describe('buildErshoufangFilterPath', () => {
   it('encodes rooms as l{n}', () => {
     expect(buildErshoufangFilterPath({ rooms: 3 })).toBe('l3');
   });
+  it('rejects out-of-range or non-numeric rooms instead of emitting garbage', () => {
+    expect(() => buildErshoufangFilterPath({ rooms: 0 })).toThrow(/rooms/);
+    expect(() => buildErshoufangFilterPath({ rooms: 6 })).toThrow(/rooms/);
+    expect(() => buildErshoufangFilterPath({ rooms: 'abc' })).toThrow(/rooms/);
+  });
   it('encodes decoration=rough as de3', () => {
     expect(buildErshoufangFilterPath({ decoration: 'rough' })).toBe('de3');
   });

--- a/clis/ke/filters.test.js
+++ b/clis/ke/filters.test.js
@@ -54,12 +54,18 @@ describe('buildErshoufangFilterPath', () => {
     expect(out).toBe('co32de3l3');
   });
 
-  // Ground-truth URL captured from the live site (Task 1): proves area comes before rooms.
+  // Ground-truth URLs captured from the live site (Task 1).
   it('matches the verified live multi-filter URL (area before rooms)', () => {
     const out = buildErshoufangFilterPath({
       sort: 'newest', features: 'five-years', elevator: 'yes',
       'min-area': 79, 'max-area': 90, rooms: 3,
     });
     expect(out).toBe('co32mw1ie2ba79ea90l3');
+  });
+  it('matches the verified live URL for usage/decoration/age/floor/orientation', () => {
+    const out = buildErshoufangFilterPath({
+      usage: 'residential', decoration: 'fine', age: '5', floor: 'low', orientation: 'south',
+    });
+    expect(out).toBe('sf1de1y1lc1f2');
   });
 });

--- a/clis/ke/filters.test.js
+++ b/clis/ke/filters.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildErshoufangFilterPath,
+  ORIENTATION, FLOOR, AGE, DECORATION, ELEVATOR, FEATURES, USAGE, SORT,
+} from './filters.js';
+
+describe('buildErshoufangFilterPath', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildErshoufangFilterPath({})).toBe('');
+  });
+
+  // ── Golden tests on confirmed anchors (de3 / l3 / p / co32) ──
+  it('encodes rooms as l{n}', () => {
+    expect(buildErshoufangFilterPath({ rooms: 3 })).toBe('l3');
+  });
+  it('encodes decoration=rough as de3', () => {
+    expect(buildErshoufangFilterPath({ decoration: 'rough' })).toBe('de3');
+  });
+  it('encodes sort=newest as co32', () => {
+    expect(buildErshoufangFilterPath({ sort: 'newest' })).toBe('co32');
+  });
+  it('keeps the existing price encoding p{min}t{max}', () => {
+    expect(buildErshoufangFilterPath({ 'min-price': 100, 'max-price': 300 })).toBe('p100t300');
+  });
+  it('encodes area range as ba{min}ea{max}', () => {
+    expect(buildErshoufangFilterPath({ 'min-area': 70, 'max-area': 120 })).toBe('ba70ea120');
+  });
+
+  // ── Parametric tests: derive expected from the tables (robust to verified codes) ──
+  it('maps each single-value enum through its own table', () => {
+    expect(buildErshoufangFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildErshoufangFilterPath({ floor: 'high' })).toBe(FLOOR.high);
+    expect(buildErshoufangFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildErshoufangFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildErshoufangFilterPath({ usage: 'villa' })).toBe(USAGE.villa);
+    expect(buildErshoufangFilterPath({ sort: 'total-price-asc' })).toBe(SORT['total-price-asc']);
+  });
+
+  it('splits --features and emits feature codes in table-definition order', () => {
+    // input order reversed; output must follow FEATURES key order
+    const expected = FEATURES['near-subway'] + FEATURES.vr;
+    expect(buildErshoufangFilterPath({ features: 'vr,near-subway' })).toBe(expected);
+  });
+  it('throws ArgumentError on an unknown feature keyword', () => {
+    expect(() => buildErshoufangFilterPath({ features: 'bogus' })).toThrow(/unknown/i);
+  });
+  it('trims and ignores blank feature entries', () => {
+    expect(buildErshoufangFilterPath({ features: ' vr , ' })).toBe(FEATURES.vr);
+  });
+
+  // ── Canonical order across categories (uses only confirmed anchors) ──
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const out = buildErshoufangFilterPath({ rooms: 3, decoration: 'rough', sort: 'newest' });
+    expect(out).toBe('co32de3l3');
+  });
+});

--- a/clis/ke/filters.test.js
+++ b/clis/ke/filters.test.js
@@ -53,4 +53,13 @@ describe('buildErshoufangFilterPath', () => {
     const out = buildErshoufangFilterPath({ rooms: 3, decoration: 'rough', sort: 'newest' });
     expect(out).toBe('co32de3l3');
   });
+
+  // Ground-truth URL captured from the live site (Task 1): proves area comes before rooms.
+  it('matches the verified live multi-filter URL (area before rooms)', () => {
+    const out = buildErshoufangFilterPath({
+      sort: 'newest', features: 'five-years', elevator: 'yes',
+      'min-area': 79, 'max-area': 90, rooms: 3,
+    });
+    expect(out).toBe('co32mw1ie2ba79ea90l3');
+  });
 });

--- a/clis/ke/filters.test.js
+++ b/clis/ke/filters.test.js
@@ -25,6 +25,16 @@ describe('buildErshoufangFilterPath', () => {
   it('encodes area range as ba{min}ea{max}', () => {
     expect(buildErshoufangFilterPath({ 'min-area': 70, 'max-area': 120 })).toBe('ba70ea120');
   });
+  it('keeps a literal 0 lower bound instead of dropping it', () => {
+    expect(buildErshoufangFilterPath({ 'min-area': 0, 'max-area': 90 })).toBe('ba0ea90');
+  });
+  it('encodes a lower-bound-only area as ba{min}ea (live: 70平以上)', () => {
+    expect(buildErshoufangFilterPath({ 'min-area': 70 })).toBe('ba70ea');
+  });
+  it('defaults min to 0 for an upper-bound-only area (live: ba0ea120 = 120平以下)', () => {
+    // Beike ignores `baea120`; an explicit min is required.
+    expect(buildErshoufangFilterPath({ 'max-area': 120 })).toBe('ba0ea120');
+  });
 
   // ── Parametric tests: derive expected from the tables (robust to verified codes) ──
   it('maps each single-value enum through its own table', () => {

--- a/clis/ke/xiaoqu-filters.js
+++ b/clis/ke/xiaoqu-filters.js
@@ -1,0 +1,48 @@
+// keyword → Beike xiaoqu code. All values verified live against sh.ke.com (Task 1).
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const SORT = { 'avg-price-asc': 'cro21', 'avg-price-desc': 'cro22' };
+const NEAR_SUBWAY_CODE = 'su1';
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function nearSubwayCode(kwargs) {
+  return kwargs['near-subway'] ? NEAR_SUBWAY_CODE : '';
+}
+function avgPriceCode(kwargs) {
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!present(min) && !present(max)) return '';
+  // Live-verified shapes: bp3ep (=3万以上), bp0ep5 (=5万以下), bp3ep5.
+  // An upper-bound-only query needs an explicit min — `bpep5` is ignored by Beike,
+  // so default the lower bound to 0 when only --max-price is given.
+  const lo = present(min) ? min : 0;
+  return `bp${lo}ep${present(max) ? max : ''}`;
+}
+
+// Deterministic emit order. Beike parses xiaoqu codes by prefix regardless of order
+// (verified live: cro21y2su1 applied all three filters), so this order is for clean,
+// stable URLs.
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(AGE, k.age),
+  (k) => nearSubwayCode(k),
+  (k) => avgPriceCode(k),
+];
+
+/**
+ * Build the Beike xiaoqu filter/sort code segment for /xiaoqu/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildXiaoquFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}

--- a/clis/ke/xiaoqu-filters.test.js
+++ b/clis/ke/xiaoqu-filters.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildXiaoquFilterPath, AGE, SORT } from './xiaoqu-filters.js';
+
+// Ground-truth URL captured from sh.ke.com (Task 1) and confirmed to filter correctly:
+// title "上海徐汇10年以内、均价从低到高、近地铁".
+describe('buildXiaoquFilterPath — live golden URL', () => {
+  it('matches a captured multi-filter URL (10年以内/均价升序/近地铁)', () => {
+    expect(buildXiaoquFilterPath({
+      age: '10', 'near-subway': true, sort: 'avg-price-asc',
+    })).toBe('cro21y2su1');
+  });
+});
+
+describe('buildXiaoquFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildXiaoquFilterPath({})).toBe('');
+  });
+  it('maps age and sort through their tables', () => {
+    expect(buildXiaoquFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildXiaoquFilterPath({ sort: 'avg-price-asc' })).toBe(SORT['avg-price-asc']);
+    expect(buildXiaoquFilterPath({ sort: 'avg-price-desc' })).toBe(SORT['avg-price-desc']);
+  });
+  it('emits the near-subway code only when truthy', () => {
+    expect(buildXiaoquFilterPath({ 'near-subway': true })).toBe('su1');
+    expect(buildXiaoquFilterPath({ 'near-subway': false })).toBe('');
+    expect(buildXiaoquFilterPath({})).toBe('');
+  });
+  it('encodes a two-sided avg-price range as bp{min}ep{max}', () => {
+    expect(buildXiaoquFilterPath({ 'min-price': 3, 'max-price': 5 })).toBe('bp3ep5');
+  });
+  it('encodes a lower-bound-only avg-price as bp{min}ep (live: 3万以上)', () => {
+    expect(buildXiaoquFilterPath({ 'min-price': 3 })).toBe('bp3ep');
+  });
+  it('defaults min to 0 for an upper-bound-only avg-price (live: bp0ep5 = 5万以下)', () => {
+    expect(buildXiaoquFilterPath({ 'max-price': 5 })).toBe('bp0ep5');
+  });
+  it('keeps a literal 0 lower bound', () => {
+    expect(buildXiaoquFilterPath({ 'min-price': 0, 'max-price': 5 })).toBe('bp0ep5');
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildXiaoquFilterPath({ age: '10', sort: 'avg-price-asc' });
+    const b = buildXiaoquFilterPath({ sort: 'avg-price-asc', age: '10' });
+    expect(a).toBe(b);
+    expect(a).toBe('cro21y2');
+  });
+});

--- a/clis/ke/xiaoqu.js
+++ b/clis/ke/xiaoqu.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { cityUrl, gotoKe } from './utils.js';
+import { buildXiaoquFilterPath } from './xiaoqu-filters.js';
 
 cli({
     site: 'ke',
@@ -10,8 +11,13 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)' },
-        { name: 'district', help: '区域拼音，如 chaoyang, haidian' },
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, tianhe, xuhui' },
+        { name: 'min-price', type: 'int', help: '最低均价（万/㎡）' },
+        { name: 'max-price', type: 'int', help: '最高均价（万/㎡）' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'near-subway', type: 'boolean', help: '仅看近地铁小区' },
+        { name: 'sort', choices: ['avg-price-asc', 'avg-price-desc'], help: '排序：avg-price-asc|desc(小区均价)；不传为默认排序' },
         { name: 'limit', type: 'int', default: 20, help: '返回数量' },
     ],
     columns: ['name', 'district', 'avg_price', 'year', 'on_sale'],
@@ -25,7 +31,8 @@ cli({
             path = `/xiaoqu/${kwargs.district}/`;
         }
 
-        await gotoKe(page, base + path);
+        const filters = buildXiaoquFilterPath(kwargs);
+        await gotoKe(page, base + path + (filters ? filters + '/' : ''));
 
         const items = await page.evaluate(`(async () => {
   const selectors = [

--- a/clis/ke/xiaoqu.test.js
+++ b/clis/ke/xiaoqu.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './xiaoqu.js';
+import { buildXiaoquFilterPath } from './xiaoqu-filters.js';
+
+const cmd = () => getRegistry().get('ke/xiaoqu');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/xiaoqu command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['min-price', 'max-price', 'age', 'near-subway', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toEqual(['avg-price-asc', 'avg-price-desc']);
+    const ns = c.args.find((a) => a.name === 'near-subway');
+    expect(ns.type).toBe('boolean');
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'xuhui', age: '10', 'near-subway': true, limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildXiaoquFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.ke.com/xiaoqu/xuhui/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: no filters, with district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'gz', district: 'tianhe', limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://gz.ke.com/xiaoqu/tianhe/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: no district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/xiaoqu/', expect.anything(),
+    );
+  });
+});

--- a/clis/ke/zufang-filters.js
+++ b/clis/ke/zufang-filters.js
@@ -46,8 +46,13 @@ function lookup(table, key) {
   return table[String(key)] || '';
 }
 function roomsCode(rooms) {
+  if (!present(rooms)) return '';
   // zufang 户型 is zero-based: 一居=l0, 两居=l1, 三居=l2, 四居+=l3.
-  return present(rooms) ? `l${Number(rooms) - 1}` : '';
+  const n = Number(rooms);
+  if (!Number.isInteger(n) || n < 1 || n > 4) {
+    throw new ArgumentError(`--rooms must be an integer 1-4 (4 = 四居+). Received: "${rooms}"`);
+  }
+  return `l${n - 1}`;
 }
 function rentCode(kwargs) {
   // Unchanged from the original zufang.js — kept exactly as-is per the spec.

--- a/clis/ke/zufang-filters.js
+++ b/clis/ke/zufang-filters.js
@@ -1,0 +1,100 @@
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+// keyword → Beike zu.ke.com code. All values verified live against sh.zu.ke.com (Task 1).
+export const RENT_TYPE = { whole: 'rt200600000001', shared: 'rt200600000002' };
+export const ORIENTATION = {
+  'south-north': 'f100500000009',
+  south: 'f100500000003',
+  east: 'f100500000001',
+  north: 'f100500000007',
+  west: 'f100500000005',
+};
+// 特色 (multi-select). Iteration order here IS the emit order.
+export const FEATURES = {
+  'near-subway': 'su1',
+  'bag-in': 'bc1',
+  fine: 'de1',
+  'deposit-one': 'rpw1',
+  new: 'in1',
+  certified: 'ht1',
+  'anytime-view': 'hk1',
+  vr: 'vr1',
+  'owner-rec': 'orec1',
+};
+export const LEASE_TERM = {
+  monthly: 'rmp1',
+  yearly: 'rmp2',
+  'min-1month': 'rmp3',
+  '1-3months': 'rmp4',
+  '4-6months': 'rmp5',
+};
+export const FLOOR = { low: 'lc200500000003', mid: 'lc200500000002', high: 'lc200500000001' };
+export const ELEVATOR = { yes: 'ie1', no: 'ie0' };
+export const SORT = {
+  newest: 'rco11',
+  'rent-asc': 'rco21',
+  'rent-desc': 'rco22',
+  'area-asc': 'rco31',
+  'area-desc': 'rco32',
+};
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function roomsCode(rooms) {
+  // zufang 户型 is zero-based: 一居=l0, 两居=l1, 三居=l2, 四居+=l3.
+  return present(rooms) ? `l${Number(rooms) - 1}` : '';
+}
+function rentCode(kwargs) {
+  // Unchanged from the original zufang.js — kept exactly as-is per the spec.
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!min && !max) return '';
+  return `rp${min || ''}t${max || ''}`;
+}
+function featuresCode(raw) {
+  if (!raw) return '';
+  const requested = new Set(String(raw).split(',').map((s) => s.trim()).filter(Boolean));
+  for (const key of requested) {
+    if (!FEATURES[key]) {
+      throw new ArgumentError(
+        `unknown --features value: "${key}"`,
+        `Allowed: ${Object.keys(FEATURES).join(', ')}`,
+      );
+    }
+  }
+  return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
+}
+
+// Deterministic emit order. Beike parses zufang codes by prefix regardless of order
+// (verified live), so this order is for clean, stable URLs; it follows the canonical
+// grouping captured in Task 1: floor/elevator/lease < features < sort < rent-type
+// < orientation < rooms, with the rent range last.
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => lookup(LEASE_TERM, k['lease-term']),
+  (k) => featuresCode(k.features),
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(RENT_TYPE, k['rent-type']),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => roomsCode(k.rooms),
+  (k) => rentCode(k),
+];
+
+/**
+ * Build the Beike zufang filter/sort code segment for /zufang/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildZufangFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}

--- a/clis/ke/zufang-filters.test.js
+++ b/clis/ke/zufang-filters.test.js
@@ -35,6 +35,11 @@ describe('buildZufangFilterPath — behavior', () => {
     expect(buildZufangFilterPath({ rooms: 2 })).toBe('l1');
     expect(buildZufangFilterPath({ rooms: 4 })).toBe('l3');
   });
+  it('rejects out-of-range or non-numeric rooms instead of emitting garbage', () => {
+    expect(() => buildZufangFilterPath({ rooms: 0 })).toThrow(/rooms/);
+    expect(() => buildZufangFilterPath({ rooms: 5 })).toThrow(/rooms/);
+    expect(() => buildZufangFilterPath({ rooms: 'abc' })).toThrow(/rooms/);
+  });
   it('keeps the existing rent encoding rp{min}t{max}', () => {
     expect(buildZufangFilterPath({ 'min-price': 2000, 'max-price': 8000 })).toBe('rp2000t8000');
   });

--- a/clis/ke/zufang-filters.test.js
+++ b/clis/ke/zufang-filters.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildZufangFilterPath,
+  RENT_TYPE, ORIENTATION, FEATURES, LEASE_TERM, FLOOR, ELEVATOR, SORT,
+} from './zufang-filters.js';
+
+// Ground-truth URLs captured from sh.zu.ke.com (Task 1) and confirmed to filter correctly.
+describe('buildZufangFilterPath — live golden URLs', () => {
+  it('matches captured multi-filter URL #1 (整租/两居/近地铁/低楼层)', () => {
+    expect(buildZufangFilterPath({
+      'rent-type': 'whole', rooms: 2, features: 'near-subway', floor: 'low',
+    })).toBe('lc200500000003su1rt200600000001l1');
+  });
+  it('matches captured multi-filter URL #2 (朝南/月租/有电梯/最新上架)', () => {
+    expect(buildZufangFilterPath({
+      orientation: 'south', 'lease-term': 'monthly', elevator: 'yes', sort: 'newest',
+    })).toBe('ie1rmp1rco11f100500000003');
+  });
+});
+
+describe('buildZufangFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildZufangFilterPath({})).toBe('');
+  });
+  it('maps each single-value enum through its own table', () => {
+    expect(buildZufangFilterPath({ 'rent-type': 'whole' })).toBe(RENT_TYPE.whole);
+    expect(buildZufangFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildZufangFilterPath({ 'lease-term': 'monthly' })).toBe(LEASE_TERM.monthly);
+    expect(buildZufangFilterPath({ floor: 'low' })).toBe(FLOOR.low);
+    expect(buildZufangFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildZufangFilterPath({ sort: 'newest' })).toBe(SORT.newest);
+  });
+  it('encodes rooms as l(n-1): 一居=l0, 两居=l1', () => {
+    expect(buildZufangFilterPath({ rooms: 1 })).toBe('l0');
+    expect(buildZufangFilterPath({ rooms: 2 })).toBe('l1');
+    expect(buildZufangFilterPath({ rooms: 4 })).toBe('l3');
+  });
+  it('keeps the existing rent encoding rp{min}t{max}', () => {
+    expect(buildZufangFilterPath({ 'min-price': 2000, 'max-price': 8000 })).toBe('rp2000t8000');
+  });
+  it('splits --features and emits feature codes in table-definition order', () => {
+    const expected = FEATURES['near-subway'] + FEATURES.fine;
+    expect(buildZufangFilterPath({ features: 'fine,near-subway' })).toBe(expected);
+  });
+  it('throws on an unknown feature keyword', () => {
+    expect(() => buildZufangFilterPath({ features: 'bogus' })).toThrow(/unknown/i);
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildZufangFilterPath({ rooms: 2, 'rent-type': 'whole', floor: 'low' });
+    const b = buildZufangFilterPath({ floor: 'low', 'rent-type': 'whole', rooms: 2 });
+    expect(a).toBe(b);
+    expect(a).toBe('lc200500000003rt200600000001l1');
+  });
+});

--- a/clis/ke/zufang.js
+++ b/clis/ke/zufang.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { gotoKe } from './utils.js';
+import { buildZufangFilterPath } from './zufang-filters.js';
 
 cli({
     site: 'ke',
@@ -10,10 +11,18 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山)' },
-        { name: 'district', help: '区域拼音，如 chaoyang, haidian' },
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, pudong' },
         { name: 'min-price', type: 'int', help: '最低月租（元）' },
         { name: 'max-price', type: 'int', help: '最高月租（元）' },
+        { name: 'rooms', type: 'int', help: '户型居室数 (1-4)，4 表示四居及以上' },
+        { name: 'rent-type', choices: ['whole', 'shared'], help: '方式：whole(整租)/shared(合租)' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(南)/east(东)/north(北)/west(西)' },
+        { name: 'features', help: '特色，逗号分隔多选：near-subway,bag-in,fine,deposit-one,new,certified,anytime-view,vr,owner-rec' },
+        { name: 'lease-term', choices: ['monthly', 'yearly', 'min-1month', '1-3months', '4-6months'], help: '租期：monthly(月租)/yearly(年租)/min-1month(一个月起租)/1-3months/4-6months' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'sort', choices: ['newest', 'rent-asc', 'rent-desc', 'area-asc', 'area-desc'], help: '排序：newest(最新上架)/rent-asc|desc(租金)/area-asc|desc(面积)' },
         { name: 'limit', type: 'int', default: 20, help: '返回数量' },
     ],
     columns: ['title', 'community', 'area', 'layout', 'price', 'url'],
@@ -26,14 +35,7 @@ cli({
             path = `/zufang/${kwargs.district}/`;
         }
 
-        const priceParts = [];
-        if (kwargs['min-price'] || kwargs['max-price']) {
-            const min = kwargs['min-price'] || '';
-            const max = kwargs['max-price'] || '';
-            priceParts.push(`rp${min}t${max}`);
-        }
-        const filters = priceParts.join('');
-
+        const filters = buildZufangFilterPath(kwargs);
         const baseUrl = `https://${city}.zu.ke.com`;
         const url = baseUrl + path + (filters ? filters + '/' : '');
 

--- a/clis/ke/zufang.test.js
+++ b/clis/ke/zufang.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './zufang.js';
+import { buildZufangFilterPath } from './zufang-filters.js';
+
+const cmd = () => getRegistry().get('ke/zufang');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/zufang command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['rent-type', 'rooms', 'orientation', 'features',
+                      'lease-term', 'floor', 'elevator', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const rt = c.args.find((a) => a.name === 'rent-type');
+    expect(rt.choices).toEqual(['whole', 'shared']);
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'pudong', 'rent-type': 'whole', rooms: 2, limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildZufangFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.zu.ke.com/zufang/pudong/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: rent range only', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'sh', 'max-price': 8000, limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://sh.zu.ke.com/zufang/rpt8000/', expect.anything(),
+    );
+  });
+
+  it('no district, no filters', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.zu.ke.com/zufang/', expect.anything(),
+    );
+  });
+});

--- a/docs/adapters/browser/ke.md
+++ b/docs/adapters/browser/ke.md
@@ -2,14 +2,81 @@
 
 **Mode**: 🔐 Browser · **Domain**: `ke.com`
 
+贝壳找房 (Beike). Each command returns a structured list and accepts optional filters and a
+sort, encoded as path segments in the Beike URL.
+
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `opencli ke ershoufang` | Browse second-hand housing listings |
-| `opencli ke zufang` | Browse rental listings |
-| `opencli ke xiaoqu` | Browse neighborhood / community listings |
-| `opencli ke chengjiao` | Browse recent transaction records |
+| `opencli ke ershoufang` | Browse second-hand housing listings (二手房) |
+| `opencli ke zufang` | Browse rental listings (租房) |
+| `opencli ke xiaoqu` | Browse neighborhood / community listings (小区) |
+| `opencli ke chengjiao` | Browse recent transaction records (成交) |
+
+## Common options
+
+| Option | Description |
+|--------|-------------|
+| `--city` | Short city code: `bj`(北京) `sh`(上海) `gz`(广州) `sz`(深圳) `hz`(杭州) `zs`(中山) … (default `bj`) |
+| `--district` | District slug used in Beike URLs, e.g. `chaoyang`, `haidian`, `tianhe`, `xuhui`, `pudong` |
+| `--limit` | Number of rows to return (default 20) |
+
+All filters are optional and combine. Beike parses the filter codes by prefix, so order
+does not matter. Enum options are validated (`choices`); an invalid value errors out.
+
+## `ershoufang` — second-hand listings
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `--min-price` / `--max-price` | int (万) | Total-price range |
+| `--min-area` / `--max-area` | int (㎡) | Building-area range |
+| `--rooms` | int 1–5 | Bedrooms (几室) |
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 |
+| `--floor` | `low` `mid` `high` | 楼层 |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄 (N 年以内 / 20+ 以上) |
+| `--decoration` | `fine` `simple` `rough` | 装修 (精装/普通/毛坯) |
+| `--elevator` | `yes` `no` | 电梯 |
+| `--features` | comma-separated: `must-see` `five-years` `two-years` `near-subway` `vr` `new-7d` `anytime-view` | 房源特色 (multi-select) |
+| `--usage` | `residential` `commercial` `villa` `courtyard` `parking` `other` | 用途 |
+| `--sort` | `newest` `total-price-asc` `total-price-desc` `unit-price-asc` `unit-price-desc` `area-asc` `area-desc` | 排序 (omit = default) |
+
+## `zufang` — rentals
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `--min-price` / `--max-price` | int (元/月) | Monthly-rent range |
+| `--rent-type` | `whole` `shared` | 方式 (整租/合租) |
+| `--rooms` | int 1–4 | 户型 (4 = 四居+) |
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 |
+| `--features` | comma-separated: `near-subway` `bag-in` `fine` `deposit-one` `new` `certified` `anytime-view` `vr` `owner-rec` | 特色 (multi-select) |
+| `--lease-term` | `monthly` `yearly` `min-1month` `1-3months` `4-6months` | 租期 |
+| `--floor` | `low` `mid` `high` | 楼层 |
+| `--elevator` | `yes` `no` | 电梯 |
+| `--sort` | `newest` `rent-asc` `rent-desc` `area-asc` `area-desc` | 排序 (omit = 综合) |
+
+## `xiaoqu` — communities
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `--min-price` / `--max-price` | int (万/㎡) | Average-price range (均价) |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄 |
+| `--near-subway` | flag | 仅看近地铁小区 (bare flag, no value) |
+| `--sort` | `avg-price-asc` `avg-price-desc` | 小区均价 (omit = default) |
+
+## `chengjiao` — transaction records
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `--min-area` / `--max-area` | int (㎡) | Building-area range |
+| `--rooms` | int 1–5 | 几室 |
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 |
+| `--floor` | `low` `mid` `high` | 楼层 |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄 |
+| `--decoration` | `fine` `simple` `rough` | 装修 |
+| `--usage` | `residential` `commercial` `villa` `courtyard` `parking` `other` | 用途 |
+| `--elevator` | `yes` `no` | 电梯 |
+| `--sort` | `total-price-asc` `total-price-desc` `unit-price-asc` `unit-price-desc` `area-asc` `area-desc` | 排序 (no `newest`; omit = default) |
 
 ## Usage Examples
 
@@ -17,14 +84,17 @@
 # Beijing second-hand housing
 opencli ke ershoufang --city bj --district chaoyang --limit 10
 
-# Rentals in Shanghai
-opencli ke zufang --city sh --district pudong --max-price 8000 --limit 10
+# Hangzhou Xihu, 3-room rough-finish, newest first
+opencli ke ershoufang --city hz --district xihuqu4 --rooms 3 --decoration rough --sort newest
 
-# Communities in Guangzhou
-opencli ke xiaoqu --city gz --district tianhe --limit 10
+# Shanghai rentals: whole-unit 2-bed under 8000/月, newest first
+opencli ke zufang --city sh --district pudong --rent-type whole --rooms 2 --max-price 8000 --sort newest
 
-# Recent transactions in Beijing Haidian
-opencli ke chengjiao --city bj --district haidian --limit 10
+# Hangzhou Xihu communities: ≤10y, near subway, cheapest avg-price first
+opencli ke xiaoqu --city hz --district xihuqu4 --age 10 --near-subway --sort avg-price-asc
+
+# Beijing Haidian deals: 3-room, highest total price first
+opencli ke chengjiao --city bj --district haidian --rooms 3 --sort total-price-desc --limit 5
 ```
 
 ## Prerequisites
@@ -34,5 +104,14 @@ opencli ke chengjiao --city bj --district haidian --limit 10
 
 ## Notes
 
-- `city` uses short city codes such as `bj`, `sh`, `gz`, `sz`
-- `district` expects the district slug used in Beike URLs, for example `chaoyang` or `haidian`
+- `--city` uses short city codes such as `bj`, `sh`, `gz`, `sz`, `hz`; `--district` expects
+  the district slug used in Beike URLs (e.g. `chaoyang`, `haidian`, `xihuqu4`).
+- For numeric ranges, an upper-bound-only query is normalized to include an explicit lower
+  bound of 0 (Beike ignores a bare upper bound), e.g. `--max-area 90` filters "90㎡以下".
+- `--features` (ershoufang/zufang) takes a comma-separated list; an unknown keyword errors out.
+- `zufang` 户型 is zero-based in Beike's URLs (一居 = `l0`); the `--rooms` value stays
+  1-based (`--rooms 2` = 两居). This is handled internally.
+- Avg/total/unit-price band differences across cities mean only the custom range
+  (`--min-price`/`--max-price`) is exposed, not the per-city preset bands.
+- Heavy filtered browsing can trigger Beike's risk-control captcha; if a command reports
+  "触发了验证码", complete the verification in your logged-in Chrome and retry.

--- a/docs/superpowers/plans/2026-06-15-ke-ershoufang-filters-sort.md
+++ b/docs/superpowers/plans/2026-06-15-ke-ershoufang-filters-sort.md
@@ -1,0 +1,492 @@
+# Expand `ke ershoufang` Filters & Sort — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Beike listing filters (朝向/楼层/楼龄/装修/电梯/房源特色/用途 + 面积区间) and result sort (`--sort`) to `opencli ke ershoufang`, encoded as URL path code segments.
+
+**Architecture:** A new pure module `clis/ke/filters.js` owns the keyword→Beike-code mapping tables and a `buildErshoufangFilterPath(kwargs)` function that emits all active codes in Beike's canonical order. `clis/ke/ershoufang.js` gains the new arg definitions and delegates URL-segment assembly to that helper; its DOM scraping is unchanged. Exact Beike codes are confirmed against the live site first.
+
+**Tech Stack:** Node ESM JS adapters (`@jackwener/opencli/registry`, `errors`), vitest (`adapter` project), `opencli browser` for live verification.
+
+Spec: `docs/superpowers/specs/2026-06-15-ke-ershoufang-filters-sort-design.md`
+
+---
+
+## File Structure
+
+- **Create** `clis/ke/filters.js` — mapping tables + `buildErshoufangFilterPath`. Pure, browser-free.
+- **Create** `clis/ke/filters.test.js` — unit tests for the helper (vitest `adapter` project).
+- **Create** `clis/ke/ershoufang.test.js` — command-level URL assembly + backward-compat tests.
+- **Modify** `clis/ke/ershoufang.js` — add arg defs, import helper, replace inline URL assembly.
+
+`clis/ke/utils.js` (gotoKe, cityUrl) is reused unchanged.
+
+---
+
+## Task 1: Verify Beike filter/sort codes & canonical order (live)
+
+This task confirms every `⚠️` code in the spec and the order codes are concatenated in.
+It needs a Chrome logged into ke.com with the OpenCLI extension (the `ershoufang`
+strategy is `COOKIE`). If you cannot run a live browser, STOP and hand this task to
+someone who can — the rest of the plan depends on its output.
+
+**Files:** none yet (produces a confirmed code table you paste into Task 2).
+
+- [ ] **Step 1: Open the reference page**
+
+Run (foreground so you can watch the URL bar):
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser open "https://hz.ke.com/ershoufang/xihuqu4/"
+```
+
+Expected: a 西湖区 二手房 list page loads. If it shows a captcha/login wall, log in /
+solve it in that window first (the command shares your live session).
+
+- [ ] **Step 2: Toggle each in-scope filter, record the code it adds to the URL**
+
+In that browser window, click ONE option at a time and read the path segment that
+appears (e.g. clicking 毛坯 turns `/xihuqu4/` into `/xihuqu4/de3/`). Record into a
+scratch table. Cover every value the spec lists:
+
+- 朝向: 南北 / 朝南 / 朝东 / 朝北 / 朝西  → `f?` codes
+- 楼层: 低楼层 / 中楼层 / 高楼层  → `lc?` codes
+- 楼龄: 5年以内 / 10年以内 / 15年以内 / 20年以内 / 20年以上  → `y?` codes
+- 装修: 精装修 / 普通装修 / 毛坯房  → `de1/de2/de3` (de3 already confirmed)
+- 电梯: 有电梯 / 无电梯  → `ie?` codes
+- 房源特色: 必看好房 / 满五年 / 满两年 / 近地铁 / VR房源 / 7日新上 / 随时看房  → per-feature codes
+- 用途: 普通住宅 / 商业类 / 别墅 / 四合院 / 车位 / 其他  → usage codes
+- 建筑面积 自定义: type a min & max into the 建筑面积 custom box, Confirm → record the
+  custom prefix (expected `ba{min}ea{max}`).
+
+- [ ] **Step 3: Record the sort codes**
+
+Click each sort tab and read the segment:
+默认排序 (none) / 最新发布 (`co32` already confirmed) / 总价↑ / 总价↓ / 房屋单价↑ /
+房屋单价↓ / 面积↑ / 面积↓  → `co??` codes.
+
+- [ ] **Step 4: Establish canonical order**
+
+Select 2–3 filters + a sort at once and read the full segment. Note the LEFT-TO-RIGHT
+order Beike emits prefixes in (known anchors: `co` … `de` … `l` … `p`). Write down the
+full relative order of: `co`, features, `f`, `lc`, `y`, `de`, `ie`, usage, `l`, `p`,
+`ba/ea`.
+
+- [ ] **Step 5: Spot-check city stability**
+
+Repeat Steps 2–4 on one other city for ~3 of the enums:
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser open "https://bj.ke.com/ershoufang/"
+```
+
+Expected: in-scope enum codes match hz (price bands may differ — out of scope).
+
+- [ ] **Step 6: Close the window**
+
+```bash
+npx tsx src/main.ts browser close
+```
+
+**Output of this task:** a confirmed table mapping each English keyword → Beike code,
+plus the canonical prefix order. You will paste these values into Task 2. Where a guessed
+value in Task 2 below matches your finding, keep it; where it differs, use YOUR value and
+update the matching test expectation in the same step.
+
+---
+
+## Task 2: Create the `filters.js` helper (TDD)
+
+**Files:**
+- Create: `clis/ke/filters.js`
+- Test: `clis/ke/filters.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `clis/ke/filters.test.js`:
+
+```js
+import { describe, expect, it } from 'vitest';
+import {
+  buildErshoufangFilterPath,
+  ORIENTATION, FLOOR, AGE, DECORATION, ELEVATOR, FEATURES, USAGE, SORT,
+} from './filters.js';
+
+describe('buildErshoufangFilterPath', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildErshoufangFilterPath({})).toBe('');
+  });
+
+  // ── Golden tests on confirmed anchors (de3 / l3 / p / co32) ──
+  it('encodes rooms as l{n}', () => {
+    expect(buildErshoufangFilterPath({ rooms: 3 })).toBe('l3');
+  });
+  it('encodes decoration=rough as de3', () => {
+    expect(buildErshoufangFilterPath({ decoration: 'rough' })).toBe('de3');
+  });
+  it('encodes sort=newest as co32', () => {
+    expect(buildErshoufangFilterPath({ sort: 'newest' })).toBe('co32');
+  });
+  it('keeps the existing price encoding p{min}t{max}', () => {
+    expect(buildErshoufangFilterPath({ 'min-price': 100, 'max-price': 300 })).toBe('p100t300');
+  });
+  it('encodes area range as ba{min}ea{max}', () => {
+    expect(buildErshoufangFilterPath({ 'min-area': 70, 'max-area': 120 })).toBe('ba70ea120');
+  });
+
+  // ── Parametric tests: derive expected from the tables (robust to verified codes) ──
+  it('maps each single-value enum through its own table', () => {
+    expect(buildErshoufangFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildErshoufangFilterPath({ floor: 'high' })).toBe(FLOOR.high);
+    expect(buildErshoufangFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildErshoufangFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildErshoufangFilterPath({ usage: 'villa' })).toBe(USAGE.villa);
+    expect(buildErshoufangFilterPath({ sort: 'total-price-asc' })).toBe(SORT['total-price-asc']);
+  });
+
+  it('splits --features and emits feature codes in table-definition order', () => {
+    // input order reversed; output must follow FEATURES key order
+    const expected = FEATURES['near-subway'] + FEATURES.vr;
+    expect(buildErshoufangFilterPath({ features: 'vr,near-subway' })).toBe(expected);
+  });
+  it('throws ArgumentError on an unknown feature keyword', () => {
+    expect(() => buildErshoufangFilterPath({ features: 'bogus' })).toThrow(/unknown/i);
+  });
+  it('trims and ignores blank feature entries', () => {
+    expect(buildErshoufangFilterPath({ features: ' vr , ' })).toBe(FEATURES.vr);
+  });
+
+  // ── Canonical order across categories (uses only confirmed anchors) ──
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const out = buildErshoufangFilterPath({ rooms: 3, decoration: 'rough', sort: 'newest' });
+    expect(out).toBe('co32de3l3');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project adapter clis/ke/filters.test.js`
+Expected: FAIL — `Failed to resolve import "./filters.js"`.
+
+- [ ] **Step 3: Implement `clis/ke/filters.js`**
+
+Paste the codes confirmed in Task 1 into the tables below. The values shown are best
+guesses to be CONFIRMED/CORRECTED in Step 4 — `de3`, `l{n}`, `co32`, and the
+`p{min}t{max}` price form are already confirmed.
+
+```js
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+// keyword → Beike URL code. Values confirmed against the live site (Task 1).
+export const ORIENTATION = {
+  'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
+};
+export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
+export const ELEVATOR = { yes: 'ie1', no: 'ie2' };
+// 房源特色 (multi-select). Iteration order here IS the emit order.
+export const FEATURES = {
+  'must-see': 'ng1',
+  'five-years': 'mw1',
+  'two-years': 'mw2',
+  'near-subway': 'nb1',
+  vr: 'vr1',
+  'new-7d': 'nd1',
+  'anytime-view': 'av1',
+};
+export const USAGE = {
+  residential: 'sf1', commercial: 'sf2', villa: 'sf3',
+  courtyard: 'sf4', parking: 'sf5', other: 'sf6',
+};
+export const SORT = {
+  newest: 'co32',
+  'total-price-asc': 'co21',
+  'total-price-desc': 'co22',
+  'unit-price-asc': 'co41',
+  'unit-price-desc': 'co42',
+  'area-asc': 'co51',
+  'area-desc': 'co52',
+};
+
+function lookup(table, key) {
+  if (key === undefined || key === null || key === '') return '';
+  return table[String(key)] || '';
+}
+
+function roomsCode(rooms) {
+  return rooms ? `l${rooms}` : '';
+}
+
+function priceCode(kwargs) {
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!min && !max) return '';
+  return `p${min || ''}t${max || ''}`;
+}
+
+function areaCode(kwargs) {
+  const min = kwargs['min-area'];
+  const max = kwargs['max-area'];
+  if (!min && !max) return '';
+  return `ba${min || ''}ea${max || ''}`;
+}
+
+function featuresCode(raw) {
+  if (!raw) return '';
+  const requested = new Set(
+    String(raw).split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  for (const key of requested) {
+    if (!FEATURES[key]) {
+      throw new ArgumentError(
+        `unknown --features value: "${key}"`,
+        `Allowed: ${Object.keys(FEATURES).join(', ')}`,
+      );
+    }
+  }
+  // emit in table-definition order, not user order
+  return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
+}
+
+// Canonical left-to-right order Beike concatenates prefixes in (confirmed in Task 1).
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => featuresCode(k.features),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(AGE, k.age),
+  (k) => lookup(DECORATION, k.decoration),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => lookup(USAGE, k.usage),
+  (k) => roomsCode(k.rooms),
+  (k) => priceCode(k),
+  (k) => areaCode(k),
+];
+
+/**
+ * Build the Beike filter/sort code segment for /ershoufang/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildErshoufangFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}
+```
+
+- [ ] **Step 4: Reconcile with Task 1 findings**
+
+Compare each table value and the `SEGMENT_PRODUCERS` order against your Task 1 recording.
+For every mismatch: change the table/order value AND update the corresponding test
+expectation (the golden tests `de3`/`l3`/`co32`/`p100t300`/`ba70ea120` and the
+`co32de3l3` order test). The parametric tests need no change — they read the tables.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run --project adapter clis/ke/filters.test.js`
+Expected: PASS (all tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clis/ke/filters.js clis/ke/filters.test.js
+git commit -m "feat(ke): add ershoufang filter/sort code helper"
+```
+
+---
+
+## Task 3: Wire the helper into `ershoufang.js` (TDD)
+
+**Files:**
+- Modify: `clis/ke/ershoufang.js`
+- Test: `clis/ke/ershoufang.test.js`
+
+- [ ] **Step 1: Write the failing command tests**
+
+Create `clis/ke/ershoufang.test.js`:
+
+```js
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './ershoufang.js';
+
+const cmd = () => getRegistry().get('ke/ershoufang');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    // readPageState + the list scrape both call evaluate; '' state => not blocked
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/ershoufang command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['orientation', 'floor', 'age', 'decoration', 'elevator',
+                      'features', 'usage', 'min-area', 'max-area', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toContain('total-price-desc');
+  });
+
+  it('builds a URL with filters + sort in canonical order', async () => {
+    const page = mockPage();
+    await cmd().func(page, {
+      city: 'hz', district: 'xihuqu4', rooms: 3, decoration: 'rough', sort: 'newest', limit: 10,
+    });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://hz.ke.com/ershoufang/xihuqu4/co32de3l3/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: rooms only', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', rooms: 2, limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/ershoufang/l2/', expect.anything(),
+    );
+  });
+
+  it('no district, no filters', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/ershoufang/', expect.anything(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run --project adapter clis/ke/ershoufang.test.js`
+Expected: FAIL — the new args are missing and the combined URL is wrong (old code emits
+price before rooms / has no filter support).
+
+- [ ] **Step 3: Update `clis/ke/ershoufang.js`**
+
+Add the import near the top (after the existing imports):
+
+```js
+import { buildErshoufangFilterPath } from './filters.js';
+```
+
+Replace the `args: [ ... ]` array with:
+
+```js
+    args: [
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, tianhe, xihuqu4' },
+        { name: 'min-price', type: 'int', help: '最低总价（万元）' },
+        { name: 'max-price', type: 'int', help: '最高总价（万元）' },
+        { name: 'min-area', type: 'int', help: '最小建筑面积（㎡）' },
+        { name: 'max-area', type: 'int', help: '最大建筑面积（㎡）' },
+        { name: 'rooms', type: 'int', help: '几居室 (1-5)' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'decoration', choices: ['fine', 'simple', 'rough'], help: '装修：fine(精装)/simple(普通)/rough(毛坯)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'features', help: '房源特色，逗号分隔多选：must-see,five-years,two-years,near-subway,vr,new-7d,anytime-view' },
+        { name: 'usage', choices: ['residential', 'commercial', 'villa', 'courtyard', 'parking', 'other'], help: '用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)' },
+        { name: 'sort', choices: ['newest', 'total-price-asc', 'total-price-desc', 'unit-price-asc', 'unit-price-desc', 'area-asc', 'area-desc'], help: '排序：newest(最新发布)/total-price-asc|desc(总价)/unit-price-asc|desc(单价)/area-asc|desc(面积)' },
+        { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+    ],
+```
+
+Replace the URL-assembly block (the `let path` / `priceParts` / `roomParts` / `filters`
+/ `url` lines, currently `clis/ke/ershoufang.js:26-44`) with:
+
+```js
+        let path = '/ershoufang/';
+        if (kwargs.district) {
+            path = `/ershoufang/${kwargs.district}/`;
+        }
+
+        const filters = buildErshoufangFilterPath(kwargs);
+        const url = base + path + (filters ? filters + '/' : '');
+```
+
+Leave everything else (the `gotoKe`, `page.evaluate` scrape, `.slice(0, limit)`)
+unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run --project adapter clis/ke/ershoufang.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clis/ke/ershoufang.js clis/ke/ershoufang.test.js
+git commit -m "feat(ke): expose ershoufang filters and sort"
+```
+
+---
+
+## Task 4: Validate, live smoke, finalize
+
+**Files:** none (verification + docs only).
+
+- [ ] **Step 1: Registry validation**
+
+Run: `npx tsx src/main.ts validate ke/ershoufang`
+Expected: passes (no duplicate args, valid description/domain). Fix any reported issue.
+
+- [ ] **Step 2: Full adapter test suite (no regressions)**
+
+Run: `npm run test:adapter`
+Expected: PASS, including the new `clis/ke/filters.test.js` and
+`clis/ke/ershoufang.test.js`.
+
+- [ ] **Step 3: Inspect the help output**
+
+Run: `npx tsx src/main.ts ke ershoufang --help`
+Expected: all new flags appear with their bilingual help strings.
+
+- [ ] **Step 4: Live smoke (needs logged-in Chrome + extension)**
+
+Run a real multi-filter query and confirm it returns filtered rows:
+
+```bash
+npx tsx src/main.ts ke ershoufang --city hz --district xihuqu4 --rooms 3 --decoration rough --sort newest --limit 5 -f json
+```
+
+Expected: a JSON array of ≤5 listings. Open the same URL the command built (visible with
+`-v`) in a browser to confirm the filters/sort actually applied. If a filter did NOT
+apply, a code or the canonical order is wrong → return to Task 1/Task 2, fix the
+constant + its test, re-run `npm run test:adapter`.
+
+- [ ] **Step 5: Final commit (only if Step 4 required fixes)**
+
+```bash
+git add clis/ke/filters.js clis/ke/filters.test.js clis/ke/ershoufang.js clis/ke/ershoufang.test.js
+git commit -m "fix(ke): correct ershoufang filter codes per live verification"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** orientation/floor/age/decoration/elevator/features/usage (Task 2/3),
+  area range min/max (Task 2/3), `--sort` Pattern-A enum (Task 2/3), `filters.js` pure
+  module (Task 2), canonical-order assembly (Task 2 `SEGMENT_PRODUCERS`), live code
+  verification (Task 1), tests in `adapter` project (Task 2–4), backward-compat
+  (Task 3 tests). All spec sections map to a task.
+- **Known-vs-guessed codes:** only `de3`, `l{n}`, `co32`, and the `p{min}t{max}` price
+  form are pre-confirmed; every other code value is a guess explicitly reconciled in
+  Task 2 Step 4 against Task 1, with parametric tests that stay correct regardless.
+- **Order fix:** the new helper emits `l`(rooms) before `p`(price), matching Beike
+  anchors (`de3l3p1`); the prior inline code emitted price before rooms. Backward-compat
+  tests cover rooms-only and price-only (unaffected); combined rooms+price now produces
+  the Beike-correct order.

--- a/docs/superpowers/plans/2026-06-16-ke-chengjiao-filters-sort.md
+++ b/docs/superpowers/plans/2026-06-16-ke-chengjiao-filters-sort.md
@@ -1,0 +1,441 @@
+# Expand `ke chengjiao` Filters & Sort — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Beike deal-record filters (房型/建筑面积/朝向/楼层/楼龄/装修/用途/电梯) and sort (`--sort` by 总价/单价/面积) to `opencli ke chengjiao`, encoded as URL path code segments on `{city}.ke.com/chengjiao`.
+
+**Architecture:** A new pure module `clis/ke/chengjiao-filters.js` (separate, independently verified — NOT importing ershoufang's `filters.js`, per the architecture decision) owns the keyword→code tables and `buildChengjiaoFilterPath(kwargs)`, which emits active codes in canonical order. `clis/ke/chengjiao.js` gains the arg defs and delegates URL-segment assembly; its DOM scraping is unchanged. Codes confirmed live first.
+
+**Tech Stack:** Node ESM JS adapters (`@jackwener/opencli/registry`, `errors`), vitest (`adapter` project), `opencli browser` for live verification.
+
+Spec: `docs/superpowers/specs/2026-06-16-ke-chengjiao-filters-sort-design.md`
+
+---
+
+## File Structure
+
+- **Create** `clis/ke/chengjiao-filters.js` — tables + `buildChengjiaoFilterPath`. Pure.
+- **Create** `clis/ke/chengjiao-filters.test.js` — unit + live-golden tests.
+- **Create** `clis/ke/chengjiao.test.js` — command URL assembly + backward-compat tests.
+- **Modify** `clis/ke/chengjiao.js` — add arg defs, import helper, replace URL assembly.
+
+`clis/ke/utils.js` (gotoKe, cityUrl) reused unchanged. `clis/ke/filters.js` (ershoufang) NOT touched.
+
+---
+
+## Task 1: Verify chengjiao codes, area prefix, sort & order (live)
+
+The chengjiao filter panel is JS-driven (not `<a href>`), so verify by constructing
+candidate URLs and reading `document.title`. PACE requests — a captcha appears after ~5
+rapid hits; close the session between batches and re-open. Needs a logged-in Chrome + extension.
+
+- [ ] **Step 1: Confirm single-filter codes via title**
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser cj open "https://sh.ke.com/chengjiao/xuhui/"
+# batch of <=4, then re-open between batches:
+for u in l3 sf1 de3 f100500000003; do
+  npx tsx src/main.ts browser cj open "https://sh.ke.com/chengjiao/xuhui/$u/" >/dev/null 2>&1
+  npx tsx src/main.ts browser cj eval 'document.title'
+done
+```
+
+Expected: `l3`→三室, `sf1`→普通住宅, `de3`→毛坯 (already confirmed). Determine 朝向 code
+(try `f100500000003` zufang-style and `f2` ershoufang-style — see which title shows 朝南).
+Then in further small batches confirm: 楼层 (低/中/高 — try `lc1`/`lc2`/`lc3` AND the long
+`lc200500000003` zufang form), 楼龄 (`y1`–`y5`), 装修 (`de1`/`de2`), 用途 (`sf2`–`sf6`),
+电梯 (有=`ie2`/无=`ie1`? confirm).
+
+- [ ] **Step 2: Confirm the area custom-range prefix + one-sided rule**
+
+```bash
+for u in ba70ea90 ba70ea ba0ea90 baea90; do
+  npx tsx src/main.ts browser cj open "https://sh.ke.com/chengjiao/xuhui/$u/" >/dev/null 2>&1
+  npx tsx src/main.ts browser cj eval 'document.title' ; done
+```
+
+Expected (mirror ershoufang): `ba70ea90`→70-90㎡, `ba70ea`→70㎡以上, `ba0ea90`→90㎡以下,
+`baea90`→ignored. Record the prefix and confirm max-only needs min=0.
+
+- [ ] **Step 3: Confirm sort codes + direction**
+
+Probe sort path segments and read the first record's price/area to infer asc/desc. Try the
+ershoufang `co` codes: `co21`/`co22` (总价), `co41`/`co42` (单价), `co11`/`co12` (面积). For
+each, read the first card's deal price / unit price / area to confirm which is asc vs desc.
+
+```bash
+for u in co21 co22 co41 co42 co11 co12; do
+  npx tsx src/main.ts browser cj open "https://sh.ke.com/chengjiao/xuhui/$u/" >/dev/null 2>&1
+  npx tsx src/main.ts browser cj eval '(() => { const c=document.querySelector(".listContent li, .sellListContent li"); const tp=c&&c.querySelector(".totalPrice span"); const up=c&&c.querySelector(".unitPrice span"); const a=c&&c.querySelector(".houseInfo"); return "tp="+(tp?tp.textContent.trim():"?")+" up="+(up?up.textContent.trim():"?")+" info="+(a?a.textContent.replace(/\s+/g," ").trim().slice(0,40):"?"); })()'
+done
+```
+
+- [ ] **Step 4: Canonical order + city spot-check**
+
+Build a multi-filter URL (e.g. `co21de3l3` or with area) and read the title to confirm all
+apply. Construct one URL in your intended producer order and verify it filters. Spot-check
+`bj.ke.com/chengjiao/` for 楼龄 + 用途 codes. Close the session.
+
+```bash
+npx tsx src/main.ts browser cj close
+```
+
+- [ ] **Step 5: Write the captured URL as a golden test**
+
+Create `clis/ke/chengjiao-filters.test.js` with the import + ≥1 real captured multi-filter
+URL as a golden assertion (skeleton; replace with real kwargs/segment from Step 4):
+
+```js
+import { describe, expect, it } from 'vitest';
+import {
+  buildChengjiaoFilterPath, ORIENTATION, FLOOR, AGE, DECORATION, ELEVATOR, USAGE, SORT,
+} from './chengjiao-filters.js';
+
+describe('buildChengjiaoFilterPath — live golden URL', () => {
+  it('matches a captured multi-filter URL', () => {
+    expect(buildChengjiaoFilterPath({
+      rooms: 3, decoration: 'rough', sort: 'total-price-asc',
+    })).toBe('REPLACE_WITH_CAPTURED_SEGMENT');
+  });
+});
+```
+
+**Output:** confirmed codes (notes for Task 2) + a golden test with a real URL.
+
+---
+
+## Task 2: Create the `chengjiao-filters.js` helper (TDD)
+
+**Files:**
+- Create: `clis/ke/chengjiao-filters.js`
+- Test: `clis/ke/chengjiao-filters.test.js` (extend the golden file from Task 1)
+
+- [ ] **Step 1: Add behavior tests**
+
+Append to `clis/ke/chengjiao-filters.test.js`:
+
+```js
+describe('buildChengjiaoFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildChengjiaoFilterPath({})).toBe('');
+  });
+  it('encodes rooms as l{n}', () => {
+    expect(buildChengjiaoFilterPath({ rooms: 3 })).toBe('l3');
+  });
+  it('maps each single-value enum through its own table', () => {
+    expect(buildChengjiaoFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildChengjiaoFilterPath({ floor: 'high' })).toBe(FLOOR.high);
+    expect(buildChengjiaoFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildChengjiaoFilterPath({ decoration: 'rough' })).toBe(DECORATION.rough);
+    expect(buildChengjiaoFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildChengjiaoFilterPath({ usage: 'villa' })).toBe(USAGE.villa);
+    expect(buildChengjiaoFilterPath({ sort: 'total-price-asc' })).toBe(SORT['total-price-asc']);
+  });
+  it('encodes a two-sided area range', () => {
+    expect(buildChengjiaoFilterPath({ 'min-area': 70, 'max-area': 90 })).toBe('ba70ea90');
+  });
+  it('encodes a lower-bound-only area as ba{min}ea', () => {
+    expect(buildChengjiaoFilterPath({ 'min-area': 70 })).toBe('ba70ea');
+  });
+  it('defaults min to 0 for an upper-bound-only area', () => {
+    expect(buildChengjiaoFilterPath({ 'max-area': 90 })).toBe('ba0ea90');
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildChengjiaoFilterPath({ rooms: 3, decoration: 'rough', sort: 'total-price-asc' });
+    const b = buildChengjiaoFilterPath({ sort: 'total-price-asc', decoration: 'rough', rooms: 3 });
+    expect(a).toBe(b);
+    expect(a).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project adapter clis/ke/chengjiao-filters.test.js`
+Expected: FAIL — `Failed to resolve import "./chengjiao-filters.js"`.
+
+- [ ] **Step 3: Implement `clis/ke/chengjiao-filters.js`**
+
+Paste the codes confirmed in Task 1 (values below are starting guesses matching ershoufang
+— REPLACE each with your Task 1 capture):
+
+```js
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+// keyword → Beike code. All values verified live against sh.ke.com/chengjiao (Task 1).
+export const ORIENTATION = {
+  'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
+};
+export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const DECORATION = { fine: 'de1', simple: 'de2', rough: 'de3' };
+export const ELEVATOR = { yes: 'ie2', no: 'ie1' };
+export const USAGE = {
+  residential: 'sf1', commercial: 'sf2', villa: 'sf3',
+  courtyard: 'sf4', parking: 'sf5', other: 'sf6',
+};
+export const SORT = {
+  'total-price-asc': 'co21', 'total-price-desc': 'co22',
+  'unit-price-asc': 'co41', 'unit-price-desc': 'co42',
+  'area-asc': 'co11', 'area-desc': 'co12',
+};
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function roomsCode(rooms) {
+  return present(rooms) ? `l${rooms}` : '';
+}
+function areaCode(kwargs) {
+  const min = kwargs['min-area'];
+  const max = kwargs['max-area'];
+  if (!present(min) && !present(max)) return '';
+  // max-only needs an explicit min (verified live); default lower bound to 0.
+  const lo = present(min) ? min : 0;
+  return `ba${lo}ea${present(max) ? max : ''}`;
+}
+
+// Canonical order confirmed in Task 1 (chengjiao has no features/price vs ershoufang).
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(USAGE, k.usage),
+  (k) => lookup(DECORATION, k.decoration),
+  (k) => lookup(AGE, k.age),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => areaCode(k),
+  (k) => roomsCode(k.rooms),
+];
+
+/**
+ * Build the Beike chengjiao filter/sort code segment for /chengjiao/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildChengjiaoFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}
+```
+
+(The `ArgumentError` import is kept for parity with the other helpers even though chengjiao
+has no multi-select feature arg; if unused after Task 1, remove it to satisfy lint.)
+
+- [ ] **Step 4: Reconcile with Task 1 findings**
+
+Replace every guessed value and reorder `SEGMENT_PRODUCERS` to match Task 1. Replace
+`REPLACE_WITH_CAPTURED_SEGMENT` in the golden test, and the `l3`/`ba70ea90`/`ba0ea90`/
+`co...`-derived expectations if any differ. Parametric tests read the tables — no change.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run --project adapter clis/ke/chengjiao-filters.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clis/ke/chengjiao-filters.js clis/ke/chengjiao-filters.test.js
+git commit -m "feat(ke): add chengjiao filter/sort code helper"
+```
+
+---
+
+## Task 3: Wire the helper into `chengjiao.js` (TDD)
+
+**Files:**
+- Modify: `clis/ke/chengjiao.js`
+- Test: `clis/ke/chengjiao.test.js`
+
+- [ ] **Step 1: Write the failing command tests**
+
+Create `clis/ke/chengjiao.test.js`:
+
+```js
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './chengjiao.js';
+import { buildChengjiaoFilterPath } from './chengjiao-filters.js';
+
+const cmd = () => getRegistry().get('ke/chengjiao');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/chengjiao command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['rooms', 'min-area', 'max-area', 'orientation', 'floor',
+                      'age', 'decoration', 'usage', 'elevator', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toContain('total-price-desc');
+    // chengjiao sort must NOT offer 'newest'
+    expect(sortArg.choices).not.toContain('newest');
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'xuhui', rooms: 3, decoration: 'rough', limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildChengjiaoFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.ke.com/chengjiao/xuhui/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: no filters, with district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', district: 'haidian', limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/chengjiao/haidian/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: no district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/chengjiao/', expect.anything(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run --project adapter clis/ke/chengjiao.test.js`
+Expected: FAIL — new args missing.
+
+- [ ] **Step 3: Update `clis/ke/chengjiao.js`**
+
+Add the import after the existing imports:
+
+```js
+import { buildChengjiaoFilterPath } from './chengjiao-filters.js';
+```
+
+Replace the `args: [ ... ]` array with:
+
+```js
+    args: [
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, xuhui' },
+        { name: 'rooms', type: 'int', help: '几室 (1-5)' },
+        { name: 'min-area', type: 'int', help: '最小建筑面积（㎡）' },
+        { name: 'max-area', type: 'int', help: '最大建筑面积（㎡）' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(朝南)/east(朝东)/north(朝北)/west(朝西)' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'decoration', choices: ['fine', 'simple', 'rough'], help: '装修：fine(精装)/simple(普通)/rough(毛坯)' },
+        { name: 'usage', choices: ['residential', 'commercial', 'villa', 'courtyard', 'parking', 'other'], help: '用途：residential(普通住宅)/commercial(商业类)/villa(别墅)/courtyard(四合院)/parking(车位)/other(其他)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'sort', choices: ['total-price-asc', 'total-price-desc', 'unit-price-asc', 'unit-price-desc', 'area-asc', 'area-desc'], help: '排序：total-price-asc|desc(总价)/unit-price-asc|desc(房屋单价)/area-asc|desc(面积)' },
+        { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+    ],
+```
+
+Replace the URL-assembly block (the `let path` / `if (kwargs.district)` lines and the
+`await gotoKe(page, base + path)` call — currently `clis/ke/chengjiao.js:23-28`) with:
+
+```js
+        let path = '/chengjiao/';
+        if (kwargs.district) {
+            path = `/chengjiao/${kwargs.district}/`;
+        }
+
+        const filters = buildChengjiaoFilterPath(kwargs);
+        await gotoKe(page, base + path + (filters ? filters + '/' : ''));
+```
+
+Leave the `page.evaluate` scrape and `.slice(0, limit)` unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run --project adapter clis/ke/chengjiao.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clis/ke/chengjiao.js clis/ke/chengjiao.test.js
+git commit -m "feat(ke): expose chengjiao filters and sort"
+```
+
+---
+
+## Task 4: Validate, rebuild manifest, live smoke, finalize
+
+**Files:** Modify `cli-manifest.json` (regenerated).
+
+- [ ] **Step 1: Registry validation**
+
+Run: `npx tsx src/main.ts validate ke/chengjiao`
+Expected: PASS (0 errors).
+
+- [ ] **Step 2: Rebuild the manifest**
+
+Run: `npx tsx src/build-manifest.ts`
+Expected: `✅ Manifest compiled`. Confirm only chengjiao changed:
+`git diff cli-manifest.json | grep -E '"site"' | grep -v '"ke"'` should be empty.
+
+- [ ] **Step 3: Full adapter test suite**
+
+Run: `npm run test:adapter`
+Expected: PASS, including the two new `clis/ke/chengjiao*.test.js` files.
+
+- [ ] **Step 4: Inspect help output**
+
+Run: `npx tsx src/main.ts ke chengjiao --help`
+Expected: all new flags appear with help + `choices`; `--sort` has no `newest`.
+
+- [ ] **Step 5: Live smoke (needs logged-in Chrome + extension)**
+
+```bash
+npx tsx src/main.ts ke chengjiao --city bj --district haidian --rooms 3 --sort total-price-desc --limit 5 -v -f json
+```
+
+Expected: a JSON array of ≤5 deal records, all 3室, ordered by descending deal price; the
+`-v` URL matches the helper output. If a filter didn't apply, fix the constant + its test
+and re-run `npm run test:adapter`.
+
+- [ ] **Step 6: Commit the manifest (+ any smoke fixes)**
+
+```bash
+git add cli-manifest.json clis/ke/chengjiao-filters.js clis/ke/chengjiao-filters.test.js
+git commit -m "chore(ke): rebuild manifest for chengjiao filters and sort"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** rooms/area-range/orientation/floor/age/decoration/usage/elevator
+  (Task 2/3), `--sort` total-price/unit-price/area asc-desc with NO newest (Task 2/3 +
+  the explicit `not.toContain('newest')` test), separate pure module (Task 2), canonical
+  order (Task 2 `SEGMENT_PRODUCERS`), live verification + golden URL (Task 1), tests in
+  `adapter` project (Task 2–4), backward-compat (Task 3 tests), no features / no price /
+  bands / 供暖 / location excluded (not in any task). All spec sections map to a task.
+- **area one-sided:** handled in `areaCode` (max-only → min 0) per the verified rule.
+- **Independent module:** `chengjiao-filters.js` does not import `filters.js`; codes
+  verified independently on the chengjiao endpoint (Task 1), even though l3/sf1/de3 match.
+- **Guessed vs confirmed:** l3/sf1/de3 pre-confirmed; every other code (orientation, floor,
+  age de1/de2, usage sf2–sf6, elevator, sort, area prefix) is a starting guess reconciled
+  in Task 2 Step 4 against Task 1; the golden URL pins real behavior. Floor is verified
+  properly here (ershoufang's floor codes were never confirmed).

--- a/docs/superpowers/plans/2026-06-16-ke-xiaoqu-filters-sort.md
+++ b/docs/superpowers/plans/2026-06-16-ke-xiaoqu-filters-sort.md
@@ -1,0 +1,406 @@
+# Expand `ke xiaoqu` Filters & Sort — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Beike community filters (均价 custom range, 楼龄, 近地铁) and sort (`--sort` by 小区均价) to `opencli ke xiaoqu`, encoded as URL path code segments on `{city}.ke.com/xiaoqu`.
+
+**Architecture:** A new pure module `clis/ke/xiaoqu-filters.js` owns the keyword→code tables and `buildXiaoquFilterPath(kwargs)`, which emits active codes (avg-price range, age, near-subway, sort) in canonical order. `clis/ke/xiaoqu.js` gains the arg defs and delegates URL-segment assembly to the helper; its DOM scraping is unchanged. All codes are confirmed live first.
+
+**Tech Stack:** Node ESM JS adapters (`@jackwener/opencli/registry`, `errors`), vitest (`adapter` project), `opencli browser` for live verification.
+
+Spec: `docs/superpowers/specs/2026-06-16-ke-xiaoqu-filters-sort-design.md`
+
+---
+
+## File Structure
+
+- **Create** `clis/ke/xiaoqu-filters.js` — tables + `buildXiaoquFilterPath`. Pure, browser-free.
+- **Create** `clis/ke/xiaoqu-filters.test.js` — unit + live-golden tests (vitest `adapter`).
+- **Create** `clis/ke/xiaoqu.test.js` — command-level URL assembly + backward-compat tests.
+- **Modify** `clis/ke/xiaoqu.js` — add arg defs, import helper, replace inline URL assembly.
+
+`clis/ke/utils.js` (gotoKe, cityUrl) reused unchanged. `clis/ke/filters.js` (ershoufang) NOT touched.
+
+---
+
+## Task 1: Verify xiaoqu codes, avg-price prefix & order (live)
+
+Needs a Chrome logged into ke.com with the OpenCLI extension. Output: confirmed codes +
+≥1 captured golden URL written into `clis/ke/xiaoqu-filters.test.js`.
+
+- [ ] **Step 1: Open the reference page and read filter hrefs**
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser xiaoqu open "https://sh.ke.com/xiaoqu/xuhui/"
+npx tsx src/main.ts browser xiaoqu eval '(() => {
+  const out=[];
+  document.querySelectorAll("a[href*=\"/xiaoqu/\"]").forEach(a=>{
+    const t=(a.textContent||"").trim();
+    const seg=(a.getAttribute("href")||"").replace(/^.*\/xiaoqu\//,"").replace(/\/.*$/,"");
+    if(t && t.length<=8 && /[0-9]/.test(seg) && seg.length<30) out.push(t+" => "+seg);
+  });
+  return [...new Set(out)].join("\n");
+})()'
+```
+
+Expected: lines like `5年以内 => xuhui/y1`, `近地铁 => xuhui/<code>`, plus 均价 bands.
+Record: 楼龄 (5/10/15/20年以内, 20年以上), 近地铁, and the 排序 (小区均价) code.
+
+- [ ] **Step 2: Determine the avg-price custom-range prefix + one-sided behavior**
+
+Type values into the 均价 custom box (or probe URLs) and read the path. Confirm the
+two-sided prefix, then test min-only and max-only and read the page title to see which
+applies (mirrors the ershoufang area check: `ba70ea` worked, `baea120` needed `ba0ea120`).
+Record the exact prefix and the one-sided rule.
+
+```bash
+# control + one-sided probes (replace PFX with the confirmed prefix; read title each time)
+for u in "PFX1t2" "PFX1t" "PFXt2" "PFX0t2"; do
+  npx tsx src/main.ts browser xiaoqu open "https://sh.ke.com/xiaoqu/xuhui/$u/" >/dev/null 2>&1
+  npx tsx src/main.ts browser xiaoqu eval 'document.title' ; done
+```
+
+- [ ] **Step 3: Confirm sort asc/desc + canonical order**
+
+Click 小区均价 sort (and again to toggle); read the `co` code and infer direction from the
+first community's avg price. Read a 2-filter href (e.g. with 近地铁 active, read 楼龄's href)
+to fix the canonical order.
+
+- [ ] **Step 4: Spot-check one other city**
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser xiaoqu open "https://bj.ke.com/xiaoqu/"
+```
+
+Re-check 楼龄 + 近地铁 codes; confirm they match sh.
+
+- [ ] **Step 5: Write the captured URL as a golden test + close**
+
+Create `clis/ke/xiaoqu-filters.test.js` with the import and ≥1 real captured multi-filter
+URL as a golden assertion (skeleton; replace with real values):
+
+```js
+import { describe, expect, it } from 'vitest';
+import { buildXiaoquFilterPath, AGE, SORT } from './xiaoqu-filters.js';
+
+describe('buildXiaoquFilterPath — live golden URL', () => {
+  it('matches a captured multi-filter URL', () => {
+    expect(buildXiaoquFilterPath({
+      age: '10', 'near-subway': true, sort: 'avg-price-asc',
+    })).toBe('REPLACE_WITH_CAPTURED_SEGMENT');
+  });
+});
+```
+
+```bash
+npx tsx src/main.ts browser xiaoqu close
+```
+
+**Output:** confirmed codes (notes for Task 2) + a golden test with a real URL.
+
+---
+
+## Task 2: Create the `xiaoqu-filters.js` helper (TDD)
+
+**Files:**
+- Create: `clis/ke/xiaoqu-filters.js`
+- Test: `clis/ke/xiaoqu-filters.test.js` (extend the golden file from Task 1)
+
+- [ ] **Step 1: Add behavior tests**
+
+Append to `clis/ke/xiaoqu-filters.test.js`:
+
+```js
+describe('buildXiaoquFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildXiaoquFilterPath({})).toBe('');
+  });
+  it('maps age and sort through their tables', () => {
+    expect(buildXiaoquFilterPath({ age: '10' })).toBe(AGE['10']);
+    expect(buildXiaoquFilterPath({ sort: 'avg-price-asc' })).toBe(SORT['avg-price-asc']);
+  });
+  it('emits the near-subway code only when truthy', () => {
+    expect(buildXiaoquFilterPath({ 'near-subway': true })).toBeTruthy();
+    expect(buildXiaoquFilterPath({ 'near-subway': false })).toBe('');
+    expect(buildXiaoquFilterPath({})).toBe('');
+  });
+  it('encodes a two-sided avg-price range', () => {
+    expect(buildXiaoquFilterPath({ 'min-price': 3, 'max-price': 5 })).toBe('PFX3t5');
+  });
+  it('keeps a literal 0 lower bound for avg-price', () => {
+    expect(buildXiaoquFilterPath({ 'min-price': 0, 'max-price': 5 })).toBe('PFX0t5');
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildXiaoquFilterPath({ age: '10', sort: 'avg-price-asc' });
+    const b = buildXiaoquFilterPath({ sort: 'avg-price-asc', age: '10' });
+    expect(a).toBe(b);
+    expect(a).toBeTruthy();
+  });
+});
+```
+
+(Replace `PFX` with the avg-price prefix confirmed in Task 1, in both the test and impl.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project adapter clis/ke/xiaoqu-filters.test.js`
+Expected: FAIL — `Failed to resolve import "./xiaoqu-filters.js"`.
+
+- [ ] **Step 3: Implement `clis/ke/xiaoqu-filters.js`**
+
+Paste the codes confirmed in Task 1 (values below are starting guesses — REPLACE each,
+including `PFX` and `NEAR_SUBWAY_CODE`, with your Task 1 captures):
+
+```js
+export const AGE = { '5': 'y1', '10': 'y2', '15': 'y3', '20': 'y4', '20+': 'y5' };
+export const SORT = { 'avg-price-asc': 'co21', 'avg-price-desc': 'co22' };
+const NEAR_SUBWAY_CODE = 'm1';
+const AVG_PRICE_PREFIX = { begin: 'p', mid: 't' }; // -> p{min}t{max}; confirm in Task 1
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function nearSubwayCode(kwargs) {
+  return kwargs['near-subway'] ? NEAR_SUBWAY_CODE : '';
+}
+function avgPriceCode(kwargs) {
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!present(min) && !present(max)) return '';
+  // Apply the one-sided rule confirmed in Task 1 (e.g. default min to 0 for max-only).
+  const lo = present(min) ? min : 0;
+  return `${AVG_PRICE_PREFIX.begin}${lo}${AVG_PRICE_PREFIX.mid}${present(max) ? max : ''}`;
+}
+
+// Canonical order confirmed in Task 1.
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(AGE, k.age),
+  (k) => nearSubwayCode(k),
+  (k) => avgPriceCode(k),
+];
+
+/**
+ * Build the Beike xiaoqu filter/sort code segment for /xiaoqu/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildXiaoquFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}
+```
+
+- [ ] **Step 4: Reconcile with Task 1 findings**
+
+Replace every guessed value (`AGE`, `SORT`, `NEAR_SUBWAY_CODE`, `AVG_PRICE_PREFIX`, the
+one-sided rule) and reorder `SEGMENT_PRODUCERS` to match Task 1. Replace `PFX` and
+`REPLACE_WITH_CAPTURED_SEGMENT` in the tests with the real captures.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run --project adapter clis/ke/xiaoqu-filters.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clis/ke/xiaoqu-filters.js clis/ke/xiaoqu-filters.test.js
+git commit -m "feat(ke): add xiaoqu filter/sort code helper"
+```
+
+---
+
+## Task 3: Wire the helper into `xiaoqu.js` (TDD)
+
+**Files:**
+- Modify: `clis/ke/xiaoqu.js`
+- Test: `clis/ke/xiaoqu.test.js`
+
+- [ ] **Step 1: Write the failing command tests**
+
+Create `clis/ke/xiaoqu.test.js`:
+
+```js
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './xiaoqu.js';
+import { buildXiaoquFilterPath } from './xiaoqu-filters.js';
+
+const cmd = () => getRegistry().get('ke/xiaoqu');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/xiaoqu command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['min-price', 'max-price', 'age', 'near-subway', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const sortArg = c.args.find((a) => a.name === 'sort');
+    expect(sortArg.choices).toEqual(['avg-price-asc', 'avg-price-desc']);
+    const ns = c.args.find((a) => a.name === 'near-subway');
+    expect(ns.type).toBe('boolean');
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'xuhui', age: '10', 'near-subway': true, limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildXiaoquFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.ke.com/xiaoqu/xuhui/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: no filters, with district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'gz', district: 'tianhe', limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://gz.ke.com/xiaoqu/tianhe/', expect.anything(),
+    );
+  });
+
+  it('backward-compat: no district', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.ke.com/xiaoqu/', expect.anything(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run --project adapter clis/ke/xiaoqu.test.js`
+Expected: FAIL — new args missing.
+
+- [ ] **Step 3: Update `clis/ke/xiaoqu.js`**
+
+Add the import after the existing imports:
+
+```js
+import { buildXiaoquFilterPath } from './xiaoqu-filters.js';
+```
+
+Replace the `args: [ ... ]` array with:
+
+```js
+    args: [
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, tianhe, xuhui' },
+        { name: 'min-price', type: 'int', help: '最低均价（万/㎡）' },
+        { name: 'max-price', type: 'int', help: '最高均价（万/㎡）' },
+        { name: 'age', choices: ['5', '10', '15', '20', '20+'], help: '楼龄：5/10/15/20 年以内，20+ 为 20 年以上' },
+        { name: 'near-subway', type: 'boolean', help: '仅看近地铁小区' },
+        { name: 'sort', choices: ['avg-price-asc', 'avg-price-desc'], help: '排序：avg-price-asc|desc(小区均价)；不传为默认排序' },
+        { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+    ],
+```
+
+Replace the URL-assembly block (the `let path` / `if (kwargs.district)` lines that build
+`path`, then the `await gotoKe(page, base + path)` call — currently
+`clis/ke/xiaoqu.js:13-23` region) so the filter segment is inserted:
+
+```js
+        let path = '/xiaoqu/';
+        if (kwargs.district) {
+            path = `/xiaoqu/${kwargs.district}/`;
+        }
+
+        const filters = buildXiaoquFilterPath(kwargs);
+        await gotoKe(page, base + path + (filters ? filters + '/' : ''));
+```
+
+Leave the `page.evaluate` scrape and `.slice(0, limit)` unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run --project adapter clis/ke/xiaoqu.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clis/ke/xiaoqu.js clis/ke/xiaoqu.test.js
+git commit -m "feat(ke): expose xiaoqu filters and sort"
+```
+
+---
+
+## Task 4: Validate, rebuild manifest, live smoke, finalize
+
+**Files:** Modify `cli-manifest.json` (regenerated).
+
+- [ ] **Step 1: Registry validation**
+
+Run: `npx tsx src/main.ts validate ke/xiaoqu`
+Expected: PASS (0 errors).
+
+- [ ] **Step 2: Rebuild the manifest**
+
+Run: `npx tsx src/build-manifest.ts`
+Expected: `✅ Manifest compiled`. Confirm only xiaoqu changed:
+`git diff cli-manifest.json | grep -E '"site"' | grep -v '"ke"'` should be empty.
+
+- [ ] **Step 3: Full adapter test suite**
+
+Run: `npm run test:adapter`
+Expected: PASS, including the two new `clis/ke/xiaoqu*.test.js` files.
+
+- [ ] **Step 4: Inspect help output**
+
+Run: `npx tsx src/main.ts ke xiaoqu --help`
+Expected: all new flags appear with help + `choices` (and `--near-subway` as a flag).
+
+- [ ] **Step 5: Live smoke (needs logged-in Chrome + extension)**
+
+```bash
+npx tsx src/main.ts ke xiaoqu --city gz --district tianhe --age 10 --near-subway --sort avg-price-asc --limit 5 -v -f json
+```
+
+Expected: a JSON array of ≤5 communities; the `-v` URL matches the helper output; results
+look age/subway filtered and ordered by ascending avg price. If a filter didn't apply, fix
+the constant + its test and re-run `npm run test:adapter`.
+
+- [ ] **Step 6: Commit the manifest (+ any smoke fixes)**
+
+```bash
+git add cli-manifest.json clis/ke/xiaoqu-filters.js clis/ke/xiaoqu-filters.test.js
+git commit -m "chore(ke): rebuild manifest for xiaoqu filters and sort"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** avg-price range + one-sided handling (Task 2 `avgPriceCode`), age
+  (Task 2/3), near-subway boolean (Task 2 `nearSubwayCode` + Task 3 `type: boolean`),
+  `--sort` avg-price asc/desc (Task 2/3), pure separate module (Task 2), canonical order
+  (Task 2 `SEGMENT_PRODUCERS`), live verification + golden URL (Task 1), tests in `adapter`
+  project (Task 2–4), backward-compat (Task 3 tests), bands/location excluded (no task).
+  All spec sections map to a task.
+- **avg-price one-sided:** handled in new code per the ershoufang lesson (not skipped like
+  zufang's rent, because this is fresh code) — verified live in Task 1.
+- **near-subway flag:** declared `type: boolean` with no default, so commander registers
+  `--near-subway [value]`; the bare flag yields `true`, which `coerceAndValidateArgs`
+  keeps as boolean `true`; the helper emits the code only when truthy.
+- **Guessed vs confirmed:** every code (`AGE`, `SORT`, `NEAR_SUBWAY_CODE`, `AVG_PRICE_PREFIX`,
+  the one-sided rule, the `PFX`/segment placeholders) is reconciled in Task 2 Step 4 against
+  Task 1; the golden URL pins real behavior.

--- a/docs/superpowers/plans/2026-06-16-ke-zufang-filters-sort.md
+++ b/docs/superpowers/plans/2026-06-16-ke-zufang-filters-sort.md
@@ -1,0 +1,474 @@
+# Expand `ke zufang` Filters & Sort — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Beike rental filters (方式/户型/朝向/特色/租期/楼层/电梯) and result sort (`--sort`) to `opencli ke zufang`, encoded as URL path code segments on `zu.ke.com`.
+
+**Architecture:** A new pure module `clis/ke/zufang-filters.js` (separate from ershoufang's `filters.js` — zufang uses its own codes on a different subdomain) owns the keyword→code tables and `buildZufangFilterPath(kwargs)`, which emits all active codes (including the unchanged `rp{min}t{max}` rent segment) in Beike's canonical order. `clis/ke/zufang.js` gains the arg defs and delegates URL-segment assembly to that helper; its DOM scraping is unchanged. All zufang codes are confirmed against the live rental site first.
+
+**Tech Stack:** Node ESM JS adapters (`@jackwener/opencli/registry`, `errors`), vitest (`adapter` project), `opencli browser` for live verification.
+
+Spec: `docs/superpowers/specs/2026-06-16-ke-zufang-filters-sort-design.md`
+
+---
+
+## File Structure
+
+- **Create** `clis/ke/zufang-filters.js` — mapping tables + `buildZufangFilterPath`. Pure, browser-free.
+- **Create** `clis/ke/zufang-filters.test.js` — unit tests for the helper (vitest `adapter` project).
+- **Create** `clis/ke/zufang.test.js` — command-level URL assembly + backward-compat tests.
+- **Modify** `clis/ke/zufang.js` — add arg defs, import helper, replace inline URL assembly.
+
+`clis/ke/utils.js` (gotoKe) is reused unchanged. `clis/ke/filters.js` (ershoufang) is NOT touched or imported.
+
+---
+
+## Task 1: Verify zufang codes, sort mechanism & canonical order (live)
+
+Confirms every code, the canonical concatenation order, AND whether sort is a path
+segment or a query param. Needs a Chrome logged into ke.com with the OpenCLI extension
+(zufang strategy is `COOKIE`). Output: confirmed code values + ≥2 captured golden URLs
+written straight into `clis/ke/zufang-filters.test.js`.
+
+**Files:** Create `clis/ke/zufang-filters.test.js` (golden tests only, this task).
+
+- [ ] **Step 1: Open the reference rental page**
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser zufang open "https://sh.zu.ke.com/zufang/pudong/"
+```
+
+Expected: a 浦东 租房 list loads. Solve any captcha/login in that window first.
+
+- [ ] **Step 2: Toggle each in-scope filter, record the code it adds to the URL**
+
+Click ONE option at a time, read the path segment that appears (use
+`npx tsx src/main.ts browser zufang state | grep -i title` to read the URL/title). Cover:
+
+- 方式: 整租 / 合租  → rent-type codes
+- 户型: 一居 / 两居 / 三居 / 四居+  → rooms codes
+- 朝向: 东 / 西 / 南 / 北 / 南北  → orientation codes
+- 特色: 近地铁 / 拎包入住 / 精装修 / 押一付一 / 新上 / 认证公寓 / 随时看房 / VR房源 / 业主自荐  → feature codes
+- 租期: 月租 / 年租 / 一个月起租 / 1-3个月 / 4-6个月  → lease-term codes
+- 楼层: 低楼层 / 中楼层 / 高楼层  → floor codes
+- 电梯: 有电梯 / 无电梯  → elevator codes
+
+- [ ] **Step 3: Determine the sort mechanism**
+
+Click each sort tab (综合排序 / 最新上架 / 价格 / 面积; price & area likely toggle asc/desc on
+repeat click) and read what changes. **Critical:** note whether sort appears as a PATH
+segment (e.g. `.../co32/`) or a QUERY param (e.g. `?sort=...`). Record each sort value's code.
+
+- [ ] **Step 4: Establish canonical order + rent-segment position**
+
+Select several filters at once (e.g. 整租 + 两居 + 近地铁 + 低楼层 + a rent range via the
+自定义 box). Read the full path and note the left-to-right prefix order, INCLUDING where the
+rent `rp...` segment sits among the new codes.
+
+- [ ] **Step 5: Spot-check city stability**
+
+```bash
+OPENCLI_WINDOW=foreground npx tsx src/main.ts browser zufang open "https://bj.zu.ke.com/zufang/"
+```
+
+Re-check ~3 enums; confirm in-scope codes match sh.
+
+- [ ] **Step 6: Write the captured URLs as golden tests**
+
+Create `clis/ke/zufang-filters.test.js` with the imports and the ≥2 real multi-filter URLs
+you captured, as golden assertions. Use this exact skeleton, filling the `kwargs` and
+expected string from YOUR captures (example shown; replace with real values):
+
+```js
+import { describe, expect, it } from 'vitest';
+import {
+  buildZufangFilterPath,
+  RENT_TYPE, ORIENTATION, FEATURES, LEASE_TERM, FLOOR, ELEVATOR, SORT,
+} from './zufang-filters.js';
+
+describe('buildZufangFilterPath — live golden URLs', () => {
+  // Replace each kwargs+expected with a URL captured in Task 1 Step 4.
+  it('matches captured multi-filter URL #1', () => {
+    expect(buildZufangFilterPath({
+      'rent-type': 'whole', rooms: 2, features: 'near-subway', floor: 'low',
+    })).toBe('REPLACE_WITH_CAPTURED_SEGMENT_1');
+  });
+  it('matches captured multi-filter URL #2', () => {
+    expect(buildZufangFilterPath({
+      orientation: 'south', 'lease-term': 'monthly', elevator: 'yes', sort: 'newest',
+    })).toBe('REPLACE_WITH_CAPTURED_SEGMENT_2');
+  });
+});
+```
+
+- [ ] **Step 7: Close the window**
+
+```bash
+npx tsx src/main.ts browser zufang close
+```
+
+**Output:** confirmed keyword→code values (kept in your notes for Task 2) + a
+`zufang-filters.test.js` whose two golden tests encode real captured URLs. If Step 3 found
+sort is a query param (not a path segment), note it loudly — Task 2/3 handle it (see Task 3
+Step 3 alt).
+
+---
+
+## Task 2: Create the `zufang-filters.js` helper (TDD)
+
+**Files:**
+- Create: `clis/ke/zufang-filters.js`
+- Test: `clis/ke/zufang-filters.test.js` (extend the golden file from Task 1)
+
+- [ ] **Step 1: Add parametric tests**
+
+Append to `clis/ke/zufang-filters.test.js`:
+
+```js
+describe('buildZufangFilterPath — behavior', () => {
+  it('returns empty string when nothing is active', () => {
+    expect(buildZufangFilterPath({})).toBe('');
+  });
+  it('maps each single-value enum through its own table', () => {
+    expect(buildZufangFilterPath({ 'rent-type': 'whole' })).toBe(RENT_TYPE.whole);
+    expect(buildZufangFilterPath({ orientation: 'south' })).toBe(ORIENTATION.south);
+    expect(buildZufangFilterPath({ 'lease-term': 'monthly' })).toBe(LEASE_TERM.monthly);
+    expect(buildZufangFilterPath({ floor: 'low' })).toBe(FLOOR.low);
+    expect(buildZufangFilterPath({ elevator: 'yes' })).toBe(ELEVATOR.yes);
+    expect(buildZufangFilterPath({ sort: 'newest' })).toBe(SORT.newest);
+  });
+  it('encodes rooms via the rooms producer', () => {
+    // exact prefix confirmed in Task 1; assert non-empty + stable
+    const out = buildZufangFilterPath({ rooms: 2 });
+    expect(out).toBeTruthy();
+    expect(buildZufangFilterPath({ rooms: 2 })).toBe(out);
+  });
+  it('keeps the existing rent encoding rp{min}t{max}', () => {
+    expect(buildZufangFilterPath({ 'min-price': 2000, 'max-price': 8000 })).toBe('rp2000t8000');
+  });
+  it('splits --features and emits feature codes in table-definition order', () => {
+    const expected = FEATURES['near-subway'] + FEATURES.fine;
+    expect(buildZufangFilterPath({ features: 'fine,near-subway' })).toBe(expected);
+  });
+  it('throws on an unknown feature keyword', () => {
+    expect(() => buildZufangFilterPath({ features: 'bogus' })).toThrow(/unknown/i);
+  });
+  it('emits codes in canonical order regardless of kwargs key order', () => {
+    const a = buildZufangFilterPath({ rooms: 2, 'rent-type': 'whole', floor: 'low' });
+    const b = buildZufangFilterPath({ floor: 'low', 'rent-type': 'whole', rooms: 2 });
+    expect(a).toBe(b);
+    expect(a).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project adapter clis/ke/zufang-filters.test.js`
+Expected: FAIL — `Failed to resolve import "./zufang-filters.js"`.
+
+- [ ] **Step 3: Implement `clis/ke/zufang-filters.js`**
+
+Paste the codes confirmed in Task 1 into the tables (values below are starting guesses —
+REPLACE each with your Task 1 capture; the rent `rp{min}t{max}` form is already correct):
+
+```js
+import { ArgumentError } from '@jackwener/opencli/errors';
+
+// keyword → Beike zu.ke.com code. CONFIRM/REPLACE every value from Task 1.
+export const RENT_TYPE = { whole: 'rt200600000001', shared: 'rt200600000002' };
+export const ORIENTATION = {
+  'south-north': 'f5', south: 'f2', east: 'f1', north: 'f4', west: 'f3',
+};
+export const FEATURES = {
+  'near-subway': 'nb1', 'bag-in': 'bi1', fine: 'de1', 'deposit-one': 'dp1',
+  new: 'nd1', certified: 'ct1', 'anytime-view': 'av1', vr: 'vr1', 'owner-rec': 'or1',
+};
+export const LEASE_TERM = {
+  monthly: 'lt1', yearly: 'lt2', 'min-1month': 'lt3', '1-3months': 'lt4', '4-6months': 'lt5',
+};
+export const FLOOR = { low: 'lc1', mid: 'lc2', high: 'lc3' };
+export const ELEVATOR = { yes: 'ie2', no: 'ie1' };
+export const SORT = {
+  newest: 'co32', 'rent-asc': 'co21', 'rent-desc': 'co22', 'area-asc': 'co11', 'area-desc': 'co12',
+};
+
+function present(v) {
+  return v !== undefined && v !== null && v !== '';
+}
+function lookup(table, key) {
+  if (!present(key)) return '';
+  return table[String(key)] || '';
+}
+function roomsCode(rooms) {
+  return rooms ? `l${rooms}` : ''; // ⚠️ confirm zufang rooms prefix in Task 1
+}
+function rentCode(kwargs) {
+  // Unchanged from the original zufang.js — kept exactly as-is per the spec.
+  const min = kwargs['min-price'];
+  const max = kwargs['max-price'];
+  if (!min && !max) return '';
+  return `rp${min || ''}t${max || ''}`;
+}
+function featuresCode(raw) {
+  if (!raw) return '';
+  const requested = new Set(String(raw).split(',').map((s) => s.trim()).filter(Boolean));
+  for (const key of requested) {
+    if (!FEATURES[key]) {
+      throw new ArgumentError(
+        `unknown --features value: "${key}"`,
+        `Allowed: ${Object.keys(FEATURES).join(', ')}`,
+      );
+    }
+  }
+  return Object.keys(FEATURES).filter((k) => requested.has(k)).map((k) => FEATURES[k]).join('');
+}
+
+// Canonical left-to-right order Beike concatenates prefixes in (confirmed in Task 1).
+// Reorder these producers to match the order captured in Task 1 Step 4.
+const SEGMENT_PRODUCERS = [
+  (k) => lookup(SORT, k.sort),
+  (k) => lookup(RENT_TYPE, k['rent-type']),
+  (k) => lookup(ORIENTATION, k.orientation),
+  (k) => featuresCode(k.features),
+  (k) => lookup(LEASE_TERM, k['lease-term']),
+  (k) => lookup(FLOOR, k.floor),
+  (k) => lookup(ELEVATOR, k.elevator),
+  (k) => roomsCode(k.rooms),
+  (k) => rentCode(k),
+];
+
+/**
+ * Build the Beike zufang filter/sort code segment for /zufang/{district}/{segment}/.
+ * Returns '' when no filters/sort are active.
+ */
+export function buildZufangFilterPath(kwargs) {
+  const parts = [];
+  for (const produce of SEGMENT_PRODUCERS) {
+    const code = produce(kwargs);
+    if (code) parts.push(code);
+  }
+  return parts.join('');
+}
+```
+
+- [ ] **Step 4: Reconcile with Task 1 findings**
+
+Replace every table value and reorder `SEGMENT_PRODUCERS` to match your Task 1 captures.
+Replace the two `REPLACE_WITH_CAPTURED_SEGMENT_*` strings in the golden tests with the real
+captured segments. The parametric tests need no change — they read the tables.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run --project adapter clis/ke/zufang-filters.test.js`
+Expected: PASS (golden + parametric all green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clis/ke/zufang-filters.js clis/ke/zufang-filters.test.js
+git commit -m "feat(ke): add zufang filter/sort code helper"
+```
+
+---
+
+## Task 3: Wire the helper into `zufang.js` (TDD)
+
+**Files:**
+- Modify: `clis/ke/zufang.js`
+- Test: `clis/ke/zufang.test.js`
+
+- [ ] **Step 1: Write the failing command tests**
+
+Create `clis/ke/zufang.test.js`:
+
+```js
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './zufang.js';
+import { buildZufangFilterPath } from './zufang-filters.js';
+
+const cmd = () => getRegistry().get('ke/zufang');
+
+function mockPage() {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ke/zufang command', () => {
+  it('registers with the new args', () => {
+    const c = cmd();
+    expect(c).toBeDefined();
+    const names = c.args.map((a) => a.name);
+    for (const n of ['rent-type', 'rooms', 'orientation', 'features',
+                      'lease-term', 'floor', 'elevator', 'sort']) {
+      expect(names).toContain(n);
+    }
+    const rt = c.args.find((a) => a.name === 'rent-type');
+    expect(rt.choices).toEqual(['whole', 'shared']);
+  });
+
+  it('builds a URL with filters using the helper segment', async () => {
+    const page = mockPage();
+    const kwargs = { city: 'sh', district: 'pudong', 'rent-type': 'whole', rooms: 2, limit: 10 };
+    await cmd().func(page, kwargs);
+    const seg = buildZufangFilterPath(kwargs);
+    expect(page.goto).toHaveBeenCalledWith(
+      `https://sh.zu.ke.com/zufang/pudong/${seg}/`, expect.anything(),
+    );
+  });
+
+  it('backward-compat: rent range only', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'sh', 'max-price': 8000, limit: 10 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://sh.zu.ke.com/zufang/rpt8000/', expect.anything(),
+    );
+  });
+
+  it('no district, no filters', async () => {
+    const page = mockPage();
+    await cmd().func(page, { city: 'bj', limit: 20 });
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://bj.zu.ke.com/zufang/', expect.anything(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run --project adapter clis/ke/zufang.test.js`
+Expected: FAIL — new args missing; combined URL differs from old inline logic.
+
+- [ ] **Step 3: Update `clis/ke/zufang.js`**
+
+Add the import after the existing imports:
+
+```js
+import { buildZufangFilterPath } from './zufang-filters.js';
+```
+
+Replace the `args: [ ... ]` array with:
+
+```js
+    args: [
+        { name: 'city', default: 'bj', help: '城市代码，如 bj(北京), sh(上海), gz(广州), sz(深圳), zs(中山), hz(杭州)' },
+        { name: 'district', help: '区域拼音，如 chaoyang, haidian, pudong' },
+        { name: 'min-price', type: 'int', help: '最低月租（元）' },
+        { name: 'max-price', type: 'int', help: '最高月租（元）' },
+        { name: 'rooms', type: 'int', help: '户型居室数 (1-4)，4 表示四居及以上' },
+        { name: 'rent-type', choices: ['whole', 'shared'], help: '方式：whole(整租)/shared(合租)' },
+        { name: 'orientation', choices: ['south-north', 'south', 'east', 'north', 'west'], help: '朝向：south-north(南北)/south(南)/east(东)/north(北)/west(西)' },
+        { name: 'features', help: '特色，逗号分隔多选：near-subway,bag-in,fine,deposit-one,new,certified,anytime-view,vr,owner-rec' },
+        { name: 'lease-term', choices: ['monthly', 'yearly', 'min-1month', '1-3months', '4-6months'], help: '租期：monthly(月租)/yearly(年租)/min-1month(一个月起租)/1-3months/4-6months' },
+        { name: 'floor', choices: ['low', 'mid', 'high'], help: '楼层：low(低)/mid(中)/high(高)' },
+        { name: 'elevator', choices: ['yes', 'no'], help: '电梯：yes(有)/no(无)' },
+        { name: 'sort', choices: ['newest', 'rent-asc', 'rent-desc', 'area-asc', 'area-desc'], help: '排序：newest(最新上架)/rent-asc|desc(租金)/area-asc|desc(面积)' },
+        { name: 'limit', type: 'int', default: 20, help: '返回数量' },
+    ],
+```
+
+Replace the URL-assembly block (the `let path` / `priceParts` / `filters` / `baseUrl` /
+`url` lines, currently `clis/ke/zufang.js:24-38`) with:
+
+```js
+        let path = '/zufang/';
+        if (kwargs.district) {
+            path = `/zufang/${kwargs.district}/`;
+        }
+
+        const filters = buildZufangFilterPath(kwargs);
+        const baseUrl = `https://${city}.zu.ke.com`;
+        const url = baseUrl + path + (filters ? filters + '/' : '');
+```
+
+Leave everything else (`gotoKe`, the `page.evaluate` scrape, `.slice(0, limit)`) unchanged.
+
+> **Step 3 alt (only if Task 1 found sort is a QUERY param, not a path segment):** drop
+> `sort` from `SEGMENT_PRODUCERS` in `zufang-filters.js`, export a `sortQuery(kwargs)`
+> that returns `?sort=<code>` (or ''), and in `zufang.js` append it:
+> `const url = baseUrl + path + (filters ? filters + '/' : '') + sortQuery(kwargs);`
+> Update the `sort` parametric/golden tests to assert the query form instead.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run --project adapter clis/ke/zufang.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clis/ke/zufang.js clis/ke/zufang.test.js
+git commit -m "feat(ke): expose zufang filters and sort"
+```
+
+---
+
+## Task 4: Validate, rebuild manifest, live smoke, finalize
+
+**Files:** Modify `cli-manifest.json` (regenerated).
+
+- [ ] **Step 1: Registry validation**
+
+Run: `npx tsx src/main.ts validate ke/zufang`
+Expected: PASS (0 errors). Fix any reported issue.
+
+- [ ] **Step 2: Rebuild the manifest (arg defs changed)**
+
+Run: `npx tsx src/build-manifest.ts`
+Expected: `✅ Manifest compiled`. Then confirm only zufang changed:
+`git diff --stat cli-manifest.json` should show only additions, and
+`git diff cli-manifest.json | grep -E '"site"' | grep -v '"ke"'` should be empty.
+
+- [ ] **Step 3: Full adapter test suite (no regressions)**
+
+Run: `npm run test:adapter`
+Expected: PASS, including `clis/ke/zufang-filters.test.js` and `clis/ke/zufang.test.js`.
+
+- [ ] **Step 4: Inspect help output**
+
+Run: `npx tsx src/main.ts ke zufang --help`
+Expected: all new flags appear with their bilingual help + `choices`.
+
+- [ ] **Step 5: Live smoke (needs logged-in Chrome + extension)**
+
+```bash
+npx tsx src/main.ts ke zufang --city sh --district pudong --rent-type whole --rooms 2 --max-price 8000 --sort newest --limit 5 -v -f json
+```
+
+Expected: a JSON array of ≤5 rentals; the `-v` URL matches what the helper builds. Open
+that URL in a browser to confirm the filters/sort actually applied (整租 + 两居 + ≤8000元).
+If a filter did NOT apply, a code or the order is wrong → fix the constant + its test,
+re-run `npm run test:adapter`.
+
+- [ ] **Step 6: Commit the manifest (+ any smoke fixes)**
+
+```bash
+git add cli-manifest.json clis/ke/zufang-filters.js clis/ke/zufang-filters.test.js
+git commit -m "chore(ke): rebuild manifest for zufang filters and sort"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** rent-type/rooms/orientation/features/lease-term/floor/elevator
+  (Task 2/3), `--sort` Pattern-A enum incl. query-param fallback (Task 1 Step 3 + Task 3
+  Step 3 alt), `zufang-filters.js` pure separate module (Task 2), canonical-order assembly
+  with rent segment as a producer (Task 2 `SEGMENT_PRODUCERS` + `rentCode`), live code
+  verification + ≥2 golden URLs (Task 1), tests in `adapter` project (Task 2–4),
+  backward-compat (Task 3 tests), brand/location/bands excluded (not in any task). All spec
+  sections map to a task.
+- **Rent kept as-is:** `rentCode` reproduces the original `rp{min}t{max}` byte-for-byte
+  (including one-sided/`0` behavior); the ershoufang one-sided fix is deliberately NOT
+  ported, per the spec decision.
+- **Guessed vs confirmed:** every zufang code is a starting guess reconciled in Task 2
+  Step 4 against Task 1; parametric tests read the tables so they stay correct regardless,
+  and the two golden URLs pin real behavior.
+- **Backward-compat URL note:** Task 3's `rpt8000` expectation assumes the original
+  `rp{min}t{max}` with empty min — identical to the pre-change output for `--max-price`
+  only; verify this exact string against the original code during Task 3.

--- a/docs/superpowers/specs/2026-06-15-ke-ershoufang-filters-sort-design.md
+++ b/docs/superpowers/specs/2026-06-15-ke-ershoufang-filters-sort-design.md
@@ -1,0 +1,137 @@
+# Design: Expand `ke ershoufang` filters & sort
+
+Date: 2026-06-15
+Branch: `feat/expand-ke-params`
+Status: Approved (pending spec review)
+
+## Goal
+
+Extend `opencli ke ershoufang` (贝壳找房二手房列表) to support more of the site's
+listing filters and the result sort order, exposed as optional CLI params. Today the
+command only supports `--rooms` and a price range (`--min-price`/`--max-price`). Beike
+encodes every filter and the sort as **fixed-prefix code segments concatenated into the
+URL path**, in a canonical order — e.g.:
+
+- `https://hz.ke.com/ershoufang/xihuqu4/l3/` — 三室
+- `https://hz.ke.com/ershoufang/xihuqu4/de3l3/` — 三室 + 毛坯
+- `https://hz.ke.com/ershoufang/xihuqu4/de3l3p1/` — 三室 + 毛坯 + 100万以下
+- `https://hz.ke.com/ershoufang/xihuqu4/co32l3p1/` — 三室 + 100万以下 + 最新发布排序
+
+This is the surface we are extending.
+
+## Scope
+
+### New filter params (all optional, English short-keyword values, `choices`-constrained)
+
+| Param | Values | Beike category | Code prefix |
+|-------|--------|----------------|-------------|
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 | `f?` ⚠️ verify |
+| `--floor` | `low` `mid` `high` | 楼层（低/中/高楼层） | `lc?` ⚠️ verify |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄（N 年以内/以上） | `y?` ⚠️ verify |
+| `--decoration` | `fine` `simple` `rough` | 装修（精装/普通/毛坯） | `de1/de2/de3` (de3=毛坯 confirmed) |
+| `--elevator` | `yes` `no` | 电梯 | `ie?` ⚠️ verify |
+| `--features` | comma-separated multi: `must-see` `five-years` `two-years` `near-subway` `vr` `new-7d` `anytime-view` | 房源特色（多选） | per-feature code ⚠️ verify |
+| `--usage` | `residential` `commercial` `villa` `courtyard` `parking` `other` | 用途（普通住宅/商业类/别墅/四合院/车位/其他） | enum code ⚠️ verify |
+
+### New area range param
+
+| Param | Type | Beike category | Code |
+|-------|------|----------------|------|
+| `--min-area` / `--max-area` | int (㎡) | 建筑面积 自定义区间 | custom-range code ⚠️ verify (likely `ba{min}ea{max}`) |
+
+`--min-area`/`--max-area` mirror the shape of `--min-price`/`--max-price` (a numeric
+min/max pair) but encode via Beike's own custom-area prefix (kept separate from the
+price prefix to avoid collision).
+
+### New sort param
+
+Follows the project's established convention (`--sort` single combined enum,
+Pattern A — used by ~20/29 adapters such as `eastmoney`, `coingecko`; no adapter uses a
+split field+direction form).
+
+- `--sort` : `newest` · `total-price-asc` · `total-price-desc` · `unit-price-asc` ·
+  `unit-price-desc` · `area-asc` · `area-desc`. Omitted ⇒ Beike default sort.
+  → `co??` codes ⚠️ verify (`co32`=最新发布 confirmed from example).
+
+### Unchanged (backward-compatible)
+
+`--city`, `--district`, `--rooms` (int → `l{n}`), `--min-price`/`--max-price`
+(existing `p{min}t{max}` encoding kept as-is per decision), `--limit`. All new params
+are optional; existing invocations behave identically.
+
+### Out of scope (YAGNI)
+
+区域/地铁线 location codes; 权属/类型/供暖/面积枚举段; multi-select for non-`features`
+categories; reworking the existing price `p{min}t{max}` encoding; the other `ke` commands
+(`xiaoqu`, `zufang`, `chengjiao`).
+
+## Architecture
+
+### New module: `clis/ke/filters.js` (pure, browser-free, unit-testable)
+
+Exports:
+
+1. **Mapping tables** — one per enum category (`ORIENTATION`, `FLOOR`, `AGE`,
+   `DECORATION`, `ELEVATOR`, `FEATURES`, `USAGE`, `SORT`), each mapping the
+   English keyword → Beike code.
+2. **`buildErshoufangFilterPath(kwargs)`** → returns the ordered code segment string
+   (without leading/trailing slash), or `''` when no filters/sort are active.
+
+`buildErshoufangFilterPath` is responsible for the **canonical ordering**: it walks a
+fixed ordered list of `(prefix, value)` producers and concatenates active codes in
+Beike's required order (NOT user input order). From the anchors we know the order
+includes `co`(sort) → … → `de`(decoration) → `l`(rooms) → `p`(price); the full ordering
+of all prefixes is finalized during the browser-verification step below.
+
+### `clis/ke/ershoufang.js` changes
+
+- Add the new arg definitions. Single-value enums (`--orientation`, `--floor`, `--age`,
+  `--decoration`, `--elevator`, `--usage`, `--sort`) use `choices` so
+  `coerceAndValidateArgs` rejects bad values early (see `src/execution.ts`
+  `coerceAndValidateArgs`). `--features` is comma-separated multi, so `choices` (which
+  validates the whole string) does NOT apply — each item is validated inside
+  `buildErshoufangFilterPath`, which throws `ArgumentError` on an unknown feature keyword.
+- Replace the inline price/room URL assembly with a call to
+  `buildErshoufangFilterPath(kwargs)`; build `url = base + /ershoufang/{district}/ +
+  (codeSegment ? codeSegment + '/' : '')`.
+- DOM scraping (`page.evaluate` block) and result shaping are **unchanged**.
+
+## Filter-code verification (the "explore enums" step)
+
+Before finalizing the mapping tables, verify every ⚠️ code and the canonical
+concatenation order against the live site using `opencli browser` against
+`hz.ke.com/ershoufang/xihuqu4`: toggle each filter / sort option in the UI and read the
+resulting URL path. Record the confirmed `prefix → meaning` for each value into the
+mapping tables. Known anchors to start from: `de3`=毛坯, `l3`=三室, `p1`=100万以下,
+`co32`=最新发布. Verification also confirms whether codes differ between cities for the
+in-scope categories (price bands are known to differ and are out of scope; the in-scope
+enums are expected to be city-stable — confirm at least hz + one other city, e.g. bj).
+
+## Testing
+
+Colocated `clis/ke/filters.test.js` and additions to ershoufang coverage, run via the
+vitest `adapter` project (`npm run test:adapter`). Mirrors the existing adapter test
+style (register command, mock `page.{goto,wait,evaluate}`, assert the URL passed to
+`page.goto`).
+
+1. **`buildErshoufangFilterPath` unit tests** (pure, no browser):
+   - each filter alone → expected single code
+   - `--features` multi-value → concatenated feature codes
+   - `--min-area`/`--max-area` → expected custom-area code
+   - `--sort` each value → expected `co` code
+   - a full combination → codes emitted in canonical order regardless of kwargs key order
+   - empty kwargs → `''`
+   - invalid enum value is rejected upstream by `choices` (assert via arg def / command)
+2. **`ershoufang.func` URL test**: given kwargs, assert `page.goto` is called with the
+   fully assembled URL (e.g. `https://hz.ke.com/ershoufang/xihuqu4/co32de3l3p1/`).
+3. **Backward-compat test**: existing `--rooms` / price-only invocations produce the
+   same URLs as before.
+
+## Risks
+
+- **Code drift / wrong codes**: mitigated by the live-site verification step before
+  shipping, and by unit tests pinning the expected URLs.
+- **Canonical order**: if codes are emitted in the wrong order Beike may ignore filters;
+  the fixed ordered producer list + the combination URL test guard this.
+- **City-specific codes**: in-scope enums verified on ≥2 cities; price bands explicitly
+  excluded.

--- a/docs/superpowers/specs/2026-06-16-ke-chengjiao-filters-sort-design.md
+++ b/docs/superpowers/specs/2026-06-16-ke-chengjiao-filters-sort-design.md
@@ -1,0 +1,114 @@
+# Design: Expand `ke chengjiao` filters & sort
+
+Date: 2026-06-16
+Branch: `worktree-expand-ke-params`
+Status: Approved (pending spec review)
+
+## Goal
+
+Extend `opencli ke chengjiao` (贝壳找房成交记录 — sold/deal records) to support the site's
+filters and sort, exposed as optional CLI params. Today the command supports only
+`--city`, `--district`, `--limit`. chengjiao lives on `https://{city}.ke.com/chengjiao/...`
+(same subdomain as ershoufang) and its filter codes are the SAME Beike residential scheme
+(`l3`=三室, `sf1`=普通住宅, `de3`=毛坯 confirmed identical to ershoufang). Per the
+architecture decision, the codes are nonetheless implemented in a **separate, independently
+verified module** — consistent with the zufang/xiaoqu per-command pattern; ershoufang's
+`filters.js` is NOT imported or modified.
+
+## Scope
+
+### New params (all optional, English short-keyword values, `choices`-constrained)
+
+| Param | Values | Beike category | Code |
+|-------|--------|----------------|------|
+| `--rooms` | int `1`–`5` | 房型（一~五室） | `l{n}` ⚠️ (l3=三室 confirmed) |
+| `--min-area` / `--max-area` | int (㎡) | 建筑面积 custom range | `ba{min}ea{max}`, default min→0 for max-only ⚠️ |
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 | ⚠️ verify |
+| `--floor` | `low` `mid` `high` | 楼层 | ⚠️ verify (verify properly on chengjiao) |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄 | ⚠️ verify (likely `y1`–`y5`) |
+| `--decoration` | `fine` `simple` `rough` | 装修 | ⚠️ verify (de3=毛坯 confirmed) |
+| `--usage` | `residential` `commercial` `villa` `courtyard` `parking` `other` | 用途 | ⚠️ verify (sf1=普通住宅 confirmed) |
+| `--elevator` | `yes` `no` | 电梯 | ⚠️ verify |
+| `--sort` | `total-price-asc` `total-price-desc` `unit-price-asc` `unit-price-desc` `area-asc` `area-desc` | 排序（总价/房屋单价/面积）; omitted ⇒ 默认排序 | `co??` ⚠️ verify |
+
+### Differences from ershoufang (intentional)
+
+- **No `--features`** — chengjiao has no 房源特色 category.
+- **No price filter** — deal price is not filterable on chengjiao (only sortable); the
+  numeric range filter is **area**, not price.
+- **Sort has no `newest`** — chengjiao's sort tabs are only 总价/房屋单价/面积 (no 最新发布).
+
+### Unchanged (backward-compatible)
+
+`--city`, `--district`, `--limit`. All new params optional; existing invocations behave
+identically.
+
+### Out of scope (YAGNI)
+
+房源特色, price filter, 区域/地铁线 location codes, 面积 enum bands, 供暖 (Beijing-only,
+not cross-city consistent), other `ke` commands.
+
+## Architecture
+
+### New module: `clis/ke/chengjiao-filters.js` (pure, browser-free, unit-testable)
+
+A separate module with its own tables, independently verified on the chengjiao endpoint —
+consistent with the zufang/xiaoqu per-command pattern; no shared abstraction with
+ershoufang (decoupled by decision, despite identical codes).
+
+Exports:
+
+1. **Mapping tables** — `ORIENTATION`, `FLOOR`, `AGE`, `DECORATION`, `ELEVATOR`, `USAGE`,
+   `SORT` (keyword → code), plus a `roomsCode` and an `areaCode` helper.
+2. **`buildChengjiaoFilterPath(kwargs)`** → returns the ordered code segment string (no
+   leading/trailing slash), `''` when nothing active. Owns canonical ordering via a fixed
+   `SEGMENT_PRODUCERS` list. Reuses the established helper shapes (`present()`, `lookup()`)
+   defined locally.
+
+`areaCode` applies the verified one-sided rule (min-only emits `ba{min}ea`; max-only
+defaults the lower bound to 0 → `ba0ea{max}`), mirroring ershoufang's area handling.
+
+### `clis/ke/chengjiao.js` changes
+
+- Add the new arg definitions. Single-value enums (`--orientation`, `--floor`, `--age`,
+  `--decoration`, `--usage`, `--elevator`, `--sort`) use `choices`; `--rooms`,
+  `--min-area`, `--max-area` are `int`.
+- Replace the inline path assembly with: `const filters = buildChengjiaoFilterPath(kwargs);`
+  then `gotoKe(page, base + path + (filters ? filters + '/' : ''))`.
+- DOM scraping (`page.evaluate` block) and result shaping are **unchanged**.
+
+## Filter-code verification (the "explore enums" step)
+
+The chengjiao filter panel is JS-driven (not `<a href>`), so verify by constructing
+candidate URLs and reading `document.title` (the title reflects active filters, e.g.
+`上海徐汇、三室二手房网签`), the way ershoufang's area was verified. Confirm every ⚠️ code,
+the area one-sided behavior, the sort asc/desc codes (read the first record's price/area to
+infer direction), and the canonical order. Pace requests to avoid the captcha/rate-limit
+(seen after ~5 rapid hits). Capture ≥1 real multi-filter URL as a golden test, and
+spot-check one other city (e.g. bj) for the enums.
+
+## Testing
+
+Colocated `clis/ke/chengjiao-filters.test.js` and additions to the chengjiao command
+coverage, run via the vitest `adapter` project (`npm run test:adapter`). Mirrors the
+existing adapter test style (register command, mock `page.{goto,wait,evaluate}`, assert the
+URL passed to `page.goto`).
+
+1. **`buildChengjiaoFilterPath` unit tests** (pure): each filter alone → expected code;
+   `--rooms` → expected `l{n}`; avg/area range two-sided + verified one-sided shapes;
+   `--sort` each value → expected code; canonical order regardless of kwargs key order;
+   empty kwargs → `''`.
+2. **Live golden test**: pin ≥1 real captured multi-filter URL.
+3. **`chengjiao.func` URL test**: assert `page.goto` is called with the assembled URL.
+4. **Backward-compat test**: existing no-filter / district-only invocations produce the
+   same URLs as before.
+
+## Risks
+
+- **Wrong codes / order**: mitigated by live verification + unit tests pinning expected
+  URLs + ≥1 ground-truth golden URL.
+- **Shared-code drift**: codes match ershoufang today (l3/sf1/de3 confirmed), but the
+  separate module means chengjiao is verified and maintained independently — no coupling
+  risk.
+- **area one-sided**: explicitly verified live and handled (max-only needs an explicit min).
+- **captcha during verification**: pace requests; close the browser session between batches.

--- a/docs/superpowers/specs/2026-06-16-ke-xiaoqu-filters-sort-design.md
+++ b/docs/superpowers/specs/2026-06-16-ke-xiaoqu-filters-sort-design.md
@@ -1,0 +1,101 @@
+# Design: Expand `ke xiaoqu` filters & sort
+
+Date: 2026-06-16
+Branch: `worktree-expand-ke-params`
+Status: Approved (pending spec review)
+
+## Goal
+
+Extend `opencli ke xiaoqu` (贝壳找房小区列表) to support the site's community filters and
+sort, exposed as optional CLI params. Today the command supports only `--city`,
+`--district`, `--limit`. xiaoqu's filter UI is small — just three categories (均价 custom
+range, 楼龄, 近地铁) plus a two-state sort (默认排序 / 小区均价). It lives on
+`https://{city}.ke.com/xiaoqu/...` (same subdomain as ershoufang), but its filter codes
+are verified independently and NOT shared with ershoufang's module.
+
+## Scope
+
+### New params (all optional)
+
+| Param | Values | Beike category | Code |
+|-------|--------|----------------|------|
+| `--min-price` / `--max-price` | int (万) | 均价 custom range | custom-range code ⚠️ verify |
+| `--age` | `5` `10` `15` `20` `20+` | 楼龄（N 年以内/以上） | ⚠️ verify (likely `y1`–`y5`) |
+| `--near-subway` | boolean flag | 近地铁 | ⚠️ verify |
+| `--sort` | `avg-price-asc` `avg-price-desc` | 小区均价 (toggles asc/desc); omitted ⇒ 默认排序 | `co??` ⚠️ verify |
+
+`--near-subway` is a standalone boolean (xiaoqu has only this one feature; no
+`--features` multi-select). `--age` reuses the ershoufang keyword set but its codes are
+re-verified on the xiaoqu endpoint.
+
+### Unchanged (backward-compatible)
+
+`--city`, `--district`, `--limit`. All new params optional; existing invocations behave
+identically.
+
+### Out of scope (YAGNI)
+
+区域/地铁线 location codes, 均价 enum bands (only the custom range is supported), other
+`ke` commands.
+
+## Architecture
+
+### New module: `clis/ke/xiaoqu-filters.js` (pure, browser-free, unit-testable)
+
+Mirrors the ershoufang/zufang helper shape but is a separate module with its own tables —
+xiaoqu codes are verified independently and the modules stay decoupled (YAGNI; no shared
+abstraction).
+
+Exports:
+
+1. **Mapping tables** — `AGE`, `SORT` (keyword → code).
+2. **`buildXiaoquFilterPath(kwargs)`** → returns the ordered code segment string (no
+   leading/trailing slash), `''` when nothing active. Owns canonical ordering via a fixed
+   `SEGMENT_PRODUCERS` list. Producers: sort, age, near-subway (emits its code when the
+   boolean is true), avg-price custom range.
+
+Reuses the established helper shapes (`present()`, `lookup()`) defined locally.
+
+### `clis/ke/xiaoqu.js` changes
+
+- Add the new arg definitions. `--age` and `--sort` use `choices`; `--near-subway` is
+  `type: boolean`; `--min-price`/`--max-price` are `int`.
+- Replace the inline path assembly with: `const filters = buildXiaoquFilterPath(kwargs);`
+  then `url = base + path + (filters ? filters + '/' : '')` (base = `cityUrl(city)`,
+  path = `/xiaoqu/` or `/xiaoqu/{district}/`).
+- DOM scraping (`page.evaluate` block) and result shaping are **unchanged**.
+
+## Filter-code verification (the "explore enums" step)
+
+Before finalizing the tables, verify every ⚠️ code, the avg-price custom-range prefix, the
+near-subway code, and the canonical order against the live site using `opencli browser
+eval` to read the filter-panel `<a href>` codes directly (as done for zufang) against
+`https://sh.ke.com/xiaoqu/xuhui/`. Determine the avg-price one-sided behavior (min-only /
+max-only) the way ershoufang's area was verified, and handle it correctly. Capture ≥1
+real multi-filter URL as a golden regression test, and confirm the sort asc/desc codes by
+reading the first result's avg price. Spot-check one other city (e.g. bj) for the enums.
+
+## Testing
+
+Colocated `clis/ke/xiaoqu-filters.test.js` and additions to the xiaoqu command coverage,
+run via the vitest `adapter` project (`npm run test:adapter`). Mirrors the existing adapter
+test style (register command, mock `page.{goto,wait,evaluate}`, assert the URL passed to
+`page.goto`).
+
+1. **`buildXiaoquFilterPath` unit tests** (pure): each filter alone → expected code;
+   `--near-subway true` → its code, absent/false → no code; avg-price range (two-sided and
+   the verified one-sided shapes); `--sort` each value → expected code; canonical order;
+   empty kwargs → `''`.
+2. **Live golden test**: pin ≥1 real captured multi-filter URL.
+3. **`xiaoqu.func` URL test**: assert `page.goto` is called with the assembled URL.
+4. **Backward-compat test**: existing no-filter / district-only invocations produce the
+   same URLs as before.
+
+## Risks
+
+- **Wrong codes / order**: mitigated by live verification + unit tests pinning expected
+  URLs + ≥1 ground-truth golden URL.
+- **avg-price one-sided encoding**: explicitly verified live (apply the ershoufang lesson —
+  an upper-bound-only query may need an explicit min).
+- **City-specific codes**: enums verified on ≥2 cities; avg-price bands differ per city but
+  are out of scope (custom range only).

--- a/docs/superpowers/specs/2026-06-16-ke-zufang-filters-sort-design.md
+++ b/docs/superpowers/specs/2026-06-16-ke-zufang-filters-sort-design.md
@@ -1,0 +1,121 @@
+# Design: Expand `ke zufang` filters & sort
+
+Date: 2026-06-16
+Branch: `worktree-expand-ke-params`
+Status: Approved (pending spec review)
+
+## Goal
+
+Extend `opencli ke zufang` (贝壳找房租房列表) to support the site's rental filters and
+result sort, exposed as optional CLI params. Today the command only supports a rent range
+(`--min-price`/`--max-price`). This mirrors the just-completed `ke ershoufang` work, but
+zufang is a **separate endpoint** — it lives on `https://{city}.zu.ke.com/zufang/...` and
+uses its own filter code scheme (rent price is already encoded `rp{min}t{max}`, not `p`).
+So the codes and canonical order must be verified independently against the live rental
+site; they are NOT shared with ershoufang.
+
+## Scope
+
+### New filter params (all optional, English short-keyword values, `choices`-constrained)
+
+| Param | Values | Beike category | Code |
+|-------|--------|----------------|------|
+| `--rent-type` | `whole` `shared` | 方式（整租/合租） | ⚠️ verify |
+| `--rooms` | int `1`–`4` (4 = 四居+) | 户型（一居/两居/三居/四居+） | ⚠️ verify |
+| `--orientation` | `south-north` `south` `east` `north` `west` | 朝向 | ⚠️ verify |
+| `--features` | comma-multi: `near-subway` `bag-in` `fine` `deposit-one` `new` `certified` `anytime-view` `vr` `owner-rec` | 特色 | ⚠️ verify |
+| `--lease-term` | `monthly` `yearly` `min-1month` `1-3months` `4-6months` | 租期 | ⚠️ verify |
+| `--floor` | `low` `mid` `high` | 楼层 | ⚠️ verify |
+| `--elevator` | `yes` `no` | 电梯 | ⚠️ verify |
+
+`--features` keyword→label: near-subway(近地铁), bag-in(拎包入住), fine(精装修),
+deposit-one(押一付一), new(新上), certified(认证公寓), anytime-view(随时看房), vr(VR房源),
+owner-rec(业主自荐).
+
+### New sort param
+
+Follows the project's Pattern A convention (single combined `--sort` enum), same as
+ershoufang.
+
+- `--sort` : `newest`(最新上架) · `rent-asc` · `rent-desc` · `area-asc` · `area-desc`.
+  Omitted ⇒ Beike default (综合排序). → `co??` codes ⚠️ verify.
+
+### Unchanged (backward-compatible)
+
+`--city`, `--district`, `--min-price`/`--max-price` (existing `rp{min}t{max}` rent
+encoding kept exactly as-is, per decision — including its one-sided/`0` behavior, NOT
+changed), `--limit`. All new params optional; existing invocations behave identically.
+
+### Out of scope (YAGNI)
+
+品牌(brand — city-specific and unstable), 区域/地铁线 location codes, 租金 enum bands,
+the other `ke` commands. The one-sided/`0` rent-range fix that was applied to ershoufang's
+`areaCode` is explicitly NOT applied here — rent encoding stays as-is.
+
+## Architecture
+
+### New module: `clis/ke/zufang-filters.js` (pure, browser-free, unit-testable)
+
+Mirrors `clis/ke/filters.js` (ershoufang) in shape but is a separate module with its own
+tables — zufang codes differ and the two should not be coupled (YAGNI; no shared abstraction).
+
+Exports:
+
+1. **Mapping tables** — `RENT_TYPE`, `ROOMS` (or a `roomsCode` helper), `ORIENTATION`,
+   `FEATURES`, `LEASE_TERM`, `FLOOR`, `ELEVATOR`, `SORT` — keyword → Beike code.
+2. **`buildZufangFilterPath(kwargs)`** → returns the ordered code segment string (no
+   leading/trailing slash), `''` when nothing active. Owns the canonical ordering via a
+   fixed `SEGMENT_PRODUCERS` list, like ershoufang.
+
+Reuses the same small internal helpers' *shape* (`present()`, `lookup()`, per-item
+`featuresCode` that throws `ArgumentError` on an unknown keyword) but defined locally —
+not imported from `filters.js`.
+
+### `clis/ke/zufang.js` changes
+
+- Add the new arg definitions. Single-value enums (`--rent-type`, `--orientation`,
+  `--lease-term`, `--floor`, `--elevator`, `--sort`) use `choices`. `--rooms` is `int`.
+  `--features` is comma-multi, validated per-item inside `buildZufangFilterPath` (`choices`
+  can't validate a comma list).
+- Move the rent-price encoding into `buildZufangFilterPath` as one producer in the
+  canonical `SEGMENT_PRODUCERS` list, keeping its exact `rp{min}t{max}` byte output
+  unchanged (including the one-sided/`0` behavior). `zufang.js` then assembles
+  `url = baseUrl + path + (seg ? seg + '/' : '')` where `seg = buildZufangFilterPath(kwargs)`.
+  The rent segment's position relative to the new codes is verified live.
+- DOM scraping (`page.evaluate` block) and result shaping are **unchanged**.
+
+## Filter-code verification (the "explore enums" step)
+
+Before finalizing the tables, verify every ⚠️ code and the canonical concatenation order
+against the live rental site using `opencli browser` against
+`https://sh.zu.ke.com/zufang/pudong/` (and spot-check one other city, e.g. bj, for the
+in-scope enums): toggle each filter / sort option and read the resulting URL path.
+Capture at least two real multi-filter URLs to pin as golden regression tests, and to
+establish where the rent `rp...` segment sits in the canonical order relative to the new
+codes.
+
+## Testing
+
+Colocated `clis/ke/zufang-filters.test.js` and additions to the zufang command coverage,
+run via the vitest `adapter` project (`npm run test:adapter`). Mirrors the existing adapter
+test style (register command, mock `page.{goto,wait,evaluate}`, assert the URL passed to
+`page.goto`).
+
+1. **`buildZufangFilterPath` unit tests** (pure, no browser): each filter alone →
+   expected code; `--features` multi-value → concatenated codes in table order;
+   `--rooms` → expected code; `--sort` each value → expected `co` code; a full combination
+   → canonical order regardless of kwargs key order; empty kwargs → `''`; unknown
+   `--features` keyword → throws.
+2. **Live golden tests**: pin ≥2 real captured multi-filter URLs.
+3. **`zufang.func` URL test**: assert `page.goto` is called with the fully assembled URL
+   (including the unchanged `rp{min}t{max}` rent segment in its verified position).
+4. **Backward-compat test**: existing rent-range-only and no-filter invocations produce
+   the same URLs as before.
+
+## Risks
+
+- **Wrong codes / order**: mitigated by live verification before shipping + unit tests
+  pinning expected URLs + ≥2 ground-truth golden URLs.
+- **rent segment position**: its placement among the new codes is verified live, not
+  assumed.
+- **City-specific codes**: in-scope enums verified on ≥2 cities; brand explicitly excluded.


### PR DESCRIPTION
## Description

  Expand the four `ke` (贝壳找房 / Beike) browser adapters — `ershoufang`, `zufang`, `xiaoqu`, and `chengjiao` —
  with the site's listing filters and result sort, exposed as **optional, backward-compatible** CLI flags.
  Previously each command accepted only `--city` / `--district` / `--limit`.

  Each command now supports its relevant subset of: rooms, price/area/avg-price ranges, orientation, floor, age,
  decoration, elevator, usage, features (comma-multi), rent-type, lease-term, near-subway, and a combined
  `--sort` enum. Filters are encoded as Beike URL path-code segments by a small pure helper module per command
  (`clis/ke/<cmd>-filters.js`); the existing DOM scraping is untouched. **All filter/sort codes were verified
  live against the Beike site.**

  Related issue: <!-- N/A -->

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 🌐 New site adapter
  - [x] 📝 Documentation
  - [ ] ♻️ Refactor
  - [ ] 🔧 CI / build / tooling

  ## Checklist

  - [x] I ran the checks relevant to this PR — full adapter suite **4246 passing**; `opencli validate ke/<cmd>`
  passes for all four; manifest rebuilt
  - [x] I updated tests or docs if needed — added `clis/ke/*-filters.test.js` + `clis/ke/*.test.js` (pure unit +
  live-captured golden URLs + backward-compat); updated `docs/adapters/browser/ke.md`
  - [x] I included output or screenshots when useful — see below

  ### Documentation (if adding/modifying an adapter)

  - [ ] Added doc page under `docs/adapters/` (if new adapter) — N/A (existing adapter)
  - [ ] Updated `docs/adapters/index.md` table (if new adapter) — N/A
  - [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter) — N/A
  - [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed — N/A (no new commands;
  only flags)
  - [x] Used positional args for the command's primary subject unless a named flag is clearly better — kept the
  existing named-flag convention (`--city`/`--district`); new filters are naturally named flags
  - [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error` — helpers throw
  `ArgumentError` for invalid `--rooms` / `--features`; `gotoKe` raises `AuthRequiredError` on captcha/login

  ## Screenshots / Output

  $ opencli ke zufang --city sh --district pudong --rent-type whole --rooms 2 --max-price 8000 --sort newest
  --limit 5 -f json
  [
    { "title": "整租·荡湾新村 2室1厅 南",        "layout": "2室1厅1卫", "price": "1890元/月", ... },
    { "title": "整租·东方颐城 2室2厅 南",        "layout": "2室2厅1卫", "price": "2415元/月", ... },
    { "title": "整租·复地黄龙和山 …",            "layout": "2室1厅1卫", "price": "6930元/月", ... },
    ...
  ]
  all results: 整租 (rent-type) · 2室 (rooms) · ≤8000元 (max-price) — every filter applied

  $ npm run test:adapter   # 442 files, 4246 tests, 0 failures


  Implementation notes (handy for the PR description if reviewers ask):
  - Beike parses path codes by prefix → order-independent (verified live); helpers still emit a deterministic
  order.
  - zufang 户型 is zero-based in Beike URLs (一居=l0); --rooms stays 1-based.
  - Upper-bound-only numeric ranges are normalized with an explicit 0 lower bound (Beike ignores a bare upper
  bound); a literal 0 is preserved.
  - chengjiao shares ershoufang's residential code scheme but is an independent, separately-verified module
  (anchors l3/sf1/de3/lc1 confirmed on its own endpoint).