### PR TITLE
fix: default access to 'read' for backward compatibility with user commands

### DIFF
--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -115,11 +115,31 @@ describe('cli() registration', () => {
     expect(getRegistry().get('test-registry/validated')?.validateArgs).toBe(validateArgs);
   });
 
-  it('rejects commands without explicit access metadata', () => {
-    expect(() => cli({
+  it('defaults access to read when not explicitly declared', () => {
+    cli({
       site: 'test-registry',
       name: 'missing-access',
-    } as any)).toThrow("Command test-registry/missing-access must declare access: 'read' | 'write'");
+    } as any);
+    const cmd = getRegistry().get('test-registry/missing-access');
+    expect(cmd?.access).toBe('read');
+  });
+
+  it('defaults access to read when explicitly null', () => {
+    cli({
+      site: 'test-registry',
+      name: 'null-access',
+      access: null,
+    } as any);
+    const cmd = getRegistry().get('test-registry/null-access');
+    expect(cmd?.access).toBe('read');
+  });
+
+  it('rejects commands with invalid access metadata', () => {
+    expect(() => cli({
+      site: 'test-registry',
+      name: 'invalid-access',
+      access: 'execute',
+    } as any)).toThrow("Command test-registry/invalid-access must declare access: 'read' | 'write'");
   });
 });
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -207,6 +207,10 @@ function normalizeCommand(cmd: RawCliCommand): CliCommand {
 
 function assertCommandAccess(cmd: Pick<RawCliCommand, 'site' | 'name'> & { access?: unknown }): asserts cmd is RawCliCommand {
   if (cmd.access === 'read' || cmd.access === 'write') return;
+  if (cmd.access === undefined || cmd.access === null) {
+    (cmd as any).access = 'read';
+    return;
+  }
   const key = `${cmd.site}/${cmd.name}`;
   throw new Error(`Command ${key} must declare access: 'read' | 'write'`);
 }


### PR DESCRIPTION
## Summary

After upgrading from v1.6.8 to v1.8.3, user-installed command modules in `~/.opencli/clis/` fail to load because they don't declare the `access` field that was made mandatory in commit eea9ff8b.

## Related Issue

Closes #1922

## Changes

Modified `assertCommandAccess()` in `src/registry.ts` to default `access` to `'read'` when it is `undefined` or `null`, instead of throwing. Commands with invalid non-null/non-undefined values still throw.

**Rationale for defaulting to `'read'`:**
- `'read'` is the safe/conservative default (least privilege)
- All failing commands in the issue (xueqiu/comments, instagram/download, 36kr/\*, antigravity/\*) are read-only operations
- Avoids breaking existing user workflows on upgrade
- `convention-audit.ts` already warns about missing `access` at a different severity level

## Testing

- Added test: command with no `access` field gets `'read'` assigned
- Added test: command with `access: null` gets `'read'` assigned
- Added test: command with invalid `access` value still throws
- All 23 registry tests pass
- Full unit test suite (1137+ tests across both shards) passes (pre-existing failures in article-extract are unrelated missing deps)