### PR TITLE
feat(archive): add Internet Archive read-only adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2627,6 +2627,170 @@
     "sourceFile": "apple-podcasts/top.js"
   },
   {
+    "site": "archive",
+    "name": "item",
+    "description": "Fetch metadata for a single Internet Archive item by identifier.",
+    "access": "read",
+    "domain": "archive.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "identifier",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Archive item identifier (e.g. \"open-syllabus\", \"FinalFantasy2_356\")."
+      }
+    ],
+    "columns": [
+      "identifier",
+      "title",
+      "creator",
+      "date",
+      "mediatype",
+      "collection",
+      "description",
+      "file_count",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "archive/item.js",
+    "sourceFile": "archive/item.js"
+  },
+  {
+    "site": "archive",
+    "name": "search",
+    "description": "Search Internet Archive items across books, movies, audio, software, and web.",
+    "access": "read",
+    "domain": "archive.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Full-text query (matches title, description, creator, subject)."
+      },
+      {
+        "name": "mediatype",
+        "type": "string",
+        "required": false,
+        "help": "Restrict to mediatype: texts, movies, audio, software, image, web, data, collection"
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "downloads",
+        "required": false,
+        "help": "Sort key: downloads, date, addeddate, week, title"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max items (max 100; one API page)."
+      }
+    ],
+    "columns": [
+      "rank",
+      "identifier",
+      "title",
+      "creator",
+      "date",
+      "mediatype",
+      "downloads",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "archive/search.js",
+    "sourceFile": "archive/search.js"
+  },
+  {
+    "site": "archive",
+    "name": "snapshots",
+    "description": "List Wayback Machine snapshots over time for a URL via the CDX API.",
+    "access": "read",
+    "domain": "archive.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "URL to look up (with or without scheme)."
+      },
+      {
+        "name": "from",
+        "type": "string",
+        "required": false,
+        "help": "Earliest year/timestamp (YYYY[MM[DD[hh[mm[ss]]]]])"
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "required": false,
+        "help": "Latest year/timestamp (YYYY[MM[DD[hh[mm[ss]]]]])"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max snapshots to return (max 1000)."
+      }
+    ],
+    "columns": [
+      "timestamp",
+      "snapshot_url",
+      "status",
+      "mimetype",
+      "original_url"
+    ],
+    "type": "js",
+    "modulePath": "archive/snapshots.js",
+    "sourceFile": "archive/snapshots.js"
+  },
+  {
+    "site": "archive",
+    "name": "wayback",
+    "description": "Look up the closest Wayback Machine snapshot for a URL.",
+    "access": "read",
+    "domain": "archive.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "URL to look up (with or without scheme)."
+      },
+      {
+        "name": "timestamp",
+        "type": "string",
+        "required": false,
+        "help": "Target timestamp (YYYY[MM[DD[hh[mm[ss]]]]] or ISO date). Defaults to most recent snapshot."
+      }
+    ],
+    "columns": [
+      "original_url",
+      "requested_timestamp",
+      "snapshot_timestamp",
+      "snapshot_url",
+      "status"
+    ],
+    "type": "js",
+    "modulePath": "archive/wayback.js",
+    "sourceFile": "archive/wayback.js"
+  },
+  {
     "site": "arxiv",
     "name": "author",
     "description": "List arXiv papers by a given author (newest first)",

--- a/clis/archive/archive.test.js
+++ b/clis/archive/archive.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+import './item.js';
+import './wayback.js';
+import './snapshots.js';
+
+describe('archive adapter registry contracts', () => {
+    it('declares archive search columns so identifier round-trips into archive item', () => {
+        const search = getRegistry().get('archive/search');
+        const item = getRegistry().get('archive/item');
+
+        expect(search).toBeDefined();
+        expect(item).toBeDefined();
+        expect(search.columns).toEqual(['rank', 'identifier', 'title', 'creator', 'date', 'mediatype', 'downloads', 'url']);
+        expect(item.columns).toContain('identifier');
+    });
+
+    it('declares wayback and snapshots columns so URL round-trips between them', () => {
+        const wayback = getRegistry().get('archive/wayback');
+        const snapshots = getRegistry().get('archive/snapshots');
+
+        expect(wayback).toBeDefined();
+        expect(snapshots).toBeDefined();
+        expect(wayback.columns).toContain('snapshot_url');
+        expect(snapshots.columns).toContain('snapshot_url');
+        expect(wayback.columns).toContain('original_url');
+        expect(snapshots.columns).toContain('original_url');
+    });
+
+    it('marks every archive command as read access on the archive.org domain', () => {
+        for (const name of ['search', 'item', 'wayback', 'snapshots']) {
+            const cmd = getRegistry().get(`archive/${name}`);
+            expect(cmd, name).toBeDefined();
+            expect(cmd.access, name).toBe('read');
+            expect(cmd.domain, name).toBe('archive.org');
+            expect(cmd.browser, name).toBe(false);
+        }
+    });
+});

--- a/clis/archive/archive.test.js
+++ b/clis/archive/archive.test.js
@@ -250,8 +250,12 @@ describe('archive snapshots command', () => {
     it('typed-fails malformed CDX headers and rows', async () => {
         vi.stubGlobal('fetch', vi.fn()
             .mockResolvedValueOnce(jsonResponse([['timestamp', 'original'], ['20200102030405', 'https://example.com/']]))
-            .mockResolvedValueOnce(jsonResponse([['timestamp', 'original', 'statuscode', 'mimetype'], ['', 'https://example.com/', '200', 'text/html']])));
+            .mockResolvedValueOnce(jsonResponse([['timestamp', 'original', 'statuscode', 'mimetype'], ['', 'https://example.com/', '200', 'text/html']]))
+            .mockResolvedValueOnce(jsonResponse({ timestamp: '20200102030405' }))
+            .mockResolvedValueOnce(jsonResponse([['timestamp', 'original', 'statuscode', 'mimetype'], ['20200102030405', 'https://example.com/']])));
 
+        await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
         await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });

--- a/clis/archive/archive.test.js
+++ b/clis/archive/archive.test.js
@@ -1,9 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './search.js';
 import './item.js';
 import './wayback.js';
 import './snapshots.js';
+
+function jsonResponse(body, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe('archive adapter registry contracts', () => {
     it('declares archive search columns so identifier round-trips into archive item', () => {
@@ -36,5 +48,211 @@ describe('archive adapter registry contracts', () => {
             expect(cmd.domain, name).toBe('archive.org');
             expect(cmd.browser, name).toBe(false);
         }
+    });
+});
+
+describe('archive search command', () => {
+    const command = getRegistry().get('archive/search');
+
+    it('returns stable identifier rows that round-trip to archive item', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+            response: {
+                docs: [{
+                    identifier: 'sample_item-1',
+                    title: 'Sample Item',
+                    creator: ['Alice', 'Bob'],
+                    date: '2020-01-02T00:00:00Z',
+                    mediatype: 'texts',
+                    downloads: '42',
+                }],
+            },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ query: 'sample', limit: 1 })).resolves.toEqual([{
+            rank: 1,
+            identifier: 'sample_item-1',
+            title: 'Sample Item',
+            creator: 'Alice, Bob',
+            date: '2020-01-02',
+            mediatype: 'texts',
+            downloads: 42,
+            url: 'https://archive.org/details/sample_item-1',
+        }]);
+        const url = new URL(fetchMock.mock.calls[0][0]);
+        expect(url.searchParams.get('q')).toBe('sample');
+        expect(url.searchParams.getAll('fl[]')).toContain('identifier');
+    });
+
+    it('rejects invalid arguments before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ query: ' ', limit: 1 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ query: 'x', mediatype: 'bad' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ query: 'x', sort: 'bad' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ query: 'x', limit: 101 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps true empty search results to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ response: { docs: [] } })));
+
+        await expect(command.func({ query: 'zz-no-hit', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails malformed search payloads instead of emitting empty identifiers', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ response: { docs: [{ title: 'No id' }] } })));
+
+        await expect(command.func({ query: 'bad', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('archive item command', () => {
+    const command = getRegistry().get('archive/item');
+
+    it('returns metadata for the requested stable identifier', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            metadata: {
+                identifier: 'sample_item-1',
+                title: 'Sample Item',
+                creator: 'Alice',
+                date: '2020',
+                mediatype: 'texts',
+                collection: ['opensource'],
+                description: ['Line one.', 'Line two.'],
+            },
+            files: [{ name: 'a.txt' }, { name: 'b.txt' }],
+        })));
+
+        await expect(command.func({ identifier: 'sample_item-1' })).resolves.toEqual([{
+            identifier: 'sample_item-1',
+            title: 'Sample Item',
+            creator: 'Alice',
+            date: '2020',
+            mediatype: 'texts',
+            collection: 'opensource',
+            description: 'Line one. Line two.',
+            file_count: 2,
+            url: 'https://archive.org/details/sample_item-1',
+        }]);
+    });
+
+    it('rejects invalid identifiers before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ identifier: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ identifier: '../secret' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps missing public metadata to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
+
+        await expect(command.func({ identifier: 'missing_item' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails mismatched identity and malformed files payload', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse({ metadata: { identifier: 'other_item' }, files: [] }))
+            .mockResolvedValueOnce(jsonResponse({ metadata: { identifier: 'sample_item' }, files: {} })));
+
+        await expect(command.func({ identifier: 'sample_item' })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func({ identifier: 'sample_item' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('archive wayback command', () => {
+    const command = getRegistry().get('archive/wayback');
+
+    it('returns the closest snapshot with normalized timestamp input', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+            url: 'example.com',
+            archived_snapshots: {
+                closest: {
+                    available: true,
+                    timestamp: '20200102030405',
+                    url: 'https://web.archive.org/web/20200102030405/https://example.com/',
+                    status: '200',
+                },
+            },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ url: 'example.com', timestamp: '2020-01-02T03:04:05' })).resolves.toEqual([{
+            original_url: 'example.com',
+            requested_timestamp: '20200102030405',
+            snapshot_timestamp: '20200102030405',
+            snapshot_url: 'https://web.archive.org/web/20200102030405/https://example.com/',
+            status: '200',
+        }]);
+        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get('timestamp')).toBe('20200102030405');
+    });
+
+    it('rejects invalid URL/timestamp arguments before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ url: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ url: 'example.com', timestamp: '202' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('distinguishes no snapshot from malformed closest snapshot', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse({ archived_snapshots: {} }))
+            .mockResolvedValueOnce(jsonResponse({ archived_snapshots: { closest: { available: true, url: 'x' } } })));
+
+        await expect(command.func({ url: 'example.com' })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(command.func({ url: 'example.com' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('archive snapshots command', () => {
+    const command = getRegistry().get('archive/snapshots');
+
+    it('returns CDX snapshots with stable Wayback permalinks', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse([
+            ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode'],
+            ['com,example)/', '20200102030405', 'https://example.com/', 'text/html', '200'],
+        ]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ url: 'example.com', from: '2020', limit: 1 })).resolves.toEqual([{
+            timestamp: '20200102030405',
+            snapshot_url: 'https://web.archive.org/web/20200102030405/https://example.com/',
+            status: '200',
+            mimetype: 'text/html',
+            original_url: 'https://example.com/',
+        }]);
+        const url = new URL(fetchMock.mock.calls[0][0]);
+        expect(url.protocol).toBe('http:');
+        expect(url.searchParams.get('from')).toBe('2020');
+    });
+
+    it('rejects invalid arguments before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ url: '', limit: 1 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ url: 'example.com', limit: 1001 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ url: 'example.com', from: '2020-01' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps no CDX rows to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse([['timestamp', 'original', 'statuscode', 'mimetype']])));
+
+        await expect(command.func({ url: 'missing.example', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails malformed CDX headers and rows', async () => {
+        vi.stubGlobal('fetch', vi.fn()
+            .mockResolvedValueOnce(jsonResponse([['timestamp', 'original'], ['20200102030405', 'https://example.com/']]))
+            .mockResolvedValueOnce(jsonResponse([['timestamp', 'original', 'statuscode', 'mimetype'], ['', 'https://example.com/', '200', 'text/html']])));
+
+        await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func({ url: 'example.com', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/archive/item.js
+++ b/clis/archive/item.js
@@ -1,0 +1,75 @@
+// archive item: Internet Archive item metadata (one row per identifier).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+
+cli({
+    site: 'archive',
+    name: 'item',
+    access: 'read',
+    description: 'Fetch metadata for a single Internet Archive item by identifier.',
+    domain: 'archive.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'identifier', positional: true, required: true, help: 'Archive item identifier (e.g. "open-syllabus", "FinalFantasy2_356").' },
+    ],
+    columns: ['identifier', 'title', 'creator', 'date', 'mediatype', 'collection', 'description', 'file_count', 'url'],
+    func: async (args) => {
+        const identifier = String(args.identifier ?? '').trim();
+        if (!identifier) {
+            throw new ArgumentError('archive item identifier must not be empty');
+        }
+        if (!/^[A-Za-z0-9._-]+$/.test(identifier)) {
+            throw new ArgumentError('archive item identifier may only contain letters, digits, ".", "_", "-"');
+        }
+
+        const url = `https://archive.org/metadata/${encodeURIComponent(identifier)}`;
+        let resp;
+        try {
+            resp = await fetch(url, {
+                headers: {
+                    'Accept': 'application/json',
+                    'User-Agent': 'opencli/1.0 (+https://github.com/jackwener/opencli)',
+                },
+            });
+        } catch (error) {
+            throw new CommandExecutionError(`archive item request failed: ${error?.message || error}`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`archive item failed: HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        } catch (error) {
+            throw new CommandExecutionError(`archive item returned malformed JSON: ${error?.message || error}`);
+        }
+
+        const meta = data?.metadata;
+        // The metadata endpoint returns {} for missing or dark items.
+        if (!meta || typeof meta !== 'object' || !meta.identifier) {
+            throw new EmptyResultError('archive item', `No public metadata for "${identifier}" on archive.org.`);
+        }
+
+        const creator = Array.isArray(meta.creator) ? meta.creator.join(', ') : String(meta.creator ?? '');
+        const collection = Array.isArray(meta.collection) ? meta.collection.join(', ') : String(meta.collection ?? '');
+        const description = Array.isArray(meta.description) ? meta.description.join(' ') : String(meta.description ?? '');
+        const files = Array.isArray(data.files) ? data.files : [];
+
+        return [{
+            identifier: String(meta.identifier),
+            title: String(meta.title ?? ''),
+            creator,
+            date: meta.date ? String(meta.date).slice(0, 10) : '',
+            mediatype: String(meta.mediatype ?? ''),
+            collection,
+            description,
+            file_count: files.length,
+            url: `https://archive.org/details/${meta.identifier}`,
+        }];
+    },
+});

--- a/clis/archive/item.js
+++ b/clis/archive/item.js
@@ -6,6 +6,8 @@ import {
     EmptyResultError,
 } from '@jackwener/opencli/errors';
 
+const IDENTIFIER_RE = /^[A-Za-z0-9._-]+$/;
+
 cli({
     site: 'archive',
     name: 'item',
@@ -26,7 +28,7 @@ cli({
                 'Example: opencli archive item open-syllabus',
             );
         }
-        if (!/^[A-Za-z0-9._-]+$/.test(identifier)) {
+        if (!IDENTIFIER_RE.test(identifier)) {
             throw new ArgumentError(
                 `archive item identifier "${args.identifier}" is not valid`,
                 'Archive item identifiers may only contain letters, digits, ".", "_", "-".',
@@ -60,22 +62,31 @@ cli({
         if (!meta || typeof meta !== 'object' || !meta.identifier) {
             throw new EmptyResultError('archive item', `No public metadata for "${identifier}" on archive.org.`);
         }
+        const responseIdentifier = String(meta.identifier);
+        if (!IDENTIFIER_RE.test(responseIdentifier)) {
+            throw new CommandExecutionError('archive item returned malformed payload: metadata.identifier is not stable');
+        }
+        if (responseIdentifier !== identifier) {
+            throw new CommandExecutionError(`archive item returned metadata for "${responseIdentifier}" instead of "${identifier}"`);
+        }
 
         const creator = Array.isArray(meta.creator) ? meta.creator.join(', ') : String(meta.creator ?? '');
         const collection = Array.isArray(meta.collection) ? meta.collection.join(', ') : String(meta.collection ?? '');
         const description = Array.isArray(meta.description) ? meta.description.join(' ') : String(meta.description ?? '');
-        const files = Array.isArray(data.files) ? data.files : [];
+        if (!Array.isArray(data.files)) {
+            throw new CommandExecutionError('archive item returned malformed payload: files must be an array');
+        }
 
         return [{
-            identifier: String(meta.identifier),
+            identifier: responseIdentifier,
             title: String(meta.title ?? ''),
             creator,
             date: meta.date ? String(meta.date).slice(0, 10) : '',
             mediatype: String(meta.mediatype ?? ''),
             collection,
             description,
-            file_count: files.length,
-            url: `https://archive.org/details/${meta.identifier}`,
+            file_count: data.files.length,
+            url: `https://archive.org/details/${responseIdentifier}`,
         }];
     },
 });

--- a/clis/archive/item.js
+++ b/clis/archive/item.js
@@ -21,10 +21,16 @@ cli({
     func: async (args) => {
         const identifier = String(args.identifier ?? '').trim();
         if (!identifier) {
-            throw new ArgumentError('archive item identifier must not be empty');
+            throw new ArgumentError(
+                'archive item identifier cannot be empty',
+                'Example: opencli archive item open-syllabus',
+            );
         }
         if (!/^[A-Za-z0-9._-]+$/.test(identifier)) {
-            throw new ArgumentError('archive item identifier may only contain letters, digits, ".", "_", "-"');
+            throw new ArgumentError(
+                `archive item identifier "${args.identifier}" is not valid`,
+                'Archive item identifiers may only contain letters, digits, ".", "_", "-".',
+            );
         }
 
         const url = `https://archive.org/metadata/${encodeURIComponent(identifier)}`;

--- a/clis/archive/search.js
+++ b/clis/archive/search.js
@@ -9,6 +9,7 @@ import {
 const SORT_OPTIONS = ['downloads', 'date', 'addeddate', 'week', 'title'];
 const SORT_ALIAS = { added: 'addeddate', published: 'date' };
 const MEDIATYPES = ['texts', 'movies', 'audio', 'software', 'image', 'web', 'data', 'collection'];
+const IDENTIFIER_RE = /^[A-Za-z0-9._-]+$/;
 
 cli({
     site: 'archive',
@@ -82,12 +83,22 @@ cli({
         }
 
         const docs = data?.response?.docs;
-        if (!Array.isArray(docs) || docs.length === 0) {
+        if (!Array.isArray(docs)) {
+            throw new CommandExecutionError('archive search returned malformed payload: response.docs must be an array');
+        }
+        if (docs.length === 0) {
             throw new EmptyResultError('archive search', `No items match "${query}" on archive.org.`);
         }
 
         return docs.slice(0, limit).map((d, i) => {
             const id = String(d.identifier ?? '');
+            if (!IDENTIFIER_RE.test(id)) {
+                throw new CommandExecutionError('archive search returned malformed payload: result row is missing a stable identifier');
+            }
+            const downloads = Number(d.downloads ?? 0);
+            if (!Number.isFinite(downloads)) {
+                throw new CommandExecutionError(`archive search returned malformed payload for "${id}": downloads must be numeric`);
+            }
             const creator = Array.isArray(d.creator) ? d.creator.join(', ') : String(d.creator ?? '');
             return {
                 rank: i + 1,
@@ -96,7 +107,7 @@ cli({
                 creator,
                 date: d.date ? String(d.date).slice(0, 10) : '',
                 mediatype: String(d.mediatype ?? ''),
-                downloads: Number(d.downloads ?? 0),
+                downloads,
                 url: id ? `https://archive.org/details/${id}` : '',
             };
         });

--- a/clis/archive/search.js
+++ b/clis/archive/search.js
@@ -1,0 +1,104 @@
+// archive search: Internet Archive Advanced Search across all mediatypes.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+
+const SORT_OPTIONS = ['downloads', 'date', 'addeddate', 'week', 'title'];
+const SORT_ALIAS = { added: 'addeddate', published: 'date' };
+const MEDIATYPES = ['texts', 'movies', 'audio', 'software', 'image', 'web', 'data', 'collection'];
+
+cli({
+    site: 'archive',
+    name: 'search',
+    access: 'read',
+    description: 'Search Internet Archive items across books, movies, audio, software, and web.',
+    domain: 'archive.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Full-text query (matches title, description, creator, subject).' },
+        { name: 'mediatype', type: 'string', required: false, help: `Restrict to mediatype: ${MEDIATYPES.join(', ')}` },
+        { name: 'sort', type: 'string', default: 'downloads', help: `Sort key: ${SORT_OPTIONS.join(', ')}` },
+        { name: 'limit', type: 'int', default: 20, help: 'Max items (max 100; one API page).' },
+    ],
+    columns: ['rank', 'identifier', 'title', 'creator', 'date', 'mediatype', 'downloads', 'url'],
+    func: async (args) => {
+        const sortRaw = String(args.sort ?? 'downloads').toLowerCase();
+        const sort = SORT_ALIAS[sortRaw] ?? sortRaw;
+        if (!SORT_OPTIONS.includes(sort)) {
+            throw new ArgumentError(`archive search sort must be one of ${SORT_OPTIONS.join(', ')}`);
+        }
+        if (args.mediatype && !MEDIATYPES.includes(String(args.mediatype))) {
+            throw new ArgumentError(`archive search mediatype must be one of ${MEDIATYPES.join(', ')}`);
+        }
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('archive search limit must be a positive integer');
+        }
+        if (limit > 100) {
+            throw new ArgumentError('archive search limit must be <= 100');
+        }
+
+        const query = String(args.query ?? '').trim();
+        if (!query) {
+            throw new ArgumentError('archive search query must not be empty');
+        }
+
+        const fullQuery = args.mediatype
+            ? `(${query}) AND mediatype:${args.mediatype}`
+            : query;
+
+        const url = new URL('https://archive.org/advancedsearch.php');
+        url.searchParams.set('q', fullQuery);
+        url.searchParams.set('output', 'json');
+        url.searchParams.set('rows', String(limit));
+        url.searchParams.set('sort[]', `${sort} desc`);
+        for (const fl of ['identifier', 'title', 'creator', 'date', 'mediatype', 'downloads']) {
+            url.searchParams.append('fl[]', fl);
+        }
+
+        let resp;
+        try {
+            resp = await fetch(url, {
+                headers: {
+                    'Accept': 'application/json',
+                    'User-Agent': 'opencli/1.0 (+https://github.com/jackwener/opencli)',
+                },
+            });
+        } catch (error) {
+            throw new CommandExecutionError(`archive search request failed: ${error?.message || error}`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`archive search failed: HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        } catch (error) {
+            throw new CommandExecutionError(`archive search returned malformed JSON: ${error?.message || error}`);
+        }
+
+        const docs = data?.response?.docs;
+        if (!Array.isArray(docs) || docs.length === 0) {
+            throw new EmptyResultError('archive search', `No items match "${query}" on archive.org.`);
+        }
+
+        return docs.slice(0, limit).map((d, i) => {
+            const id = String(d.identifier ?? '');
+            const creator = Array.isArray(d.creator) ? d.creator.join(', ') : String(d.creator ?? '');
+            return {
+                rank: i + 1,
+                identifier: id,
+                title: String(d.title ?? ''),
+                creator,
+                date: d.date ? String(d.date).slice(0, 10) : '',
+                mediatype: String(d.mediatype ?? ''),
+                downloads: Number(d.downloads ?? 0),
+                url: id ? `https://archive.org/details/${id}` : '',
+            };
+        });
+    },
+});

--- a/clis/archive/snapshots.js
+++ b/clis/archive/snapshots.js
@@ -11,6 +11,14 @@ function buildWaybackUrl(timestamp, original) {
     return `https://web.archive.org/web/${timestamp}/${original}`;
 }
 
+function requireCdxColumn(cols, name) {
+    const index = cols[name];
+    if (!Number.isInteger(index)) {
+        throw new CommandExecutionError(`archive snapshots returned malformed CDX payload: missing "${name}" column`);
+    }
+    return index;
+}
+
 cli({
     site: 'archive',
     name: 'snapshots',
@@ -82,17 +90,30 @@ cli({
             throw new EmptyResultError('archive snapshots', `No Wayback snapshots for "${target}".`);
         }
         const [header, ...rows] = data;
+        if (!Array.isArray(header)) {
+            throw new CommandExecutionError('archive snapshots returned malformed CDX payload: header row must be an array');
+        }
         const cols = {};
         header.forEach((name, i) => { cols[name] = i; });
+        const timestampCol = requireCdxColumn(cols, 'timestamp');
+        const originalCol = requireCdxColumn(cols, 'original');
+        const statusCol = requireCdxColumn(cols, 'statuscode');
+        const mimetypeCol = requireCdxColumn(cols, 'mimetype');
 
         return rows.slice(0, limit).map(row => {
-            const timestamp = String(row[cols.timestamp] ?? '');
-            const original = String(row[cols.original] ?? '');
+            if (!Array.isArray(row)) {
+                throw new CommandExecutionError('archive snapshots returned malformed CDX payload: snapshot row must be an array');
+            }
+            const timestamp = String(row[timestampCol] ?? '');
+            const original = String(row[originalCol] ?? '');
+            if (!/^\d{14}$/.test(timestamp) || !original) {
+                throw new CommandExecutionError('archive snapshots returned malformed CDX payload: snapshot row is missing timestamp/original URL');
+            }
             return {
                 timestamp,
                 snapshot_url: buildWaybackUrl(timestamp, original),
-                status: String(row[cols.statuscode] ?? ''),
-                mimetype: String(row[cols.mimetype] ?? ''),
+                status: String(row[statusCol] ?? ''),
+                mimetype: String(row[mimetypeCol] ?? ''),
                 original_url: original,
             };
         });

--- a/clis/archive/snapshots.js
+++ b/clis/archive/snapshots.js
@@ -29,7 +29,10 @@ cli({
     func: async (args) => {
         const target = String(args.url ?? '').trim();
         if (!target) {
-            throw new ArgumentError('archive snapshots url must not be empty');
+            throw new ArgumentError(
+                'archive snapshots url cannot be empty',
+                'Example: opencli archive snapshots wikipedia.org',
+            );
         }
         const limit = Number(args.limit ?? 20);
         if (!Number.isInteger(limit) || limit <= 0) {

--- a/clis/archive/snapshots.js
+++ b/clis/archive/snapshots.js
@@ -86,7 +86,10 @@ cli({
         }
 
         // CDX returns an array of arrays; the first row is the header.
-        if (!Array.isArray(data) || data.length < 2) {
+        if (!Array.isArray(data)) {
+            throw new CommandExecutionError('archive snapshots returned malformed CDX payload: top-level payload must be an array');
+        }
+        if (data.length < 2) {
             throw new EmptyResultError('archive snapshots', `No Wayback snapshots for "${target}".`);
         }
         const [header, ...rows] = data;
@@ -106,14 +109,19 @@ cli({
             }
             const timestamp = String(row[timestampCol] ?? '');
             const original = String(row[originalCol] ?? '');
+            const status = row[statusCol];
+            const mimetype = row[mimetypeCol];
             if (!/^\d{14}$/.test(timestamp) || !original) {
                 throw new CommandExecutionError('archive snapshots returned malformed CDX payload: snapshot row is missing timestamp/original URL');
+            }
+            if (status == null || mimetype == null || String(status) === '' || String(mimetype) === '') {
+                throw new CommandExecutionError('archive snapshots returned malformed CDX payload: snapshot row is missing statuscode/mimetype');
             }
             return {
                 timestamp,
                 snapshot_url: buildWaybackUrl(timestamp, original),
-                status: String(row[statusCol] ?? ''),
-                mimetype: String(row[mimetypeCol] ?? ''),
+                status: String(status),
+                mimetype: String(mimetype),
                 original_url: original,
             };
         });

--- a/clis/archive/snapshots.js
+++ b/clis/archive/snapshots.js
@@ -1,0 +1,97 @@
+// archive snapshots: Wayback Machine CDX history for a URL.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+
+function buildWaybackUrl(timestamp, original) {
+    if (!timestamp || !original) return '';
+    return `https://web.archive.org/web/${timestamp}/${original}`;
+}
+
+cli({
+    site: 'archive',
+    name: 'snapshots',
+    access: 'read',
+    description: 'List Wayback Machine snapshots over time for a URL via the CDX API.',
+    domain: 'archive.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'url', positional: true, required: true, help: 'URL to look up (with or without scheme).' },
+        { name: 'from', type: 'string', required: false, help: 'Earliest year/timestamp (YYYY[MM[DD[hh[mm[ss]]]]])' },
+        { name: 'to', type: 'string', required: false, help: 'Latest year/timestamp (YYYY[MM[DD[hh[mm[ss]]]]])' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max snapshots to return (max 1000).' },
+    ],
+    columns: ['timestamp', 'snapshot_url', 'status', 'mimetype', 'original_url'],
+    func: async (args) => {
+        const target = String(args.url ?? '').trim();
+        if (!target) {
+            throw new ArgumentError('archive snapshots url must not be empty');
+        }
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) {
+            throw new ArgumentError('archive snapshots limit must be a positive integer');
+        }
+        if (limit > 1000) {
+            throw new ArgumentError('archive snapshots limit must be <= 1000');
+        }
+        for (const key of ['from', 'to']) {
+            const v = args[key];
+            if (v != null && !/^\d{4,14}$/.test(String(v))) {
+                throw new ArgumentError(`archive snapshots ${key} must be a digit-only timestamp (YYYY[MM[DD[hh[mm[ss]]]]])`);
+            }
+        }
+
+        // Wayback CDX is served on HTTP only; the HTTPS endpoint returns 503.
+        const apiUrl = new URL('http://web.archive.org/cdx/search/cdx');
+        apiUrl.searchParams.set('url', target);
+        apiUrl.searchParams.set('output', 'json');
+        apiUrl.searchParams.set('limit', String(limit));
+        if (args.from) apiUrl.searchParams.set('from', String(args.from));
+        if (args.to) apiUrl.searchParams.set('to', String(args.to));
+
+        let resp;
+        try {
+            resp = await fetch(apiUrl, {
+                headers: {
+                    'Accept': 'application/json',
+                    'User-Agent': 'opencli/1.0 (+https://github.com/jackwener/opencli)',
+                },
+            });
+        } catch (error) {
+            throw new CommandExecutionError(`archive snapshots request failed: ${error?.message || error}`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`archive snapshots failed: HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        } catch (error) {
+            throw new CommandExecutionError(`archive snapshots returned malformed JSON: ${error?.message || error}`);
+        }
+
+        // CDX returns an array of arrays; the first row is the header.
+        if (!Array.isArray(data) || data.length < 2) {
+            throw new EmptyResultError('archive snapshots', `No Wayback snapshots for "${target}".`);
+        }
+        const [header, ...rows] = data;
+        const cols = {};
+        header.forEach((name, i) => { cols[name] = i; });
+
+        return rows.slice(0, limit).map(row => {
+            const timestamp = String(row[cols.timestamp] ?? '');
+            const original = String(row[cols.original] ?? '');
+            return {
+                timestamp,
+                snapshot_url: buildWaybackUrl(timestamp, original),
+                status: String(row[cols.statuscode] ?? ''),
+                mimetype: String(row[cols.mimetype] ?? ''),
+                original_url: original,
+            };
+        });
+    },
+});

--- a/clis/archive/wayback.js
+++ b/clis/archive/wayback.js
@@ -32,7 +32,10 @@ cli({
     func: async (args) => {
         const target = String(args.url ?? '').trim();
         if (!target) {
-            throw new ArgumentError('archive wayback url must not be empty');
+            throw new ArgumentError(
+                'archive wayback url cannot be empty',
+                'Example: opencli archive wayback wikipedia.org',
+            );
         }
         const timestamp = args.timestamp ? normalizeTimestamp(args.timestamp) : '';
 

--- a/clis/archive/wayback.js
+++ b/clis/archive/wayback.js
@@ -1,0 +1,77 @@
+// archive wayback: Wayback Machine closest-snapshot lookup for a URL.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+
+function normalizeTimestamp(raw) {
+    // Accept YYYY, YYYYMM, YYYYMMDD, YYYYMMDDhh, YYYYMMDDhhmm, YYYYMMDDhhmmss,
+    // YYYY-MM-DD, or YYYY-MM-DDThh:mm:ss. Strip non-digits and validate length.
+    const digits = String(raw).replace(/[^0-9]/g, '');
+    if (!/^\d{4,14}$/.test(digits) || digits.length % 2 !== 0 && digits.length !== 4) {
+        throw new ArgumentError('archive wayback timestamp must be YYYY[MM[DD[hh[mm[ss]]]]] or an ISO date');
+    }
+    return digits;
+}
+
+cli({
+    site: 'archive',
+    name: 'wayback',
+    access: 'read',
+    description: 'Look up the closest Wayback Machine snapshot for a URL.',
+    domain: 'archive.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'url', positional: true, required: true, help: 'URL to look up (with or without scheme).' },
+        { name: 'timestamp', type: 'string', required: false, help: 'Target timestamp (YYYY[MM[DD[hh[mm[ss]]]]] or ISO date). Defaults to most recent snapshot.' },
+    ],
+    columns: ['original_url', 'requested_timestamp', 'snapshot_timestamp', 'snapshot_url', 'status'],
+    func: async (args) => {
+        const target = String(args.url ?? '').trim();
+        if (!target) {
+            throw new ArgumentError('archive wayback url must not be empty');
+        }
+        const timestamp = args.timestamp ? normalizeTimestamp(args.timestamp) : '';
+
+        const apiUrl = new URL('https://archive.org/wayback/available');
+        apiUrl.searchParams.set('url', target);
+        if (timestamp) apiUrl.searchParams.set('timestamp', timestamp);
+
+        let resp;
+        try {
+            resp = await fetch(apiUrl, {
+                headers: {
+                    'Accept': 'application/json',
+                    'User-Agent': 'opencli/1.0 (+https://github.com/jackwener/opencli)',
+                },
+            });
+        } catch (error) {
+            throw new CommandExecutionError(`archive wayback request failed: ${error?.message || error}`);
+        }
+        if (!resp.ok) {
+            throw new CommandExecutionError(`archive wayback failed: HTTP ${resp.status}`);
+        }
+        let data;
+        try {
+            data = await resp.json();
+        } catch (error) {
+            throw new CommandExecutionError(`archive wayback returned malformed JSON: ${error?.message || error}`);
+        }
+
+        const snap = data?.archived_snapshots?.closest;
+        if (!snap || !snap.available || !snap.url) {
+            throw new EmptyResultError('archive wayback', `No Wayback snapshot for "${target}".`);
+        }
+
+        return [{
+            original_url: String(data.url ?? target),
+            requested_timestamp: timestamp,
+            snapshot_timestamp: String(snap.timestamp ?? ''),
+            snapshot_url: String(snap.url),
+            status: String(snap.status ?? ''),
+        }];
+    },
+});

--- a/clis/archive/wayback.js
+++ b/clis/archive/wayback.js
@@ -65,8 +65,11 @@ cli({
         }
 
         const snap = data?.archived_snapshots?.closest;
-        if (!snap || !snap.available || !snap.url) {
+        if (!snap || !snap.available) {
             throw new EmptyResultError('archive wayback', `No Wayback snapshot for "${target}".`);
+        }
+        if (typeof snap.url !== 'string' || !snap.url || !/^\d{14}$/.test(String(snap.timestamp ?? ''))) {
+            throw new CommandExecutionError('archive wayback returned malformed payload: closest snapshot is missing url/timestamp');
         }
 
         return [{

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -130,6 +130,7 @@ export default defineConfig({
                 { text: 'Apple Podcasts', link: '/adapters/browser/apple-podcasts' },
                 { text: 'Xiaoyuzhou', link: '/adapters/browser/xiaoyuzhou' },
                 { text: 'Yahoo Finance', link: '/adapters/browser/yahoo-finance' },
+                { text: 'Internet Archive', link: '/adapters/browser/archive' },
                 { text: 'arXiv', link: '/adapters/browser/arxiv' },
                 { text: 'dblp', link: '/adapters/browser/dblp' },
                 { text: 'PubMed', link: '/adapters/browser/pubmed' },

--- a/docs/adapters/browser/archive.md
+++ b/docs/adapters/browser/archive.md
@@ -1,0 +1,81 @@
+# Internet Archive
+
+**Mode**: 🌐 Public · **Domain**: `archive.org`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli archive search <query>` | Search Internet Archive items across books, movies, audio, software, and web |
+| `opencli archive item <identifier>` | Fetch metadata for a single Internet Archive item by identifier |
+| `opencli archive wayback <url>` | Look up the closest Wayback Machine snapshot for a URL |
+| `opencli archive snapshots <url>` | List Wayback Machine snapshots over time for a URL via the CDX API |
+
+## Usage Examples
+
+```bash
+# Full-text search across all mediatypes (default sort by downloads)
+opencli archive search "machine learning" --limit 10
+
+# Restrict to a mediatype
+opencli archive search "newton principia" --mediatype texts --limit 5
+opencli archive search "moon landing" --mediatype movies --sort date --limit 5
+
+# Single item metadata
+opencli archive item open-syllabus
+opencli archive item FinalFantasy2_356
+
+# Closest Wayback snapshot, optionally near a date
+opencli archive wayback wikipedia.org
+opencli archive wayback wikipedia.org --timestamp 2015
+
+# Wayback CDX history for a URL
+opencli archive snapshots wikipedia.org --limit 20
+opencli archive snapshots wikipedia.org --from 2010 --to 2015 --limit 50
+
+# JSON output
+opencli archive search "machine learning" -f json
+```
+
+### `search` Options
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Full-text query (matches title, description, creator, subject) |
+| `--mediatype` | `texts` / `movies` / `audio` / `software` / `image` / `web` / `data` / `collection` |
+| `--sort` | `downloads` (default) / `date` / `addeddate` / `week` / `title` |
+| `--limit` | Max items (1-100, default: 20) |
+
+Returns rows with `rank, identifier, title, creator, date, mediatype, downloads, url`. The `identifier` round-trips into `opencli archive item <identifier>`.
+
+### `item` Options
+
+| Option | Description |
+|--------|-------------|
+| `identifier` (positional) | Archive item identifier (letters, digits, ".", "_", "-") |
+
+Returns one row with `identifier, title, creator, date, mediatype, collection, description, file_count, url`.
+
+### `wayback` Options
+
+| Option | Description |
+|--------|-------------|
+| `url` (positional) | URL to look up (with or without scheme) |
+| `--timestamp` | Target timestamp (`YYYY[MM[DD[hh[mm[ss]]]]]` or ISO date). Defaults to most recent snapshot |
+
+Returns one row with `original_url, requested_timestamp, snapshot_timestamp, snapshot_url, status`. The `snapshot_url` round-trips into a regular browser fetch.
+
+### `snapshots` Options
+
+| Option | Description |
+|--------|-------------|
+| `url` (positional) | URL to look up (with or without scheme) |
+| `--from` | Earliest digit-only timestamp |
+| `--to` | Latest digit-only timestamp |
+| `--limit` | Max snapshots (1-1000, default: 20) |
+
+Returns rows with `timestamp, snapshot_url, status, mimetype, original_url`. Each `snapshot_url` is a direct Wayback Machine permalink. The CDX endpoint is served over HTTP only; the HTTPS endpoint returns 503 in practice.
+
+## Prerequisites
+
+- No browser required; uses public archive.org APIs (Advanced Search, Metadata, Wayback Available, CDX).

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -105,6 +105,7 @@ Run `opencli list` for the live registry.
 | **[apple-podcasts](./browser/apple-podcasts.md)** | `search` `episodes` `top`                                                                                                                      | 🌐 Public    |
 | **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🔑 Local API |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
+| **[archive](./browser/archive.md)**               | `search` `item` `wayback` `snapshots`                                                                                                          | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
 | **[dblp](./browser/dblp.md)**                     | `search` `author` `paper` `venue`                                                                                                              | 🌐 Public    |
 | **[pubmed](./browser/pubmed.md)**                 | `search` `article` `author` `citations` `related` `clinical-trial` `review` `mesh` `journal`                                                 | 🌐 Public    |


### PR DESCRIPTION
## Description

Adds a native read-only adapter for the Internet Archive (archive.org). Four commands wrap the four public REST endpoints that cover the most common agent use cases: full-text search across all mediatypes, per-item metadata, the Wayback Machine closest-snapshot lookup, and the Wayback CDX history. No login, no browser, no external CLI wrap. Follows the same Strategy.PUBLIC pattern as `hf`, `smzdm`, and the other read-only adapters.

Related issue: Closes #1896.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Added doc page under `docs/adapters/` (if new adapter)
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [x] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Commands:

```
archive search <query>      [--mediatype texts|movies|audio|software|image|web|data|collection] [--sort downloads|date|addeddate|week|title] [--limit N]
archive item <identifier>
archive wayback <url>        [--timestamp YYYY[MM[DD[hh[mm[ss]]]]] | ISO date]
archive snapshots <url>      [--from YYYY...] [--to YYYY...] [--limit N]
```

Live runs against archive.org (real session, no auth):

```
$ opencli archive search "machine learning" --limit 3 -f json
[
  { "rank": 1, "identifier": "open-syllabus", "title": "Open Syllabus", "mediatype": "collection", "downloads": 129540246, "url": "https://archive.org/details/open-syllabus", ... },
  { "rank": 2, "identifier": "FinalFantasy2_356", "title": "Final Fantasy II (SNES) - 3:56 - Kevin Juang", "creator": "Kevin 'Enhasa' Juang", "mediatype": "movies", "downloads": 6855428, ... },
  ...
]
```

```
$ opencli archive item open-syllabus -f json
[ { "identifier": "open-syllabus", "title": "Open Syllabus", "mediatype": "collection", "file_count": 7, "url": "https://archive.org/details/open-syllabus", ... } ]
```

```
$ opencli archive wayback wikipedia.org --timestamp 2015 -f json
[ { "original_url": "wikipedia.org", "requested_timestamp": "2015", "snapshot_timestamp": "20151231235819", "snapshot_url": "http://web.archive.org/web/20151231235819/https://www.wikipedia.org/", "status": "200" } ]
```

```
$ opencli archive snapshots wikipedia.org --limit 3 -f json
[
  { "timestamp": "20010727112808", "snapshot_url": "https://web.archive.org/web/20010727112808/http://www.wikipedia.org:80/", "status": "200", "mimetype": "text/html", ... },
  ...
]
```

Typed-error paths also exercised:

```
$ opencli archive search "x" --mediatype bogus
ok: false
error:
  code: ARGUMENT
  message: archive search mediatype must be one of texts, movies, audio, software, image, web, data, collection
```

```
$ opencli archive search "asdkjfhasdkfjhasdkjfh"
ok: false
error:
  code: EMPTY_RESULT
  message: archive search returned no data
  help: No items match "asdkjfhasdkfjhasdkjfh" on archive.org.
```

```
$ opencli archive item "bad id with spaces"
ok: false
error:
  code: ARGUMENT
  message: archive item identifier may only contain letters, digits, ".", "_", "-"
```

Notes for review:

- CDX is served over HTTP only (the HTTPS endpoint returns 503 in practice); `snapshots.js` documents that next to the URL.
- `cli-manifest.json` regenerated; the diff contains only the four new `archive/*` entries.

`clis/archive/archive.test.js` passes 3 / 3 locally; `npm run check:typed-error-lint` and `npm run check:silent-column-drop` both report `new=0`.
