### PR TITLE
feat(typora): add Typora adapter

### DIFF
--- a/clis/typora/_utils.js
+++ b/clis/typora/_utils.js
@@ -1,0 +1,46 @@
+// Shared helpers for the Typora adapter.
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+
+export const TYPORA_APP = '/Applications/Typora.app';
+
+export function runJxa(script) {
+    try {
+        return execFileSync('osascript', ['-l', 'JavaScript', '-e', script], {
+            encoding: 'utf-8',
+            timeout: 20_000,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+    } catch (err) {
+        const stderr = err.stderr?.toString() || '';
+        throw new Error(`AppleScript/JXA failed: ${err.message}${stderr ? ` (${stderr})` : ''}`);
+    }
+}
+
+export function ensureTyporaInstalled() {
+    if (!fs.existsSync(TYPORA_APP)) {
+        throw new Error('Typora is not installed at /Applications/Typora.app. Install it from https://typora.io');
+    }
+}
+
+export function activateTypora() {
+    runJxa('Application("Typora").activate();');
+}
+
+export function getFrontDocumentPath() {
+    const result = runJxa(`
+        (function() {
+            var t = Application("Typora");
+            var docs = t.documents;
+            if (docs.length === 0) return JSON.stringify({ path: null });
+            var d = docs[0];
+            return JSON.stringify({ path: d.path() });
+        })();
+    `);
+    return JSON.parse(result).path;
+}
+
+export function openInTypora(filePath) {
+    runJxa(`Application("Typora").open(${JSON.stringify(filePath)});`);
+}

--- a/clis/typora/export.js
+++ b/clis/typora/export.js
@@ -1,0 +1,102 @@
+// opencli typora export — trigger File → Export for the current document.
+//
+// Requires Accessibility permission for System Events to click menus and fill
+// the save panel. Without it, the export menu is triggered but the user must
+// confirm the dialog manually.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import * as path from 'node:path';
+import { ensureTyporaInstalled, getFrontDocumentPath, runJxa } from './_utils.js';
+
+const FORMAT_LABELS = {
+    pdf: 'PDF',
+    html: 'HTML',
+    image: '图像',
+    docx: 'Word (.docx)',
+    openoffice: 'OpenOffice',
+    rtf: 'RTF',
+    epub: 'Epub',
+    latex: 'LaTeX',
+    wiki: 'Media Wiki',
+    rst: 'reStructuredText',
+    textile: 'Textile',
+    opml: 'OPML',
+};
+
+cli({
+    site: 'typora',
+    name: 'export',
+    access: 'write',
+    description: 'Trigger File → Export for the current document. Requires Accessibility permission for System Events.',
+    domain: 'typora.io',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'to', type: 'string', default: 'pdf', help: 'pdf | html | image | docx | openoffice | rtf | epub | latex | wiki | rst | textile | opml' },
+        { name: 'output', type: 'string', required: false, help: 'Desired output path (best-effort; export dialog may still appear without Accessibility permission)' },
+    ],
+    columns: ['status', 'file', 'format', 'output', 'note'],
+    func: async (args) => {
+        ensureTyporaInstalled();
+        const format = String(args.to || 'pdf').toLowerCase();
+        const outputArg = args.output ? path.resolve(String(args.output)) : '';
+
+        const sourcePath = getFrontDocumentPath();
+        if (!sourcePath) {
+            throw new EmptyResultError('typora export', 'No Typora document is currently open');
+        }
+
+        const menuLabel = FORMAT_LABELS[format];
+        if (!menuLabel) {
+            throw new ArgumentError(`unsupported export format: ${format}`);
+        }
+
+        const outputPath = outputArg || path.join(
+            path.dirname(sourcePath),
+            `${path.basename(sourcePath, path.extname(sourcePath))}.${format === 'image' ? 'png' : format}`
+        );
+
+        try {
+            runJxa(`
+                (function() {
+                    var se = Application("System Events");
+                    se.includeStandardAdditions = true;
+                    var proc = se.processes.byName("Typora");
+                    proc.menuBars[0].menuBarItems.byName("文件").menus[0]
+                        .menuItems.byName("导出").menus[0]
+                        .menuItems.byName(${JSON.stringify(menuLabel)}).click();
+                })();
+            `);
+        } catch (err) {
+            throw new CommandExecutionError(String(err.message || err), 'Menu click failed. Check System Events Accessibility permission in System Settings.');
+        }
+
+        // Best-effort: if the save panel appears, fill it in and confirm.
+        try {
+            runJxa(`
+                (function() {
+                    var app = Application("Typora");
+                    app.activate();
+                    delay(0.8);
+                    var sheet = app.windows[0].sheets[0];
+                    var textField = sheet.textFields[0];
+                    textField.value.set("");
+                    textField.value.set(${JSON.stringify(outputPath)});
+                    delay(0.2);
+                    sheet.buttons.byName("存储").click();
+                })();
+            `);
+        } catch {
+            // Without Accessibility permission the panel may not exist or may not be controllable.
+        }
+
+        return [{
+            status: 'export-triggered',
+            file: sourcePath,
+            format,
+            output: outputPath,
+            note: 'Export dialog may require manual confirmation if Accessibility permission is not granted.',
+        }];
+    },
+});

--- a/clis/typora/open.js
+++ b/clis/typora/open.js
@@ -1,0 +1,34 @@
+// opencli typora open — open a Markdown file in Typora.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ensureTyporaInstalled, openInTypora } from './_utils.js';
+
+cli({
+    site: 'typora',
+    name: 'open',
+    access: 'write',
+    description: 'Open a Markdown file in Typora.',
+    domain: 'typora.io',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'file', type: 'string', required: true, positional: true, help: 'Path to the Markdown file' },
+    ],
+    columns: ['status', 'file'],
+    func: async (args) => {
+        ensureTyporaInstalled();
+        const filePath = path.resolve(String(args.file || ''));
+        if (!fs.existsSync(filePath)) {
+            throw new ArgumentError(`file not found: ${filePath}`);
+        }
+        try {
+            openInTypora(filePath);
+        } catch (err) {
+            throw new CommandExecutionError(String(err.message || err), '');
+        }
+        return [{ status: 'opened', file: filePath }];
+    },
+});

--- a/clis/typora/read.js
+++ b/clis/typora/read.js
@@ -1,0 +1,61 @@
+// opencli typora read — read the source Markdown of the current Typora document.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import * as fs from 'node:fs';
+import { ensureTyporaInstalled, getFrontDocumentPath, runJxa } from './_utils.js';
+
+cli({
+    site: 'typora',
+    name: 'read',
+    access: 'read',
+    description: 'Read the Markdown source of the current Typora document.',
+    domain: 'typora.io',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'as', type: 'string', default: 'markdown', help: 'markdown | html | plain (html/plain require Accessibility permission)' },
+    ],
+    columns: ['status', 'file', 'content', 'format'],
+    func: async (args) => {
+        ensureTyporaInstalled();
+        const format = String(args.as || 'markdown').toLowerCase();
+        const docPath = getFrontDocumentPath();
+        if (!docPath || !fs.existsSync(docPath)) {
+            throw new EmptyResultError('typora read', 'No Typora document is currently open, or it has not been saved');
+        }
+
+        if (format === 'markdown' || format === 'md') {
+            const content = fs.readFileSync(docPath, 'utf-8');
+            return [{ status: 'read', file: docPath, content, format: 'markdown' }];
+        }
+
+        const menuLabels = {
+            html: '复制为 HTML 代码',
+            plain: '复制为纯文本',
+        };
+        const menuLabel = menuLabels[format];
+        if (!menuLabel) {
+            throw new ArgumentError(`unsupported read format: ${format}`);
+        }
+
+        try {
+            const result = runJxa(`
+                (function() {
+                    var se = Application("System Events");
+                    se.includeStandardAdditions = true;
+                    var proc = se.processes.byName("Typora");
+                    proc.menuBars[0].menuBarItems.byName("编辑").menus[0].menuItems.byName(${JSON.stringify(menuLabel)}).click();
+                    delay(0.5);
+                    var content = se.theClipboard();
+                    se.setTheClipboardTo("");
+                    return JSON.stringify({ content: content });
+                })();
+            `);
+            const { content } = JSON.parse(result);
+            return [{ status: 'read', file: docPath, content, format }];
+        } catch (err) {
+            throw new CommandExecutionError(String(err.message || err), 'Copy-via-menu failed. Check System Events Accessibility permission in System Settings.');
+        }
+    },
+});

--- a/clis/typora/write.js
+++ b/clis/typora/write.js
@@ -1,0 +1,34 @@
+// opencli typora write — write Markdown content to a file and open it in Typora.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ensureTyporaInstalled, openInTypora } from './_utils.js';
+
+cli({
+    site: 'typora',
+    name: 'write',
+    access: 'write',
+    description: 'Write Markdown content to a file and open it in Typora.',
+    domain: 'typora.io',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'file', type: 'string', required: true, positional: true, help: 'Path to the Markdown file' },
+        { name: 'content', type: 'string', required: false, positional: true, help: 'Markdown content to write (omit to just open the file)' },
+    ],
+    columns: ['status', 'file'],
+    func: async (args) => {
+        ensureTyporaInstalled();
+        const filePath = path.resolve(String(args.file || ''));
+        const content = String(args.content ?? '');
+        fs.writeFileSync(filePath, content, 'utf-8');
+        try {
+            openInTypora(filePath);
+        } catch (err) {
+            throw new CommandExecutionError(String(err.message || err), '');
+        }
+        return [{ status: 'written', file: filePath }];
+    },
+});


### PR DESCRIPTION
Add `opencli typora` commands to control the Typora Markdown editor on macOS:

- `opencli typora open <file.md>`
- `opencli typora read [--as markdown|html|plain]`
- `opencli typora write <file.md> [content]`
- `opencli typora export --to pdf|html|image|... [--output <path>]`

Typora is a native macOS app (Cocoa + WKWebView), so this adapter uses AppleScript/JXA instead of CDP.

🤖 Generated with [Claude Code](https://claude.com/code)