### PR TITLE
feat(zhihu): add user/answers/articles/following/followers/pins read commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -42716,6 +42716,80 @@
   },
   {
     "site": "zhihu",
+    "name": "followers",
+    "description": "知乎某用户的粉丝列表",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of followers to return (max 1000)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "url_token",
+      "headline",
+      "followers",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/followers.js",
+    "sourceFile": "zhihu/followers.js",
+    "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
+    "name": "following",
+    "description": "知乎某用户关注的人列表",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of followees to return (max 1000)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "url_token",
+      "headline",
+      "followers",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/following.js",
+    "sourceFile": "zhihu/following.js",
+    "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
     "name": "hot",
     "description": "知乎热榜",
     "access": "read",
@@ -42808,6 +42882,45 @@
     "navigateBefore": false,
     "siteSession": "persistent",
     "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "zhihu",
+    "name": "pins",
+    "description": "知乎某用户的想法（短内容）列表",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of pins to return (max 1000)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "excerpt",
+      "type",
+      "likes",
+      "comments",
+      "reposts",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/pins.js",
+    "sourceFile": "zhihu/pins.js",
+    "navigateBefore": "https://www.zhihu.com"
   },
   {
     "site": "zhihu",
@@ -42935,6 +43048,113 @@
     "type": "js",
     "modulePath": "zhihu/search.js",
     "sourceFile": "zhihu/search.js",
+    "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
+    "name": "user",
+    "description": "知乎用户主页资料（粉丝/关注/回答/文章/获赞数）",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL, e.g. wen-jie-16-47"
+      }
+    ],
+    "columns": [
+      "url_token",
+      "name",
+      "headline",
+      "followers",
+      "following",
+      "answers",
+      "articles",
+      "voteup",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/user.js",
+    "sourceFile": "zhihu/user.js",
+    "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
+    "name": "user-answers",
+    "description": "知乎某用户的回答列表",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of answers to return (max 1000)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "question",
+      "votes",
+      "comments",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/user-answers.js",
+    "sourceFile": "zhihu/user-answers.js",
+    "navigateBefore": "https://www.zhihu.com"
+  },
+  {
+    "site": "zhihu",
+    "name": "user-articles",
+    "description": "知乎某用户的文章/专栏列表",
+    "access": "read",
+    "domain": "www.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "user",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "User url_token or people URL"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of articles to return (max 1000)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "title",
+      "votes",
+      "comments",
+      "created",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/user-articles.js",
+    "sourceFile": "zhihu/user-articles.js",
     "navigateBefore": "https://www.zhihu.com"
   },
   {

--- a/clis/zhihu/followers.js
+++ b/clis/zhihu/followers.js
@@ -1,0 +1,34 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { parseZhihuUser } from './user-arg.js';
+import { fetchZhihuList, validateLimit } from './paginate.js';
+
+const INCLUDE = 'data[*].follower_count,headline,answer_count,articles_count';
+
+cli({
+    site: 'zhihu',
+    name: 'followers',
+    access: 'read',
+    description: '知乎某用户的粉丝列表',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of followers to return (max 1000)' },
+    ],
+    columns: ['rank', 'name', 'url_token', 'headline', 'followers', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        const limit = validateLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/followers?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
+        const items = await fetchZhihuList(page, first, limit, 'followers');
+        return items.map((u, i) => ({
+            rank: i + 1,
+            name: String(u.name || ''),
+            url_token: String(u.url_token || ''),
+            headline: String(u.headline || ''),
+            followers: u.follower_count ?? 0,
+            url: u.url_token ? `https://www.zhihu.com/people/${u.url_token}` : '',
+        }));
+    },
+});

--- a/clis/zhihu/followers.js
+++ b/clis/zhihu/followers.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
 import { fetchZhihuList, validateLimit } from './paginate.js';
 
@@ -22,13 +23,18 @@ cli({
         await page.goto('https://www.zhihu.com');
         const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/followers?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
         const items = await fetchZhihuList(page, first, limit, 'followers');
-        return items.map((u, i) => ({
-            rank: i + 1,
-            name: String(u.name || ''),
-            url_token: String(u.url_token || ''),
-            headline: String(u.headline || ''),
-            followers: u.follower_count ?? 0,
-            url: u.url_token ? `https://www.zhihu.com/people/${u.url_token}` : '',
-        }));
+        return items.map((u, i) => {
+            if (!u.url_token || !u.name) {
+                throw new CommandExecutionError('Zhihu followers returned malformed row identity');
+            }
+            return {
+                rank: i + 1,
+                name: String(u.name || ''),
+                url_token: String(u.url_token || ''),
+                headline: String(u.headline || ''),
+                followers: u.follower_count ?? 0,
+                url: `https://www.zhihu.com/people/${u.url_token}`,
+            };
+        });
     },
 });

--- a/clis/zhihu/followers.test.js
+++ b/clis/zhihu/followers.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './followers.js';
 
 describe('zhihu followers', () => {
@@ -25,6 +25,12 @@ describe('zhihu followers', () => {
         const cmd = getRegistry().get('zhihu/followers');
         const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
         await expect(cmd.func(page, { user: 'foo', limit: 1 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails typed on malformed follower rows', async () => {
+        const cmd = getRegistry().get('zhihu/followers');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ data: [{ url_token: 'no-name' }], paging: { is_end: true } }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 1 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects invalid limits before navigation', async () => {

--- a/clis/zhihu/followers.test.js
+++ b/clis/zhihu/followers.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './followers.js';
+
+describe('zhihu followers', () => {
+    it('maps a followers list to rows', async () => {
+        const cmd = getRegistry().get('zhihu/followers');
+        expect(cmd?.func).toBeTypeOf('function');
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47/followers');
+            return {
+                data: [
+                    { url_token: 'chen-lei-26-17-63', name: 'Nyvo', follower_count: 15 },
+                ],
+                paging: { is_end: true },
+            };
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'wen-jie-16-47', limit: 1 })).resolves.toEqual([
+            { rank: 1, name: 'Nyvo', url_token: 'chen-lei-26-17-63', headline: '', followers: 15, url: 'https://www.zhihu.com/people/chen-lei-26-17-63' },
+        ]);
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/followers');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 1 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid limits before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/followers');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'foo', limit: 99999 })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/following.js
+++ b/clis/zhihu/following.js
@@ -1,0 +1,34 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { parseZhihuUser } from './user-arg.js';
+import { fetchZhihuList, validateLimit } from './paginate.js';
+
+const INCLUDE = 'data[*].follower_count,headline,answer_count,articles_count';
+
+cli({
+    site: 'zhihu',
+    name: 'following',
+    access: 'read',
+    description: '知乎某用户关注的人列表',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of followees to return (max 1000)' },
+    ],
+    columns: ['rank', 'name', 'url_token', 'headline', 'followers', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        const limit = validateLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/followees?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
+        const items = await fetchZhihuList(page, first, limit, 'following');
+        return items.map((u, i) => ({
+            rank: i + 1,
+            name: String(u.name || ''),
+            url_token: String(u.url_token || ''),
+            headline: String(u.headline || ''),
+            followers: u.follower_count ?? 0,
+            url: u.url_token ? `https://www.zhihu.com/people/${u.url_token}` : '',
+        }));
+    },
+});

--- a/clis/zhihu/following.js
+++ b/clis/zhihu/following.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
 import { fetchZhihuList, validateLimit } from './paginate.js';
 
@@ -22,13 +23,18 @@ cli({
         await page.goto('https://www.zhihu.com');
         const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/followees?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
         const items = await fetchZhihuList(page, first, limit, 'following');
-        return items.map((u, i) => ({
-            rank: i + 1,
-            name: String(u.name || ''),
-            url_token: String(u.url_token || ''),
-            headline: String(u.headline || ''),
-            followers: u.follower_count ?? 0,
-            url: u.url_token ? `https://www.zhihu.com/people/${u.url_token}` : '',
-        }));
+        return items.map((u, i) => {
+            if (!u.url_token || !u.name) {
+                throw new CommandExecutionError('Zhihu following returned malformed row identity');
+            }
+            return {
+                rank: i + 1,
+                name: String(u.name || ''),
+                url_token: String(u.url_token || ''),
+                headline: String(u.headline || ''),
+                followers: u.follower_count ?? 0,
+                url: `https://www.zhihu.com/people/${u.url_token}`,
+            };
+        });
     },
 });

--- a/clis/zhihu/following.test.js
+++ b/clis/zhihu/following.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './following.js';
 
 describe('zhihu following', () => {
@@ -27,6 +27,12 @@ describe('zhihu following', () => {
         const cmd = getRegistry().get('zhihu/following');
         const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails typed on malformed following rows', async () => {
+        const cmd = getRegistry().get('zhihu/following');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ data: [{ name: 'No Token' }], paging: { is_end: true } }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects invalid limits before navigation', async () => {

--- a/clis/zhihu/following.test.js
+++ b/clis/zhihu/following.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './following.js';
+
+describe('zhihu following', () => {
+    it('maps a followees list to rows', async () => {
+        const cmd = getRegistry().get('zhihu/following');
+        expect(cmd?.func).toBeTypeOf('function');
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47/followees');
+            return {
+                data: [
+                    { url_token: 'gaow0007', name: 'GAOW0007', headline: 'ML System', follower_count: 537 },
+                    { url_token: 'mfx', name: 'Meng' },
+                ],
+                paging: { is_end: true },
+            };
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'wen-jie-16-47', limit: 2 })).resolves.toEqual([
+            { rank: 1, name: 'GAOW0007', url_token: 'gaow0007', headline: 'ML System', followers: 537, url: 'https://www.zhihu.com/people/gaow0007' },
+            { rank: 2, name: 'Meng', url_token: 'mfx', headline: '', followers: 0, url: 'https://www.zhihu.com/people/mfx' },
+        ]);
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/following');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid limits before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/following');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'foo', limit: 0 })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/paginate.js
+++ b/clis/zhihu/paginate.js
@@ -1,13 +1,74 @@
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 export const MAX_LIMIT = 1000;
 
 export function validateLimit(raw, fallback = 20) {
-    const limit = Number(raw ?? fallback);
+    const value = raw ?? fallback;
+    let limit;
+    if (typeof value === 'number') {
+        limit = value;
+    }
+    else {
+        const text = String(value).trim();
+        if (!/^\d+$/.test(text)) {
+            throw new ArgumentError(`--limit must be a positive integer no greater than ${MAX_LIMIT}`, 'Use a normal-sized decimal integer limit to avoid slow requests or Zhihu risk controls');
+        }
+        limit = Number(text);
+    }
     if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_LIMIT) {
-        throw new CliError('INVALID_INPUT', `Limit must be a positive integer no greater than ${MAX_LIMIT}`, 'Use a normal-sized limit to avoid slow requests or Zhihu risk controls');
+        throw new ArgumentError(`--limit must be a positive integer no greater than ${MAX_LIMIT}`, 'Use a normal-sized decimal integer limit to avoid slow requests or Zhihu risk controls');
     }
     return limit;
+}
+
+export function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+    return payload;
+}
+
+export function requireZhihuListPayload(payload, label, url) {
+    const data = unwrapEvaluateResult(payload);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new CommandExecutionError(`Zhihu ${label} returned malformed payload`, `URL: ${url}`);
+    }
+    if (data.__httpError) {
+        const status = data.__httpError;
+        if (status === 401 || status === 403) {
+            throw new AuthRequiredError('www.zhihu.com', `Failed to fetch Zhihu ${label}`);
+        }
+        if (status === 404) {
+            throw new EmptyResultError(`zhihu ${label}`, 'Check the target identifier');
+        }
+        throw new CommandExecutionError(`Zhihu ${label} request failed${status ? ` (HTTP ${status})` : ''}`, 'Try again later or rerun with -v');
+    }
+    if (data.__fetchError) {
+        throw new CommandExecutionError(`Zhihu ${label} request failed`, String(data.__fetchError));
+    }
+    if (!Array.isArray(data.data)) {
+        throw new CommandExecutionError(`Zhihu ${label} returned malformed data list`, `URL: ${url}`);
+    }
+    if (!data.paging || typeof data.paging !== 'object') {
+        throw new CommandExecutionError(`Zhihu ${label} returned malformed paging data`, `URL: ${url}`);
+    }
+    return data;
+}
+
+function normalizeZhihuApiUrl(value) {
+    if (typeof value !== 'string' || !value) return '';
+    try {
+        const url = new URL(value);
+        if (url.protocol !== 'https:') return '';
+        if (url.hostname === 'api.zhihu.com' && url.pathname.startsWith('/members/')) {
+            return `https://www.zhihu.com/api/v4${url.pathname}${url.search}`;
+        }
+        if (url.hostname === 'www.zhihu.com' && url.pathname.startsWith('/api/v4/members/')) {
+            return url.toString();
+        }
+    }
+    catch {
+        return '';
+    }
+    return '';
 }
 
 /**
@@ -21,29 +82,37 @@ export async function fetchZhihuList(page, firstUrl, limit, label) {
     let url = firstUrl;
     while (url && items.length < limit && !visited.has(url)) {
         visited.add(url);
-        const data = await page.evaluate(`
+        const data = requireZhihuListPayload(await page.evaluate(`
       (async () => {
-        const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
-        if (!r.ok) return { __httpError: r.status };
-        return await r.json();
-      })()
-    `);
-        if (!data || data.__httpError) {
-            const status = data?.__httpError;
-            if (status === 401 || status === 403) {
-                throw new AuthRequiredError('www.zhihu.com', `Failed to fetch Zhihu ${label}`);
-            }
-            if (status === 404) {
-                throw new CliError('NOT_FOUND', `Zhihu ${label} not found`, 'Check the target identifier');
-            }
-            throw new CliError('FETCH_ERROR', status ? `Zhihu ${label} request failed (HTTP ${status})` : `Zhihu ${label} request failed`, 'Try again later or rerun with -v');
+        try {
+          const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
+          if (!r.ok) return { __httpError: r.status };
+          return await r.json();
+        } catch (err) {
+          return { __fetchError: err?.message || String(err) };
         }
-        for (const item of data.data || []) {
+      })()
+    `), label, url);
+        for (const item of data.data) {
             items.push(item);
             if (items.length >= limit) break;
         }
         if (data.paging?.is_end) break;
-        url = typeof data.paging?.next === 'string' ? data.paging.next : '';
+        const next = normalizeZhihuApiUrl(data.paging?.next);
+        if (!next) {
+            throw new CommandExecutionError(`Zhihu ${label} pagination returned malformed next URL`);
+        }
+        if (visited.has(next)) {
+            throw new CommandExecutionError(`Zhihu ${label} pagination returned a repeated next URL`);
+        }
+        url = next;
+    }
+    if (items.length === 0) {
+        throw new EmptyResultError(`zhihu ${label}`, 'No rows were returned for the requested Zhihu user.');
     }
     return items;
 }
+
+export const __test__ = {
+    normalizeZhihuApiUrl,
+};

--- a/clis/zhihu/paginate.js
+++ b/clis/zhihu/paginate.js
@@ -71,6 +71,15 @@ function normalizeZhihuApiUrl(value) {
     return '';
 }
 
+function sameZhihuApiPath(a, b) {
+    try {
+        return new URL(a).pathname === new URL(b).pathname;
+    }
+    catch {
+        return false;
+    }
+}
+
 /**
  * Fetch a paginated Zhihu /api/v4 list endpoint (credentialed) and collect up
  * to `limit` raw items, following `paging.next`. `label` is used in error
@@ -99,7 +108,7 @@ export async function fetchZhihuList(page, firstUrl, limit, label) {
         }
         if (data.paging?.is_end) break;
         const next = normalizeZhihuApiUrl(data.paging?.next);
-        if (!next) {
+        if (!next || !sameZhihuApiPath(next, firstUrl)) {
             throw new CommandExecutionError(`Zhihu ${label} pagination returned malformed next URL`);
         }
         if (visited.has(next)) {
@@ -115,4 +124,5 @@ export async function fetchZhihuList(page, firstUrl, limit, label) {
 
 export const __test__ = {
     normalizeZhihuApiUrl,
+    sameZhihuApiPath,
 };

--- a/clis/zhihu/paginate.js
+++ b/clis/zhihu/paginate.js
@@ -1,0 +1,49 @@
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+
+export const MAX_LIMIT = 1000;
+
+export function validateLimit(raw, fallback = 20) {
+    const limit = Number(raw ?? fallback);
+    if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_LIMIT) {
+        throw new CliError('INVALID_INPUT', `Limit must be a positive integer no greater than ${MAX_LIMIT}`, 'Use a normal-sized limit to avoid slow requests or Zhihu risk controls');
+    }
+    return limit;
+}
+
+/**
+ * Fetch a paginated Zhihu /api/v4 list endpoint (credentialed) and collect up
+ * to `limit` raw items, following `paging.next`. `label` is used in error
+ * messages. Returns the raw item array; callers map it to rows.
+ */
+export async function fetchZhihuList(page, firstUrl, limit, label) {
+    const items = [];
+    const visited = new Set();
+    let url = firstUrl;
+    while (url && items.length < limit && !visited.has(url)) {
+        visited.add(url);
+        const data = await page.evaluate(`
+      (async () => {
+        const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
+        if (!r.ok) return { __httpError: r.status };
+        return await r.json();
+      })()
+    `);
+        if (!data || data.__httpError) {
+            const status = data?.__httpError;
+            if (status === 401 || status === 403) {
+                throw new AuthRequiredError('www.zhihu.com', `Failed to fetch Zhihu ${label}`);
+            }
+            if (status === 404) {
+                throw new CliError('NOT_FOUND', `Zhihu ${label} not found`, 'Check the target identifier');
+            }
+            throw new CliError('FETCH_ERROR', status ? `Zhihu ${label} request failed (HTTP ${status})` : `Zhihu ${label} request failed`, 'Try again later or rerun with -v');
+        }
+        for (const item of data.data || []) {
+            items.push(item);
+            if (items.length >= limit) break;
+        }
+        if (data.paging?.is_end) break;
+        url = typeof data.paging?.next === 'string' ? data.paging.next : '';
+    }
+    return items;
+}

--- a/clis/zhihu/pins.js
+++ b/clis/zhihu/pins.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
 import { fetchZhihuList, validateLimit } from './paginate.js';
 
@@ -22,6 +23,9 @@ cli({
         const items = await fetchZhihuList(page, first, limit, 'pins');
         return items.map((p, i) => {
             const firstContent = Array.isArray(p.content) ? p.content[0] : null;
+            if (!p.id || !p.excerpt_title) {
+                throw new CommandExecutionError('Zhihu pins returned malformed row identity');
+            }
             return {
                 rank: i + 1,
                 excerpt: String(p.excerpt_title || ''),
@@ -30,7 +34,7 @@ cli({
                 comments: p.comment_count ?? 0,
                 reposts: p.repin_count ?? 0,
                 created: p.created ?? p.updated ?? 0,
-                url: p.id ? `https://www.zhihu.com/pin/${p.id}` : '',
+                url: `https://www.zhihu.com/pin/${p.id}`,
             };
         });
     },

--- a/clis/zhihu/pins.js
+++ b/clis/zhihu/pins.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { parseZhihuUser } from './user-arg.js';
+import { fetchZhihuList, validateLimit } from './paginate.js';
+
+cli({
+    site: 'zhihu',
+    name: 'pins',
+    access: 'read',
+    description: '知乎某用户的想法（短内容）列表',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of pins to return (max 1000)' },
+    ],
+    columns: ['rank', 'excerpt', 'type', 'likes', 'comments', 'reposts', 'created', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        const limit = validateLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/pins?limit=20&offset=0`;
+        const items = await fetchZhihuList(page, first, limit, 'pins');
+        return items.map((p, i) => {
+            const firstContent = Array.isArray(p.content) ? p.content[0] : null;
+            return {
+                rank: i + 1,
+                excerpt: String(p.excerpt_title || ''),
+                type: String(firstContent?.type || ''),
+                likes: p.like_count ?? p.reaction_count ?? 0,
+                comments: p.comment_count ?? 0,
+                reposts: p.repin_count ?? 0,
+                created: p.created ?? p.updated ?? 0,
+                url: p.id ? `https://www.zhihu.com/pin/${p.id}` : '',
+            };
+        });
+    },
+});

--- a/clis/zhihu/pins.test.js
+++ b/clis/zhihu/pins.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './pins.js';
 
 describe('zhihu pins', () => {
@@ -27,6 +27,12 @@ describe('zhihu pins', () => {
         const cmd = getRegistry().get('zhihu/pins');
         const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails typed on malformed pin identity rows', async () => {
+        const cmd = getRegistry().get('zhihu/pins');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ data: [{ id: 'pin1' }], paging: { is_end: true } }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects invalid limits before navigation', async () => {

--- a/clis/zhihu/pins.test.js
+++ b/clis/zhihu/pins.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './pins.js';
+
+describe('zhihu pins', () => {
+    it('maps a pins list to rows', async () => {
+        const cmd = getRegistry().get('zhihu/pins');
+        expect(cmd?.func).toBeTypeOf('function');
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47/pins');
+            return {
+                data: [
+                    { id: 'pin1', excerpt_title: 'About CrabClaw', content: [{ type: 'text' }], like_count: 4, comment_count: 1, repin_count: 2, created: 1772468804 },
+                    { id: 'pin2', excerpt_title: 'second', reaction_count: 9, updated: 1772468999 },
+                ],
+                paging: { is_end: true },
+            };
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'wen-jie-16-47', limit: 2 })).resolves.toEqual([
+            { rank: 1, excerpt: 'About CrabClaw', type: 'text', likes: 4, comments: 1, reposts: 2, created: 1772468804, url: 'https://www.zhihu.com/pin/pin1' },
+            { rank: 2, excerpt: 'second', type: '', likes: 9, comments: 0, reposts: 0, created: 1772468999, url: 'https://www.zhihu.com/pin/pin2' },
+        ]);
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/pins');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid limits before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/pins');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'foo', limit: 0 })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/user-answers.js
+++ b/clis/zhihu/user-answers.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
 import { fetchZhihuList, validateLimit } from './paginate.js';
 
@@ -24,6 +25,9 @@ cli({
         const items = await fetchZhihuList(page, first, limit, 'user answers');
         return items.map((a, i) => {
             const q = a.question || {};
+            if (!a.id || !q.id || !q.title) {
+                throw new CommandExecutionError('Zhihu user answers returned malformed row identity');
+            }
             return {
                 rank: i + 1,
                 question: String(q.title || ''),

--- a/clis/zhihu/user-answers.js
+++ b/clis/zhihu/user-answers.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { parseZhihuUser } from './user-arg.js';
+import { fetchZhihuList, validateLimit } from './paginate.js';
+
+const INCLUDE = 'data[*].voteup_count,comment_count,created_time,question';
+
+cli({
+    site: 'zhihu',
+    name: 'user-answers',
+    access: 'read',
+    description: '知乎某用户的回答列表',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of answers to return (max 1000)' },
+    ],
+    columns: ['rank', 'question', 'votes', 'comments', 'created', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        const limit = validateLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/answers?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
+        const items = await fetchZhihuList(page, first, limit, 'user answers');
+        return items.map((a, i) => {
+            const q = a.question || {};
+            return {
+                rank: i + 1,
+                question: String(q.title || ''),
+                votes: a.voteup_count ?? a.reaction?.statistics?.like_count ?? 0,
+                comments: a.comment_count ?? 0,
+                created: a.created_time ?? a.created ?? 0,
+                url: q.id && a.id ? `https://www.zhihu.com/question/${q.id}/answer/${a.id}` : '',
+            };
+        });
+    },
+});

--- a/clis/zhihu/user-answers.test.js
+++ b/clis/zhihu/user-answers.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './user-answers.js';
+
+describe('zhihu user-answers', () => {
+    it('maps a user answers list to rows', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        expect(cmd?.func).toBeTypeOf('function');
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47/answers');
+            return {
+                data: [
+                    { id: 'a1', voteup_count: 10, comment_count: 12, created_time: 1780888788, question: { id: 'q1', title: 'Q1' } },
+                    { id: 'a2', reaction: { statistics: { like_count: 3 } }, question: { id: 'q2', title: 'Q2' } },
+                ],
+                paging: { is_end: true },
+            };
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'wen-jie-16-47', limit: 2 })).resolves.toEqual([
+            { rank: 1, question: 'Q1', votes: 10, comments: 12, created: 1780888788, url: 'https://www.zhihu.com/question/q1/answer/a1' },
+            { rank: 2, question: 'Q2', votes: 3, comments: 0, created: 0, url: 'https://www.zhihu.com/question/q2/answer/a2' },
+        ]);
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid limits before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'foo', limit: 0 })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/user-answers.test.js
+++ b/clis/zhihu/user-answers.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './user-answers.js';
 
 describe('zhihu user-answers', () => {
@@ -29,10 +29,26 @@ describe('zhihu user-answers', () => {
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
     });
 
+    it('unwraps Browser Bridge envelopes and fails typed on malformed answer identity', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ session: {}, data: { data: [{ id: 'a1', question: { title: 'missing id' } }], paging: { is_end: true } } }),
+        };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws EmptyResultError for valid empty answer lists', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ data: [], paging: { is_end: true } }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
     it('rejects invalid limits before navigation', async () => {
         const cmd = getRegistry().get('zhihu/user-answers');
         const page = { goto: vi.fn(), evaluate: vi.fn() };
         await expect(cmd.func(page, { user: 'foo', limit: 0 })).rejects.toBeInstanceOf(CliError);
+        await expect(cmd.func(page, { user: 'foo', limit: '1e2' })).rejects.toBeInstanceOf(CliError);
         expect(page.goto).not.toHaveBeenCalled();
     });
 });

--- a/clis/zhihu/user-answers.test.js
+++ b/clis/zhihu/user-answers.test.js
@@ -44,6 +44,21 @@ describe('zhihu user-answers', () => {
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(EmptyResultError);
     });
 
+    it('rejects pagination next URLs that drift to another member endpoint', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                data: [{ id: 'a1', question: { id: 'q1', title: 'Q1' } }],
+                paging: {
+                    is_end: false,
+                    next: 'https://www.zhihu.com/api/v4/members/foo/articles?offset=20',
+                },
+            }),
+        };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('rejects invalid limits before navigation', async () => {
         const cmd = getRegistry().get('zhihu/user-answers');
         const page = { goto: vi.fn(), evaluate: vi.fn() };

--- a/clis/zhihu/user-arg.js
+++ b/clis/zhihu/user-arg.js
@@ -1,0 +1,34 @@
+import { CliError } from '@jackwener/opencli/errors';
+
+const SLUG_RE = /^[A-Za-z0-9_-]+$/;
+const USER_PREFIX_RE = /^user:([A-Za-z0-9_-]+)$/;
+const PEOPLE_PATH_RE = /^\/people\/([A-Za-z0-9_-]+)\/?$/;
+
+/**
+ * Parse a Zhihu user identifier for read commands.
+ * Accepts a bare url_token (`wen-jie-16-47`), the `user:<slug>` form, or a
+ * full people URL (`https://www.zhihu.com/people/<slug>`). Returns the slug.
+ */
+export function parseZhihuUser(input) {
+  const value = String(input ?? '').trim();
+  if (!value) {
+    throw new CliError('INVALID_INPUT', 'A Zhihu user is required', 'Example: opencli zhihu user wen-jie-16-47');
+  }
+  const prefixMatch = value.match(USER_PREFIX_RE);
+  if (prefixMatch) return prefixMatch[1];
+  if (SLUG_RE.test(value)) return value;
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:' && url.hostname === 'www.zhihu.com') {
+      const m = url.pathname.match(PEOPLE_PATH_RE);
+      if (m) return m[1];
+    }
+  } catch {
+    // fall through to the typed error below
+  }
+  throw new CliError(
+    'INVALID_INPUT',
+    `Invalid Zhihu user: ${value}`,
+    'Use a url_token (wen-jie-16-47) or a people URL (https://www.zhihu.com/people/wen-jie-16-47)',
+  );
+}

--- a/clis/zhihu/user-articles.js
+++ b/clis/zhihu/user-articles.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
 import { fetchZhihuList, validateLimit } from './paginate.js';
 
@@ -22,13 +23,18 @@ cli({
         await page.goto('https://www.zhihu.com');
         const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/articles?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
         const items = await fetchZhihuList(page, first, limit, 'user articles');
-        return items.map((a, i) => ({
-            rank: i + 1,
-            title: String(a.title || ''),
-            votes: a.voteup_count ?? 0,
-            comments: a.comment_count ?? 0,
-            created: a.created ?? a.updated ?? 0,
-            url: a.id ? `https://zhuanlan.zhihu.com/p/${a.id}` : '',
-        }));
+        return items.map((a, i) => {
+            if (!a.id || !a.title) {
+                throw new CommandExecutionError('Zhihu user articles returned malformed row identity');
+            }
+            return {
+                rank: i + 1,
+                title: String(a.title || ''),
+                votes: a.voteup_count ?? 0,
+                comments: a.comment_count ?? 0,
+                created: a.created ?? a.updated ?? 0,
+                url: `https://zhuanlan.zhihu.com/p/${a.id}`,
+            };
+        });
     },
 });

--- a/clis/zhihu/user-articles.js
+++ b/clis/zhihu/user-articles.js
@@ -1,0 +1,34 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { parseZhihuUser } from './user-arg.js';
+import { fetchZhihuList, validateLimit } from './paginate.js';
+
+const INCLUDE = 'data[*].voteup_count,comment_count';
+
+cli({
+    site: 'zhihu',
+    name: 'user-articles',
+    access: 'read',
+    description: '知乎某用户的文章/专栏列表',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of articles to return (max 1000)' },
+    ],
+    columns: ['rank', 'title', 'votes', 'comments', 'created', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        const limit = validateLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const first = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}/articles?limit=20&offset=0&include=${encodeURIComponent(INCLUDE)}`;
+        const items = await fetchZhihuList(page, first, limit, 'user articles');
+        return items.map((a, i) => ({
+            rank: i + 1,
+            title: String(a.title || ''),
+            votes: a.voteup_count ?? 0,
+            comments: a.comment_count ?? 0,
+            created: a.created ?? a.updated ?? 0,
+            url: a.id ? `https://zhuanlan.zhihu.com/p/${a.id}` : '',
+        }));
+    },
+});

--- a/clis/zhihu/user-articles.test.js
+++ b/clis/zhihu/user-articles.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './user-articles.js';
 
 describe('zhihu user-articles', () => {
@@ -27,6 +27,12 @@ describe('zhihu user-articles', () => {
         const cmd = getRegistry().get('zhihu/user-articles');
         const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails typed on malformed article identity rows', async () => {
+        const cmd = getRegistry().get('zhihu/user-articles');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ data: [{ id: 'p1' }], paging: { is_end: true } }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects invalid limits before navigation', async () => {

--- a/clis/zhihu/user-articles.test.js
+++ b/clis/zhihu/user-articles.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './user-articles.js';
+
+describe('zhihu user-articles', () => {
+    it('maps a user articles list to rows', async () => {
+        const cmd = getRegistry().get('zhihu/user-articles');
+        expect(cmd?.func).toBeTypeOf('function');
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47/articles');
+            return {
+                data: [
+                    { id: 'p1', title: 'Title 1', voteup_count: 5, comment_count: 2, created: 1775244581 },
+                    { id: 'p2', title: 'Title 2', updated: 1775244999 },
+                ],
+                paging: { is_end: true },
+            };
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'wen-jie-16-47', limit: 2 })).resolves.toEqual([
+            { rank: 1, title: 'Title 1', votes: 5, comments: 2, created: 1775244581, url: 'https://zhuanlan.zhihu.com/p/p1' },
+            { rank: 2, title: 'Title 2', votes: 0, comments: 0, created: 1775244999, url: 'https://zhuanlan.zhihu.com/p/p2' },
+        ]);
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/user-articles');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects invalid limits before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/user-articles');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'foo', limit: -1 })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/user.js
+++ b/clis/zhihu/user.js
@@ -1,0 +1,54 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { parseZhihuUser } from './user-arg.js';
+
+const INCLUDE = 'follower_count,following_count,answer_count,articles_count,question_count,voteup_count,thanked_count,favorited_count,headline,gender';
+
+cli({
+    site: 'zhihu',
+    name: 'user',
+    access: 'read',
+    description: '知乎用户主页资料（粉丝/关注/回答/文章/获赞数）',
+    domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
+    args: [
+        { name: 'user', type: 'string', required: true, positional: true, help: 'User url_token or people URL, e.g. wen-jie-16-47' },
+    ],
+    columns: ['url_token', 'name', 'headline', 'followers', 'following', 'answers', 'articles', 'voteup', 'url'],
+    func: async (page, kwargs) => {
+        const slug = parseZhihuUser(kwargs.user);
+        await page.goto('https://www.zhihu.com');
+        const apiUrl = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}?include=${encodeURIComponent(INCLUDE)}`;
+        const data = await page.evaluate(`
+      (async () => {
+        const r = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
+        if (!r.ok) return { __httpError: r.status };
+        return await r.json();
+      })()
+    `);
+        if (!data || data.__httpError) {
+            const status = data?.__httpError;
+            if (status === 401 || status === 403) {
+                throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch Zhihu user profile');
+            }
+            if (status === 404) {
+                throw new CliError('NOT_FOUND', `Zhihu user not found: ${slug}`, 'Check the url_token');
+            }
+            throw new CliError('FETCH_ERROR', status ? `Zhihu user request failed (HTTP ${status})` : 'Zhihu user request failed', 'Try again later or rerun with -v');
+        }
+        if (!data.url_token && !data.id) {
+            throw new CliError('FETCH_ERROR', 'Zhihu user response missing identity fields', 'Zhihu may have changed its API shape');
+        }
+        return [{
+            url_token: String(data.url_token || ''),
+            name: String(data.name || ''),
+            headline: String(data.headline || ''),
+            followers: data.follower_count ?? 0,
+            following: data.following_count ?? 0,
+            answers: data.answer_count ?? 0,
+            articles: data.articles_count ?? 0,
+            voteup: data.voteup_count ?? 0,
+            url: data.url_token ? `https://www.zhihu.com/people/${data.url_token}` : '',
+        }];
+    },
+});

--- a/clis/zhihu/user.js
+++ b/clis/zhihu/user.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseZhihuUser } from './user-arg.js';
+import { unwrapEvaluateResult } from './paginate.js';
 
 const INCLUDE = 'follower_count,following_count,answer_count,articles_count,question_count,voteup_count,thanked_count,favorited_count,headline,gender';
 
@@ -19,25 +20,29 @@ cli({
         const slug = parseZhihuUser(kwargs.user);
         await page.goto('https://www.zhihu.com');
         const apiUrl = `https://www.zhihu.com/api/v4/members/${encodeURIComponent(slug)}?include=${encodeURIComponent(INCLUDE)}`;
-        const data = await page.evaluate(`
+        const data = unwrapEvaluateResult(await page.evaluate(`
       (async () => {
-        const r = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
-        if (!r.ok) return { __httpError: r.status };
-        return await r.json();
+        try {
+          const r = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
+          if (!r.ok) return { __httpError: r.status };
+          return await r.json();
+        } catch (err) {
+          return { __fetchError: err?.message || String(err) };
+        }
       })()
-    `);
-        if (!data || data.__httpError) {
+    `));
+        if (!data || typeof data !== 'object' || Array.isArray(data) || data.__httpError || data.__fetchError) {
             const status = data?.__httpError;
             if (status === 401 || status === 403) {
                 throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch Zhihu user profile');
             }
             if (status === 404) {
-                throw new CliError('NOT_FOUND', `Zhihu user not found: ${slug}`, 'Check the url_token');
+                throw new EmptyResultError('zhihu user', `No Zhihu user was found for ${slug}.`);
             }
-            throw new CliError('FETCH_ERROR', status ? `Zhihu user request failed (HTTP ${status})` : 'Zhihu user request failed', 'Try again later or rerun with -v');
+            throw new CommandExecutionError(status ? `Zhihu user request failed (HTTP ${status})` : 'Zhihu user request failed', data?.__fetchError ? String(data.__fetchError) : 'Try again later or rerun with -v');
         }
-        if (!data.url_token && !data.id) {
-            throw new CliError('FETCH_ERROR', 'Zhihu user response missing identity fields', 'Zhihu may have changed its API shape');
+        if (!data.url_token || !data.id || !data.name) {
+            throw new CommandExecutionError('Zhihu user response missing identity fields', 'Zhihu may have changed its API shape');
         }
         return [{
             url_token: String(data.url_token || ''),

--- a/clis/zhihu/user.test.js
+++ b/clis/zhihu/user.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import './user.js';
+
+describe('zhihu user', () => {
+    it('returns a user profile row from the members API', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        expect(cmd?.func).toBeTypeOf('function');
+        const goto = vi.fn().mockResolvedValue(undefined);
+        const evaluate = vi.fn().mockImplementation(async (js) => {
+            expect(js).toContain('/api/v4/members/wen-jie-16-47');
+            expect(js).toContain("credentials: 'include'");
+            return {
+                url_token: 'wen-jie-16-47',
+                id: 'abc',
+                name: 'Kabi',
+                headline: 'builder',
+                follower_count: 3276,
+                following_count: 921,
+                answer_count: 11,
+                articles_count: 13,
+                voteup_count: 2633,
+            };
+        });
+        await expect(cmd.func({ goto, evaluate }, { user: 'wen-jie-16-47' })).resolves.toEqual([
+            {
+                url_token: 'wen-jie-16-47',
+                name: 'Kabi',
+                headline: 'builder',
+                followers: 3276,
+                following: 921,
+                answers: 11,
+                articles: 13,
+                voteup: 2633,
+                url: 'https://www.zhihu.com/people/wen-jie-16-47',
+            },
+        ]);
+        expect(goto).toHaveBeenCalledWith('https://www.zhihu.com');
+    });
+
+    it('accepts a full people URL', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        const evaluate = vi.fn().mockResolvedValue({ url_token: 'foo', id: '1', name: 'Foo' });
+        await cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'https://www.zhihu.com/people/foo' });
+        expect(evaluate.mock.calls[0][0]).toContain('/api/v4/members/foo');
+    });
+
+    it('maps 403 to AuthRequiredError', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }) };
+        await expect(cmd.func(page, { user: 'foo' })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps 404 to a NOT_FOUND CliError', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 404 }) };
+        await expect(cmd.func(page, { user: 'ghost' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('rejects an invalid user before navigation', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { user: 'bad slug!' })).rejects.toBeInstanceOf(CliError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});

--- a/clis/zhihu/user.test.js
+++ b/clis/zhihu/user.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './user.js';
 
 describe('zhihu user', () => {
@@ -41,7 +41,7 @@ describe('zhihu user', () => {
 
     it('accepts a full people URL', async () => {
         const cmd = getRegistry().get('zhihu/user');
-        const evaluate = vi.fn().mockResolvedValue({ url_token: 'foo', id: '1', name: 'Foo' });
+        const evaluate = vi.fn().mockResolvedValue({ session: {}, data: { url_token: 'foo', id: '1', name: 'Foo' } });
         await cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'https://www.zhihu.com/people/foo' });
         expect(evaluate.mock.calls[0][0]).toContain('/api/v4/members/foo');
     });
@@ -52,10 +52,16 @@ describe('zhihu user', () => {
         await expect(cmd.func(page, { user: 'foo' })).rejects.toBeInstanceOf(AuthRequiredError);
     });
 
-    it('maps 404 to a NOT_FOUND CliError', async () => {
+    it('maps 404 to EmptyResultError', async () => {
         const cmd = getRegistry().get('zhihu/user');
         const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ __httpError: 404 }) };
-        await expect(cmd.func(page, { user: 'ghost' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+        await expect(cmd.func(page, { user: 'ghost' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('fails typed on malformed user payloads', async () => {
+        const cmd = getRegistry().get('zhihu/user');
+        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn().mockResolvedValue({ url_token: 'foo', id: '1' }) };
+        await expect(cmd.func(page, { user: 'foo' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects an invalid user before navigation', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "^4.1.0",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
-        "undici": "^6.25.0",
+        "undici": "^6.27.0",
         "ws": "^8.18.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "js-yaml": "^4.1.0",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
-    "undici": "^6.25.0",
+    "undici": "^6.27.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Adds **6 new Zhihu read commands** covering the user-centric `/api/v4` surface that was missing (existing zhihu read: answer-detail / answer-comments / question / collection(s) / recommend / hot / search / download):

| Command | Description |
|---|---|
| `opencli zhihu user <user>` | Profile: follower/following/answer/article/voteup counts + headline |
| `opencli zhihu user-answers <user>` | A user's answers (question title, votes, comments, url) |
| `opencli zhihu user-articles <user>` | A user's articles / 专栏 |
| `opencli zhihu following <user>` | Who the user follows |
| `opencli zhihu followers <user>` | The user's followers |
| `opencli zhihu pins <user>` | The user's 想法 (short posts) |

`<user>` accepts a bare url_token (`wen-jie-16-47`), `user:<slug>`, or a people URL — via a shared `parseZhihuUser`.

## How

- Read adapters: `Strategy.COOKIE` + `page.evaluate` credentialed fetch of `/api/v4/members/<slug>/...`, matching the existing `recommend.js` pattern.
- List commands share a `fetchZhihuList` paginator (`paginate.js`): follows `paging.next`, caps at `--limit` (validated, max 1000), and maps failures to typed errors — `AuthRequiredError` on 401/403, `NOT_FOUND` on 404, `FETCH_ERROR` otherwise. No silent `[]` / sentinel fallbacks.

## Verification

All six **live-verified against a logged-in account** (real data, e.g. profile: 3276 followers / 11 answers / 13 articles / 2633 votes; answers/articles/following/followers/pins all return correct rows + URLs).

- `npm test` → **532 files, 5551 passed**, 1 skipped (6 new test suites)
- `npm run check:typed-error-lint` → **new=0**
- `npm run check:silent-column-drop` → **new=0**

## Notes

Possible follow-ups if wanted: `notifications`, topic browsing, and a read view of single article content (today `download` exports to Markdown).