### PR TITLE
fix(gemini): match Traditional Chinese 'send' label in composer submit (#1849)

### DIFF
--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -594,7 +594,7 @@ function submitComposerScript() {
       }
 
       const excludedPattern = /main menu|主菜单|microphone|麦克风|upload|上传|mode|模式|tools|工具|settings|临时对话|new chat|新对话/i;
-      const submitPattern = /send|发送|submit|提交/i;
+      const submitPattern = /send|发送|傳送|submit|提交/i;
       let bestButton = null;
       let bestScore = -1;
 

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -151,6 +151,9 @@ describe('gemini send strategy', () => {
     it('keeps a button submit path in the generated submit script', () => {
         expect(__test__.submitComposerScript()).toContain('.click()');
     });
+    it('matches the Traditional Chinese send label in the generated submit script', () => {
+        expect(__test__.submitComposerScript()).toContain('傳送');
+    });
     it('supports localized new chat labels in the generated new-chat script', () => {
         expect(__test__.clickNewChatScript()).toContain('发起新对话');
     });


### PR DESCRIPTION
## What
`opencli gemini ask` times out on the **Traditional Chinese** Gemini UI — the adapter cannot find/click the send button.

## Root cause
`submitComposerScript` in `clis/gemini/utils.js` scores candidate buttons with:
```js
const submitPattern = /send|发送|submit|提交/i;
```
This only covers Simplified Chinese 「发送」. On the Traditional Chinese UI the send button is labeled 「傳送訊息」, which matches none of the alternatives, so it scores 0 and the adapter times out. Fixes #1849.

## Fix
Add 「傳送」 (a substring of 「傳送訊息」) to `submitPattern`. One-line change, no behavior change for existing locales.

## Test
Added a unit test asserting the generated submit script contains 「傳送」, alongside the existing `.click()` / 「发起新对话」 assertions in `clis/gemini/utils.test.js`.

## Verification
- `npm run build` — ok
- `npx vitest run clis/gemini/utils.test.js` — 27 passed
- `npm run check:typed-error-lint` — no new violations
- `npm run check:silent-column-drop` — no new violations