### PR TITLE
fix(deepseek): throw TimeoutError on no-reply instead of a silent sentinel row

### DIFF
--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
+import { CliError, CommandExecutionError, EXIT_CODES, TimeoutError } from '@jackwener/opencli/errors';
 import {
     DEEPSEEK_DOMAIN, DEEPSEEK_URL, ensureOnDeepSeek, selectModel, setFeature,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
@@ -131,7 +131,7 @@ export const askCommand = cli({
             // 3 s settle here was a redundant sleep on top of the first poll.
             const result = await waitForResponse(page, baseline, prompt, timeoutMs, wantThink);
             if (!result) {
-                return [{ response: `[NO RESPONSE] No reply within ${kwargs.timeout}s.` }];
+                throw new TimeoutError('deepseek ask', kwargs.timeout, 'No DeepSeek reply observed before timeout. Retry with --timeout increased.');
             }
             if (wantThink && typeof result === 'object' && result.response !== undefined) {
                 return [result];
@@ -147,7 +147,7 @@ export const askCommand = cli({
 
         const result = await waitForResponse(page, baseline, prompt, timeoutMs, wantThink);
         if (!result) {
-            return [{ response: `[NO RESPONSE] No reply within ${kwargs.timeout}s.` }];
+            throw new TimeoutError('deepseek ask', kwargs.timeout, 'No DeepSeek reply observed before timeout. Retry with --timeout increased.');
         }
 
         if (wantThink && typeof result === 'object' && result.response !== undefined) {

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
+import { CliError, CommandExecutionError, EXIT_CODES, TimeoutError } from '@jackwener/opencli/errors';
 
 const {
   mockEnsureOnDeepSeek,
@@ -362,5 +362,38 @@ describe('deepseek ask conversation resume', () => {
     expect(mockSetFeature).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(mockSendWithFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('deepseek ask timeout surfaces TimeoutError (not a silent sentinel row)', () => {
+  const page = {
+    wait: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue('https://chat.deepseek.com/'),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+    mockEnsureOnDeepSeek.mockResolvedValue(false);
+    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
+    mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockSendWithFile.mockResolvedValue({ ok: true });
+    mockGetBubbleCount.mockResolvedValue(3);
+    // No reply within the window.
+    mockWaitForResponse.mockResolvedValue(null);
+  });
+
+  it('throws TimeoutError on the normal send path when no reply arrives', async () => {
+    await expect(askCommand.func(page, {
+      prompt: 'hello', timeout: 30, new: false, model: 'default', think: false, search: false,
+    })).rejects.toThrow(TimeoutError);
+  });
+
+  it('throws TimeoutError on the --file path when no reply arrives', async () => {
+    await expect(askCommand.func(page, {
+      prompt: 'summarize', timeout: 30, file: './report.pdf', new: false, model: 'instant', think: false, search: false,
+    })).rejects.toThrow(TimeoutError);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4049,9 +4049,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Bug (correctness / data-integrity)

deepseek `ask` returned `[{ response: '[NO RESPONSE] No reply within Ns.' }]` at **exit 0** on both the normal and `--file` paths when no reply arrived (`ask.js:134`, `ask.js:150`) — the same sentinel-row anti-pattern fixed for other adapters in #1981. Every sibling chat adapter throws a typed error in this condition (claude → `EmptyResultError`, grok/qwen → `TimeoutError`). So an agent/script branching on exit code or error type saw **success** and consumed the literal `[NO RESPONSE] ...` string as if it were the model's answer.

## Fix
Both paths now `throw new TimeoutError('deepseek ask', kwargs.timeout, ...)`, making the failure observable via the TIMEOUT exit code.

## Tests
- New tests assert TimeoutError on both the normal send path and the `--file` path when `waitForResponse` yields no reply. **Reverse-validated** — reverting a throw to a sentinel fails its test.
- deepseek ask suite green (16/16).

## Deliberately out of scope (follow-up)
The deeper root cause is that `sendMessage` in `utils.js` can silently no-op server-side — it uses `execCommand('insertText')` + a fixed 800ms wait, the **exact** pattern `send.js:39-44` documents as unreliable. The robust fix is to port `send.js`'s proven path (`page.nativeType` + poll `aria-disabled` + verify the user bubble persists), ideally extracted as a shared helper so `send.js` and the `ask` path stop duplicating it. That change is UI-timing-sensitive and can't be verified offline, so it warrants its own PR with live smoke against deepseek. **This PR at least turns the silent no-op into a loud timeout** so the failure is no longer mistaken for success.

Found in the bug-hunt sweep (thread #OpenCLI). Reviewer: @opus-reviewer.