### PR TITLE
fix(adapters): surface empty results as EmptyResultError, not sentinel rows

### DIFF
--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -5,6 +5,7 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import './channels.js';
 import './goto.js';
 import './read.js';
+import './search.js';
 import './servers.js';
 import './thread-read.js';
 import './threads.js';
@@ -145,6 +146,46 @@ describe('discord-app command registration', () => {
             expect(cmd.browser).toBe(true);
             expect(cmd.domain).toBe('localhost');
         }
+    });
+});
+
+describe('discord-app search', () => {
+    function createSearchPage(bodyText = '', resultRows = []) {
+        return {
+            pressKey: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                if (script.includes('const input = document.querySelector')) return undefined;
+                if (script.includes('const items = []')) {
+                    const rowsHtml = resultRows.map((row, index) => `
+                      <div class="searchResult_${index}" id="search-result-${index}">
+                        <span class="username">${row.author}</span>
+                        <div id="message-content-${index}">${row.message}</div>
+                      </div>
+                    `).join('');
+                    const dom = new JSDOM(`<!doctype html><body>${bodyText}${rowsHtml}</body>`, {
+                        url: 'https://discord.com/channels/111/222',
+                        runScripts: 'outside-only',
+                    });
+                    return dom.window.eval(script);
+                }
+                throw new Error(`unexpected evaluate script: ${script.slice(0, 80)}`);
+            }),
+        };
+    }
+
+    it('throws EmptyResultError when Discord shows an explicit no-results state', async () => {
+        const cmd = getRegistry().get('discord-app/search');
+        const page = createSearchPage('<div>No results found</div>');
+
+        await expect(cmd.func(page, { query: 'missing' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('throws CommandExecutionError when result selectors return no rows and no empty-state marker', async () => {
+        const cmd = getRegistry().get('discord-app/search');
+        const page = createSearchPage('<main>search panel changed</main>');
+
+        await expect(cmd.func(page, { query: 'missing' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });
 

--- a/clis/discord-app/search.js
+++ b/clis/discord-app/search.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 export const searchCommand = cli({
     site: 'discord-app',
     name: 'search',
@@ -30,7 +30,7 @@ export const searchCommand = cli({
         await page.pressKey('Enter');
         await page.wait(2);
         // Scrape search results
-        const results = await page.evaluate(`
+        const searchState = await page.evaluate(`
       (function() {
         const items = [];
         const resultNodes = document.querySelectorAll('[class*="searchResult_"], [id*="search-result"]');
@@ -45,12 +45,21 @@ export const searchCommand = cli({
           });
         });
         
-        return items;
+        const bodyText = document.body?.innerText || document.body?.textContent || '';
+        const empty = /no results|no messages match|没有结果|无结果/i.test(bodyText);
+        return { items, empty };
       })()
     `);
+        if (!searchState || !Array.isArray(searchState.items)) {
+            throw new CommandExecutionError('Discord search returned malformed browser payload.');
+        }
+        const results = searchState.items;
         // Close search
         await page.pressKey('Escape');
         if (results.length === 0) {
+            if (!searchState.empty) {
+                throw new CommandExecutionError('Discord search result selector returned no rows and no explicit empty-state marker.');
+            }
             throw new EmptyResultError('discord-app search', `No results for "${query}".`);
         }
         return results;

--- a/clis/discord-app/search.js
+++ b/clis/discord-app/search.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 export const searchCommand = cli({
     site: 'discord-app',
     name: 'search',
@@ -50,7 +51,7 @@ export const searchCommand = cli({
         // Close search
         await page.pressKey('Escape');
         if (results.length === 0) {
-            return [{ Index: 0, Author: 'System', Message: `No results for "${query}"` }];
+            throw new EmptyResultError('discord-app search', `No results for "${query}".`);
         }
         return results;
     },

--- a/clis/maimai/search-talents.js
+++ b/clis/maimai/search-talents.js
@@ -3,7 +3,7 @@
  * Reuses Chrome login session to search for candidates on maimai.cn
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 cli({
   site: 'maimai',
@@ -124,10 +124,24 @@ cli({
       return result;
     }`);
 
-    // Extract talent list from response
-    const talentList = data.data?.list || data.data?.talent_list || data.list || data.talent_list || [];
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new CommandExecutionError('Maimai search returned malformed API payload');
+    }
 
-    if (!talentList || talentList.length === 0) {
+    // Extract talent list from response. Missing list fields mean the API
+    // shape drifted; only an explicit empty array is a true empty result.
+    const talentListCandidates = [
+      data.data?.list,
+      data.data?.talent_list,
+      data.list,
+      data.talent_list,
+    ];
+    const talentList = talentListCandidates.find((value) => Array.isArray(value));
+    if (!talentList) {
+      throw new CommandExecutionError('Maimai search API payload missing talent list');
+    }
+
+    if (talentList.length === 0) {
       throw new EmptyResultError('maimai search-talents', `未找到匹配 "${query}" 的候选人`);
     }
 

--- a/clis/maimai/search-talents.js
+++ b/clis/maimai/search-talents.js
@@ -3,6 +3,7 @@
  * Reuses Chrome login session to search for candidates on maimai.cn
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 
 cli({
   site: 'maimai',
@@ -127,7 +128,7 @@ cli({
     const talentList = data.data?.list || data.data?.talent_list || data.list || data.talent_list || [];
 
     if (!talentList || talentList.length === 0) {
-      return [{ error: '未找到匹配的候选人', query: query }];
+      throw new EmptyResultError('maimai search-talents', `未找到匹配 "${query}" 的候选人`);
     }
 
     // Map to output format

--- a/clis/maimai/search-talents.test.js
+++ b/clis/maimai/search-talents.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search-talents.js';
+
+function createPageMock(apiPayload) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    waitForTimeout: vi.fn().mockResolvedValue(undefined),
+    getCookies: vi.fn().mockResolvedValue([{ name: 'csrftoken', value: 'csrf' }]),
+    evaluate: vi.fn().mockResolvedValue(apiPayload),
+  };
+}
+
+describe('maimai search-talents', () => {
+  const command = getRegistry().get('maimai/search-talents');
+
+  it('throws EmptyResultError for an explicit empty talent list', async () => {
+    const page = createPageMock({ code: 200, data: { list: [] } });
+
+    await expect(command.func(page, { query: 'Java' })).rejects.toBeInstanceOf(EmptyResultError);
+  });
+
+  it('throws CommandExecutionError when API payload is missing the talent list shape', async () => {
+    const page = createPageMock({ code: 200, data: { items: [] } });
+
+    await expect(command.func(page, { query: 'Java' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+});

--- a/clis/pixiv/download.js
+++ b/clis/pixiv/download.js
@@ -32,7 +32,7 @@ cli({
         // pixivFetch handles navigate + error checking; returns the response body directly
         const pages = await pixivFetch(page, `/ajax/illust/${illustId}/pages`, {
             notFoundMsg: `Illustration not found: ${illustId}`,
-        }) || [];
+        });
         if (!Array.isArray(pages)) {
             throw new CommandExecutionError('Pixiv pages API returned malformed payload');
         }

--- a/clis/pixiv/download.js
+++ b/clis/pixiv/download.js
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { formatCookieHeader, httpDownload } from '@jackwener/opencli/download';
 import { formatBytes } from '@jackwener/opencli/download/progress';
-import { CommandExecutionError, getErrorMessage } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError, getErrorMessage } from '@jackwener/opencli/errors';
 import { pixivFetch } from './utils.js';
 cli({
     site: 'pixiv',
@@ -34,7 +34,7 @@ cli({
             notFoundMsg: `Illustration not found: ${illustId}`,
         }) || [];
         if (pages.length === 0) {
-            return [{ index: 0, type: '-', status: 'failed', size: 'No images found' }];
+            throw new EmptyResultError('pixiv download', `No images found for illustration ${illustId}.`);
         }
         // Extract cookies for authenticated downloads
         const cookies = formatCookieHeader(await page.getCookies({ domain: 'pixiv.net' }));

--- a/clis/pixiv/download.js
+++ b/clis/pixiv/download.js
@@ -33,6 +33,9 @@ cli({
         const pages = await pixivFetch(page, `/ajax/illust/${illustId}/pages`, {
             notFoundMsg: `Illustration not found: ${illustId}`,
         }) || [];
+        if (!Array.isArray(pages)) {
+            throw new CommandExecutionError('Pixiv pages API returned malformed payload');
+        }
         if (pages.length === 0) {
             throw new EmptyResultError('pixiv download', `No images found for illustration ${illustId}.`);
         }

--- a/clis/pixiv/download.test.js
+++ b/clis/pixiv/download.test.js
@@ -52,6 +52,11 @@ describe('pixiv download', () => {
         await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }))
             .rejects.toThrow(CommandExecutionError);
     });
+    it('throws CommandExecutionError when pages payload is null', async () => {
+        const page = createPageMock([{ body: null }]);
+        await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
     it('downloads images with Referer header', async () => {
         mockHttpDownload.mockResolvedValue({ success: true, size: 1024000 });
         const page = createPageMock([

--- a/clis/pixiv/download.test.js
+++ b/clis/pixiv/download.test.js
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { createPageMock } from '../test-utils.js';
 // Mock download dependencies before importing the adapter
 const { mockHttpDownload, mockMkdirSync } = vi.hoisted(() => ({
@@ -42,10 +42,10 @@ describe('pixiv download', () => {
         const page = createPageMock([{ __httpError: 500 }]);
         await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' })).rejects.toThrow(CommandExecutionError);
     });
-    it('returns failure when no images found', async () => {
+    it('throws EmptyResultError when no images found', async () => {
         const page = createPageMock([{ body: [] }]);
-        const result = (await cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }));
-        expect(result).toEqual([{ index: 0, type: '-', status: 'failed', size: 'No images found' }]);
+        await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }))
+            .rejects.toThrow(EmptyResultError);
     });
     it('downloads images with Referer header', async () => {
         mockHttpDownload.mockResolvedValue({ success: true, size: 1024000 });

--- a/clis/pixiv/download.test.js
+++ b/clis/pixiv/download.test.js
@@ -47,6 +47,11 @@ describe('pixiv download', () => {
         await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }))
             .rejects.toThrow(EmptyResultError);
     });
+    it('throws CommandExecutionError when pages payload is malformed', async () => {
+        const page = createPageMock([{ body: { pages: [] } }]);
+        await expect(cmd.func(page, { 'illust-id': '12345', output: '/tmp/test' }))
+            .rejects.toThrow(CommandExecutionError);
+    });
     it('downloads images with Referer header', async () => {
         mockHttpDownload.mockResolvedValue({ success: true, size: 1024000 });
         const page = createPageMock([

--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -9,7 +9,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { formatCookieHeader } from '@jackwener/opencli/download';
 import { downloadMedia } from '@jackwener/opencli/download/media-download';
-import { CliError, EmptyResultError } from '@jackwener/opencli/errors';
+import { CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { buildNoteUrl, parseNoteId } from './note-helpers.js';
 /**
  * Build the media-extraction IIFE. The note id is interpolated as a default
@@ -227,7 +227,10 @@ export const command = cli({
                 ? 'The page may be temporarily restricted. Try again later or from a different session.'
                 : 'Try using a full URL from search results (with xsec_token) instead of a bare note ID.');
         }
-        if (!data || !data.media || data.media.length === 0) {
+        if (!data || typeof data !== 'object' || !Array.isArray(data.media)) {
+            throw new CommandExecutionError('Xiaohongshu media extraction returned malformed payload.');
+        }
+        if (data.media.length === 0) {
             throw new EmptyResultError('xiaohongshu download', 'No downloadable media found on this note.');
         }
         // Extract cookies for authenticated downloads

--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -9,7 +9,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { formatCookieHeader } from '@jackwener/opencli/download';
 import { downloadMedia } from '@jackwener/opencli/download/media-download';
-import { CliError } from '@jackwener/opencli/errors';
+import { CliError, EmptyResultError } from '@jackwener/opencli/errors';
 import { buildNoteUrl, parseNoteId } from './note-helpers.js';
 /**
  * Build the media-extraction IIFE. The note id is interpolated as a default
@@ -228,7 +228,7 @@ export const command = cli({
                 : 'Try using a full URL from search results (with xsec_token) instead of a bare note ID.');
         }
         if (!data || !data.media || data.media.length === 0) {
-            return [{ index: 0, type: '-', status: 'failed', size: 'No media found' }];
+            throw new EmptyResultError('xiaohongshu download', 'No downloadable media found on this note.');
         }
         // Extract cookies for authenticated downloads
         const cookies = formatCookieHeader(await page.getCookies({ domain: 'xiaohongshu.com' }));

--- a/clis/xiaohongshu/download.test.js
+++ b/clis/xiaohongshu/download.test.js
@@ -10,6 +10,7 @@ vi.mock('@jackwener/opencli/download', () => ({
     formatCookieHeader: mockFormatCookieHeader,
 }));
 import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { JSDOM } from 'jsdom';
 import './download.js';
 import { buildDownloadExtractJs } from './download.js';
@@ -112,6 +113,28 @@ describe('xiaohongshu download', () => {
             code: 'SECURITY_BLOCK',
             hint: expect.stringContaining('Try again later'),
         });
+        expect(mockDownloadMedia).not.toHaveBeenCalled();
+    });
+    it('throws EmptyResultError when extraction returns an explicit empty media array', async () => {
+        const page = createPageMock({
+            noteId: '69bc166f000000001a02069a',
+            media: [],
+        });
+        await expect(command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/explore/69bc166f000000001a02069a?xsec_token=abc',
+            output: './out',
+        })).rejects.toBeInstanceOf(EmptyResultError);
+        expect(mockDownloadMedia).not.toHaveBeenCalled();
+    });
+    it('throws CommandExecutionError when extraction media shape is malformed', async () => {
+        const page = createPageMock({
+            noteId: '69bc166f000000001a02069a',
+            media: { url: 'https://ci.xiaohongshu.com/example.jpg' },
+        });
+        await expect(command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/explore/69bc166f000000001a02069a?xsec_token=abc',
+            output: './out',
+        })).rejects.toBeInstanceOf(CommandExecutionError);
         expect(mockDownloadMedia).not.toHaveBeenCalled();
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4049,9 +4049,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Bug class (correctness)

Four adapters returned a fabricated row (exit **0**) on the not-found/empty path instead of throwing `EmptyResultError`. The framework gives `EMPTY_RESULT` its own exit code so agents can distinguish "no results" from success; a sentinel row breaks that contract.

| Adapter | Before | Notes |
|---------|--------|-------|
| `maimai/search-talents` | `return [{error, query}]` | **Triple bug**: `error`/`query` aren't in `columns`, so the message was silently column-dropped — the user saw an empty/garbage row, never the reason. Now throws `EmptyResultError` (fixes the column-drop too). |
| `discord-app/search` | `return [{Index:0, Author:'System', ...}]` | Synthetic "System" row on no matches. |
| `pixiv/download` | `return [{...status:'failed', size:'No images found'}]` | File already throws typed errors elsewhere. **Test updated** to assert the throw (it previously asserted the sentinel). |
| `xiaohongshu/download` | `return [{...status:'failed', size:'No media found'}]` | File already throws `CliError` for the security-block branch. |

## Scope
- Per-image partial-failure `status:'failed'` rows in the download **loops** are left as-is (legitimate batch reporting — distinct from the top-level empty path).
- Auth-path conversions (`tiktok`/`facebook` `throw new Error('AUTH_REQUIRED:..')` string-prefix hack, and `maimai`'s **in-page** auth throw) are a **separate follow-up** — they need in-page-throw handling, not a mechanical swap.

## Verify
- `pixiv` + `xiaohongshu` suites green (20/20).
- `check:typed-error-lint` and `check:silent-column-drop`: **no new violations** (current column-drop count drops). Baselines intentionally left untouched (they carry pre-existing drift across unrelated files; a separate baseline refresh can prune the now-resolved entries).
- `npm run build` — manifest compiles, all adapters load.

Found in the bug-hunt sweep (thread #OpenCLI). Reviewer: @opus-reviewer.