### PR TITLE
feat(daemon): 浏览器操作结构化 trace(env-gated)+ 扩展窗口复用日志

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1441,6 +1441,7 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
     await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
     const initialTabId2 = await findReusableOwnedContainerTab(existingGroup.windowId, existingGroup.id);
     await persistRuntimeState();
+    console.log(`[opencli] Reused owned ${role} window ${existingGroup.windowId} (initialTab=${initialTabId2 ?? "none"})`);
     return {
       windowId: existingGroup.windowId,
       initialTabId: initialTabId2

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -985,6 +985,11 @@ async function ensureOwnedContainerWindowUnlocked(
     await focusOwnedWindowIfRequested(existingGroup.windowId, mode);
     const initialTabId = await findReusableOwnedContainerTab(existingGroup.windowId, existingGroup.id);
     await persistRuntimeState();
+    // Trace: window reuse (pairs with the "Created owned … window" log below so the
+    // browser-op trace analyzer can compute the new-window-vs-reuse ratio — the core
+    // "开窗 vs 复用" waste signal). console.log is forwarded to the daemon trace file
+    // only when OPENCLI_BROWSER_TRACE_FILE is set; otherwise just normal logging.
+    console.log(`[opencli] Reused owned ${role} window ${existingGroup.windowId} (initialTab=${initialTabId ?? 'none'})`);
     return {
       windowId: existingGroup.windowId,
       initialTabId,

--- a/src/browser/trace.ts
+++ b/src/browser/trace.ts
@@ -1,0 +1,99 @@
+/**
+ * 浏览器操作 trace —— env-gated 结构化事件落盘（JSONL）。
+ *
+ * 目标：把 daemon 收到的每条浏览器命令的生命周期（dispatch / result / timeout）、扩展
+ * 连接/断开、以及扩展转发来的日志，以「一行一个 JSON 事件」append 到
+ * `OPENCLI_BROWSER_TRACE_FILE` 指向的文件，供下游分析「哪些开浏览器操作无效 / 浪费 / 待改进」
+ * （慢命令、重复导航、stale 重试、daemon 冷启重连开销、开窗 vs 复用窗口等）。
+ *
+ * 设计：
+ *  - env 未置位 → 所有导出函数 no-op，零开销零侵入（对正常用户完全透明）。
+ *  - 用 `fs.appendFileSync`（每条同步写），不用 createWriteStream：daemon 常被调用方
+ *    `pkill` 冷启，同步写保证被杀时已写的事件不丢；每 run 几百条 × ~150B 的同步 IO 完全
+ *    淹没在秒级浏览器命令的噪声里。
+ *  - `write()` 全程 try/catch + 只警告一次：trace 自身故障绝不影响命令执行。
+ *  - 隐私铁律：只取 action / session / surface / origin+pathname；绝不写 exec 的 JS 源、
+ *    insert-text 文本、cookies、cdpParams 等可能含敏感数据的字段。
+ */
+import { appendFileSync } from 'node:fs';
+import { log } from '../logger.js';
+
+const TRACE_FILE = process.env.OPENCLI_BROWSER_TRACE_FILE?.trim();
+const enabled = !!TRACE_FILE;
+let warned = false;
+
+function write(obj: Record<string, unknown>): void {
+  if (!enabled) return;
+  try {
+    appendFileSync(TRACE_FILE!, JSON.stringify({ t: Date.now(), ...obj }) + '\n');
+  } catch (err) {
+    if (!warned) {
+      warned = true;
+      log.warn(`[trace] failed to write browser trace to ${TRACE_FILE}: ${err instanceof Error ? err.message : String(err)} (further trace errors suppressed)`);
+    }
+  }
+}
+
+/** 仅对 navigate 取 url，并裁成 origin+pathname（去掉 query/fragment，避免泄露搜索词/token）。 */
+function safeUrl(action: unknown, url: unknown): string | undefined {
+  if (action !== 'navigate' || typeof url !== 'string' || !url) return undefined;
+  try {
+    const u = new URL(url);
+    return u.origin + u.pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+interface CommandBody {
+  id?: unknown;
+  action?: unknown;
+  contextId?: unknown;
+  session?: unknown;
+  surface?: unknown;
+  url?: unknown;
+}
+
+/** 命令已下发给扩展。 */
+export function traceDispatch(body: CommandBody): void {
+  if (!enabled) return;
+  write({
+    ev: 'dispatch',
+    id: typeof body.id === 'string' ? body.id : undefined,
+    action: typeof body.action === 'string' ? body.action : 'unknown',
+    ctx: typeof body.contextId === 'string' ? body.contextId : undefined,
+    session: typeof body.session === 'string' ? body.session : undefined,
+    surface: typeof body.surface === 'string' ? body.surface : undefined,
+    url: safeUrl(body.action, body.url),
+  });
+}
+
+/** 命令拿到结果（成功 / 业务失败 / 断连致 result-unknown）。ms = dispatch→result 的延迟。 */
+export function traceResult(id: string, ok: boolean, ms: number, errorCode?: string, page?: string): void {
+  if (!enabled) return;
+  write({ ev: 'result', id, ok, ms, errorCode, page });
+}
+
+/** 命令超时（daemon 侧 timeoutMs 到点仍无结果）。 */
+export function traceTimeout(id: string, ms: number, action?: string): void {
+  if (!enabled) return;
+  write({ ev: 'timeout', id, ms, action });
+}
+
+/** 扩展（某 profile/contextId）连上 daemon。冷启后的首个 connect 即重连开销的右端点。 */
+export function traceExtConnect(ctx: string, extVersion?: string | null): void {
+  if (!enabled) return;
+  write({ ev: 'ext-connect', ctx, extVersion: extVersion ?? undefined });
+}
+
+/** 扩展断开。与下一个 ext-connect 配对即一次重连开销。 */
+export function traceExtDisconnect(ctx: string): void {
+  if (!enabled) return;
+  write({ ev: 'ext-disconnect', ctx });
+}
+
+/** 扩展转发来的 console 日志（Phase 2 的开窗 / 复用 / 销毁细节走这条）。 */
+export function traceExtLog(level: string, msg: string): void {
+  if (!enabled) return;
+  write({ ev: 'ext-log', level, msg });
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -42,6 +42,7 @@ import {
   getSessionLeaseKey,
   isSessionLeaseCommand,
 } from './session-lease.js';
+import * as trace from './browser/trace.js';
 
 const PORT = DEFAULT_DAEMON_PORT;
 if (!isIgnorableDaemonPortEnv(process.env.OPENCLI_DAEMON_PORT)) {
@@ -68,6 +69,7 @@ type PendingEntry = {
   contextId: string;
   action: string;
   dispatched: boolean;
+  dispatchTs: number;
   /**
    * All HTTP requests waiting on this command id. The first settler is the
    * original request; transport retries with the same id attach here instead
@@ -199,6 +201,7 @@ function unregisterExtensionConnection(ws: WebSocket): void {
   for (const [contextId, connection] of extensionProfiles.entries()) {
     if (connection.ws !== ws) continue;
     extensionProfiles.delete(contextId);
+    trace.traceExtDisconnect(contextId);
     for (const [id, p] of pending) {
       if (p.contextId !== contextId) continue;
       const failure = buildExtensionDisconnectFailure({
@@ -210,6 +213,7 @@ function unregisterExtensionConnection(ws: WebSocket): void {
         commandResultUnknownCount++;
         log.warn(`[daemon] Command result unknown after extension disconnect (id=${id}, action=${p.action}, context=${contextId})`);
       }
+      trace.traceResult(id, false, Date.now() - p.dispatchTs, failure.errorCode);
       settlePending(id, p, { error: new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status) });
     }
   }
@@ -444,12 +448,14 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
             commandResultUnknownCount++;
             log.warn(`[daemon] Command timed out after dispatch (id=${body.id}, action=${entry.action}, timeout=${timeoutMs}ms)`);
           }
+          trace.traceTimeout(body.id, timeoutMs, entry.action);
           settlePending(body.id, entry, { error: new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status) });
         }, timeoutMs);
         const entry: PendingEntry = {
           contextId: route.connection!.contextId,
           action: typeof body.action === 'string' ? body.action : 'unknown',
           dispatched: false,
+          dispatchTs: Date.now(),
           settlers: [{ resolve, reject }],
           timer,
           ...(leaseKey && leaseRunId ? { leaseKey, runId: leaseRunId } : {}),
@@ -469,6 +475,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
           // result is later lost; do not downgrade later disconnects to a
           // pre-dispatch failure just because no result/ack has arrived yet.
           entry.dispatched = true;
+          trace.traceDispatch(body);
         } catch (err) {
           failBeforeDispatch(err);
         }
@@ -542,6 +549,7 @@ wss.on('connection', (ws: WebSocket) => {
         connection.lastSeenAt = Date.now();
         if (connection.extensionVersion) recordExtensionVersion(connection.extensionVersion);
         log.info(`[daemon] Extension profile connected: ${connection.contextId}`);
+        trace.traceExtConnect(connection.contextId, connection.extensionVersion);
         return;
       }
 
@@ -551,6 +559,7 @@ wss.on('connection', (ws: WebSocket) => {
         else if (msg.level === 'warn') log.warn(`[ext] ${msg.msg}`);
         else log.info(`[ext] ${msg.msg}`);
         pushLog({ level: msg.level, msg: msg.msg, ts: msg.ts ?? Date.now() });
+        trace.traceExtLog(msg.level, msg.msg);
         return;
       }
 
@@ -561,6 +570,7 @@ wss.on('connection', (ws: WebSocket) => {
       // Handle command results
       const p = pending.get(msg.id);
       if (p) {
+        trace.traceResult(msg.id, !!msg.ok, Date.now() - p.dispatchTs, typeof msg.errorCode === 'string' ? msg.errorCode : undefined, typeof msg.page === 'string' ? msg.page : undefined);
         settlePending(msg.id, p, { data: msg });
       }
     } catch (err) {


### PR DESCRIPTION
给 opencli 的浏览器层操作加一层**可选的**可观测性,方便排查性能问题(命令为什么慢、窗口为什么反复开关、是否有冗余导航)。

## 动机

daemon 由 `spawn(detached, stdio:'ignore')` 启动、自身输出被丢弃,所以无论是 CLI 用户还是上层脚本,此前都只能看到命令级 success / fail,看不到 daemon 内部发生了什么。想知道「哪条命令慢在哪、是不是反复 stale 重试、是不是冷启重连开销、有没有冗余的重复导航」时,没有任何抓手。

## 改动

### Phase 1 — daemon 命令级 trace(`src/browser/trace.ts` 新增 + `src/daemon.ts`)

- 新 env `OPENCLI_BROWSER_TRACE_FILE=<path>`:置位时 daemon 把每条命令的生命周期 append 成 JSONL(`dispatch` / `result` / `timeout`)+ 扩展连接/断开 + 扩展转发日志;
- **未置位 → 全程 no-op,零开销、零侵入**(默认行为完全不变,普通用户无感);
- `fs.appendFileSync`(每条同步写):daemon 常被 pkill 冷启,同步写保证被杀时已写的事件不丢;每 run 几百条 × ~150B 的同步 IO 淹没在秒级命令噪声里;
- **隐私铁律**:只记录 `action / session / surface / origin+pathname`,**绝不**写 exec 的 JS 源、insert-text 文本、cookies、cdpParams;
- 不动 `daemon-lifecycle.ts` 的 `stdio:'ignore'` —— trace 直接 fs 写文件,与 stdout/stderr 无关。

### Phase 2 — 扩展窗口复用日志(`extension/src/background.ts`,+5 行)

- existingGroup 复用路径补一行 `console.log('[opencli] Reused owned <role> window …')`,与既有的 "Created owned … window" 配对,让分析器能算「新开窗 vs 复用」比率(核心浪费信号);
- 其余窗口 churn(开窗 / tab 释放 + reason / drift / stale)扩展早已 log,经现有 WS 转发管道自动流进 trace 文件。

## 验证

- `tsc --noEmit` + `npm run build` 通过;daemon + browser 测试 **390 通过**;extension 测试 **70 通过**;
- 端到端:`OPENCLI_BROWSER_TRACE_FILE=… opencli youtube search …` 落出 17 条事件(`ext-connect` / `navigate 3.3s` / `exec 4.0s` / `close-window` / `tab-lease-reused`),结构正确。

## 兼容性 / 范围

- **完全 opt-in**:不设 env 时零行为变化、零开销;
- 不改任何命令的输出或退出码,纯诊断设施;
- 隐私上只记录操作元数据(action / session / origin),不碰任何内容或凭据。