### PR TITLE
fix(core): stop silently swallowing pipeline context + daemon WS errors

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -446,8 +446,15 @@ wss.on('connection', (ws: WebSocket) => {
         pending.delete(msg.id);
         p.resolve(msg);
       }
-    } catch {
-      // Ignore malformed messages
+    } catch (err) {
+      // Malformed message from the extension. Surface so protocol drift /
+      // version skew between daemon and extension shows up in the log
+      // instead of presenting as a generic command timeout downstream.
+      const sample = data.toString().slice(0, 200);
+      log.warn(
+        `[daemon] Ignoring malformed WS message from extension: ` +
+        `${err instanceof Error ? err.message : String(err)} (first 200 chars: ${JSON.stringify(sample)})`,
+      );
     }
   });
 

--- a/src/pipeline/template.test.ts
+++ b/src/pipeline/template.test.ts
@@ -178,3 +178,27 @@ describe('normalizeEvaluateSource', () => {
     expect(normalizeEvaluateSource('')).toBe('() => undefined');
   });
 });
+
+describe('sanitizeContext (via VM sandbox path)', () => {
+  it('coerces BigInt fields to string instead of silently dropping the branch', () => {
+    // Previously a BigInt anywhere in args would make JSON.stringify throw and
+    // sanitizeContext returned {}, so any reference to args.id in the JS
+    // sandbox would resolve to undefined. We now serialize BigInt as string
+    // so the value survives the sandbox copy.
+    const id = BigInt('9007199254740993'); // > Number.MAX_SAFE_INTEGER
+    const ctx = { args: { id } };
+    // Use an expression that forces evalJsExpr (not the resolvePath fast path)
+    // so it goes through sanitizeContext + VM sandbox.
+    expect(evalExpr('String(args.id)', ctx)).toBe('9007199254740993');
+  });
+
+  it('does not crash on circular references (returns {} after warning)', () => {
+    // Circular refs still can't be safely round-tripped; verify the
+    // fallback is the empty-object path, not a crash.
+    const args: Record<string, unknown> = { keep: 'me' };
+    args.self = args;
+    const ctx = { args };
+    // The expression must not throw even if the args object has a cycle.
+    expect(() => evalExpr('args.keep || "fallback"', ctx)).not.toThrow();
+  });
+});

--- a/src/pipeline/template.ts
+++ b/src/pipeline/template.ts
@@ -13,6 +13,7 @@ export interface RenderContext {
 }
 
 import { isRecord } from '../utils.js';
+import { log } from '../logger.js';
 
 export function render(template: unknown, ctx: RenderContext): unknown {
   if (typeof template !== 'string') return template;
@@ -209,10 +210,19 @@ function sanitizeContext(obj: unknown): unknown {
   const cached = _sanitizeCache.get(objRef);
   if (cached !== undefined) return JSON.parse(cached);
   try {
-    const jsonStr = JSON.stringify(obj);
+    // BigInt is non-serializable by default but is the most common cause of
+    // sanitizeContext failures (e.g. GraphQL 64-bit IDs). Coerce to string
+    // so callers see the value instead of a silent {}.
+    const jsonStr = JSON.stringify(obj, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
     _sanitizeCache.set(objRef, jsonStr);
     return JSON.parse(jsonStr);
-  } catch {
+  } catch (err) {
+    log.warn(
+      `[pipeline/template] sanitizeContext failed: ${err instanceof Error ? err.message : String(err)}. ` +
+      `Returning {} for this branch. Likely cause: circular reference, Symbol, or other non-serializable value in pipeline context.`,
+    );
     return {};
   }
 }


### PR DESCRIPTION
## Summary

Two unrelated try/catch blocks were eating errors with no observable signal, both reachable from production paths. Identified during the joint src/ + extension bug audit (opus-reviewer + coding-claude-opus).

## Bug 1 — `src/pipeline/template.ts:215` `sanitizeContext` silently returns `{}` on JSON failure

The JSON round-trip that severs prototype chains before handing pipeline context to the VM sandbox caught any `JSON.stringify` failure and returned `{}`. The most common cause is a BigInt anywhere in `data` / `args` / `item` / `root` (e.g. GraphQL 64-bit IDs). After collapse, every template expression referencing that branch resolved to `undefined`, producing silent column-drops downstream with no warning.

**Fix:**
- Add a `JSON.stringify` replacer that coerces BigInt to string, so the common BigInt-in-context case survives the sandbox copy.
- For everything else (circular references, Symbol, etc.), the fallback is still `{}` but now `log.warn` so the failure shows up in logs instead of silently producing blank rows.

## Bug 2 — `src/daemon.ts:445` WS message handler swallows malformed messages

The WS message handler from the extension caught `JSON.parse` failures and ran the `// Ignore malformed messages` comment. A malformed message presents downstream as a generic command timeout (`pending` never resolves), so the actual protocol drift / version skew between daemon and extension never surfaced in the log.

**Fix:** `log.warn` the parse error plus the first 200 chars of the offending frame so the root cause is visible during triage.

## Type of Change

- [x] 🐛 Bug fix

## Why these are observability-only

No successful path changes behavior; only previously-silent failure paths get a log line, plus BigInt now serializes to a string instead of nuking its containing branch.

## Tests

- `src/pipeline/template.test.ts`: two new cases covering the BigInt preservation path (forces the VM sandbox via `String(args.id)`, not the `resolvePath` fast path) and the circular-ref no-crash invariant.
- daemon WS handler change is log-only; existing daemon tests cover the message dispatch path.
- `npx vitest run --project unit src/pipeline/` — 98/98 passed.
- `npm run typecheck` — clean.