### PR TITLE
fix(chatgpt): support current intelligence levels

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6169,7 +6169,7 @@
   {
     "site": "chatgpt",
     "name": "model",
-    "description": "Switch ChatGPT web model/mode (instant, thinking, pro)",
+    "description": "Switch ChatGPT web intelligence level (instant, medium, high, extra-high, pro; thinking aliases high)",
     "access": "write",
     "domain": "chatgpt.com",
     "strategy": "cookie",
@@ -6180,11 +6180,14 @@
         "type": "str",
         "required": true,
         "positional": true,
-        "help": "Model/mode to switch to",
+        "help": "Intelligence level to switch to; thinking is a backward-compatible alias for high",
         "choices": [
           "instant",
-          "thinking",
-          "pro"
+          "medium",
+          "high",
+          "extra-high",
+          "pro",
+          "thinking"
         ]
       }
     ],

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -75,7 +75,7 @@ describe('chatgpt browser command registration', () => {
                 name: 'model',
                 positional: true,
                 required: true,
-                choices: ['instant', 'thinking', 'pro'],
+                choices: ['instant', 'medium', 'high', 'extra-high', 'pro', 'thinking'],
             }),
         ]);
         expect(model.columns).toEqual(['Status', 'Model']);

--- a/clis/chatgpt/model.js
+++ b/clis/chatgpt/model.js
@@ -9,14 +9,14 @@ export const modelCommand = cli({
     site: 'chatgpt',
     name: 'model',
     access: 'write',
-    description: 'Switch ChatGPT web model/mode (instant, thinking, pro)',
+    description: 'Switch ChatGPT web intelligence level (instant, medium, high, extra-high, pro; thinking aliases high)',
     domain: CHATGPT_DOMAIN,
     strategy: Strategy.COOKIE,
     browser: true,
     siteSession: 'persistent',
     navigateBefore: false,
     args: [
-        { name: 'model', required: true, positional: true, help: 'Model/mode to switch to', choices: CHATGPT_MODEL_CHOICES },
+        { name: 'model', required: true, positional: true, help: 'Intelligence level to switch to; thinking is a backward-compatible alias for high', choices: CHATGPT_MODEL_CHOICES },
     ],
     columns: ['Status', 'Model'],
     func: async (page, kwargs) => {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -9,12 +9,50 @@ import { ArgumentError, AuthRequiredError, CommandExecutionError, TimeoutError }
 export const CHATGPT_DOMAIN = 'chatgpt.com';
 export const CHATGPT_URL = 'https://chatgpt.com';
 
-const CHATGPT_MODEL_OPTIONS = {
-    instant: { label: 'Instant', labels: ['Instant', '即时'], testId: 'model-switcher-gpt-5-5' },
-    thinking: { label: 'Thinking', labels: ['Thinking', '思考'], testId: 'model-switcher-gpt-5-5-thinking' },
-    pro: { label: 'Pro', labels: ['Pro', '进阶专业'], testId: 'model-switcher-gpt-5-5-pro' },
+const CHATGPT_MODEL_TARGETS = {
+    instant: {
+        label: 'Instant',
+        labels: ['Instant', '即时', '极速'],
+        optionLabels: ['Instant', '极速', '即时'],
+        testIds: ['model-switcher-gpt-5-5'],
+        intelligenceOrder: 0,
+    },
+    medium: {
+        label: 'Medium',
+        labels: ['Medium', '均衡'],
+        optionLabels: ['Medium', '均衡'],
+        testIds: [],
+        intelligenceOrder: 1,
+    },
+    high: {
+        label: 'High',
+        labels: ['High', '高级', 'Thinking', '思考'],
+        optionLabels: ['High', '高级', 'Thinking', '思考'],
+        testIds: ['model-switcher-gpt-5-5-thinking'],
+        intelligenceOrder: 2,
+    },
+    'extra-high': {
+        label: 'Extra High',
+        labels: ['Extra High', '超高'],
+        optionLabels: ['Extra High', '超高'],
+        testIds: [],
+        intelligenceOrder: 3,
+    },
+    pro: {
+        label: 'Pro',
+        labels: ['Pro', '进阶专业', '专业'],
+        optionLabels: ['专业', 'Pro', '进阶专业'],
+        testIds: ['model-switcher-gpt-5-5-pro'],
+        intelligenceOrder: 4,
+    },
 };
-export const CHATGPT_MODEL_CHOICES = Object.keys(CHATGPT_MODEL_OPTIONS);
+const CHATGPT_MODEL_ALIASES = {
+    thinking: 'high',
+};
+export const CHATGPT_MODEL_CHOICES = [
+    ...Object.keys(CHATGPT_MODEL_TARGETS),
+    ...Object.keys(CHATGPT_MODEL_ALIASES),
+];
 
 const CHATGPT_TOOL_OPTIONS = {
     'deep-research': { label: 'Deep Research', labels: ['深度研究', 'Deep Research'] },
@@ -300,14 +338,15 @@ export async function ensureChatGPTComposer(page, message = 'ChatGPT composer is
 
 function requireKnownChatGPTModel(model) {
     const key = String(model ?? '').trim().toLowerCase();
-    const option = CHATGPT_MODEL_OPTIONS[key];
+    const targetKey = CHATGPT_MODEL_ALIASES[key] || key;
+    const option = CHATGPT_MODEL_TARGETS[targetKey];
     if (!option) {
         throw new ArgumentError(
             `Unknown ChatGPT model "${model}"`,
             `Choose one of: ${CHATGPT_MODEL_CHOICES.join(', ')}`,
         );
     }
-    return { key, ...option };
+    return { key: targetKey, alias: key !== targetKey ? key : null, ...option };
 }
 
 function requireKnownChatGPTTool(tool) {
@@ -332,17 +371,56 @@ export async function getCurrentChatGPTModel(page) {
             return rect.width > 0 && rect.height > 0;
         };
         const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
-        const labels = ${JSON.stringify(CHATGPT_MODEL_OPTIONS)};
-        const button = Array.from(document.querySelectorAll('form button')).find((node) => {
+        const escapeRegExp = (value) => String(value).replace(/[|\\\\{}()[\\]^$+*?.]/g, '\\\\$&');
+        const textMatchesLabel = (text, label) => {
+            const normalizedText = normalize(text);
+            const normalizedLabel = normalize(label);
+            if (!normalizedText || !normalizedLabel) return false;
+            if (normalizedText === normalizedLabel) return true;
+            if (/^[\\x00-\\x7F]+$/.test(normalizedLabel)) {
+                return new RegExp('(^|\\\\b)' + escapeRegExp(normalizedLabel) + '(\\\\b|$)', 'i').test(normalizedText);
+            }
+            return normalizedText.replace(/\\s+/g, '').includes(normalizedLabel.replace(/\\s+/g, ''));
+        };
+        const labels = ${JSON.stringify(CHATGPT_MODEL_TARGETS)};
+        const findEntryForText = (text) => {
+            const matches = [];
+            for (const [key, value] of Object.entries(labels)) {
+                for (const item of value.labels || []) {
+                    if (textMatchesLabel(text, item)) {
+                        matches.push({ key, value, length: normalize(item).length });
+                    }
+                }
+            }
+            matches.sort((a, b) => b.length - a.length);
+            return matches[0] || null;
+        };
+        const form = Array.from(document.querySelectorAll('form')).find((node) => node instanceof HTMLElement && isVisible(node));
+        const testIdNode = form
+            ? Array.from(form.querySelectorAll('[data-testid]')).find((node) => {
+                if (!(node instanceof HTMLElement) || !isVisible(node)) return false;
+                const testId = node.getAttribute('data-testid');
+                return Object.values(labels).some((entry) => (entry.testIds || []).includes(testId));
+            })
+            : null;
+        const testId = testIdNode?.getAttribute('data-testid') || '';
+        const testIdEntry = Object.entries(labels).find(([, value]) => (value.testIds || []).includes(testId));
+        if (testIdEntry) {
+            return {
+                model: testIdEntry[0],
+                label: testIdEntry[1].label,
+            };
+        }
+        const button = Array.from((form || document).querySelectorAll('button')).find((node) => {
             if (!isVisible(node)) return false;
             const text = normalize(node.textContent);
-            return Object.values(labels).some((entry) => entry.labels.includes(text));
+            return Object.values(labels).some((entry) => entry.labels.some((label) => textMatchesLabel(text, label)));
         });
         const label = normalize(button?.textContent || '');
-        const entry = Object.entries(labels).find(([, value]) => value.labels.includes(label));
+        const entry = findEntryForText(label);
         return {
-            model: entry?.[0] ?? null,
-            label: entry?.[1]?.label ?? null,
+            model: entry?.key ?? null,
+            label: entry?.value?.label ?? null,
         };
     })()`)), 'chatgpt current model');
 }
@@ -369,10 +447,32 @@ export async function selectChatGPTModel(page, model) {
             return rect.width > 0 && rect.height > 0;
         };
         const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
-        const labels = ${JSON.stringify(Object.values(CHATGPT_MODEL_OPTIONS).flatMap((entry) => entry.labels))};
-        const button = Array.from(document.querySelectorAll('form button')).find((node) =>
-            isVisible(node) && labels.includes(normalize(node.textContent))
+        const escapeRegExp = (value) => String(value).replace(/[|\\\\{}()[\\]^$+*?.]/g, '\\\\$&');
+        const textMatchesLabel = (text, label) => {
+            const normalizedText = normalize(text);
+            const normalizedLabel = normalize(label);
+            if (!normalizedText || !normalizedLabel) return false;
+            if (normalizedText === normalizedLabel) return true;
+            if (/^[\\x00-\\x7F]+$/.test(normalizedLabel)) {
+                return new RegExp('(^|\\\\b)' + escapeRegExp(normalizedLabel) + '(\\\\b|$)', 'i').test(normalizedText);
+            }
+            return normalizedText.replace(/\\s+/g, '').includes(normalizedLabel.replace(/\\s+/g, ''));
+        };
+        const labels = ${JSON.stringify(Object.values(CHATGPT_MODEL_TARGETS).flatMap((entry) => entry.labels))};
+        const menuButtonSelectors = [
+            'button[data-testid="model-switcher-dropdown-button"]',
+            'button[aria-label*="model" i]',
+            'button[aria-label*="模型"]',
+            'button[aria-label*="智能"]',
+        ];
+        let button = Array.from(document.querySelectorAll('form button')).find((node) =>
+            isVisible(node) && labels.some((label) => textMatchesLabel(node.textContent, label))
         );
+        if (!button) {
+            button = menuButtonSelectors
+                .map((selector) => document.querySelector(selector))
+                .find((node) => node instanceof HTMLElement && isVisible(node));
+        }
         if (!button) return { found: false };
         button.scrollIntoView({ block: 'center', inline: 'center' });
         const rect = button.getBoundingClientRect();
@@ -398,7 +498,56 @@ export async function selectChatGPTModel(page, model) {
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };
-            const option = document.querySelector(${JSON.stringify(`[data-testid="${target.testId}"]`)});
+            const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+            const escapeRegExp = (value) => String(value).replace(/[|\\\\{}()[\\]^$+*?.]/g, '\\\\$&');
+            const textMatchesLabel = (text, label) => {
+                const normalizedText = normalize(text);
+                const normalizedLabel = normalize(label);
+                if (!normalizedText || !normalizedLabel) return false;
+                if (normalizedText === normalizedLabel) return true;
+                if (/^[\\x00-\\x7F]+$/.test(normalizedLabel)) {
+                    return new RegExp('(^|\\\\b)' + escapeRegExp(normalizedLabel) + '(\\\\b|$)', 'i').test(normalizedText);
+                }
+                return normalizedText.replace(/\\s+/g, '').includes(normalizedLabel.replace(/\\s+/g, ''));
+            };
+            const target = ${JSON.stringify(target)};
+            const clickableSelector = '[role="menuitemradio"], [role="menuitem"], [role="option"], button, [data-testid^="model-switcher"]';
+            const intelligenceContent = document.querySelector('[data-testid="composer-intelligence-picker-content"]');
+            const intelligenceOptions = intelligenceContent
+                ? Array.from(intelligenceContent.querySelectorAll('[role="menuitemradio"]')).filter(isVisible)
+                : [];
+            let option = null;
+            for (const testId of target.testIds || []) {
+                option = Array.from(document.querySelectorAll('[data-testid]')).find((candidate) =>
+                    candidate instanceof HTMLElement && candidate.getAttribute('data-testid') === testId
+                ) || null;
+                if (option instanceof HTMLElement && isVisible(option)) break;
+                option = null;
+            }
+            const clickables = intelligenceOptions.length ? intelligenceOptions : Array.from(document.querySelectorAll(clickableSelector));
+            for (const label of target.optionLabels || target.labels || []) {
+                option = clickables.find((candidate) =>
+                    candidate instanceof HTMLElement
+                    && isVisible(candidate)
+                    && textMatchesLabel(candidate.textContent, label)
+                ) || null;
+                if (option) break;
+
+                const labelRoot = intelligenceContent || document;
+                const labelNode = Array.from(labelRoot.querySelectorAll('span, div, p')).find((candidate) =>
+                    candidate instanceof HTMLElement
+                    && isVisible(candidate)
+                    && textMatchesLabel(candidate.textContent, label)
+                );
+                option = labelNode?.closest(clickableSelector) || null;
+                if (option instanceof HTMLElement && isVisible(option)) break;
+                option = null;
+            }
+            if (!option && Number.isInteger(target.intelligenceOrder)) {
+                if (intelligenceOptions.length === 5) {
+                    option = intelligenceOptions[target.intelligenceOrder] || null;
+                }
+            }
             if (!(option instanceof HTMLElement) || !isVisible(option)) return { found: false };
             option.scrollIntoView({ block: 'center', inline: 'center' });
             const rect = option.getBoundingClientRect();
@@ -419,6 +568,32 @@ export async function selectChatGPTModel(page, model) {
     await page.wait(0.5);
     const after = await getCurrentChatGPTModel(page);
     if (after.model !== target.key) {
+        await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
+        await page.wait(0.5);
+        const checked = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
+            const isVisible = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const style = window.getComputedStyle(el);
+                if (style.display === 'none' || style.visibility === 'hidden') return false;
+                const rect = el.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0;
+            };
+            const target = ${JSON.stringify(target)};
+            const intelligenceContent = document.querySelector('[data-testid="composer-intelligence-picker-content"]');
+            const options = intelligenceContent
+                ? Array.from(intelligenceContent.querySelectorAll('[role="menuitemradio"]')).filter(isVisible)
+                : [];
+            const checkedIndex = options.findIndex((node) => node.getAttribute('aria-checked') === 'true');
+            return {
+                recognized: options.length === 5 && Number.isInteger(target.intelligenceOrder),
+                checkedIndex,
+            };
+        })()`)), 'chatgpt model checked intelligence option');
+        if (checked.recognized && checked.checkedIndex === target.intelligenceOrder) {
+            await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
+            return { Status: 'Success', Model: target.label };
+        }
+        await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
         throw new CommandExecutionError(`ChatGPT model did not switch to ${target.label}.`);
     }
     return { Status: 'Success', Model: target.label };

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -43,10 +43,12 @@ function createDomEvaluatePage(html) {
         url: 'https://chatgpt.com/',
         runScripts: 'outside-only',
     });
-    for (const node of dom.window.document.querySelectorAll('button')) {
+    for (const node of dom.window.document.querySelectorAll('form, button, [role="menuitemradio"], [role="menuitem"], [role="option"], #prompt-textarea, [data-testid]')) {
         node.getBoundingClientRect = () => ({ width: 120, height: 36 });
+        node.scrollIntoView = () => {};
     }
     return {
+        dom,
         evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(script))),
     };
 }
@@ -160,6 +162,259 @@ describe('chatgpt model selection validation', () => {
         await expect(selectChatGPTModel(page, 'pro')).resolves.toEqual({ Status: 'Success', Model: 'Pro' });
         expect(page.nativeClick).toHaveBeenNthCalledWith(1, 10, 20);
         expect(page.nativeClick).toHaveBeenNthCalledWith(2, 30, 40);
+    });
+
+    it('selects current Chinese intelligence options by exact visible menu text', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">GPT-5.5 均衡</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu">
+              <div role="menuitemradio">极速</div>
+              <div role="menuitemradio">均衡</div>
+              <div role="menuitemradio">高级</div>
+              <div role="menuitemradio">超高</div>
+              <div role="menuitemradio">专业</div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                page.evaluate(`document.querySelector('[data-testid="model-switcher-dropdown-button"]').textContent = 'GPT-5.5 高级'`);
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'high')).resolves.toEqual({ Status: 'Success', Model: 'High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('verifies selection from stable model test id when the current visible label is unknown', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Mode rapide</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu">
+              <div role="menuitemradio">高级</div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                await page.evaluate(`
+                    const button = document.querySelector('[data-testid="model-switcher-dropdown-button"]');
+                    button.innerHTML = '<span data-testid="model-switcher-gpt-5-5-thinking">Mode raisonnement</span>';
+                `);
+                for (const node of page.dom.window.document.querySelectorAll('[data-testid]')) {
+                    node.getBoundingClientRect = () => ({ width: 120, height: 36 });
+                    node.scrollIntoView = () => {};
+                }
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'thinking')).resolves.toEqual({ Status: 'Success', Model: 'High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects actual English intelligence options by visible menu text', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Instant</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio">Instant</div>
+                <div role="menuitemradio">Medium</div>
+                <div role="menuitemradio">High</div>
+                <div role="menuitemradio">Extra High</div>
+                <div role="menuitemradio">Pro</div>
+              </div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                page.evaluate(`document.querySelector('[data-testid="model-switcher-dropdown-button"]').textContent = 'Extra High'`);
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'extra-high')).resolves.toEqual({ Status: 'Success', Model: 'Extra High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects Instant when the current precise level is Medium', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Medium</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio">Instant</div>
+                <div role="menuitemradio">Medium</div>
+                <div role="menuitemradio">High</div>
+                <div role="menuitemradio">Extra High</div>
+                <div role="menuitemradio">Pro</div>
+              </div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                page.evaluate(`document.querySelector('[data-testid="model-switcher-dropdown-button"]').textContent = 'Instant'`);
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'instant')).resolves.toEqual({ Status: 'Success', Model: 'Instant' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects High when the current precise level is Extra High', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Extra High</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio">Instant</div>
+                <div role="menuitemradio">Medium</div>
+                <div role="menuitemradio">High</div>
+                <div role="menuitemradio">Extra High</div>
+                <div role="menuitemradio">Pro</div>
+              </div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                page.evaluate(`document.querySelector('[data-testid="model-switcher-dropdown-button"]').textContent = 'High'`);
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'high')).resolves.toEqual({ Status: 'Success', Model: 'High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('thinking alias selects the High intelligence level', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Instant</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio">Instant</div>
+                <div role="menuitemradio">Medium</div>
+                <div role="menuitemradio">High</div>
+                <div role="menuitemradio">Extra High</div>
+                <div role="menuitemradio">Pro</div>
+              </div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                page.evaluate(`document.querySelector('[data-testid="model-switcher-dropdown-button"]').textContent = 'High'`);
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'thinking')).resolves.toEqual({ Status: 'Success', Model: 'High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses guarded intelligence menu order for unknown localized labels', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Mode rapide</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio" aria-checked="false">L0</div>
+                <div role="menuitemradio" aria-checked="false">L1</div>
+                <div role="menuitemradio" aria-checked="false">L2</div>
+                <div role="menuitemradio" aria-checked="false">L3</div>
+                <div role="menuitemradio" aria-checked="false">L4</div>
+              </div>
+            </div>
+        `);
+        let clickCount = 0;
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockImplementation(async () => {
+            clickCount += 1;
+            if (clickCount === 2) {
+                const options = page.dom.window.document.querySelectorAll('[role="menuitemradio"]');
+                for (const option of options) option.setAttribute('aria-checked', 'false');
+                options[3].setAttribute('aria-checked', 'true');
+            }
+        });
+
+        await expect(selectChatGPTModel(page, 'extra-high')).resolves.toEqual({ Status: 'Success', Model: 'Extra High' });
+        expect(page.nativeClick).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not use order fallback outside the guarded five-option intelligence picker', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Mode rapide</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu">
+              <div role="group">
+                <div role="menuitemradio">L0</div>
+                <div role="menuitemradio">L1</div>
+                <div role="menuitemradio">L2</div>
+                <div role="menuitemradio">L3</div>
+                <div role="menuitemradio">L4</div>
+              </div>
+            </div>
+        `);
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockResolvedValue(undefined);
+
+        await expect(selectChatGPTModel(page, 'extra-high')).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Could not click the ChatGPT Extra High model option'),
+        });
+    });
+
+    it('does not use order fallback when the intelligence picker does not expose exactly five options', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button" data-testid="model-switcher-dropdown-button">Mode rapide</button>
+              <div id="prompt-textarea" contenteditable="true"></div>
+            </form>
+            <div role="menu" data-testid="composer-intelligence-picker-content">
+              <div role="group">
+                <div role="menuitemradio">L0</div>
+                <div role="menuitemradio">L1</div>
+                <div role="menuitemradio">L2</div>
+                <div role="menuitemradio">L3</div>
+              </div>
+            </div>
+        `);
+        page.wait = vi.fn().mockResolvedValue(undefined);
+        page.nativeClick = vi.fn().mockResolvedValue(undefined);
+
+        await expect(selectChatGPTModel(page, 'pro')).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('Could not click the ChatGPT Pro model option'),
+        });
     });
 
     it('fails closed when the postcondition does not prove the requested model', async () => {
@@ -418,13 +673,33 @@ describe('chatgpt generation state', () => {
 describe('chatgpt current model detection', () => {
     it.each([
         ['Instant', { model: 'instant', label: 'Instant' }],
-        ['Thinking', { model: 'thinking', label: 'Thinking' }],
+        ['Medium', { model: 'medium', label: 'Medium' }],
+        ['Thinking', { model: 'high', label: 'High' }],
+        ['High', { model: 'high', label: 'High' }],
+        ['Extra High', { model: 'extra-high', label: 'Extra High' }],
         ['Pro', { model: 'pro', label: 'Pro' }],
+        ['GPT-5.5 极速', { model: 'instant', label: 'Instant' }],
+        ['GPT-5.5 均衡', { model: 'medium', label: 'Medium' }],
+        ['智能水平 高级', { model: 'high', label: 'High' }],
+        ['GPT-5.5 超高', { model: 'extra-high', label: 'Extra High' }],
+        ['GPT-5.5 专业', { model: 'pro', label: 'Pro' }],
         ['进阶专业', { model: 'pro', label: 'Pro' }],
     ])('detects the visible %s model label', async (label, expected) => {
         const page = createDomEvaluatePage(`<form><button>${label}</button></form>`);
 
         await expect(getCurrentChatGPTModel(page)).resolves.toEqual(expected);
+    });
+
+    it('uses model-specific test ids before visible text labels', async () => {
+        const page = createDomEvaluatePage(`
+            <form>
+              <button type="button">
+                <span data-testid="model-switcher-gpt-5-5-pro">Niveau inconnu</span>
+              </button>
+            </form>
+        `);
+
+        await expect(getCurrentChatGPTModel(page)).resolves.toEqual({ model: 'pro', label: 'Pro' });
     });
 
     it('returns null fields when the model selector is missing', async () => {

--- a/docs/adapters/browser/chatgpt.md
+++ b/docs/adapters/browser/chatgpt.md
@@ -14,6 +14,7 @@
 | `opencli chatgpt new` | Start a new conversation |
 | `opencli chatgpt status` | Check page and login state |
 | `opencli chatgpt image <prompt>` | Generate images in ChatGPT web and optionally save them locally |
+| `opencli chatgpt model <level>` | Switch the ChatGPT web intelligence level |
 
 ## Usage Examples
 
@@ -36,6 +37,13 @@ opencli chatgpt new
 
 # Generate an image and save it to the default directory
 opencli chatgpt image "a cyberpunk city at night"
+
+# Switch ChatGPT's intelligence level
+opencli chatgpt model instant
+opencli chatgpt model medium
+opencli chatgpt model high
+opencli chatgpt model extra-high
+opencli chatgpt model pro
 
 # Upload a local image, ask ChatGPT to edit it, and save the result
 opencli chatgpt image "make the background blue" --image ./cat.png
@@ -62,12 +70,14 @@ opencli chatgpt image "a tiny watercolor fox" --sd true
 | `--image` | Local image path to attach before prompting; comma-separated paths are supported |
 | `--op` | Output directory for downloaded images (default: `~/Pictures/chatgpt`) |
 | `--sd` | Skip download and only print the ChatGPT conversation link |
+| `model` | ChatGPT intelligence level for `model`: `instant`, `medium`, `high`, `extra-high`, or `pro`; `thinking` is accepted as a backward-compatible alias for `high` |
 
 ## Behavior
 
 - ChatGPT web commands use persistent site sessions by default, so consecutive `ask` / `send` / `read` / `detail` commands continue in the same ChatGPT tab. Use `--site-session ephemeral` for one-shot isolated tabs.
 - `ask` waits for the first stable assistant response after sending. `send` submits only and returns immediately.
 - `history` reads visible `/c/<id>` links from the ChatGPT sidebar; it does not use private backend APIs.
+- `model` switches the visible ChatGPT web intelligence level. It recognizes the current English labels (`Instant`, `Medium`, `High`, `Extra High`, `Pro`) and Chinese labels (`极速`, `均衡`, `高级`, `超高`, `专业`). If labels are localized differently, it only falls back to option order after confirming the guarded five-option ChatGPT intelligence picker structure.
 - `image` opens a fresh `chatgpt.com/new` page before sending the image prompt.
 - When `--image` is provided, local images are uploaded first and the prompt is sent as an image edit request.
 - `image` output is plain `status / file / link`, not a markdown table.


### PR DESCRIPTION
# Summary

- Expand `opencli chatgpt model` from the legacy three public choices to the current five ChatGPT Web intelligence levels:
  - `instant`
  - `medium`
  - `high`
  - `extra-high`
  - `pro`
- Preserve `thinking` as a backward-compatible alias for `high`.
- Return precise current model values from `getCurrentChatGPTModel()`:
  - `Instant` / `极速` -> `instant`
  - `Medium` / `均衡` -> `medium`
  - `High` / `高级` -> `high`
  - `Extra High` / `超高` -> `extra-high`
  - `Pro` / `专业` -> `pro`
- Ensure `selectChatGPTModel()` only short-circuits on exact canonical matches, so `Medium -> instant` and `Extra High -> high` still click the requested target.
- Prefer stable model-specific ids where ChatGPT still exposes them, then explicit English/Chinese text matching, then guarded order fallback.
- Keep the order fallback conservative: it is only used after confirming `data-testid="composer-intelligence-picker-content"` and exactly five visible `role="menuitemradio"` options.

## DOM Evidence

- Chinese ChatGPT UI showed intelligence labels `极速`, `均衡`, `高级`, `超高`, `专业`.
- English mode was achieved through ChatGPT Settings -> General -> Language -> `English (US)`.
- English ChatGPT UI showed intelligence labels `Instant`, `Medium`, `High`, `Extra High`, `Pro`.
- In both locales, the intelligence menu used `data-testid="composer-intelligence-picker-content"` for the container and visible `role="menuitemradio"` rows for the options.
- Inspection did not find stable one-to-one per-level `data-testid`, `value`, `href`, or dataset model keys for all five intelligence levels.
- Because per-level ids are absent, the adapter uses explicit English/Chinese label matching first and only falls back to order inside the guarded five-option picker.

## Test Plan

- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node --check clis/chatgpt/utils.js`
  - Passed.
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node --check clis/chatgpt/utils.test.js`
  - Passed.
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && ./node_modules/.bin/vitest run --project adapter clis/chatgpt/utils.test.js clis/chatgpt/commands.test.js`
  - Passed: 2 test files, 77 tests.
- `git diff --check`
  - Passed.
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run build-manifest`
  - Passed with elevated permissions after sandbox blocked `tsx` IPC pipe creation.
  - Manifest compiled 1225 entries.
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && node dist/src/main.js chatgpt model --help`
  - Passed.
  - Help shows choices `instant, medium, high, extra-high, pro, thinking`.
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm test`
  - Initial sandboxed run failed because tests need to write `~/.opencli` and bind local test servers.
  - Elevated rerun passed: 521 test files passed, 5450 tests passed, 1 skipped.

## Real Smoke

Using this repo's local CLI. No prompts were sent and Deep Research was not launched.

- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model instant -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"Instant"}]`
- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model medium -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"Medium"}]`
- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model high -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"High"}]`
- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model extra-high -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"Extra High"}]`
- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model pro -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"Pro"}]`
- `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model thinking -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"High"}]`
- Final restore:
  - `/Users/marvin/.nvm/versions/node/v24.4.1/bin/node dist/src/main.js chatgpt model pro -f json --trace retain-on-failure`
  - Result: `[{"Status":"Success","Model":"Pro"}]`

## Notes

- `thinking` remains accepted to avoid breaking existing scripts, but it is documented as a compatibility alias for `high`.
- The fallback is not fully locale-independent in the strong sense of stable per-level DOM ids; ChatGPT currently does not expose those ids for all five rows. Unknown locales are supported only through the guarded five-row intelligence picker order.
- `node dist/src/main.js chatgpt model --help` emitted a local symlink permission warning for `~/.opencli/node_modules`, but printed the expected help successfully.
