### PR TITLE
fix(package): include guide docs in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "files": [
     "dist/src/",
     "clis/",
+    "docs/guide/",
     "skills/opencli-*/**",
     "cli-manifest.json",
     "scripts/",


### PR DESCRIPTION
## Summary
- include `docs/guide/` in the npm package whitelist
- keep README links such as `./docs/guide/extending-opencli.md` valid for installed-package readers

Fixes #1918.

## Verification
- `node -e "const pkg = require('./package.json'); if (!pkg.files.includes('docs/guide/')) process.exit(1); console.log('docs/guide/ is included in package files')"`
- `npm pack --dry-run --json` showed `docs/guide/extending-opencli.md` in the package file list; this worktree does not have local dev dependencies installed, so npm prepare printed missing `tsx`/`tsc` tooling during the dry run.