### PR TITLE
fix(gemini/history): expand collapsed Recents sidebar before extraction

### DIFF
--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -1006,11 +1006,21 @@ function expandGeminiRecentScript() {
       // 2. Expand the "最近" / "Recents" toggle if it is currently collapsed.
       const recentToggle = buttons.find((b) => {
         const label = normalize(b.getAttribute('aria-label') || '');
-        return /最近|recent/i.test(label) && /展开|收起|expand|collapse|toggle|show|hide/i.test(label);
+        const expanded = (b.getAttribute('aria-expanded') || '').toLowerCase();
+        return /最近|recent/i.test(label) && (
+          /展开|收起|expand|collapse|toggle|show|hide/i.test(label)
+          || expanded === 'false'
+          || expanded === 'true'
+        );
       });
       if (recentToggle) {
+        const label = normalize(recentToggle.getAttribute('aria-label') || '');
         const expanded = (recentToggle.getAttribute('aria-expanded') || '').toLowerCase();
-        if (expanded !== 'true') { recentToggle.click(); changed = true; }
+        const explicitExpandLabel = /展开|显示|expand|show/i.test(label) && !/收起|collapse|hide/i.test(label);
+        if (expanded === 'false' || (expanded !== 'true' && explicitExpandLabel)) {
+          recentToggle.click();
+          changed = true;
+        }
       }
 
       return changed;
@@ -1842,6 +1852,7 @@ export const __test__ = {
     hasGeminiTurnPrefix,
     readGeminiSnapshot,
     readGeminiSnapshotScript,
+    expandGeminiRecentScript,
     submitComposerScript,
     insertComposerTextFallbackScript,
 };

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -972,6 +972,51 @@ function getGeminiConversationListScript() {
     })()
   `;
 }
+
+// Gemini collapses the sidebar's "最近" / "Recents" section by default, so the
+// /app/<id> conversation anchors are not present in the DOM (or are hidden)
+// until that section is expanded. The script below opens the sidebar if it is
+// collapsed and expands the Recents toggle, returning true if it likely
+// changed the DOM and the caller should retry extraction.
+function expandGeminiRecentScript() {
+    return `
+    (() => {
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = (el.getAttribute('aria-hidden') || '').toLowerCase();
+        if (ariaHidden === 'true' || el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0) return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+      let changed = false;
+      const buttons = Array.from(document.querySelectorAll('button')).filter(isVisible);
+
+      // 1. Open the sidebar if it is collapsed (button only renders when closed).
+      const openSidebar = buttons.find((b) => {
+        const label = normalize(b.getAttribute('aria-label') || '');
+        return /打开边栏|open sidebar|open navigation|展开边栏/i.test(label);
+      });
+      if (openSidebar) { openSidebar.click(); changed = true; }
+
+      // 2. Expand the "最近" / "Recents" toggle if it is currently collapsed.
+      const recentToggle = buttons.find((b) => {
+        const label = normalize(b.getAttribute('aria-label') || '');
+        return /最近|recent/i.test(label) && /展开|收起|expand|collapse|toggle|show|hide/i.test(label);
+      });
+      if (recentToggle) {
+        const expanded = (recentToggle.getAttribute('aria-expanded') || '').toLowerCase();
+        if (expanded !== 'true') { recentToggle.click(); changed = true; }
+      }
+
+      return changed;
+    })()
+  `;
+}
 function clickGeminiConversationByTitleScript(query) {
     const normalizedQuery = normalizeGeminiTitle(query);
     return `
@@ -1082,15 +1127,29 @@ export async function startNewGeminiChat(page) {
 }
 export async function getGeminiConversationList(page) {
     await ensureGeminiPage(page);
-    const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
-    const rows = raw.flatMap((item) => {
-        if (!isObjectRecord(item) || typeof item.title !== 'string' || typeof item.url !== 'string') {
-            throw new CommandExecutionError('Gemini conversation list returned a malformed row');
-        }
-        if (!isGeminiConversationUrl(item.url))
-            return [];
-        return { Title: item.title, Url: item.url };
-    });
+    let rows = [];
+    // Gemini collapses the sidebar "最近"/Recents section by default, hiding
+    // the conversation anchors. Retry extraction after expanding it.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
+        rows = raw.flatMap((item) => {
+            if (!isObjectRecord(item) || typeof item.title !== 'string' || typeof item.url !== 'string') {
+                throw new CommandExecutionError('Gemini conversation list returned a malformed row');
+            }
+            if (!isGeminiConversationUrl(item.url))
+                return [];
+            return { Title: item.title, Url: item.url };
+        });
+        if (rows.length > 0)
+            break;
+        const changedRaw = unwrapGeminiEvaluateResult(await page.evaluate(expandGeminiRecentScript()), 'Gemini sidebar expand');
+        const changed = changedRaw === true;
+        // Give the React sidebar a moment to render the expanded anchors,
+        // longer on the first expansion (sidebar slide-in is async).
+        await page.wait(attempt === 0 ? 1.2 : 0.6);
+        if (!changed && attempt > 0)
+            break;
+    }
     return rows;
 }
 export async function clickGeminiConversationByTitle(page, query) {

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -207,6 +207,38 @@ describe('gemini evaluate result boundaries', () => {
             { Title: 'Chat A', Url: 'https://gemini.google.com/app/abc123' },
         ]);
     });
+    it('expands collapsed Recents and retries conversation extraction', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        const wait = vi.mocked(page.wait);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce([
+            { title: 'Recovered Chat', url: 'https://gemini.google.com/app/recovered123' },
+        ]);
+        await expect(getGeminiConversationList(page)).resolves.toEqual([
+            { Title: 'Recovered Chat', Url: 'https://gemini.google.com/app/recovered123' },
+        ]);
+        expect(evaluate).toHaveBeenCalledTimes(4);
+        expect(wait).toHaveBeenCalledWith(1.2);
+    });
+    it('does not expand Recents when visible conversation links already exist', async () => {
+        const page = createPageMock();
+        const evaluate = vi.mocked(page.evaluate);
+        const wait = vi.mocked(page.wait);
+        evaluate
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce([
+            { title: 'Chat A', url: 'https://gemini.google.com/app/abc123' },
+        ]);
+        await expect(getGeminiConversationList(page)).resolves.toEqual([
+            { Title: 'Chat A', Url: 'https://gemini.google.com/app/abc123' },
+        ]);
+        expect(evaluate).toHaveBeenCalledTimes(2);
+        expect(wait).not.toHaveBeenCalled();
+    });
     it('typed-fails malformed Browser Bridge envelopes instead of treating them as empty', async () => {
         const page = createPageMock();
         const evaluate = vi.mocked(page.evaluate);

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
 function createPageMock() {
@@ -181,6 +182,43 @@ describe('gemini turn normalization', () => {
     });
 });
 describe('gemini evaluate result boundaries', () => {
+    function runExpandRecentScript(buttonHtml) {
+        const dom = new JSDOM(`<!doctype html><body>${buttonHtml}</body>`, {
+            pretendToBeVisual: true,
+            runScripts: 'outside-only',
+        });
+        const { window } = dom;
+        Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            value: () => ({ width: 100, height: 24, top: 0, left: 0, right: 100, bottom: 24 }),
+        });
+        let clicks = 0;
+        window.document.querySelector('button')?.addEventListener('click', () => {
+            clicks += 1;
+        });
+        const changed = window.eval(__test__.expandGeminiRecentScript());
+        return { changed, clicks };
+    }
+    it('does not collapse already-expanded Recents when aria-expanded is missing', () => {
+        expect(runExpandRecentScript('<button aria-label="Collapse Recents">Recents</button>')).toEqual({
+            changed: false,
+            clicks: 0,
+        });
+        expect(runExpandRecentScript('<button aria-label="收起最近">最近</button>')).toEqual({
+            changed: false,
+            clicks: 0,
+        });
+    });
+    it('expands Recents when the label or aria-expanded explicitly says it is collapsed', () => {
+        expect(runExpandRecentScript('<button aria-label="Expand Recents">Recents</button>')).toEqual({
+            changed: true,
+            clicks: 1,
+        });
+        expect(runExpandRecentScript('<button aria-label="Recents" aria-expanded="false">Recents</button>')).toEqual({
+            changed: true,
+            clicks: 1,
+        });
+    });
     it('unwraps Browser Bridge envelopes for conversation lists', async () => {
         const page = createPageMock();
         const evaluate = vi.mocked(page.evaluate);


### PR DESCRIPTION
## Description

`opencli gemini history` returned `EMPTY_RESULT` ("No conversation links were visible in the sidebar") even when logged in, because Gemini collapses the sidebar **最近 / Recents** section by default — the `/app/<id>` conversation anchors are absent from the DOM until that section is expanded.

`getGeminiConversationList` now retries extraction (up to 3 times). While empty, it runs a new `expandGeminiRecentScript()` that clicks the sidebar-open button plus the Recents expand/collapse toggle (matched by `aria-label` in both zh and en), then waits for the React sidebar to render and re-extracts.

Isolated change to `clis/gemini/utils.js` (+68 / −9). No existing tests changed.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I included output or screenshots when useful

## Screenshots / Output

```
$ opencli gemini history --limit 5
→ returns 5 conversations (Index, Id, Title, Url) in 2.5s  (previously: EMPTY_RESULT)

$ opencli gemini detail <id>
→ reads full conversation turns
```

Tested with opencli 1.8.4 on a logged-in Gemini session (zh-CN UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>