### PR TITLE
fix(qwen): anchor waitForAnswer to stop returning the previous answer

### DIFF
--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -59,9 +59,9 @@ cli({
         if (useThink) await setFeatureToggle(page, 'think', true);
         if (useResearch) await setFeatureToggle(page, 'research', true);
 
-        // Anchor on the last assistant turn BEFORE sending so waitForAnswer can
-        // skip it — otherwise a follow-up ask returns the previous answer.
-        const baselineLastAssistantId = await getBaselineLastAssistantId(page);
+        // Anchor on the visible transcript BEFORE sending so waitForAnswer can
+        // bind the reply to the newly sent prompt instead of an older answer.
+        const baselineAnchor = await getBaselineChatAnchor(page);
 
         const send = await sendMessage(page, prompt);
         if (!send?.ok) {
@@ -69,7 +69,7 @@ cli({
             throw new CommandExecutionError(send?.reason || 'Failed to send Qianwen prompt');
         }
 
-        const result = await waitForAnswer(page, prompt, timeout, baselineLastAssistantId);
+        const result = await waitForAnswer(page, prompt, timeout, baselineAnchor);
         if (result.status === 'auth_required') throw authRequired();
         if (result.status === 'timeout') {
             throw new TimeoutError('qianwen ask', timeout, 'No Qianwen reply observed before timeout. Retry with --timeout increased.');
@@ -88,12 +88,17 @@ cli({
     },
 });
 
-async function getBaselineLastAssistantId(page) {
+async function getBaselineChatAnchor(page) {
     const bubbles = await getMessageBubbles(page);
+    const lastBubbleId = bubbles.length ? bubbles[bubbles.length - 1].id : '';
+    let lastAssistantId = '';
     for (let i = bubbles.length - 1; i >= 0; i -= 1) {
-        if (bubbles[i].role === 'Assistant') return bubbles[i].id;
+        if (bubbles[i].role === 'Assistant') {
+            lastAssistantId = bubbles[i].id;
+            break;
+        }
     }
-    return '';
+    return { lastBubbleId, lastAssistantId };
 }
 
-export const __test__ = { getBaselineLastAssistantId };
+export const __test__ = { getBaselineChatAnchor };

--- a/clis/qwen/ask.js
+++ b/clis/qwen/ask.js
@@ -59,13 +59,17 @@ cli({
         if (useThink) await setFeatureToggle(page, 'think', true);
         if (useResearch) await setFeatureToggle(page, 'research', true);
 
+        // Anchor on the last assistant turn BEFORE sending so waitForAnswer can
+        // skip it — otherwise a follow-up ask returns the previous answer.
+        const baselineLastAssistantId = await getBaselineLastAssistantId(page);
+
         const send = await sendMessage(page, prompt);
         if (!send?.ok) {
             if (await hasLoginGate(page)) throw authRequired();
             throw new CommandExecutionError(send?.reason || 'Failed to send Qianwen prompt');
         }
 
-        const result = await waitForAnswer(page, prompt, timeout);
+        const result = await waitForAnswer(page, prompt, timeout, baselineLastAssistantId);
         if (result.status === 'auth_required') throw authRequired();
         if (result.status === 'timeout') {
             throw new TimeoutError('qianwen ask', timeout, 'No Qianwen reply observed before timeout. Retry with --timeout increased.');
@@ -83,3 +87,13 @@ cli({
         ];
     },
 });
+
+async function getBaselineLastAssistantId(page) {
+    const bubbles = await getMessageBubbles(page);
+    for (let i = bubbles.length - 1; i >= 0; i -= 1) {
+        if (bubbles[i].role === 'Assistant') return bubbles[i].id;
+    }
+    return '';
+}
+
+export const __test__ = { getBaselineLastAssistantId };

--- a/clis/qwen/ask.test.js
+++ b/clis/qwen/ask.test.js
@@ -2,26 +2,35 @@ import { describe, expect, it } from 'vitest';
 import { __test__ } from './ask.js';
 
 describe('qwen ask helpers', () => {
-    describe('getBaselineLastAssistantId', () => {
+    describe('getBaselineChatAnchor', () => {
         // getMessageBubbles drives a page.evaluate that returns the raw bubble
         // array; in tests we route page.evaluate straight to an in-memory array.
         const fakePage = (bubbles) => ({ evaluate: () => Promise.resolve(bubbles) });
 
-        it('returns the id of the most recent Assistant bubble, ignoring later User turns', async () => {
+        it('returns the last visible bubble and most recent Assistant bubble', async () => {
             const bubbles = [
                 { id: 'a1', role: 'Assistant', text: 'first answer', html: '' },
                 { id: 'u1', role: 'User', text: 'follow-up', html: '' },
                 { id: 'a2', role: 'Assistant', text: 'second answer', html: '' },
                 { id: 'u2', role: 'User', text: 'newest user turn', html: '' },
             ];
-            expect(await __test__.getBaselineLastAssistantId(fakePage(bubbles))).toBe('a2');
+            expect(await __test__.getBaselineChatAnchor(fakePage(bubbles))).toEqual({
+                lastBubbleId: 'u2',
+                lastAssistantId: 'a2',
+            });
         });
 
-        it('returns empty string when no Assistant bubble exists yet (fresh chat)', async () => {
-            expect(await __test__.getBaselineLastAssistantId(fakePage([]))).toBe('');
-            expect(await __test__.getBaselineLastAssistantId(fakePage([
+        it('returns empty assistant id when no Assistant bubble exists yet (fresh chat)', async () => {
+            expect(await __test__.getBaselineChatAnchor(fakePage([]))).toEqual({
+                lastBubbleId: '',
+                lastAssistantId: '',
+            });
+            expect(await __test__.getBaselineChatAnchor(fakePage([
                 { id: 'u1', role: 'User', text: 'hello', html: '' },
-            ]))).toBe('');
+            ]))).toEqual({
+                lastBubbleId: 'u1',
+                lastAssistantId: '',
+            });
         });
     });
 });

--- a/clis/qwen/ask.test.js
+++ b/clis/qwen/ask.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './ask.js';
+
+describe('qwen ask helpers', () => {
+    describe('getBaselineLastAssistantId', () => {
+        // getMessageBubbles drives a page.evaluate that returns the raw bubble
+        // array; in tests we route page.evaluate straight to an in-memory array.
+        const fakePage = (bubbles) => ({ evaluate: () => Promise.resolve(bubbles) });
+
+        it('returns the id of the most recent Assistant bubble, ignoring later User turns', async () => {
+            const bubbles = [
+                { id: 'a1', role: 'Assistant', text: 'first answer', html: '' },
+                { id: 'u1', role: 'User', text: 'follow-up', html: '' },
+                { id: 'a2', role: 'Assistant', text: 'second answer', html: '' },
+                { id: 'u2', role: 'User', text: 'newest user turn', html: '' },
+            ];
+            expect(await __test__.getBaselineLastAssistantId(fakePage(bubbles))).toBe('a2');
+        });
+
+        it('returns empty string when no Assistant bubble exists yet (fresh chat)', async () => {
+            expect(await __test__.getBaselineLastAssistantId(fakePage([]))).toBe('');
+            expect(await __test__.getBaselineLastAssistantId(fakePage([
+                { id: 'u1', role: 'User', text: 'hello', html: '' },
+            ]))).toBe('');
+        });
+    });
+});

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -301,14 +301,23 @@ function normalizeWaitAnchor(anchor) {
 function findAssistantAfterPrompt(bubbles, prompt, anchor) {
     const normalizedPrompt = normalizePromptText(prompt);
     let startIndex = -1;
+    const hasAnchor = Boolean(anchor.lastBubbleId || anchor.lastAssistantId);
+    let foundAnchor = false;
     if (anchor.lastBubbleId) {
         const lastBubbleIndex = bubbles.findIndex((bubble) => bubble.id === anchor.lastBubbleId);
-        if (lastBubbleIndex >= 0) startIndex = lastBubbleIndex;
+        if (lastBubbleIndex >= 0) {
+            startIndex = lastBubbleIndex;
+            foundAnchor = true;
+        }
     }
     if (anchor.lastAssistantId) {
         const lastAssistantIndex = bubbles.findIndex((bubble) => bubble.id === anchor.lastAssistantId);
-        if (lastAssistantIndex >= 0) startIndex = Math.max(startIndex, lastAssistantIndex);
+        if (lastAssistantIndex >= 0) {
+            startIndex = Math.max(startIndex, lastAssistantIndex);
+            foundAnchor = true;
+        }
     }
+    if (hasAnchor && !foundAnchor) return null;
 
     let promptIndex = -1;
     for (let i = startIndex + 1; i < bubbles.length; i += 1) {

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -284,11 +284,53 @@ function stripNoise(text) {
         .trim();
 }
 
-export async function waitForAnswer(page, prompt, timeoutSeconds, baselineLastAssistantId) {
+function normalizePromptText(text) {
+    return stripNoise(text).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeWaitAnchor(anchor) {
+    if (typeof anchor === 'string') {
+        return { lastBubbleId: '', lastAssistantId: anchor };
+    }
+    return {
+        lastBubbleId: String(anchor?.lastBubbleId || ''),
+        lastAssistantId: String(anchor?.lastAssistantId || ''),
+    };
+}
+
+function findAssistantAfterPrompt(bubbles, prompt, anchor) {
+    const normalizedPrompt = normalizePromptText(prompt);
+    let startIndex = -1;
+    if (anchor.lastBubbleId) {
+        const lastBubbleIndex = bubbles.findIndex((bubble) => bubble.id === anchor.lastBubbleId);
+        if (lastBubbleIndex >= 0) startIndex = lastBubbleIndex;
+    }
+    if (anchor.lastAssistantId) {
+        const lastAssistantIndex = bubbles.findIndex((bubble) => bubble.id === anchor.lastAssistantId);
+        if (lastAssistantIndex >= 0) startIndex = Math.max(startIndex, lastAssistantIndex);
+    }
+
+    let promptIndex = -1;
+    for (let i = startIndex + 1; i < bubbles.length; i += 1) {
+        if (bubbles[i].role === 'User' && normalizePromptText(bubbles[i].text) === normalizedPrompt) {
+            promptIndex = i;
+        }
+    }
+    if (promptIndex < 0) return null;
+
+    for (let i = promptIndex + 1; i < bubbles.length; i += 1) {
+        if (bubbles[i].role === 'Assistant') return bubbles[i];
+    }
+    return null;
+}
+
+export async function waitForAnswer(page, prompt, timeoutSeconds, baselineAnchor) {
+    const anchor = normalizeWaitAnchor(baselineAnchor);
     const startTime = Date.now();
     let previousText = '';
     let stableCount = 0;
     let lastCandidate = '';
+    let lastAssistantCandidate = null;
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {
         await page.wait(POLL_INTERVAL_SECONDS);
@@ -298,19 +340,18 @@ export async function waitForAnswer(page, prompt, timeoutSeconds, baselineLastAs
         }
 
         const bubbles = await getMessageBubbles(page);
-        const lastAssistant = [...bubbles].reverse().find((b) => b.role === 'Assistant');
+        const lastAssistant = findAssistantAfterPrompt(bubbles, prompt, anchor);
         if (!lastAssistant) continue;
 
-        // Skip the stale assistant turn that existed before our send. For a
-        // follow-up ask in an existing conversation, getMessageBubbles returns
-        // the previous (already-complete, already-stable) answer; without this
-        // guard the stability check returns it as if it were the new reply.
-        if (baselineLastAssistantId && lastAssistant.id === baselineLastAssistantId) continue;
+        // Guard against stale assistant turns that existed before our send even
+        // if the DOM briefly reorders or rehydrates while the new turn loads.
+        if (anchor.lastAssistantId && lastAssistant.id === anchor.lastAssistantId) continue;
 
         const text = stripNoise(lastAssistant.text);
         if (!text || text === prompt) continue;
 
         lastCandidate = text;
+        lastAssistantCandidate = lastAssistant;
 
         const waitedLongEnough = Date.now() - startTime >= MIN_WAIT_MS;
         if (text === previousText) {
@@ -325,9 +366,7 @@ export async function waitForAnswer(page, prompt, timeoutSeconds, baselineLastAs
     }
 
     if (lastCandidate) {
-        const bubbles = await getMessageBubbles(page);
-        const lastAssistant = [...bubbles].reverse().find((b) => b.role === 'Assistant');
-        return { status: 'partial', assistant: lastAssistant };
+        return { status: 'partial', assistant: lastAssistantCandidate };
     }
     return { status: 'timeout' };
 }

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -284,12 +284,11 @@ function stripNoise(text) {
         .trim();
 }
 
-export async function waitForAnswer(page, prompt, timeoutSeconds) {
+export async function waitForAnswer(page, prompt, timeoutSeconds, baselineLastAssistantId) {
     const startTime = Date.now();
     let previousText = '';
     let stableCount = 0;
     let lastCandidate = '';
-    let seenAssistantId = '';
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {
         await page.wait(POLL_INTERVAL_SECONDS);
@@ -302,10 +301,15 @@ export async function waitForAnswer(page, prompt, timeoutSeconds) {
         const lastAssistant = [...bubbles].reverse().find((b) => b.role === 'Assistant');
         if (!lastAssistant) continue;
 
+        // Skip the stale assistant turn that existed before our send. For a
+        // follow-up ask in an existing conversation, getMessageBubbles returns
+        // the previous (already-complete, already-stable) answer; without this
+        // guard the stability check returns it as if it were the new reply.
+        if (baselineLastAssistantId && lastAssistant.id === baselineLastAssistantId) continue;
+
         const text = stripNoise(lastAssistant.text);
         if (!text || text === prompt) continue;
 
-        if (!seenAssistantId) seenAssistantId = lastAssistant.id;
         lastCandidate = text;
 
         const waitedLongEnough = Date.now() - startTime >= MIN_WAIT_MS;

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -21,6 +21,53 @@ describe('qwen waitForAnswer baseline anchoring', () => {
         expect(result.status).toBe('timeout');
         expect(result.assistant).toBeUndefined();
     });
+
+    it('returns only an assistant turn after the newly sent prompt', async () => {
+        const bubbles = [
+            { id: 'u1', role: 'User', text: 'old question', html: '' },
+            { id: 'a1', role: 'Assistant', text: 'old answer', html: '' },
+            { id: 'u2', role: 'User', text: 'new question', html: '' },
+            { id: 'a2', role: 'Assistant', text: 'new answer', html: '<p>new answer</p>' },
+        ];
+        const result = await waitForAnswer(
+            fakePage(bubbles),
+            'new question',
+            0.2,
+            { lastBubbleId: 'a1', lastAssistantId: 'a1' },
+        );
+        expect(result.status).toBe('partial');
+        expect(result.assistant).toEqual(bubbles[3]);
+    });
+
+    it('does not match a repeated prompt that existed before the pre-send anchor', async () => {
+        const bubbles = [
+            { id: 'u1', role: 'User', text: 'same prompt', html: '' },
+            { id: 'a1', role: 'Assistant', text: 'old answer', html: '' },
+        ];
+        const result = await waitForAnswer(
+            fakePage(bubbles),
+            'same prompt',
+            0.05,
+            { lastBubbleId: 'a1', lastAssistantId: 'a1' },
+        );
+        expect(result.status).toBe('timeout');
+        expect(result.assistant).toBeUndefined();
+    });
+
+    it('supports a fresh chat with no baseline anchor', async () => {
+        const bubbles = [
+            { id: 'u1', role: 'User', text: 'fresh question', html: '' },
+            { id: 'a1', role: 'Assistant', text: 'fresh answer', html: '' },
+        ];
+        const result = await waitForAnswer(
+            fakePage(bubbles),
+            'fresh question',
+            0.2,
+            { lastBubbleId: '', lastAssistantId: '' },
+        );
+        expect(result.status).toBe('partial');
+        expect(result.assistant).toEqual(bubbles[1]);
+    });
 });
 
 describe('qwen parseQianwenSessionId', () => {

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -54,6 +54,21 @@ describe('qwen waitForAnswer baseline anchoring', () => {
         expect(result.assistant).toBeUndefined();
     });
 
+    it('does not scan the visible transcript when a non-empty baseline anchor is missing', async () => {
+        const bubbles = [
+            { id: 'u1-new-visible-id', role: 'User', text: 'same prompt', html: '' },
+            { id: 'a1-new-visible-id', role: 'Assistant', text: 'old answer', html: '' },
+        ];
+        const result = await waitForAnswer(
+            fakePage(bubbles),
+            'same prompt',
+            0.05,
+            { lastBubbleId: 'a-anchor-missing', lastAssistantId: 'a-anchor-missing' },
+        );
+        expect(result.status).toBe('timeout');
+        expect(result.assistant).toBeUndefined();
+    });
+
     it('supports a fresh chat with no baseline anchor', async () => {
         const bubbles = [
             { id: 'u1', role: 'User', text: 'fresh question', html: '' },

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -1,6 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { parseQianwenSessionId } from './utils.js';
+import { parseQianwenSessionId, waitForAnswer } from './utils.js';
+
+describe('qwen waitForAnswer baseline anchoring', () => {
+    // page.evaluate serves both getMessageBubbles (data-chat-question-wrap) and
+    // hasLoginGate (alert-biz-modal); route by inspecting the injected JS.
+    const fakePage = (bubbles) => ({
+        wait: () => new Promise((r) => setTimeout(r, 5)),
+        evaluate: (js) => Promise.resolve(
+            String(js).includes('alert-biz-modal') ? false : bubbles,
+        ),
+    });
+
+    it('does not return the pre-send assistant turn (it is skipped via baseline id)', async () => {
+        // Only the previous, already-complete answer is present. With the
+        // baseline anchored to its id, waitForAnswer must skip it and time out
+        // rather than return the stale answer as the new reply.
+        const bubbles = [{ id: 'a1', role: 'Assistant', text: 'old answer', html: '' }];
+        const result = await waitForAnswer(fakePage(bubbles), 'new question', 0.05, 'a1');
+        expect(result.status).toBe('timeout');
+        expect(result.assistant).toBeUndefined();
+    });
+});
 
 describe('qwen parseQianwenSessionId', () => {
     const id = 'abcd1234ef567890abcd1234ef567890';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4049,9 +4049,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Bug (correctness — silently wrong output)

qwen `waitForAnswer` (`clis/qwen/utils.js`) took **no pre-send baseline** and never skipped stale turns — `seenAssistantId` was assigned but never read (dead code). `getMessageBubbles` returns *every* turn, including the already-complete previous answer. So a follow-up `qwen ask` into an existing conversation (`siteSession: 'persistent'`, no `--new`) saw the prior answer on the first polls; being already stable, the stability check returned it as if it were the reply to the **new** prompt.

### Trigger
`opencli qwen ask "second question"` — any non-`--new` follow-up in a conversation that already has a prior answer.

### Impact
Returns the previous turn's answer as the new reply — silently wrong, no error.

## Fix
Mirror grok's reference pattern (`grok/utils.js` + `grok/ask.js:getBaselineLastAssistantId`):
- Capture the last assistant turn's id **before** sending (`getBaselineLastAssistantId` in `ask.js`).
- In `waitForAnswer`, `continue` while the latest assistant id equals that baseline.
- Remove the dead `seenAssistantId`.

## Tests
- `getBaselineLastAssistantId` helper (mirrors grok's `ask.test.js`).
- A direct `waitForAnswer` test: with only the pre-send turn present, it must skip it and time out rather than return the stale answer. **Reverse-validated** — fails (returns `partial` with the stale answer) when the skip line is removed.
- qwen suites green (8/8).

Found in the bug-hunt sweep (thread #OpenCLI). Reviewer: @opus-reviewer.