### PR TITLE
fix(extension): cdp network-capture + frame-eval robustness (3 fixes)

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -395,25 +395,33 @@ async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = fal
   });
   const contexts = tabFrameContexts.get(tabId);
   const contextId = contexts?.get(frameId);
-  if (contextId === void 0) {
-    await sendCommandInFrameTarget(tabId, frameId, "Runtime.enable", {}, aggressiveRetry).catch(() => void 0);
-    const result2 = await sendCommandInFrameTarget(tabId, frameId, "Runtime.evaluate", {
-      expression,
-      returnByValue: true,
-      awaitPromise: true
-    }, aggressiveRetry);
-    if (result2.exceptionDetails) {
-      const errMsg = result2.exceptionDetails.exception?.description || result2.exceptionDetails.text || "Eval error";
-      throw new Error(errMsg);
+  if (contextId !== void 0) {
+    try {
+      const result2 = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+        expression,
+        contextId,
+        returnByValue: true,
+        awaitPromise: true
+      });
+      if (result2.exceptionDetails) {
+        const errMsg = result2.exceptionDetails.exception?.description || result2.exceptionDetails.text || "Eval error";
+        throw new Error(errMsg);
+      }
+      return result2.result?.value;
+    } catch (err) {
+      const msg = String(err?.message || err);
+      if (!/Cannot find context|context with specified id|Execution context was destroyed/i.test(msg)) {
+        throw err;
+      }
+      contexts?.delete(frameId);
     }
-    return result2.result?.value;
   }
-  const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+  await sendCommandInFrameTarget(tabId, frameId, "Runtime.enable", {}, aggressiveRetry).catch(() => void 0);
+  const result = await sendCommandInFrameTarget(tabId, frameId, "Runtime.evaluate", {
     expression,
-    contextId,
     returnByValue: true,
     awaitPromise: true
-  });
+  }, aggressiveRetry);
   if (result.exceptionDetails) {
     const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
     throw new Error(errMsg);
@@ -533,36 +541,38 @@ function registerListeners() {
         requestHeaders: normalizeHeaders(request?.headers)
       });
       if (!entry) return;
-      entry.requestBodyKind = request?.hasPostData ? "string" : "empty";
-      {
-        const raw = String(request?.postData || "");
-        const fullSize = raw.length;
-        const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
-        entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
-        entry.requestBodyFullSize = fullSize;
-        entry.requestBodyTruncated = truncated;
-      }
-      try {
-        const postData = await chrome.debugger.sendCommand({ tabId }, "Network.getRequestPostData", { requestId });
-        if (postData?.postData) {
-          const raw = postData.postData;
+      if (!eventParams?.redirectResponse) {
+        entry.requestBodyKind = request?.hasPostData ? "string" : "empty";
+        {
+          const raw = String(request?.postData || "");
           const fullSize = raw.length;
           const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
-          entry.requestBodyKind = "string";
           entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
           entry.requestBodyFullSize = fullSize;
           entry.requestBodyTruncated = truncated;
         }
-      } catch {
+        try {
+          const postData = await chrome.debugger.sendCommand({ tabId }, "Network.getRequestPostData", { requestId });
+          if (postData?.postData) {
+            const raw = postData.postData;
+            const fullSize = raw.length;
+            const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
+            entry.requestBodyKind = "string";
+            entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+            entry.requestBodyFullSize = fullSize;
+            entry.requestBodyTruncated = truncated;
+          }
+        } catch {
+        }
       }
       return;
     }
     if (method === "Network.responseReceived") {
       const requestId = String(eventParams?.requestId || "");
       const response = eventParams?.response;
-      const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, {
-        url: response?.url
-      });
+      const stateEntryIndex = state.requestToIndex.get(requestId);
+      if (stateEntryIndex === void 0) return;
+      const entry = state.entries[stateEntryIndex];
       if (!entry) return;
       entry.responseStatus = response?.status;
       entry.responseContentType = response?.mimeType || "";

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -465,3 +465,146 @@ describe('cdp network capture survives forced re-attach', () => {
     expect(mock.networkEnableCount()).toBeGreaterThan(enablesAfterStart);
   });
 });
+
+describe('cdp network capture correctness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createNetworkMock() {
+    const onEventListeners = [];
+    const debuggerApi = {
+      attach: vi.fn(async () => {}),
+      detach: vi.fn(async () => {}),
+      sendCommand: vi.fn(async (_target, method, params) => {
+        if (method === 'Runtime.evaluate' && params?.expression === '1') return { result: { value: '1' } };
+        if (method === 'Network.getRequestPostData') return {}; // no override; use inline postData
+        return {};
+      }),
+      onDetach: { addListener: vi.fn() },
+      onEvent: { addListener: vi.fn((fn) => { onEventListeners.push(fn); }) },
+    };
+    const tabs = {
+      get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://x.com/home' })),
+      onRemoved: { addListener: vi.fn() },
+      onUpdated: { addListener: vi.fn() },
+    };
+    const fire = async (method, params) => {
+      for (const fn of onEventListeners) await fn({ tabId: 1 }, method, params);
+    };
+    return {
+      chrome: { tabs, debugger: debuggerApi, scripting: {}, runtime: { id: 'opencli-test' } },
+      fire,
+    };
+  }
+
+  it('preserves the original POST body when a captured request follows a redirect', async () => {
+    const mock = createNetworkMock();
+    vi.stubGlobal('chrome', mock.chrome);
+    const mod = await import('./cdp');
+    mod.registerListeners();
+    await mod.startNetworkCapture(1, 'api.example');
+
+    // Initial POST with a body.
+    await mock.fire('Network.requestWillBeSent', {
+      requestId: 'r1',
+      request: { url: 'https://api.example/login', method: 'POST', postData: 'user=a&pass=b', hasPostData: true },
+    });
+    // The 302 target re-fires with the SAME requestId, carried via redirectResponse,
+    // as a GET with no postData — this must NOT wipe the captured body.
+    await mock.fire('Network.requestWillBeSent', {
+      requestId: 'r1',
+      redirectResponse: { status: 302, url: 'https://api.example/login' },
+      request: { url: 'https://api.example/home', method: 'GET' },
+    });
+
+    const entries = await mod.readNetworkCapture(1);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].requestBodyPreview).toBe('user=a&pass=b');
+    expect(entries[0].requestBodyKind).toBe('string');
+  });
+
+  it('does not create an orphan entry from a response after the request was drained', async () => {
+    const mock = createNetworkMock();
+    vi.stubGlobal('chrome', mock.chrome);
+    const mod = await import('./cdp');
+    mod.registerListeners();
+    await mod.startNetworkCapture(1, 'api.example');
+
+    await mock.fire('Network.requestWillBeSent', {
+      requestId: 'r2',
+      request: { url: 'https://api.example/x', method: 'GET' },
+    });
+    // Read drains entries + clears requestToIndex while the request is in flight.
+    const first = await mod.readNetworkCapture(1);
+    expect(first).toHaveLength(1);
+
+    // Late response for the drained request must not resurrect a half-entry.
+    await mock.fire('Network.responseReceived', {
+      requestId: 'r2',
+      response: { url: 'https://api.example/x', status: 200, mimeType: 'text/html' },
+    });
+    const second = await mod.readNetworkCapture(1);
+    expect(second).toEqual([]);
+  });
+});
+
+describe('cdp evaluateInFrame stale context fallback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to the frame target when the cached context id went stale', async () => {
+    const debuggerEventListeners = [];
+    const debuggerApi = {
+      attach: vi.fn(async () => {}),
+      detach: vi.fn(async () => {}),
+      sendCommand: vi.fn(async (target, method, params) => {
+        if (method === 'Runtime.enable') return {};
+        // The cached context id is stale after the frame navigated: CDP rejects.
+        if (method === 'Runtime.evaluate' && params?.contextId === 99) {
+          throw new Error('Cannot find context with specified id');
+        }
+        if (method === 'Target.setDiscoverTargets') return {};
+        if (method === 'Target.setAutoAttach') return {};
+        if (method === 'Target.getTargets') {
+          return { targetInfos: [{ targetId: 'stale-frame', type: 'iframe', url: 'https://frame.test' }] };
+        }
+        if (target?.targetId === 'stale-frame' && method === 'Runtime.evaluate') {
+          return { result: { value: 'frame-ok' } };
+        }
+        return {};
+      }),
+      onDetach: { addListener: vi.fn() },
+      onEvent: { addListener: vi.fn((fn) => { debuggerEventListeners.push(fn); }) },
+    };
+    const tabs = {
+      get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://x.com/home' })),
+      onRemoved: { addListener: vi.fn() },
+      onUpdated: { addListener: vi.fn() },
+    };
+    vi.stubGlobal('chrome', { tabs, debugger: debuggerApi, scripting: {}, runtime: { id: 'opencli-test' } });
+
+    const mod = await import('./cdp');
+    mod.registerFrameTracking();
+    // Cache a context id (99) for the frame, which then goes stale.
+    for (const fn of debuggerEventListeners) {
+      fn({ tabId: 1 }, 'Runtime.executionContextCreated', {
+        context: { id: 99, auxData: { frameId: 'stale-frame', isDefault: true } },
+      });
+    }
+
+    const result = await mod.evaluateInFrame(1, 'document.title', 'stale-frame');
+
+    expect(result).toBe('frame-ok');
+    expect(debuggerApi.attach).toHaveBeenCalledWith({ targetId: 'stale-frame' }, '1.3');
+  });
+});

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -588,33 +588,46 @@ export async function evaluateInFrame(
   const contexts = tabFrameContexts.get(tabId);
   const contextId = contexts?.get(frameId);
 
-  if (contextId === undefined) {
-    await sendCommandInFrameTarget(tabId, frameId, 'Runtime.enable', {}, aggressiveRetry).catch(() => undefined);
-    const result = await sendCommandInFrameTarget(tabId, frameId, 'Runtime.evaluate', {
-      expression,
-      returnByValue: true,
-      awaitPromise: true,
-    }, aggressiveRetry) as {
-      result?: { type: string; value?: unknown; description?: string; subtype?: string };
-      exceptionDetails?: { exception?: { description?: string }; text?: string };
-    };
-
-    if (result.exceptionDetails) {
-      const errMsg = result.exceptionDetails.exception?.description
-        || result.exceptionDetails.text
-        || 'Eval error';
-      throw new Error(errMsg);
+  if (contextId !== undefined) {
+    try {
+      const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+        expression,
+        contextId,
+        returnByValue: true,
+        awaitPromise: true,
+      }) as {
+        result?: { type: string; value?: unknown; description?: string; subtype?: string };
+        exceptionDetails?: { exception?: { description?: string }; text?: string };
+      };
+      if (result.exceptionDetails) {
+        const errMsg = result.exceptionDetails.exception?.description
+          || result.exceptionDetails.text
+          || 'Eval error';
+        throw new Error(errMsg);
+      }
+      return result.result?.value;
+    } catch (err) {
+      // A navigated/reloaded frame invalidates its cached context id, but the
+      // Runtime.executionContextDestroyed event may not have been processed
+      // yet — the cache still holds the stale id and Runtime.evaluate rejects
+      // with "Cannot find context with specified id". Drop the stale id and
+      // fall through to the frame-target path instead of failing (evaluate()
+      // likewise re-resolves on a dead context). Re-throw genuine page errors.
+      const msg = String((err as { message?: string })?.message || err);
+      if (!/Cannot find context|context with specified id|Execution context was destroyed/i.test(msg)) {
+        throw err;
+      }
+      contexts?.delete(frameId);
     }
-
-    return result.result?.value;
   }
 
-  const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+  // No cached context, or the cached one went stale: resolve via the frame target.
+  await sendCommandInFrameTarget(tabId, frameId, 'Runtime.enable', {}, aggressiveRetry).catch(() => undefined);
+  const result = await sendCommandInFrameTarget(tabId, frameId, 'Runtime.evaluate', {
     expression,
-    contextId,
     returnByValue: true,
     awaitPromise: true,
-  }) as {
+  }, aggressiveRetry) as {
     result?: { type: string; value?: unknown; description?: string; subtype?: string };
     exceptionDetails?: { exception?: { description?: string }; text?: string };
   };
@@ -765,28 +778,35 @@ export function registerListeners(): void {
         requestHeaders: normalizeHeaders(request?.headers),
       });
       if (!entry) return;
-      entry.requestBodyKind = request?.hasPostData ? 'string' : 'empty';
-      {
-        const raw = String(request?.postData || '');
-        const fullSize = raw.length;
-        const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
-        entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
-        entry.requestBodyFullSize = fullSize;
-        entry.requestBodyTruncated = truncated;
-      }
-      try {
-        const postData = await chrome.debugger.sendCommand({ tabId }, 'Network.getRequestPostData', { requestId }) as { postData?: string };
-        if (postData?.postData) {
-          const raw = postData.postData;
+      // On an HTTP 30x, CDP re-fires requestWillBeSent with the SAME requestId
+      // (the prior hop is carried in `redirectResponse`) for the redirect
+      // target — typically a GET with no postData. Overwriting the body here
+      // would wipe the original request's captured POST body, so only populate
+      // the body on the initial send.
+      if (!eventParams?.redirectResponse) {
+        entry.requestBodyKind = request?.hasPostData ? 'string' : 'empty';
+        {
+          const raw = String(request?.postData || '');
           const fullSize = raw.length;
           const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
-          entry.requestBodyKind = 'string';
           entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
           entry.requestBodyFullSize = fullSize;
           entry.requestBodyTruncated = truncated;
         }
-      } catch {
-        // Optional; some requests do not expose postData.
+        try {
+          const postData = await chrome.debugger.sendCommand({ tabId }, 'Network.getRequestPostData', { requestId }) as { postData?: string };
+          if (postData?.postData) {
+            const raw = postData.postData;
+            const fullSize = raw.length;
+            const truncated = fullSize > CDP_REQUEST_BODY_CAPTURE_LIMIT;
+            entry.requestBodyKind = 'string';
+            entry.requestBodyPreview = truncated ? raw.slice(0, CDP_REQUEST_BODY_CAPTURE_LIMIT) : raw;
+            entry.requestBodyFullSize = fullSize;
+            entry.requestBodyTruncated = truncated;
+          }
+        } catch {
+          // Optional; some requests do not expose postData.
+        }
       }
       return;
     }
@@ -799,9 +819,14 @@ export function registerListeners(): void {
         status?: number;
         headers?: Record<string, unknown>;
       } | undefined;
-      const entry = getOrCreateNetworkCaptureEntry(tabId, requestId, {
-        url: response?.url,
-      });
+      // Lookup-only (like loadingFinished below): never create an entry from a
+      // response. If the matching requestWillBeSent was already drained by a
+      // readNetworkCapture() while the request was in flight, creating one here
+      // produces an orphan half-entry with a defaulted method ('GET') and no
+      // request data.
+      const stateEntryIndex = state.requestToIndex.get(requestId);
+      if (stateEntryIndex === undefined) return;
+      const entry = state.entries[stateEntryIndex];
       if (!entry) return;
       entry.responseStatus = response?.status;
       entry.responseContentType = response?.mimeType || '';


### PR DESCRIPTION
Three independent CDP-layer correctness fixes (all in `extension/src/cdp.ts`), each with a reverse-validated test.

## 1. Redirect wiped the captured POST body (data-integrity)
On an HTTP 30x, CDP re-fires `Network.requestWillBeSent` with the **same requestId** (the prior hop is carried in `redirectResponse`) for the redirect target — usually a GET with no `postData`. The handler overwrote the entry's request-body fields unconditionally, **destroying the original POST body**. Now the body is populated only on the initial send (guarded on `!redirectResponse`).
- Trigger: `web network` capturing a POST that 301/302/307-redirects (auth POSTs, URL shorteners) → read shows an empty body.

## 2. responseReceived created orphan entries (data-integrity)
If `readNetworkCapture()` drained the entries (clearing `requestToIndex`) while a request was in flight, the later `Network.responseReceived` ran `getOrCreate` and produced a half-entry with a defaulted method (`GET`) and no request data. Now it is **lookup-only**, mirroring `loadingFinished`.
- Trigger: polling `web network` while requests are still in flight (the normal streaming pattern).

## 3. evaluateInFrame had no retry on a stale cached context (correctness)
A navigated/reloaded frame invalidates its cached execution-context id, but the `executionContextDestroyed` event may not be processed yet, so `Runtime.evaluate` rejects with `"Cannot find context with specified id"`. `evaluate()` has a re-resolution path; `evaluateInFrame` did not — it failed. Now the rejection drops the stale id and falls through to the frame-target path; genuine page-eval errors still propagate.
- Trigger: `web eval --frame N` right after the target iframe reloads (SPA dashboards).

## Tests
- redirect-body preservation, orphan-entry prevention, stale-context fallback — each **reverse-validated** (neutralizing the fix fails its test).
- cdp suite green (15/15), `tsc --noEmit` clean, `extension/dist/background.js` rebuilt.

Found in the bug-hunt sweep (thread #OpenCLI). Reviewer: @opus-reviewer.