### PR TITLE
feat(cli): support per-command rate limiting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command, InvalidArgumentError, Option } from 'commander';
+import yaml from 'js-yaml';
 import { findPackageRoot, getBuiltEntryCandidates } from './package-paths.js';
 import { type CliCommand, fullName, getRegistry, strategyLabel } from './registry.js';
 import { serializeCommand, formatArgSummary } from './serialization.js';
@@ -20,7 +21,7 @@ import { loadExternalClis, executeExternalCli, installExternalCli, registerExter
 import { listOpenCliSkills, readOpenCliSkill } from './skills.js';
 import { registerAllCommands } from './commanderAdapter.js';
 import { classifyAdapter, formatRootAdapterHelpText, installCommanderNamespaceStructuredHelp, installStructuredHelp, leadingPositionalFromUsage, rootHelpData, type RootAdapterGroups } from './help.js';
-import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError } from './errors.js';
+import { EXIT_CODES, getErrorMessage, BrowserConnectError, CliError, toEnvelope } from './errors.js';
 import { TargetError, type TargetErrorCode } from './browser/target-errors.js';
 import { resolveTargetJs, getTextResolvedJs, getValueResolvedJs, getAttributesResolvedJs, selectResolvedJs, isAutocompleteResolvedJs, type ResolveOptions, type TargetMatchLevel } from './browser/target-resolver.js';
 import { buildFindJs, buildSemanticFindJs, isFindError, type FindResult, type FindError, type SemanticFindOptions } from './browser/find.js';
@@ -3456,8 +3457,13 @@ cli({
     try {
       executeExternalCli(name, args, externalClis);
     } catch (err) {
-      console.error(`Error: ${getErrorMessage(err)}`);
-      process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      if (err instanceof CliError) {
+        process.stderr.write(yaml.dump(toEnvelope(err), { sortKeys: false, lineWidth: 120, noRefs: true }));
+        process.exitCode = err.exitCode;
+      } else {
+        console.error(`Error: ${getErrorMessage(err)}`);
+        process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      }
     }
   }
 

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -3,9 +3,10 @@ import { Command } from 'commander';
 import type { CliCommand } from './registry.js';
 import { attachTraceReceipt, EmptyResultError, selectorError } from './errors.js';
 
-const { mockExecuteCommand, mockRenderOutput } = vi.hoisted(() => ({
+const { mockExecuteCommand, mockRenderOutput, mockEnforceRateLimit } = vi.hoisted(() => ({
   mockExecuteCommand: vi.fn(),
   mockRenderOutput: vi.fn(),
+  mockEnforceRateLimit: vi.fn(),
 }));
 
 vi.mock('./execution.js', async () => {
@@ -20,7 +21,12 @@ vi.mock('./output.js', () => ({
   render: mockRenderOutput,
 }));
 
+vi.mock('./rate-limit.js', () => ({
+  enforceRateLimit: mockEnforceRateLimit,
+}));
+
 import { registerCommandToProgram } from './commanderAdapter.js';
+import { RateLimitError } from './errors.js';
 
 describe('commanderAdapter arg passing', () => {
   const cmd: CliCommand = {
@@ -40,6 +46,7 @@ describe('commanderAdapter arg passing', () => {
     mockExecuteCommand.mockReset();
     mockExecuteCommand.mockResolvedValue([]);
     mockRenderOutput.mockReset();
+    mockEnforceRateLimit.mockReset();
     delete process.env.OPENCLI_VERBOSE;
     process.exitCode = undefined;
   });
@@ -99,6 +106,42 @@ describe('commanderAdapter arg passing', () => {
     );
   });
 
+  it('checks rate limits after args are prepared and before execution', async () => {
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', './paper.pdf']);
+
+    expect(mockEnforceRateLimit).toHaveBeenCalledWith('paperreview/submit');
+    expect(mockExecuteCommand).toHaveBeenCalled();
+  });
+
+  it('does not execute when the rate limit blocks the command', async () => {
+    mockEnforceRateLimit.mockImplementationOnce(() => {
+      throw new RateLimitError('paperreview/submit', 5_000, '/tmp/rate-limits.yaml');
+    });
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', './paper.pdf']);
+
+    expect(mockExecuteCommand).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(75);
+  });
+
+  it('counts command aliases against the canonical command name', async () => {
+    const aliasCmd: CliCommand = { ...cmd, name: 'delete', aliases: ['rm'] };
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, aliasCmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'rm', './paper.pdf']);
+
+    expect(mockEnforceRateLimit).toHaveBeenCalledWith('paperreview/delete');
+  });
+
   it('rejects invalid bool values before calling executeCommand', async () => {
     const program = new Command();
     const siteCmd = program.command('paperreview');
@@ -108,6 +151,7 @@ describe('commanderAdapter arg passing', () => {
 
     // prepareCommandArgs validates bools before dispatch; executeCommand should not be reached
     expect(mockExecuteCommand).not.toHaveBeenCalled();
+    expect(mockEnforceRateLimit).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -16,6 +16,7 @@ import yaml from 'js-yaml';
 import { type CliCommand, fullName, getRegistry } from './registry.js';
 import { render as renderOutput } from './output.js';
 import { executeCommand, prepareCommandArgs } from './execution.js';
+import { enforceRateLimit } from './rate-limit.js';
 import {
   commandHelpData,
   formatCommandHelpText,
@@ -108,6 +109,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         rawKwargs.__opencliOptionSources = optionSources;
       }
       const kwargs = prepareCommandArgs(cmd, rawKwargs);
+      enforceRateLimit(fullName(cmd));
 
       const verbose = optionsRecord.verbose === true;
       let format = typeof optionsRecord.format === 'string' ? optionsRecord.format : 'table';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -125,6 +125,18 @@ export class TimeoutError extends CliError {
   }
 }
 
+export class RateLimitError extends CliError {
+  constructor(command: string, retryAfterMs: number, configPath: string) {
+    const retryAfter = formatRetryAfter(retryAfterMs);
+    super(
+      'RATE_LIMITED',
+      `Rate limit exceeded for ${command}`,
+      `Retry after ${retryAfter}. To change this limit, edit ${configPath}.`,
+      EXIT_CODES.TEMPFAIL,
+    );
+  }
+}
+
 export class ArgumentError extends CliError {
   constructor(message: string, hint?: string) {
     super('ARGUMENT', message, hint, EXIT_CODES.USAGE_ERROR);
@@ -159,6 +171,17 @@ export class PluginError extends CliError {
   constructor(message: string, hint?: string) {
     super('PLUGIN', message, hint, EXIT_CODES.GENERIC_ERROR);
   }
+}
+
+function formatRetryAfter(ms: number): string {
+  const safeMs = Math.max(0, Math.ceil(ms));
+  if (safeMs < 1_000) return `${safeMs}ms`;
+  const seconds = Math.ceil(safeMs / 1_000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.ceil(minutes / 60);
+  return `${hours}h`;
 }
 
 /**

--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -4,13 +4,15 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
-const { mockExecFileSync, mockPlatform } = vi.hoisted(() => ({
+const { mockExecFileSync, mockSpawnSync, mockPlatform, mockEnforceRateLimit } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
+  mockSpawnSync: vi.fn(),
   mockPlatform: vi.fn(() => 'darwin'),
+  mockEnforceRateLimit: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
-  spawnSync: vi.fn(),
+  spawnSync: mockSpawnSync,
   execFileSync: mockExecFileSync,
 }));
 
@@ -22,7 +24,12 @@ vi.mock('node:os', async () => {
   };
 });
 
-import { formatExternalCliLabel, installExternalCli, parseCommand, type ExternalCliConfig } from './external.js';
+vi.mock('./rate-limit.js', () => ({
+  enforceRateLimit: mockEnforceRateLimit,
+}));
+
+import { executeExternalCli, formatExternalCliLabel, installExternalCli, parseCommand, type ExternalCliConfig } from './external.js';
+import { RateLimitError } from './errors.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -144,5 +151,41 @@ describe('installExternalCli', () => {
 
     expect(installExternalCli(cli)).toBe(false);
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('executeExternalCli rate limits', () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    mockSpawnSync.mockReset();
+    mockEnforceRateLimit.mockReset();
+    process.exitCode = undefined;
+  });
+
+  it('checks the external command name before binary lookup and spawn', () => {
+    mockEnforceRateLimit.mockImplementationOnce(() => {
+      throw new RateLimitError('gh', 60_000, '/tmp/rate-limits.yaml');
+    });
+
+    expect(() => executeExternalCli('gh', ['issue', 'list'], [
+      { name: 'gh', binary: 'gh' },
+    ])).toThrow(RateLimitError);
+
+    expect(mockEnforceRateLimit).toHaveBeenCalledWith('gh');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary when the command is under its limit', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from('/usr/bin/gh'));
+    mockSpawnSync.mockReturnValue({ status: 0, error: undefined });
+
+    executeExternalCli('gh', ['issue', 'list'], [
+      { name: 'gh', binary: 'gh' },
+    ]);
+
+    expect(mockEnforceRateLimit).toHaveBeenCalledWith('gh');
+    expect(mockSpawnSync).toHaveBeenCalledWith('gh', ['issue', 'list'], { stdio: 'inherit' });
+    expect(process.exitCode).toBe(0);
   });
 });

--- a/src/external.ts
+++ b/src/external.ts
@@ -6,6 +6,7 @@ import { spawnSync, execFileSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import { log } from './logger.js';
 import { EXIT_CODES, getErrorMessage } from './errors.js';
+import { enforceRateLimit } from './rate-limit.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -185,6 +186,8 @@ export function executeExternalCli(name: string, args: string[], preloaded?: Ext
   if (!cli) {
     throw new Error(`External CLI '${name}' not found in registry.`);
   }
+
+  enforceRateLimit(name);
 
   // 1. Check if installed
   if (!isBinaryInstalled(cli.binary)) {

--- a/src/rate-limit.test.ts
+++ b/src/rate-limit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { enforceRateLimit, loadRateLimitRules } from './rate-limit.js';
+import { ConfigError, RateLimitError } from './errors.js';
+
+describe('rate-limit', () => {
+  it('does nothing when the config file is absent', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-rate-limit-'));
+
+    expect(() => enforceRateLimit('xiaohongshu/delete-note', {
+      configPath: path.join(dir, 'missing.yaml'),
+      statePath: path.join(dir, 'state.json'),
+      now: 1_000,
+    })).not.toThrow();
+  });
+
+  it('blocks attempts above the configured sliding window limit', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-rate-limit-'));
+    const configPath = path.join(dir, 'rate-limits.yaml');
+    const statePath = path.join(dir, 'state.json');
+    fs.writeFileSync(configPath, [
+      'rules:',
+      '  - command: xiaohongshu/delete-note',
+      '    limit: 2',
+      '    window: 10s',
+      '',
+    ].join('\n'), 'utf-8');
+
+    enforceRateLimit('xiaohongshu/delete-note', { configPath, statePath, now: 1_000 });
+    enforceRateLimit('xiaohongshu/delete-note', { configPath, statePath, now: 2_000 });
+
+    expect(() => enforceRateLimit('xiaohongshu/delete-note', { configPath, statePath, now: 3_000 }))
+      .toThrow(RateLimitError);
+  });
+
+  it('allows a command again after the oldest attempt leaves the window', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-rate-limit-'));
+    const configPath = path.join(dir, 'rate-limits.yaml');
+    const statePath = path.join(dir, 'state.json');
+    fs.writeFileSync(configPath, [
+      'rules:',
+      '  - command: tiktok/unfollow',
+      '    limit: 1',
+      '    window: 5s',
+      '',
+    ].join('\n'), 'utf-8');
+
+    enforceRateLimit('tiktok/unfollow', { configPath, statePath, now: 1_000 });
+    enforceRateLimit('tiktok/unfollow', { configPath, statePath, now: 6_001 });
+
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as { commands: Record<string, number[]> };
+    expect(state.commands['tiktok/unfollow']).toEqual([6_001]);
+  });
+
+  it('rejects invalid YAML config', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-rate-limit-'));
+    const configPath = path.join(dir, 'rate-limits.yaml');
+    fs.writeFileSync(configPath, 'rules:\n  - command: [', 'utf-8');
+
+    expect(() => loadRateLimitRules(configPath)).toThrow(ConfigError);
+  });
+
+  it('rejects invalid rule fields', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-rate-limit-'));
+    const configPath = path.join(dir, 'rate-limits.yaml');
+    fs.writeFileSync(configPath, [
+      'rules:',
+      '  - command: gh',
+      '    limit: 0',
+      '    window: soon',
+      '',
+    ].join('\n'), 'utf-8');
+
+    expect(() => loadRateLimitRules(configPath)).toThrow(ConfigError);
+  });
+});

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,164 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import { ConfigError, RateLimitError, getErrorMessage } from './errors.js';
+import { isRecord } from './utils.js';
+
+export interface RateLimitRule {
+  command: string;
+  limit: number;
+  windowMs: number;
+}
+
+export interface RateLimitOptions {
+  configPath?: string;
+  statePath?: string;
+  now?: number;
+}
+
+interface RateLimitState {
+  version: 1;
+  commands: Record<string, number[]>;
+}
+
+const CONFIG_FILE = 'rate-limits.yaml';
+const STATE_FILE = 'rate-limit-state.json';
+
+export function getRateLimitConfigPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.opencli', CONFIG_FILE);
+}
+
+export function getRateLimitStatePath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.opencli', STATE_FILE);
+}
+
+export function enforceRateLimit(command: string, opts: RateLimitOptions = {}): void {
+  const configPath = opts.configPath ?? getRateLimitConfigPath();
+  const rule = findRateLimitRule(command, configPath);
+  if (!rule) return;
+
+  const statePath = opts.statePath ?? getRateLimitStatePath();
+  const now = opts.now ?? Date.now();
+  const state = loadState(statePath);
+  const existing = Array.isArray(state.commands[command]) ? state.commands[command] : [];
+  const cutoff = now - rule.windowMs;
+  const recent = existing.filter((timestamp) => Number.isFinite(timestamp) && timestamp > cutoff);
+
+  if (recent.length >= rule.limit) {
+    const oldest = Math.min(...recent);
+    const retryAfterMs = Math.max(0, oldest + rule.windowMs - now);
+    state.commands[command] = recent;
+    saveState(statePath, state);
+    throw new RateLimitError(command, retryAfterMs, configPath);
+  }
+
+  state.commands[command] = [...recent, now];
+  saveState(statePath, state);
+}
+
+export function findRateLimitRule(command: string, configPath: string = getRateLimitConfigPath()): RateLimitRule | null {
+  const rules = loadRateLimitRules(configPath);
+  return rules.find((rule) => rule.command === command) ?? null;
+}
+
+export function loadRateLimitRules(configPath: string = getRateLimitConfigPath()): RateLimitRule[] {
+  if (!fs.existsSync(configPath)) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(fs.readFileSync(configPath, 'utf-8')) ?? {};
+  } catch (err) {
+    throw new ConfigError(
+      `Failed to parse ${configPath}: ${getErrorMessage(err)}`,
+      'Fix the YAML syntax or remove the file to disable command rate limits.',
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new ConfigError(`Invalid ${configPath}: root value must be an object with a rules array.`);
+  }
+
+  const rawRules = parsed.rules;
+  if (rawRules === undefined) return [];
+  if (!Array.isArray(rawRules)) {
+    throw new ConfigError(`Invalid ${configPath}: rules must be an array.`);
+  }
+
+  return rawRules.map((rawRule, index) => parseRule(rawRule, index, configPath));
+}
+
+function parseRule(rawRule: unknown, index: number, configPath: string): RateLimitRule {
+  const label = `${configPath} rules[${index}]`;
+  if (!isRecord(rawRule)) {
+    throw new ConfigError(`Invalid ${label}: rule must be an object.`);
+  }
+
+  const command = typeof rawRule.command === 'string' ? rawRule.command.trim() : '';
+  if (!command) {
+    throw new ConfigError(`Invalid ${label}: command must be a non-empty string.`);
+  }
+
+  const limit = Number(rawRule.limit);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new ConfigError(`Invalid ${label}: limit must be a positive integer.`);
+  }
+
+  if (typeof rawRule.window !== 'string' && typeof rawRule.window !== 'number') {
+    throw new ConfigError(`Invalid ${label}: window must be a duration like 10m, 1h, or 500ms.`);
+  }
+
+  return {
+    command,
+    limit,
+    windowMs: parseDurationMs(rawRule.window, `${label}.window`),
+  };
+}
+
+function parseDurationMs(raw: string | number, label: string): number {
+  const value = String(raw).trim();
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m|h)?$/.exec(value);
+  if (!match) {
+    throw new ConfigError(`Invalid ${label}: expected a duration like 10m, 1h, or 500ms.`);
+  }
+
+  const amount = Number.parseFloat(match[1]);
+  const unit = match[2] ?? 'ms';
+  const multiplier = unit === 'h' ? 3_600_000 : unit === 'm' ? 60_000 : unit === 's' ? 1_000 : 1;
+  const ms = Math.round(amount * multiplier);
+  if (!Number.isFinite(ms) || ms <= 0) {
+    throw new ConfigError(`Invalid ${label}: duration must be greater than zero.`);
+  }
+  return ms;
+}
+
+function loadState(statePath: string): RateLimitState {
+  if (!fs.existsSync(statePath)) return emptyState();
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.commands)) return emptyState();
+
+    const commands: Record<string, number[]> = {};
+    for (const [command, timestamps] of Object.entries(parsed.commands)) {
+      if (!Array.isArray(timestamps)) continue;
+      commands[command] = timestamps.filter((timestamp): timestamp is number =>
+        typeof timestamp === 'number' && Number.isFinite(timestamp),
+      );
+    }
+    return { version: 1, commands };
+  } catch {
+    return emptyState();
+  }
+}
+
+function saveState(statePath: string, state: RateLimitState): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmpPath, statePath);
+}
+
+function emptyState(): RateLimitState {
+  return { version: 1, commands: {} };
+}


### PR DESCRIPTION
## Summary

- add explicit per-command rate limit config via ~/.opencli/rate-limits.yaml
- block configured adapter and external CLI commands before execution with RATE_LIMITED errors
- persist sliding-window attempt state in ~/.opencli/rate-limit-state.json
- cover rate-limit parsing, adapter dispatch, and external CLI passthrough behavior in tests

## Validation

- npx vitest run --project unit src/rate-limit.test.ts src/commanderAdapter.test.ts src/external.test.ts
- npm run typecheck
- npm test
- npm run build
