### PR TITLE
perf(reddit): 删除冗余的首页预导航步,每命令双导航→单导航

### DIFF
--- a/clis/reddit/popular.js
+++ b/clis/reddit/popular.js
@@ -12,7 +12,6 @@ cli({
     ],
     columns: ['rank', 'id', 'title', 'subreddit', 'score', 'comments', 'author', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
-        { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
   function decodeHtml(s) {
     if (typeof s !== 'string' || !s) return '';

--- a/clis/reddit/popular.test.js
+++ b/clis/reddit/popular.test.js
@@ -14,9 +14,9 @@ describe('reddit popular adapter', () => {
   });
 
   it('surfaces media via extractRedditMedia in evaluate + map', () => {
-    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
-    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
-    expect(command?.pipeline?.[2]?.map).toMatchObject({
+    expect(command?.pipeline?.[0]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[0]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[1]?.map).toMatchObject({
       post_hint: '${{ item.post_hint }}',
       url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
       preview_image_url: '${{ item.preview_image_url }}',

--- a/clis/reddit/read.js
+++ b/clis/reddit/read.js
@@ -140,7 +140,8 @@ cli({
         const expandRounds = parseExpandRounds(kwargs['expand-rounds']);
         const postId = normalizeRedditPostId(kwargs['post-id']);
 
-        await page.goto('https://www.reddit.com');
+        // 不再显式导航首页：框架 navigateBefore（domain=reddit.com）已把页面带到 reddit origin，
+        // 下面的相对 fetch(/comments/<id>.json) 照常可用。省掉每条评论命令一次冗余首页导航。
 
         // The in-browser script returns a discriminated union so we can map
         // each failure mode to its proper typed error on the Node side

--- a/clis/reddit/read.test.js
+++ b/clis/reddit/read.test.js
@@ -175,7 +175,8 @@ describe('reddit read adapter', () => {
             expandMeta: { rounds: 0, fetched: 0, capped: false, errors: [] },
         });
         const result = await command.func(page, { 'post-id': 'abc123', limit: 5 });
-        expect(page.goto).toHaveBeenCalledWith('https://www.reddit.com');
+        // perf: read 不再显式导航首页——框架 navigateBefore（domain=reddit.com）已把页面带到 reddit origin
+        expect(page.goto).not.toHaveBeenCalledWith('https://www.reddit.com');
         expect(result).toEqual([
             { type: 'POST', author: 'alice', score: 10, text: 'Title',
               post_hint: 'image', url_overridden_by_dest: 'https://i.redd.it/a.jpg',

--- a/clis/reddit/search.js
+++ b/clis/reddit/search.js
@@ -31,7 +31,6 @@ cli({
     ],
     columns: ['id', 'title', 'subreddit', 'author', 'score', 'comments', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
-        { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
   function decodeHtml(s) {
     if (typeof s !== 'string' || !s) return '';

--- a/clis/reddit/search.test.js
+++ b/clis/reddit/search.test.js
@@ -14,9 +14,9 @@ describe('reddit search adapter', () => {
   });
 
   it('surfaces media via extractRedditMedia in evaluate + map', () => {
-    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
-    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
-    expect(command?.pipeline?.[2]?.map).toMatchObject({
+    expect(command?.pipeline?.[0]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[0]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[1]?.map).toMatchObject({
       post_hint: '${{ item.post_hint }}',
       url_overridden_by_dest: '${{ item.url_overridden_by_dest }}',
       preview_image_url: '${{ item.preview_image_url }}',

--- a/clis/reddit/subreddit.js
+++ b/clis/reddit/subreddit.js
@@ -25,7 +25,6 @@ cli({
     ],
     columns: ['id', 'title', 'subreddit', 'author', 'upvotes', 'comments', 'url', 'created_utc', 'selftext', 'post_hint', 'url_overridden_by_dest', 'preview_image_url', 'gallery_urls'],
     pipeline: [
-        { navigate: 'https://www.reddit.com' },
         { evaluate: `(async () => {
   function decodeHtml(s) {
     if (typeof s !== 'string' || !s) return '';

--- a/clis/reddit/subreddit.test.js
+++ b/clis/reddit/subreddit.test.js
@@ -14,9 +14,9 @@ describe('reddit subreddit adapter', () => {
   });
 
   it('shapes children into the intermediate-object pattern with media spread in', () => {
-    expect(command?.pipeline?.[1]?.evaluate).toContain('function extractRedditMedia');
-    expect(command?.pipeline?.[1]?.evaluate).toContain('...extractRedditMedia(c.data)');
-    expect(command?.pipeline?.[2]?.map).toMatchObject({
+    expect(command?.pipeline?.[0]?.evaluate).toContain('function extractRedditMedia');
+    expect(command?.pipeline?.[0]?.evaluate).toContain('...extractRedditMedia(c.data)');
+    expect(command?.pipeline?.[1]?.map).toMatchObject({
       title: '${{ item.title }}',
       author: '${{ item.author }}',
       upvotes: '${{ item.upvotes }}',


### PR DESCRIPTION
reddit 的 `popular` / `subreddit` / `search` / `read` 命令都先用框架 navigateBefore(`domain=reddit.com` → 302 到 www.reddit.com)把页面带到 reddit origin,**又**额外硬编码一步导航到 `https://www.reddit.com` 首页,然后才发相对 fetch(`/r/popular.json`、`/comments/<id>.json` 等)。两次导航到同一站点首页纯属冗余 —— 框架那次已经够让相对 fetch 工作。

实测:一次串行抓取仅 reddit 就因此重复导航首页约 24 次(每次 6-15s),是可观的无谓开销。

## 改动(+13 / -14,纯删冗余)

- 删掉 `popular` / `subreddit` / `search` 的 pipeline `{ navigate: 'https://www.reddit.com' }` 步;
- 删掉 `read.js` func 里的 `await page.goto('https://www.reddit.com')`;
- 框架 navigateBefore 仍把页面带到 reddit origin,相对 fetch 照常工作 —— **行为不变,只少一次导航**。

## 配套测试调整

- `read.test.js`:原本断言「导航到首页」,改为**反向回归保护**(`page.goto` 不再以首页 URL 被调用),正好锁住本次优化不被回退;
- `popular` / `search` / `subreddit.test.js`:删掉一个 pipeline 步后,`evaluate` / `map` 的索引各前移一位(`[1]→[0]`、`[2]→[1]`),同步更新断言。

## 验证

- 逐一实测 `opencli reddit popular / subreddit / search / read` 均正常返回数据;
- reddit 全量适配器测试 **88 通过**;`tsc --noEmit` 干净;`npm run build` 干净。

## 兼容性

纯性能优化,输出数据完全不变(框架 navigateBefore 保证相对 fetch 的 origin 上下文)。