### PR TITLE
fix(twitter): neutralize onbeforeunload so CDP automation can't be wedged

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -76,6 +76,26 @@ async function insertComposerText(page, text) {
     const focusResult = await focusComposer(page);
     if (!focusResult?.ok) return focusResult;
 
+    // Neutralize beforeunload BEFORE inserting text. X's /compose/post can fire
+    // a "Leave page?" beforeunload dialog during/after text insertion (notably
+    // when the text contains a URL that X unfurls). While that dialog is open,
+    // page JS execution is SUSPENDED, so the subsequent verifyComposerText
+    // evaluate (a setTimeout poll loop) never advances — it hangs until the CDP
+    // target is detached and the page falls to about:blank. Strip the handler so
+    // the composer stays put and JS keeps running. Must run before nativeType so
+    // it is in place before any dialog can appear.
+    try {
+        await page.evaluate(`(() => {
+            window.onbeforeunload = null;
+            window.addEventListener('beforeunload', (e) => {
+                e.stopImmediatePropagation();
+                e.preventDefault();
+                delete e.returnValue;
+            }, true);
+            return true;
+        })()`);
+    } catch { /* non-fatal: best-effort hardening */ }
+
     const nativeInserters = [
         page.nativeType?.bind(page),
         page.insertText?.bind(page),

--- a/clis/twitter/reply.js
+++ b/clis/twitter/reply.js
@@ -53,6 +53,15 @@ async function openReplyComposer(page, rawUrl) {
 }
 
 async function insertReplyText(page, text) {
+    // Neutralize beforeunload right before focusing the composer. The stealth
+    // layer already strips this globally on every navigation, but re-strip here
+    // as defense-in-depth: x.com can re-register onbeforeunload after load
+    // (e.g. once media is staged), and if a "Leave site?" dialog opens during
+    // the text-insert -> submit window it wedges the CDP-controlled tab with no
+    // user to dismiss it, aborting every later navigate/exec.
+    try {
+        await page.evaluate(`(() => { try { window.onbeforeunload = null; } catch (e) {} })()`);
+    } catch { /* non-fatal: best-effort hardening */ }
     return page.evaluate(`(async () => {
       try {
           const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);

--- a/src/browser/stealth.ts
+++ b/src/browser/stealth.ts
@@ -354,6 +354,37 @@ export function generateStealthJs(): string {
         }
       } catch {}
 
+      // 14. beforeunload neutralization (x.com "Leave site?" dialog hardening)
+      //     x.com registers an onbeforeunload handler once the composer has
+      //     staged unsaved state (uploaded media, typed text). Under CDP /
+      //     extension automation there is no user to dismiss the resulting
+      //     "Leave site?" dialog, and the CLI side cannot intercept the raw
+      //     CDP Page.javascriptDialogOpening event (the daemon owns the CDP
+      //     session), so the dialog wedges the tab: every subsequent
+      //     navigate/exec aborts with "This operation was aborted" until a
+      //     human manually clicks "Stay". This repeatedly broke twitter
+      //     post/reply on the image->text transition and poisoned later reads.
+      //     Defense: a capturing-phase listener that swallows the event, plus
+      //     an accessor on window.onbeforeunload that silently drops future
+      //     assignments — so no dialog can ever open. Runs in stealth (injected
+      //     on every navigation), covering post, reply, and reads uniformly.
+      try {
+        window.addEventListener('beforeunload', (e) => {
+          try { e.stopImmediatePropagation(); } catch {}
+          try { e.preventDefault(); } catch {}
+          try { delete e.returnValue; } catch {}
+          try { e.returnValue = undefined; } catch {}
+        }, true);
+        try { window.onbeforeunload = null; } catch {}
+        try {
+          Object.defineProperty(window, 'onbeforeunload', {
+            get: () => null,
+            set: () => {},
+            configurable: true,
+          });
+        } catch {}
+      } catch {}
+
       return 'applied';
     })()
   `);


### PR DESCRIPTION
## Problem

When automating `twitter post` / `twitter reply` against x.com, the tab repeatedly
wedges on the **image → text** transition (and any later navigation). x.com registers
an `onbeforeunload` handler once the composer has staged unsaved state (uploaded media,
typed text), so the transition fires a **"Leave site?"** dialog. Under CDP / Browser
Bridge automation:

- there is no user present to click **Stay**, and
- the CLI side cannot intercept the raw `Page.javascriptDialogOpening` CDP event because
  the daemon owns the CDP session.

While that dialog is open, page JS execution is **suspended**, so every subsequent
`navigate` / `exec` aborts with `"This operation was aborted"` until a human manually
dismisses the dialog. The most reproducible trigger is inserting text **after** images
have been attached — exactly the order `post.js` uses today (media first, then text).

## Fix

Three layered, defense-in-depth neutralizers so the dialog can never open:

1. **`src/browser/stealth.ts`** — a global neutralizer injected on every navigation
   (item #14 in `generateStealthJs`). A capturing-phase `beforeunload` listener calls
   `stopImmediatePropagation` + `preventDefault` so x.com's own handler never runs, and
   `window.onbeforeunload` is redefined as an accessor whose setter is a no-op so future
   assignments by the page are silently dropped. Covers post, reply, **and** reads
   uniformly.

2. **`clis/twitter/post.js`** — strips `onbeforeunload` in `insertComposerText` right
   after the focus guard, before `nativeType`. This is the surgical fix for the
   image→text wedge: while a dialog is open the `verifyComposerText` poll loop never
   advances, the CDP target detaches, and the page falls to `about:blank`. Installing
   the strip before any text insertion guarantees JS keeps running.

3. **`clis/twitter/reply.js`** — same strip at the top of `insertReplyText`, so the
   text-insert → submit window is protected even if x.com re-registers
   `onbeforeunload` after load (e.g. once media is staged).

All three are `try { … } catch { /* non-fatal */ }` — best-effort hardening that cannot
regress the existing flows.

## Why three layers

The stealth layer alone fixes it in practice, but it runs at navigation time. x.com can
re-register `onbeforeunload` after load, and the post/reply text-insert path is the
highest-risk window, so the per-command strips are belt-and-suspenders. Each is
independently sufficient and independently harmless.

## Status

Draft. Tested locally against a v1.8.3 install (these exact patches, hand-applied to the
shipped `dist` + `clis` files) — `twitter post` with images + text and `twitter reply`
both complete without the wedge. Wanted to upstream them rather than carry local
`node_modules` patches that `npm install -g` wipes.

Happy to adjust scope (e.g. drop the per-command strips and keep only the stealth layer,
or gate behind an opt-in env var) if you'd prefer a smaller blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
