### PR TITLE
fix(cli): accept trailing browser --window option

### DIFF
--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -116,6 +116,108 @@ describe('rewriteBrowserArgv', () => {
     ]);
   });
 
+  it('hoists a trailing browser --window option to the namespace slot', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'open', 'https://x.com', '--window', 'background'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'background',
+      'open',
+      'https://x.com',
+    ]);
+    expect(rewriteBrowserArgv(['browser', 'work', 'state', '--window', 'foreground'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'foreground',
+      'state',
+    ]);
+  });
+
+  it('hoists trailing browser --window after leading root options', () => {
+    expect(rewriteBrowserArgv(['--profile', 'sandbox', 'browser', 'work', 'state', '--window', 'background'])).toEqual([
+      '--profile',
+      'sandbox',
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'background',
+      'state',
+    ]);
+  });
+
+  it('hoists a trailing browser --window=<mode> option', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'open', 'https://x.com', '--window=background'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window=background',
+      'open',
+      'https://x.com',
+    ]);
+  });
+
+  it('hoists browser --window after nested browser leaf commands', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'get', 'url', '--window', 'background'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'background',
+      'get',
+      'url',
+    ]);
+    expect(rewriteBrowserArgv(['browser', 'work', 'tab', 'close', 'abc123', '--window', 'background'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'background',
+      'tab',
+      'close',
+      'abc123',
+    ]);
+  });
+
+  it('leaves an already parent-slot browser --window option untouched', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', '--window', 'background', 'open', 'https://x.com'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      '--window',
+      'background',
+      'open',
+      'https://x.com',
+    ]);
+  });
+
+  it('does not hoist browser --window after a literal -- separator', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'eval', 'console.log(1)', '--', '--window', 'background'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      'eval',
+      'console.log(1)',
+      '--',
+      '--window',
+      'background',
+    ]);
+  });
+
+  it('does not hoist a bare trailing browser --window without a value', () => {
+    expect(rewriteBrowserArgv(['browser', 'work', 'open', 'https://x.com', '--window'])).toEqual([
+      'browser',
+      '--session',
+      'work',
+      'open',
+      'https://x.com',
+      '--window',
+    ]);
+  });
+
   it('leaves argv alone when the root command is not `browser`, even if `browser` appears later', () => {
     // The first browser keyword does NOT win — it must be at the root.
     expect(rewriteBrowserArgv(['twitter', 'browser', 'work', 'state'])).toEqual([

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -116,7 +116,40 @@ export function rewriteBrowserArgv(argv: readonly string[]): string[] {
   if (BROWSER_SUBCOMMAND_NAMES.has(next)) return result;
   // Splice in --session <name> in place of the positional.
   result.splice(sessionIdx, 1, '--session', next);
+  // `--window` is a browser namespace option, so commander accepts it before the
+  // leaf command. Users naturally put it at the end:
+  // `browser work open https://x.com --window background`. Hoist that public
+  // form into the namespace-option slot instead of mirroring the option onto
+  // every browser leaf command.
+  hoistBrowserWindowOption(result, sessionIdx + 2);
   return result;
+}
+
+/**
+ * Move one trailing `--window <mode>` / `--window=<mode>` from after the browser
+ * subcommand to just before it. Stops at `--` so literal browser arguments are
+ * untouched. Mutates `argv` in place.
+ */
+function hoistBrowserWindowOption(argv: string[], fromIndex: number): void {
+  const subcommandIdx = argv.findIndex((tok, idx) => idx >= fromIndex && BROWSER_SUBCOMMAND_NAMES.has(tok));
+  if (subcommandIdx === -1) return;
+
+  for (let i = subcommandIdx + 1; i < argv.length; i += 1) {
+    const tok = argv[i];
+    if (tok === '--') return;
+    if (tok.startsWith('--window=')) {
+      const removed = argv.splice(i, 1);
+      argv.splice(subcommandIdx, 0, ...removed);
+      return;
+    }
+    if (tok === '--window') {
+      const value = argv[i + 1];
+      if (value === undefined || value === '--') return;
+      const removed = argv.splice(i, 2);
+      argv.splice(subcommandIdx, 0, ...removed);
+      return;
+    }
+  }
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -885,6 +885,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
 
 Examples:
   $ opencli browser work open https://x.com
+  $ opencli browser work open https://x.com --window background
   $ opencli browser work click 12
   $ opencli browser work state
   $ opencli browser work bind


### PR DESCRIPTION
## What

Fixes #1850 by accepting the natural browser command shape:

```bash
opencli browser work open https://x.com --window background
```

`--window` remains a browser namespace option. Instead of registering it on every browser leaf command, the existing `rewriteBrowserArgv` preprocessor now hoists a trailing `--window <mode>` / `--window=<mode>` into the namespace-option slot before Commander parses argv.

The branch also includes a lockfile-only production dependency refresh for `ws` and `js-yaml` because the required CI audit gate flagged the old locked versions. `package.json` ranges already allow the patched versions, so no range change is needed.

## Why this version

This integrates the useful parts of both open PRs:

- PR #1926 had the lower-blast fix: keep the command tree unchanged and rewrite the user-facing argv shape in the browser preprocessor.
- PR #1899 correctly called out the help/UX confusion and added broader coverage, but the leaf-option mirroring approach is easier to get subtly wrong as the browser command tree evolves. For example, it classifies root `browser close` as a skipped session command even though `browser close` routes through `browserAction`.

This PR uses the preprocessor approach, adds nested-command coverage from the broader concern, avoids rewriting anything after a literal `--`, avoids hoisting a bare `--window` without a value, and documents the trailing placement in browser help examples.

## Tests

- `npx vitest run src/cli-argv-preprocess.test.ts`
- `npm run typecheck`
- `npm run build`
- `HOME=$(mktemp -d) npx vitest run src/cli-argv-preprocess.test.ts src/cli.test.ts`
- `npm audit --omit=dev --audit-level=high`
- `HOME=$(mktemp -d) npm test`

Supersedes #1926 and #1899.
Fixes #1850.
