### PR TITLE
feat(chatgpt): add project commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6385,6 +6385,68 @@
   },
   {
     "site": "chatgpt",
+    "name": "project-file-add",
+    "description": "Upload files to a ChatGPT project as project knowledge (not just conversation attachments)",
+    "access": "write",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "file",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Local file path(s) to upload; comma-separated paths are supported"
+      },
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "help": "Project ID or /g/g-p-<id> URL"
+      }
+    ],
+    "columns": [
+      "Status",
+      "File"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/project-file-add.js",
+    "sourceFile": "chatgpt/project-file-add.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
+    "name": "project-list",
+    "description": "List visible ChatGPT projects from the sidebar",
+    "access": "read",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max projects to show"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Id",
+      "Title",
+      "Url"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/project-list.js",
+    "sourceFile": "chatgpt/project-list.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
     "name": "read",
     "description": "Read messages in the current ChatGPT web conversation",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6124,6 +6124,13 @@
         "help": "Continue an existing ChatGPT conversation ID or /c/<id> URL"
       },
       {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL"
+      },
+      {
         "name": "wait",
         "type": "boolean",
         "default": true,
@@ -6502,6 +6509,13 @@
         "required": false,
         "valueRequired": true,
         "help": "Continue an existing ChatGPT conversation ID or /c/<id> URL"
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL"
       }
     ],
     "columns": [

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6274,6 +6274,13 @@
         "help": "Local image path to attach before prompting; comma-separated paths are supported"
       },
       {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "Start image generation inside a ChatGPT project ID or /g/g-p-<id> URL"
+      },
+      {
         "name": "op",
         "type": "str",
         "required": false,
@@ -6360,6 +6367,13 @@
           "pro",
           "thinking"
         ]
+      },
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "Open a ChatGPT project ID or /g/g-p-<id> URL before switching intelligence level"
       }
     ],
     "columns": [
@@ -6380,7 +6394,15 @@
     "domain": "chatgpt.com",
     "strategy": "cookie",
     "browser": true,
-    "args": [],
+    "args": [
+      {
+        "name": "project",
+        "type": "str",
+        "required": false,
+        "valueRequired": true,
+        "help": "Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL"
+      }
+    ],
     "columns": [
       "Status"
     ],

--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -17,6 +17,7 @@ import {
     selectChatGPTTool,
     isGenerating,
     startNewChat,
+    navigateToProject,
     waitForChatGPTResponse,
 } from './utils.js';
 
@@ -49,6 +50,7 @@ export const askCommand = cli({
         { name: 'timeout', type: 'int', default: 120, help: 'Max seconds to wait for response' },
         { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending' },
         { name: 'conversation', valueRequired: true, help: 'Continue an existing ChatGPT conversation ID or /c/<id> URL' },
+        { name: 'project', valueRequired: true, help: 'Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL' },
         { name: 'wait', type: 'boolean', default: true, help: 'Wait for the assistant response after sending' },
         { name: 'deep-research', type: 'boolean', default: false, help: 'Enable ChatGPT 深度研究 (Deep Research)' },
         { name: 'web-search', type: 'boolean', default: false, help: 'Enable ChatGPT 网页搜索 (Web Search)' },
@@ -76,10 +78,18 @@ export const askCommand = cli({
                 'Choose either a new chat or an existing conversation.',
             );
         }
+        if (kwargs.project && kwargs.conversation) {
+            throw new ArgumentError(
+                'chatgpt ask cannot use --project and --conversation together',
+                'Choose either a project new chat or an existing conversation.',
+            );
+        }
         const tool = useDeepResearch ? 'deep-research' : (useWebSearch ? 'web-search' : null);
 
         if (kwargs.conversation) {
             await openChatGPTConversation(page, kwargs.conversation);
+        } else if (kwargs.project) {
+            await navigateToProject(page, kwargs.project);
         } else if (normalizeBooleanFlag(kwargs.new)) {
             await startNewChat(page);
         } else {

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -77,6 +77,7 @@ describe('chatgpt browser command registration', () => {
             expect.objectContaining({ name: 'timeout', type: 'int', default: 120 }),
             expect.objectContaining({ name: 'new', type: 'boolean', default: false }),
             expect.objectContaining({ name: 'conversation', valueRequired: true }),
+            expect.objectContaining({ name: 'project', valueRequired: true }),
             expect.objectContaining({ name: 'wait', type: 'boolean', default: true }),
             expect.objectContaining({ name: 'deep-research', type: 'boolean', default: false }),
             expect.objectContaining({ name: 'web-search', type: 'boolean', default: false }),
@@ -84,12 +85,28 @@ describe('chatgpt browser command registration', () => {
         expect(ask.columns).toEqual(['conversationId', 'conversationUrl', 'tool', 'response']);
     });
 
-    it('registers send conversation routing option', () => {
+    it('registers send conversation and project routing options', () => {
         const send = getRegistry().get('chatgpt/send');
         expect(send.args).toEqual(expect.arrayContaining([
             expect.objectContaining({ name: 'new', type: 'boolean', default: false }),
             expect.objectContaining({ name: 'conversation', valueRequired: true }),
+            expect.objectContaining({ name: 'project', valueRequired: true }),
         ]));
+    });
+
+    it('rejects using project and conversation routing together', async () => {
+        const ask = getRegistry().get('chatgpt/ask');
+        const send = getRegistry().get('chatgpt/send');
+        const page = {
+            goto: () => {
+                throw new Error('should not navigate');
+            },
+        };
+
+        await expect(ask.func(page, { prompt: 'hello', project: '12345678', conversation: 'abcdefghi' }))
+            .rejects.toMatchObject({ code: 'ARGUMENT' });
+        await expect(send.func(page, { prompt: 'hello', project: '12345678', conversation: 'abcdefghi' }))
+            .rejects.toMatchObject({ code: 'ARGUMENT' });
     });
 
     it('registers detail wait options and generation state columns', () => {

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -119,16 +119,35 @@ describe('chatgpt browser command registration', () => {
         expect(detail.columns).toEqual(['Index', 'Role', 'Text', 'Generating', 'StableSeconds']);
     });
 
+    it('registers project routing on chat-starting commands', () => {
+        for (const name of ['new', 'image', 'model']) {
+            const cmd = getRegistry().get(`chatgpt/${name}`);
+            expect(cmd.args).toEqual(expect.arrayContaining([
+                expect.objectContaining({ name: 'project', valueRequired: true }),
+            ]));
+        }
+    });
+
+    it('starts a new chat inside a project when new receives project routing', async () => {
+        const cmd = getRegistry().get('chatgpt/new');
+        const page = createProjectUploadPageMock();
+
+        await expect(cmd.func(page, { project: '12345678' }))
+            .resolves.toEqual([{ Status: 'New chat started' }]);
+        expect(page.goto).toHaveBeenCalledWith('https://chatgpt.com/g/g-p-12345678', { settleMs: 2000 });
+    });
+
     it('registers chatgpt model with web model choices', () => {
         const model = getRegistry().get('chatgpt/model');
-        expect(model.args).toEqual([
+        expect(model.args).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 name: 'model',
                 positional: true,
                 required: true,
                 choices: ['instant', 'medium', 'high', 'extra-high', 'pro', 'thinking'],
             }),
-        ]);
+            expect.objectContaining({ name: 'project', valueRequired: true }),
+        ]));
         expect(model.columns).toEqual(['Status', 'Model']);
     });
 

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './ask.js';
 import './send.js';
@@ -9,6 +12,35 @@ import './new.js';
 import './status.js';
 import './image.js';
 import './model.js';
+import './project-list.js';
+import './project-file-add.js';
+
+const tempDirs = [];
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    while (tempDirs.length) {
+        fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+});
+
+function createProjectUploadPageMock() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        setFileInput: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn((script) => {
+            const s = String(script);
+            if (s.includes('isVisible') && s.includes('hasComposer') && s.includes('isLoggedIn')) {
+                return Promise.resolve({ session: 'test', data: { url: 'https://chatgpt.com/g/g-p-12345678', title: 'Project', hasComposer: true, isLoggedIn: true, hasLoginGate: false } });
+            }
+            if (s.includes('expectedFileNames')) return Promise.resolve({ ok: true });
+            if (s.includes('Add files')) return Promise.resolve(true);
+            if (s.includes('role="dialog"')) return Promise.resolve(true);
+            return Promise.resolve(undefined);
+        }),
+    };
+}
 
 describe('chatgpt browser command registration', () => {
     it('registers the baseline web chat commands with persistent site sessions', () => {
@@ -22,6 +54,8 @@ describe('chatgpt browser command registration', () => {
             status: 'read',
             image: 'write',
             model: 'write',
+            'project-list': 'read',
+            'project-file-add': 'write',
         };
 
         for (const [name, access] of Object.entries(expectedAccess)) {
@@ -94,5 +128,41 @@ describe('chatgpt browser command registration', () => {
             .rejects.toMatchObject({ code: 'ARGUMENT' });
         await expect(send.func(page, { prompt: 'hello', conversation: 'https://evil.test/c/abc_123-def' }))
             .rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('does not expose command-level system proxy mutation for project-file-add', () => {
+        const cmd = getRegistry().get('chatgpt/project-file-add');
+        expect(cmd.args.map(arg => arg.name)).toEqual(['file', 'id']);
+    });
+
+    it('rejects empty project-file-add file input', async () => {
+        const cmd = getRegistry().get('chatgpt/project-file-add');
+        await expect(cmd.func(createProjectUploadPageMock(), { file: ' , ', id: '12345678' }))
+            .rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('maps successful project-file-add uploads to table rows', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'report.pdf');
+        fs.writeFileSync(filePath, 'fake-pdf');
+
+        const cmd = getRegistry().get('chatgpt/project-file-add');
+        await expect(cmd.func(createProjectUploadPageMock(), { file: filePath, id: '12345678' }))
+            .resolves.toEqual([
+                {
+                    Status: '📄 uploaded to project knowledge',
+                    File: filePath,
+                },
+            ]);
+    });
+
+    it('wraps project-file-add upload failures as command execution errors', async () => {
+        const cmd = getRegistry().get('chatgpt/project-file-add');
+        await expect(cmd.func(createProjectUploadPageMock(), { file: '/no/such/report.pdf', id: '12345678' }))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('File not found'),
+            });
     });
 });

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -193,11 +193,11 @@ describe('chatgpt browser command registration', () => {
             ]);
     });
 
-    it('wraps project-file-add upload failures as command execution errors', async () => {
+    it('maps project-file-add local file validation failures to argument errors', async () => {
         const cmd = getRegistry().get('chatgpt/project-file-add');
         await expect(cmd.func(createProjectUploadPageMock(), { file: '/no/such/report.pdf', id: '12345678' }))
             .rejects.toMatchObject({
-                code: 'COMMAND_EXEC',
+                code: 'ARGUMENT',
                 message: expect.stringContaining('File not found'),
             });
     });

--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { clearChatGPTDraft, getChatGPTVisibleImageUrls, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, unwrapEvaluateResult, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
+import { clearChatGPTDraft, getChatGPTVisibleImageUrls, navigateToProject, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, unwrapEvaluateResult, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
 
@@ -72,6 +72,7 @@ export const imageCommand = cli({
     args: [
         { name: 'prompt', positional: true, required: true, help: 'Image prompt to send to ChatGPT' },
         { name: 'image', help: 'Local image path to attach before prompting; comma-separated paths are supported' },
+        { name: 'project', valueRequired: true, help: 'Start image generation inside a ChatGPT project ID or /g/g-p-<id> URL' },
         { name: 'op', help: 'Output directory (default: ~/Pictures/chatgpt)' },
         { name: 'sd', type: 'boolean', default: false, help: 'Skip download shorthand; only show ChatGPT link' },
         { name: 'timeout', type: 'int', required: false, default: 240, help: 'Max seconds for the overall command (default: 240)' },
@@ -92,8 +93,12 @@ export const imageCommand = cli({
             throw new ArgumentError(preparedImages.reason);
         }
 
-        // Navigate to chatgpt.com/new with full reload to clear React sidebar state
-        await page.goto(`https://${CHATGPT_DOMAIN}/new`, { settleMs: 2000 });
+        // Navigate with full reload to clear React sidebar state before editing the draft.
+        if (kwargs.project) {
+            await navigateToProject(page, kwargs.project);
+        } else {
+            await page.goto(`https://${CHATGPT_DOMAIN}/new`, { settleMs: 2000 });
+        }
         await clearChatGPTDraft(page);
 
         if (imagePaths.length) {

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     prepareChatGPTImagePaths: vi.fn(),
     sendChatGPTMessage: vi.fn(),
     uploadChatGPTImages: vi.fn(),
+    navigateToProject: vi.fn(),
     waitForChatGPTImages: vi.fn(),
     getChatGPTImageAssets: vi.fn(),
     saveBase64ToFile: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./utils.js', () => ({
     clearChatGPTDraft: mocks.clearChatGPTDraft,
     getChatGPTVisibleImageUrls: mocks.getChatGPTVisibleImageUrls,
+    navigateToProject: mocks.navigateToProject,
     normalizeBooleanFlag: (value, fallback = false) => {
         if (typeof value === 'boolean') return value;
         if (value == null || value === '') return fallback;
@@ -56,6 +58,7 @@ beforeEach(() => {
     mocks.getChatGPTVisibleImageUrls.mockReset().mockResolvedValue([]);
     mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
     mocks.uploadChatGPTImages.mockReset().mockResolvedValue({ ok: true });
+    mocks.navigateToProject.mockReset().mockResolvedValue(undefined);
     mocks.waitForChatGPTImages.mockReset().mockResolvedValue(['https://images.example/generated.png']);
     mocks.getChatGPTImageAssets.mockReset().mockResolvedValue([{
         url: 'https://images.example/generated.png',
@@ -89,6 +92,22 @@ describe('chatgpt image output paths', () => {
 });
 
 describe('chatgpt image upload flow', () => {
+    it('starts image generation inside a specified project', async () => {
+        const page = createPage();
+        await imageCommand.func(page, {
+            prompt: 'cat in a lab',
+            project: '12345678',
+            op: '',
+            sd: true,
+            timeout: 240,
+        });
+
+        expect(mocks.navigateToProject).toHaveBeenCalledWith(page, '12345678');
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(mocks.clearChatGPTDraft).toHaveBeenCalled();
+        expect(mocks.sendChatGPTMessage).toHaveBeenCalledWith(page, 'Generate an image of: cat in a lab');
+    });
+
     it('uploads local images before sending an edit prompt', async () => {
         mocks.prepareChatGPTImagePaths.mockResolvedValue({ ok: true, paths: ['/abs/cat.png', '/abs/dog.jpg'] });
         await imageCommand.func(createPage(), {

--- a/clis/chatgpt/model.js
+++ b/clis/chatgpt/model.js
@@ -2,6 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import {
     CHATGPT_DOMAIN,
     CHATGPT_MODEL_CHOICES,
+    navigateToProject,
     selectChatGPTModel,
 } from './utils.js';
 
@@ -17,9 +18,13 @@ export const modelCommand = cli({
     navigateBefore: false,
     args: [
         { name: 'model', required: true, positional: true, help: 'Intelligence level to switch to; thinking is a backward-compatible alias for high', choices: CHATGPT_MODEL_CHOICES },
+        { name: 'project', valueRequired: true, help: 'Open a ChatGPT project ID or /g/g-p-<id> URL before switching intelligence level' },
     ],
     columns: ['Status', 'Model'],
     func: async (page, kwargs) => {
+        if (kwargs.project) {
+            await navigateToProject(page, kwargs.project);
+        }
         const result = await selectChatGPTModel(page, kwargs.model);
         return [{ Status: result.Status, Model: result.Model }];
     },

--- a/clis/chatgpt/model.test.js
+++ b/clis/chatgpt/model.test.js
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    navigateToProject: vi.fn(),
+    selectChatGPTModel: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+    CHATGPT_DOMAIN: 'chatgpt.com',
+    CHATGPT_MODEL_CHOICES: ['instant', 'medium', 'high', 'extra-high', 'pro', 'thinking'],
+    navigateToProject: mocks.navigateToProject,
+    selectChatGPTModel: mocks.selectChatGPTModel,
+}));
+
+const { modelCommand } = await import('./model.js');
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.navigateToProject.mockReset().mockResolvedValue(undefined);
+    mocks.selectChatGPTModel.mockReset().mockResolvedValue({ Status: 'Success', Model: 'High' });
+});
+
+describe('chatgpt model project routing', () => {
+    it('opens a project before selecting the requested model', async () => {
+        const page = {};
+
+        await expect(modelCommand.func(page, { model: 'high', project: '12345678' }))
+            .resolves.toEqual([{ Status: 'Success', Model: 'High' }]);
+
+        expect(mocks.navigateToProject).toHaveBeenCalledWith(page, '12345678');
+        expect(mocks.navigateToProject.mock.invocationCallOrder[0]).toBeLessThan(
+            mocks.selectChatGPTModel.mock.invocationCallOrder[0],
+        );
+        expect(mocks.selectChatGPTModel).toHaveBeenCalledWith(page, 'high');
+    });
+});

--- a/clis/chatgpt/new.js
+++ b/clis/chatgpt/new.js
@@ -3,6 +3,7 @@ import {
     CHATGPT_DOMAIN,
     ensureChatGPTComposer,
     startNewChat,
+    navigateToProject,
 } from './utils.js';
 
 export const newCommand = cli({
@@ -15,10 +16,16 @@ export const newCommand = cli({
     browser: true,
     siteSession: 'persistent',
     navigateBefore: false,
-    args: [],
+    args: [
+        { name: 'project', valueRequired: true, help: 'Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL' },
+    ],
     columns: ['Status'],
-    func: async (page) => {
-        await startNewChat(page);
+    func: async (page, kwargs = {}) => {
+        if (kwargs.project) {
+            await navigateToProject(page, kwargs.project);
+        } else {
+            await startNewChat(page);
+        }
         await ensureChatGPTComposer(page, 'ChatGPT new requires a logged-in ChatGPT session with a visible composer.');
         return [{ Status: 'New chat started' }];
     },

--- a/clis/chatgpt/project-file-add.js
+++ b/clis/chatgpt/project-file-add.js
@@ -1,0 +1,67 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    CHATGPT_DOMAIN,
+    CHATGPT_URL,
+    parseChatGPTProjectId,
+    uploadChatGPTProjectFiles,
+} from './utils.js';
+
+function parseFilePaths(value) {
+    if (Array.isArray(value)) {
+        return value.flatMap(item => parseFilePaths(item));
+    }
+    return String(value ?? '')
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+}
+
+export const projectFileAddCommand = cli({
+    site: 'chatgpt',
+    name: 'project-file-add',
+    access: 'write',
+    description: 'Upload files to a ChatGPT project as project knowledge (not just conversation attachments)',
+    domain: CHATGPT_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'file', positional: true, required: true, help: 'Local file path(s) to upload; comma-separated paths are supported' },
+        { name: 'id', required: true, help: 'Project ID or /g/g-p-<id> URL' },
+    ],
+    columns: ['Status', 'File'],
+    func: async (page, kwargs) => {
+        const filePaths = parseFilePaths(kwargs.file);
+        if (!filePaths.length) {
+            throw new ArgumentError(
+                'chatgpt project-file-add requires at least one file path',
+                'Example: opencli chatgpt project-file-add report.pdf --id 12345678',
+            );
+        }
+
+        const projectId = parseChatGPTProjectId(kwargs.id);
+
+        let upload;
+        try {
+            upload = await uploadChatGPTProjectFiles(page, projectId, filePaths);
+        } catch (err) {
+            throw new CommandExecutionError(
+                `Failed to upload file to ChatGPT project knowledge: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+
+        if (!upload?.ok) {
+            throw new CommandExecutionError(
+                upload?.reason || 'Failed to upload file to ChatGPT project knowledge',
+                `Open ${CHATGPT_URL}/g/g-p-${projectId} and verify the project accepts file uploads. If your browser needs a proxy, configure it outside this command.`,
+            );
+        }
+
+        return upload.files.map(file => ({
+            Status: '📄 uploaded to project knowledge',
+            File: file,
+        }));
+    },
+});

--- a/clis/chatgpt/project-file-add.js
+++ b/clis/chatgpt/project-file-add.js
@@ -52,6 +52,13 @@ export const projectFileAddCommand = cli({
             );
         }
 
+        if (upload?.inputError) {
+            throw new ArgumentError(
+                upload.reason || 'Invalid project file path',
+                'Provide an existing local file path that ChatGPT project knowledge can upload.',
+            );
+        }
+
         if (!upload?.ok) {
             throw new CommandExecutionError(
                 upload?.reason || 'Failed to upload file to ChatGPT project knowledge',

--- a/clis/chatgpt/project-list.js
+++ b/clis/chatgpt/project-list.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    CHATGPT_DOMAIN,
+    ensureChatGPTLogin,
+    getProjectList,
+    requirePositiveInt,
+} from './utils.js';
+
+export const projectListCommand = cli({
+    site: 'chatgpt',
+    name: 'project-list',
+    access: 'read',
+    description: 'List visible ChatGPT projects from the sidebar',
+    domain: CHATGPT_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max projects to show' },
+    ],
+    columns: ['Index', 'Id', 'Title', 'Url'],
+    func: async (page, kwargs) => {
+        const limit = requirePositiveInt(
+            Number(kwargs.limit ?? 20),
+            'chatgpt project-list --limit',
+            'Example: opencli chatgpt project-list --limit 20',
+        );
+        await ensureChatGPTLogin(page, 'ChatGPT project-list requires a logged-in ChatGPT session.');
+        const projects = await getProjectList(page);
+        if (!projects.length) {
+            throw new EmptyResultError('chatgpt project-list', 'No ChatGPT project links were visible in the sidebar.');
+        }
+        return projects.slice(0, limit);
+    },
+});

--- a/clis/chatgpt/send.js
+++ b/clis/chatgpt/send.js
@@ -10,6 +10,7 @@ import {
     requireNonEmptyPrompt,
     sendChatGPTMessage,
     startNewChat,
+    navigateToProject,
 } from './utils.js';
 
 export const sendCommand = cli({
@@ -26,6 +27,7 @@ export const sendCommand = cli({
         { name: 'prompt', positional: true, required: true, help: 'Prompt to send' },
         { name: 'new', type: 'boolean', default: false, help: 'Start a new chat before sending' },
         { name: 'conversation', valueRequired: true, help: 'Continue an existing ChatGPT conversation ID or /c/<id> URL' },
+        { name: 'project', valueRequired: true, help: 'Start a new chat inside a ChatGPT project ID or /g/g-p-<id> URL' },
     ],
     columns: ['Status', 'InjectedText'],
     func: async (page, kwargs) => {
@@ -37,9 +39,17 @@ export const sendCommand = cli({
                 'Choose either a new chat or an existing conversation.',
             );
         }
+        if (kwargs.project && kwargs.conversation) {
+            throw new ArgumentError(
+                'chatgpt send cannot use --project and --conversation together',
+                'Choose either a project new chat or an existing conversation.',
+            );
+        }
 
         if (kwargs.conversation) {
             await openChatGPTConversation(page, kwargs.conversation);
+        } else if (kwargs.project) {
+            await navigateToProject(page, kwargs.project);
         } else if (normalizeBooleanFlag(kwargs.new)) {
             await startNewChat(page);
         } else {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -255,6 +255,7 @@ export async function isOnChatGPT(page) {
 // we only need to know "the composer is ready", not which variant rendered.
 const COMPOSER_WAIT_SELECTOR = '#prompt-textarea, [data-testid="prompt-textarea"]';
 const CONVERSATION_LINK_SELECTOR = 'a[href*="/c/"]';
+const PROJECT_LINK_SELECTOR = 'a[href*="/g/g-p-"]';
 // Selector used by detail.js to wait for at least one rendered message bubble
 // after navigating to /c/<id>; mirrors the markup queried by getVisibleMessages.
 export const CONVERSATION_MESSAGE_SELECTOR = '[data-message-author-role], article[data-testid*="conversation-turn"]';
@@ -739,6 +740,20 @@ export async function clearChatGPTDraft(page) {
         })()
     `);
     await page.wait(0.5);
+}
+
+export function parseChatGPTProjectId(value) {
+    const raw = String(value ?? '').trim();
+    const match = raw.match(/(?:^|\/g\/g-p-)([a-f0-9]+)(?:[-\/?#]|$)/i);
+    if (match) return match[1];
+    // Accept project slug pattern: g-p-{hex_id}-{slug} or just hex id
+    const slugMatch = raw.match(/^g-p-([a-f0-9]+)/i);
+    if (slugMatch) return slugMatch[1];
+    if (/^[a-f0-9]{8,}$/i.test(raw)) return raw.toLowerCase();
+    throw new ArgumentError(
+        'chatgpt project commands require a project id or /g/g-p-<id> URL',
+        'Example: opencli chatgpt project-file-add report.pdf --id 12345678',
+    );
 }
 
 /**
@@ -1533,6 +1548,512 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     return lastUrls;
 }
 
+/**
+ * Get the list of ChatGPT Projects from the sidebar.
+ * Navigates to chatgpt.com if not already there, opens the sidebar,
+ * and extracts project links (matching /g/g-p-*).
+ */
+export async function getProjectList(page) {
+    await ensureOnChatGPT(page);
+
+    // Ensure sidebar is open
+    const openSidebar = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
+        const button = Array.from(document.querySelectorAll('button'))
+            .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
+        if (button instanceof HTMLElement) {
+            button.click();
+            return true;
+        }
+        return false;
+    })()`)), 'chatgpt sidebar open state');
+    if (openSidebar) {
+        await page.wait(0.5);
+    }
+
+    // Click "Show more" to reveal all projects
+    await page.evaluate(`(() => {
+        var btn = Array.from(document.querySelectorAll('button')).find(function(b) {
+            var text = (b.innerText || '').trim();
+            return text === 'Show more' || text === '显示更多' || text === '查看更多';
+        });
+        if (btn instanceof HTMLElement) {
+            btn.click();
+        }
+    })()`);
+    await page.wait(0.5);
+
+    let items = await extractProjectLinks(page);
+    if (!items.length) {
+        await page.goto(CHATGPT_URL, { settleMs: 2000 });
+        await page.wait(1);
+        // Try clicking Show more again on fresh page
+        await page.evaluate(`(() => {
+            var btn = Array.from(document.querySelectorAll('button')).find(function(b) {
+                var text = (b.innerText || '').trim();
+                return text === 'Show more' || text === '显示更多' || text === '查看更多';
+            });
+            if (btn instanceof HTMLElement) {
+                btn.click();
+            }
+        })()`);
+        await page.wait(0.5);
+        items = await extractProjectLinks(page);
+    }
+
+    return items;
+}
+
+async function extractProjectLinks(page) {
+    const items = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
+        const projectLinkSelector = ${JSON.stringify(PROJECT_LINK_SELECTOR)};
+        const isVisible = (el) => {
+            if (!(el instanceof HTMLElement)) return false;
+            const style = window.getComputedStyle(el);
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+        };
+        const cleanText = (value) => String(value || '').replace(new RegExp('\\\\s+', 'g'), ' ').trim();
+        const parseProjectId = (value) => {
+            const raw = String(value || '').trim();
+            const match = raw.match(new RegExp('(?:^|/g/g-p-)([a-f0-9]+)(?:[-/?#]|$)', 'i'));
+            if (match) return match[1].toLowerCase();
+            const slugMatch = raw.match(new RegExp('^g-p-([a-f0-9]+)', 'i'));
+            if (slugMatch) return slugMatch[1].toLowerCase();
+            if (new RegExp('^[a-f0-9]{8,}$', 'i').test(raw)) return raw.toLowerCase();
+            return '';
+        };
+        const normalizeProjectUrl = (href, projectId) => {
+            try {
+                const url = new URL(href, '${CHATGPT_URL}');
+                url.search = '';
+                url.hash = '';
+                return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
+            } catch {
+                return '${CHATGPT_URL}' + '/g/g-p-' + projectId;
+            }
+        };
+
+        var seen = new Set();
+        var rows = [];
+        const addRow = (projectId, title, url) => {
+            if (!projectId || seen.has(projectId)) return;
+            seen.add(projectId);
+            rows.push({
+                Id: projectId,
+                Title: cleanText(title) || '(untitled project)',
+                Url: url || ('${CHATGPT_URL}' + '/g/g-p-' + projectId),
+            });
+        };
+
+        // Prefer explicit project anchors when the sidebar exposes them. This is
+        // stable across React internals and matches the URL shape documented by
+        // PROJECT_LINK_SELECTOR.
+        for (const link of Array.from(document.querySelectorAll(projectLinkSelector))) {
+            if (!isVisible(link)) continue;
+            const href = link.getAttribute('href') || link.href || '';
+            const projectId = parseProjectId(href);
+            if (!projectId) continue;
+            const container = link.closest('[data-sidebar-item="true"]') || link;
+            addRow(projectId, cleanText(container.innerText || container.textContent || link.textContent), normalizeProjectUrl(href, projectId));
+        }
+
+        // Fallback for ChatGPT sidebar builds that render project rows without
+        // anchors but keep gizmo data on React Fiber props.
+        const projectEls = Array.from(document.querySelectorAll('[data-sidebar-item="true"]'))
+            .filter(function(el) {
+                if (!isVisible(el)) return false;
+                var icon = el.querySelector('[data-testid="project-folder-icon"]');
+                if (!icon) return false;
+                var text = cleanText(el.innerText || el.textContent);
+                if (!text) return false;
+                if (el.getAttribute('data-testid') === 'accounts-profile-button') return false;
+                return true;
+            });
+
+        for (var i = 0; i < projectEls.length; i++) {
+            var el = projectEls[i];
+            var title = cleanText(el.innerText || el.textContent);
+            var projectId = '';
+            var shortUrl = '';
+            var fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
+            if (fiberKey) {
+                var f = el[fiberKey];
+                for (var d = 0; f && d < 15; d++) {
+                    var props = f.memoizedProps || f.pendingProps;
+                    if (props && props.gizmo) {
+                        var g = props.gizmo;
+                        var gId = g.gizmo && g.gizmo.id ? g.gizmo.id : g.id;
+                        if (gId) {
+                            projectId = String(gId).replace(/^g-p-/, '').toLowerCase();
+                            shortUrl = String(g.short_url || g.gizmo && g.gizmo.short_url || '');
+                            break;
+                        }
+                    }
+                    f = f.return;
+                }
+            }
+            if (!projectId) continue;
+            var url = shortUrl ? '${CHATGPT_URL}' + '/g/' + shortUrl : '${CHATGPT_URL}' + '/g/g-p-' + projectId;
+            addRow(projectId, title, url);
+        }
+
+        return rows;
+    })()`)), 'chatgpt project link extraction');
+    return items.map(function(item, index) {
+        return {
+            Index: index + 1,
+            Id: String(item?.Id || ''),
+            Title: String(item?.Title || '(untitled project)').trim() || '(untitled project)',
+            Url: String(item?.Url || ''),
+        };
+    }).filter(function(item) { return item.Id; });
+}
+
+/**
+ * Navigate to a ChatGPT project page.
+ */
+const PROJECT_ADD_FILES_LABELS = [
+    'Add files',
+    'Add sources',
+    '添加文件',
+    'Project files',
+    '项目文件',
+];
+
+const PROJECT_ADD_FILES_DIALOG_SELECTORS = [
+    '[role="tabpanel"][data-state="active"] [data-project-home-sources-surface="true"] input[type="file"]:not([accept])',
+    '[data-project-home-sources-surface="true"] input[type="file"]:not([accept])',
+    '[role="dialog"] input[type="file"]',
+    '[data-testid*="project-files"] input[type="file"]',
+    '[data-testid*="project"] input[type="file"]',
+];
+
+/**
+ * Navigate to a ChatGPT project page.
+ */
+export async function navigateToProject(page, projectId) {
+    const id = parseChatGPTProjectId(projectId);
+    await page.goto(`${CHATGPT_URL}/g/g-p-${id}`, { settleMs: 2000 });
+    try {
+        await page.wait({ selector: COMPOSER_WAIT_SELECTOR, timeout: 10 });
+    } catch {
+        // Composer may not mount if project requires login; downstream ensureChatGPTLogin handles it.
+    }
+}
+
+/**
+ * Open the Project knowledge files dialog by clicking the "Add files" button
+ * in the project header area (NOT the chat composer's plus button).
+ * Returns true if the dialog appeared.
+ */
+export async function openProjectKnowledgeDialog(page) {
+    const rawOpenResult = unwrapEvaluateResult(await page.evaluate(`
+        (() => {
+            const labels = ${JSON.stringify(PROJECT_ADD_FILES_LABELS)};
+            const isVisible = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const style = window.getComputedStyle(el);
+                if (style.display === 'none' || style.visibility === 'hidden') return false;
+                const rect = el.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0;
+            };
+
+            // Current ChatGPT project pages expose project knowledge under a
+            // Sources tab. Prefer that surface when present; it contains the
+            // project-source file input and avoids the chat composer's plus menu.
+            const sourceInput = document.querySelector('[data-project-home-sources-surface="true"] input[type="file"]:not([accept])');
+            if (sourceInput instanceof HTMLInputElement) return { ok: true };
+
+            const sourcesTab = Array.from(document.querySelectorAll('[role="tab"], button')).find(el => {
+                const text = (el.innerText || el.textContent || '').trim();
+                const id = el.id || '';
+                return text === 'Sources' || text === '资料' || id.includes('-sources');
+            });
+            if (sourcesTab instanceof HTMLElement) {
+                if (sourcesTab.getAttribute('aria-selected') === 'true') return { ok: true };
+                const rect = sourcesTab.getBoundingClientRect();
+                const centerX = rect.left + rect.width / 2;
+                const centerY = rect.top + rect.height / 2;
+                const nativeClick = rect.width > 0 && rect.height > 0 && Number.isFinite(centerX) && Number.isFinite(centerY) ? {
+                    x: centerX,
+                    y: centerY,
+                } : null;
+
+                // Radix-powered tabs on the live ChatGPT project page do not
+                // respond reliably to HTMLElement.click(); they activate after
+                // the same pointer/mouse sequence a real browser click emits.
+                const eventInit = {
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true,
+                    view: window,
+                    clientX: nativeClick ? nativeClick.x : 0,
+                    clientY: nativeClick ? nativeClick.y : 0,
+                    button: 0,
+                    buttons: 1,
+                };
+                for (const type of ['pointerover', 'pointerenter', 'mouseover', 'mouseenter', 'pointermove', 'mousemove', 'pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {
+                    const Ctor = type.startsWith('pointer') && typeof PointerEvent !== 'undefined' ? PointerEvent : MouseEvent;
+                    sourcesTab.dispatchEvent(new Ctor(type, eventInit));
+                }
+                return { ok: true, nativeClick };
+            }
+
+            // Older project pages opened a dedicated project files dialog.
+            // Strategy 1: aria-label or data-testid
+            const byAttr = Array.from(document.querySelectorAll('button, a, [role="button"]')).find(el => {
+                if (!isVisible(el)) return false;
+                if (el.closest('[role="textbox"], #prompt-textarea, [data-testid="composer"], form[data-type="unified-composer"]')) return false;
+                const aria = (el.getAttribute('aria-label') || '').toLowerCase();
+                const testid = (el.getAttribute('data-testid') || '').toLowerCase();
+                const text = (el.innerText || el.textContent || '').trim();
+                if (aria.includes('add sources') || aria.includes('project files')) return true;
+                if (aria === 'add files') return true;
+                if (testid.includes('add-files') || testid.includes('project-files')) return true;
+                if (labels.some(l => text === l)) return true;
+                return false;
+            });
+            if (byAttr instanceof HTMLElement) { byAttr.click(); return { ok: true }; }
+
+            // Strategy 2: look for buttons that contain "Add files"/"Add sources"
+            // text, but exclude the composer plus button (which has a different role).
+            const allButtons = Array.from(document.querySelectorAll('button'));
+            for (const btn of allButtons) {
+                if (!isVisible(btn)) continue;
+                const text = (btn.innerText || btn.textContent || '').trim();
+                if (labels.some(l => text === l) && !btn.closest('[role="textbox"], #prompt-textarea, [data-testid="composer"]')) {
+                    btn.click();
+                    return { ok: true };
+                }
+            }
+
+            return { ok: false };
+        })()
+    `));
+    const openResult = typeof rawOpenResult === 'boolean'
+        ? { ok: rawOpenResult }
+        : requireObjectEvaluateResult(rawOpenResult, 'chatgpt project knowledge dialog open');
+
+    if (openResult.ok) {
+        if (openResult.nativeClick && typeof page.nativeClick === 'function') {
+            try { await page.nativeClick(openResult.nativeClick.x, openResult.nativeClick.y); } catch {}
+        }
+        if (openResult.nativeClick && typeof page.click === 'function') {
+            try { await page.click('[role="tab"][id$="-sources"]'); } catch {}
+        }
+        // Wait for the dialog or Sources tab content to appear
+        await page.wait(1);
+        try {
+            await page.wait({ selector: '[role="dialog"], [data-project-home-sources-surface="true"] input[type="file"]', timeout: 5 });
+        } catch {
+            // Dialog/source input may use a different shape; upload selectors surface the precise failure.
+        }
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Upload files to a ChatGPT Project's knowledge base.
+ * This navigates to the project page, opens the knowledge files dialog,
+ * and uploads files through the dialog's file input.
+ */
+export async function uploadChatGPTProjectFiles(page, projectId, filePaths) {
+    const id = parseChatGPTProjectId(projectId);
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+
+    const prepared = await prepareChatGPTFilePaths(filePaths);
+    if (!prepared.ok) return prepared;
+    const absPaths = prepared.paths;
+
+    // Navigate to project and open knowledge dialog
+    await navigateToProject(page, id);
+    await ensureChatGPTLogin(page, 'ChatGPT project file upload requires a logged-in ChatGPT session.');
+
+    const dialogOpened = await openProjectKnowledgeDialog(page);
+    if (!dialogOpened) {
+        return { ok: false, reason: 'could not find or click the project "Add files" button' };
+    }
+
+    // Try uploading via dialog file input (multiple selector patterns)
+    const fileNames = absPaths.map(fp => path.default.basename(fp));
+
+    let uploaded = false;
+    if (page.setFileInput) {
+        for (const selector of PROJECT_ADD_FILES_DIALOG_SELECTORS) {
+            try {
+                await page.setFileInput(absPaths, selector);
+                uploaded = true;
+                break;
+            } catch (err) {
+                const msg = String(err?.message || err);
+                if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found')) {
+                    throw err;
+                }
+            }
+        }
+    }
+
+    if (!uploaded) {
+        // Fallback: try all dialog file inputs via evaluate
+        const files = absPaths.map(absPath => ({
+            name: path.default.basename(absPath),
+            mime: mimeFromFilePath(absPath),
+            base64: fs.default.readFileSync(absPath).toString('base64'),
+        }));
+        const fallbackResult = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
+            (() => {
+                const files = ${JSON.stringify(files)};
+
+                // Look for file input inside a dialog or the project area
+                const selectors = ${JSON.stringify(PROJECT_ADD_FILES_DIALOG_SELECTORS)};
+                let input = null;
+                for (const sel of selectors) {
+                    input = document.querySelector(sel);
+                    if (input instanceof HTMLInputElement) break;
+                }
+                // Last resort: any file input not inside the composer area (exclude #upload-files, #upload-photos, #upload-camera)
+                if (!(input instanceof HTMLInputElement)) {
+                    const allFileInputs = document.querySelectorAll('input[type="file"]');
+                    for (const fi of allFileInputs) {
+                        const id = fi.id || '';
+                        if (id !== 'upload-files' && id !== 'upload-photos' && id !== 'upload-camera') {
+                            input = fi;
+                            break;
+                        }
+                    }
+                }
+                if (!(input instanceof HTMLInputElement)) {
+                    return { ok: false, reason: 'project file input not found' };
+                }
+
+                const dt = new DataTransfer();
+                for (const item of files) {
+                    const binary = atob(item.base64);
+                    const bytes = new Uint8Array(binary.length);
+                    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+                    dt.items.add(new File([bytes], item.name, { type: item.mime }));
+                }
+                input.files = dt.files;
+
+                const propsKey = Object.keys(input).find(key => key.startsWith('__reactProps$'));
+                if (propsKey && input[propsKey] && typeof input[propsKey].onChange === 'function') {
+                    const nativeEvent = new Event('change', { bubbles: true });
+                    input[propsKey].onChange({
+                        target: input,
+                        currentTarget: input,
+                        nativeEvent,
+                        preventDefault() {},
+                        stopPropagation() {},
+                        isDefaultPrevented() { return false; },
+                        isPropagationStopped() { return false; },
+                        persist() {},
+                    });
+                } else {
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                return { ok: true };
+            })()
+        `)), 'chatgpt project file upload fallback');
+        if (fallbackResult && !fallbackResult.ok) return fallbackResult;
+    }
+
+    const confirmation = await waitForChatGPTProjectUploadConfirmation(page, fileNames);
+    if (!confirmation.ok) return confirmation;
+
+    return { ok: true, files: absPaths };
+}
+
+async function waitForChatGPTProjectUploadConfirmation(page, fileNames) {
+    const expectedFileNames = fileNames.map(name => String(name || '').trim()).filter(Boolean);
+    if (!expectedFileNames.length) return { ok: true };
+
+    let lastReason = 'uploaded file did not appear in project knowledge';
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+        const result = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
+            (() => {
+                const expectedFileNames = ${JSON.stringify(expectedFileNames)};
+                const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+                const root = document.querySelector('[role="dialog"]') || document.body;
+                const text = normalize(root?.innerText || root?.textContent || '');
+                const errorNode = Array.from((root || document).querySelectorAll('[role="alert"], [data-testid*="error"], [class*="error"]')).find((node) => {
+                    const label = normalize(node.innerText || node.textContent || node.getAttribute('aria-label') || '');
+                    return /failed|error|unable|could not|too large|unsupported/i.test(label);
+                });
+                if (errorNode) {
+                    return { ok: false, reason: normalize(errorNode.innerText || errorNode.textContent || errorNode.getAttribute('aria-label') || 'project upload failed') };
+                }
+                const missing = expectedFileNames.filter((name) => !text.includes(name));
+                if (!missing.length) return { ok: true };
+                return { ok: false, pending: true, reason: 'uploaded file did not appear in project knowledge: ' + missing.join(', ') };
+            })()
+        `)), 'chatgpt project upload confirmation');
+
+        if (result.ok === true) return { ok: true };
+        lastReason = String(result.reason || lastReason);
+        if (!result.pending) return { ok: false, reason: lastReason };
+        await page.wait(0.5);
+    }
+
+    return { ok: false, reason: lastReason };
+}
+
+/**
+ * Validate local file paths for project file upload.
+ * Accepts all file types with a 512 MB per-file limit (matching ChatGPT's project limit).
+ */
+export async function prepareChatGPTFilePaths(filePaths) {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const absPaths = filePaths.map(filePath => path.default.resolve(filePath));
+
+    for (const absPath of absPaths) {
+        if (!fs.default.existsSync(absPath)) {
+            return { ok: false, reason: `File not found: ${absPath}` };
+        }
+        const stat = fs.default.statSync(absPath);
+        if (!stat.isFile()) {
+            return { ok: false, reason: `Not a file: ${absPath}` };
+        }
+        if (stat.size > 512 * 1024 * 1024) {
+            return { ok: false, reason: `File too large (${(stat.size / 1024 / 1024).toFixed(1)} MB). Max: 512 MB` };
+        }
+    }
+
+    return { ok: true, paths: absPaths };
+}
+
+function mimeFromFilePath(filePath) {
+    const lower = String(filePath || '').toLowerCase();
+    if (lower.endsWith('.pdf')) return 'application/pdf';
+    if (lower.endsWith('.doc')) return 'application/msword';
+    if (lower.endsWith('.docx')) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    if (lower.endsWith('.xls')) return 'application/vnd.ms-excel';
+    if (lower.endsWith('.xlsx')) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    if (lower.endsWith('.ppt')) return 'application/vnd.ms-powerpoint';
+    if (lower.endsWith('.pptx')) return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    if (lower.endsWith('.csv')) return 'text/csv';
+    if (lower.endsWith('.txt')) return 'text/plain';
+    if (lower.endsWith('.json')) return 'application/json';
+    if (lower.endsWith('.xml')) return 'application/xml';
+    if (lower.endsWith('.html') || lower.endsWith('.htm')) return 'text/html';
+    if (lower.endsWith('.md')) return 'text/markdown';
+    if (lower.endsWith('.py')) return 'text/x-python';
+    if (lower.endsWith('.js')) return 'text/javascript';
+    if (lower.endsWith('.ts')) return 'application/typescript';
+    if (lower.endsWith('.jsx')) return 'text/jsx';
+    if (lower.endsWith('.tsx')) return 'text/tsx';
+    if (lower.endsWith('.png')) return 'image/png';
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+    if (lower.endsWith('.gif')) return 'image/gif';
+    if (lower.endsWith('.webp')) return 'image/webp';
+    if (lower.endsWith('.svg')) return 'image/svg+xml';
+    return 'application/octet-stream';
+}
+
 export const __test__ = {
     COMPOSER_SELECTORS,
     SEND_BUTTON_SELECTOR,
@@ -1542,7 +2063,10 @@ export const __test__ = {
     buildComposerLocatorScript,
     isSameChatGPTConversation,
     parseChatGPTConversationId,
+    parseChatGPTProjectId,
     imageMimeFromPath,
+    mimeFromFilePath,
+    PROJECT_LINK_SELECTOR,
 };
 
 /**

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -214,7 +214,7 @@ export function parseChatGPTConversationId(value) {
             if (parsed.protocol !== 'https:' || (parsed.hostname !== CHATGPT_DOMAIN && !parsed.hostname.endsWith(`.${CHATGPT_DOMAIN}`))) {
                 throw new Error('off-domain');
             }
-            const match = parsed.pathname.match(/^\/c\/([A-Za-z0-9_-]{8,})$/);
+            const match = parsed.pathname.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_-]{8,})$/);
             if (match) return match[1];
         } catch {
             // Fall through to the shared typed ArgumentError below.
@@ -224,7 +224,7 @@ export function parseChatGPTConversationId(value) {
             'Example: opencli chatgpt detail https://chatgpt.com/c/123e4567-e89b-12d3-a456-426614174000',
         );
     }
-    const pathMatch = raw.match(/^\/c\/([A-Za-z0-9_-]{8,})(?:[?#].*)?$/);
+    const pathMatch = raw.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_-]{8,})(?:[?#].*)?$/);
     if (pathMatch) return pathMatch[1];
     if (/^[A-Za-z0-9_-]{8,}$/.test(raw)) return raw;
     throw new ArgumentError(

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -206,6 +206,25 @@ export function requireBooleanEvaluateResult(payload, label) {
     return payload;
 }
 
+function isTrustedChatGPTHost(hostname) {
+    return hostname === CHATGPT_DOMAIN || hostname.endsWith(`.${CHATGPT_DOMAIN}`);
+}
+
+function projectIdFromPathname(pathname) {
+    const match = String(pathname || '').match(/^\/g\/g-p-([a-f0-9]+)(?:[-/]|$)/i);
+    return match ? match[1].toLowerCase() : '';
+}
+
+function projectIdFromUrl(value) {
+    try {
+        const url = new URL(String(value || ''), CHATGPT_URL);
+        if (url.protocol !== 'https:' || !isTrustedChatGPTHost(url.hostname)) return '';
+        return projectIdFromPathname(url.pathname);
+    } catch {
+        return '';
+    }
+}
+
 export function parseChatGPTConversationId(value) {
     const raw = String(value ?? '').trim();
     if (/^https?:\/\//i.test(raw)) {
@@ -744,11 +763,17 @@ export async function clearChatGPTDraft(page) {
 
 export function parseChatGPTProjectId(value) {
     const raw = String(value ?? '').trim();
-    const match = raw.match(/(?:^|\/g\/g-p-)([a-f0-9]+)(?:[-\/?#]|$)/i);
-    if (match) return match[1];
+    if (/^https?:\/\//i.test(raw) || raw.startsWith('/')) {
+        const id = projectIdFromUrl(raw);
+        if (id) return id;
+        throw new ArgumentError(
+            'chatgpt project commands require a chatgpt.com project id or /g/g-p-<id> URL',
+            'Example: opencli chatgpt project-file-add report.pdf --id 12345678',
+        );
+    }
     // Accept project slug pattern: g-p-{hex_id}-{slug} or just hex id
     const slugMatch = raw.match(/^g-p-([a-f0-9]+)/i);
-    if (slugMatch) return slugMatch[1];
+    if (slugMatch) return slugMatch[1].toLowerCase();
     if (/^[a-f0-9]{8,}$/i.test(raw)) return raw.toLowerCase();
     throw new ArgumentError(
         'chatgpt project commands require a project id or /g/g-p-<id> URL',
@@ -1614,10 +1639,22 @@ async function extractProjectLinks(page) {
             return rect.width > 0 && rect.height > 0;
         };
         const cleanText = (value) => String(value || '').replace(new RegExp('\\\\s+', 'g'), ' ').trim();
+        const trustedHost = (hostname) => hostname === '${CHATGPT_DOMAIN}' || hostname.endsWith('.${CHATGPT_DOMAIN}');
+        const projectIdFromPathname = (pathname) => {
+            const match = String(pathname || '').match(new RegExp('^/g/g-p-([a-f0-9]+)(?:[-/]|$)', 'i'));
+            return match ? match[1].toLowerCase() : '';
+        };
         const parseProjectId = (value) => {
             const raw = String(value || '').trim();
-            const match = raw.match(new RegExp('(?:^|/g/g-p-)([a-f0-9]+)(?:[-/?#]|$)', 'i'));
-            if (match) return match[1].toLowerCase();
+            if (new RegExp('^https?://', 'i').test(raw) || raw.startsWith('/')) {
+                try {
+                    const url = new URL(raw, '${CHATGPT_URL}');
+                    if (url.protocol !== 'https:' || !trustedHost(url.hostname)) return '';
+                    return projectIdFromPathname(url.pathname);
+                } catch {
+                    return '';
+                }
+            }
             const slugMatch = raw.match(new RegExp('^g-p-([a-f0-9]+)', 'i'));
             if (slugMatch) return slugMatch[1].toLowerCase();
             if (new RegExp('^[a-f0-9]{8,}$', 'i').test(raw)) return raw.toLowerCase();
@@ -1626,6 +1663,8 @@ async function extractProjectLinks(page) {
         const normalizeProjectUrl = (href, projectId) => {
             try {
                 const url = new URL(href, '${CHATGPT_URL}');
+                if (url.protocol !== 'https:' || !trustedHost(url.hostname)) return '';
+                if (projectIdFromPathname(url.pathname) !== projectId) return '';
                 url.search = '';
                 url.hash = '';
                 return url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
@@ -1740,6 +1779,15 @@ export async function navigateToProject(page, projectId) {
     } catch {
         // Composer may not mount if project requires login; downstream ensureChatGPTLogin handles it.
     }
+    const state = await getPageState(page);
+    if (projectIdFromUrl(state.url) === id) return id;
+    if (state.hasLoginGate || !state.isLoggedIn) {
+        throw new AuthRequiredError(CHATGPT_DOMAIN, 'ChatGPT project requires a logged-in ChatGPT session.');
+    }
+    throw new CommandExecutionError(
+        `ChatGPT did not open the requested project ${id}.`,
+        `Current URL: ${state.url || '(unknown)'}`,
+    );
 }
 
 /**
@@ -1865,7 +1913,7 @@ export async function uploadChatGPTProjectFiles(page, projectId, filePaths) {
     const path = await import('node:path');
 
     const prepared = await prepareChatGPTFilePaths(filePaths);
-    if (!prepared.ok) return prepared;
+    if (!prepared.ok) return { ...prepared, inputError: true };
     const absPaths = prepared.paths;
 
     // Navigate to project and open knowledge dialog
@@ -1914,15 +1962,15 @@ export async function uploadChatGPTProjectFiles(page, projectId, filePaths) {
                     input = document.querySelector(sel);
                     if (input instanceof HTMLInputElement) break;
                 }
-                // Last resort: any file input not inside the composer area (exclude #upload-files, #upload-photos, #upload-camera)
+                // Last resort: stay scoped to project knowledge containers. Do
+                // not fall back to arbitrary page inputs, because the composer
+                // attachment input can also accept files but uploads them to
+                // the conversation instead of project knowledge.
                 if (!(input instanceof HTMLInputElement)) {
-                    const allFileInputs = document.querySelectorAll('input[type="file"]');
+                    const allFileInputs = document.querySelectorAll('[data-project-home-sources-surface="true"] input[type="file"], [role="dialog"] input[type="file"], [data-testid*="project"] input[type="file"]');
                     for (const fi of allFileInputs) {
-                        const id = fi.id || '';
-                        if (id !== 'upload-files' && id !== 'upload-photos' && id !== 'upload-camera') {
-                            input = fi;
-                            break;
-                        }
+                        input = fi;
+                        break;
                     }
                 }
                 if (!(input instanceof HTMLInputElement)) {
@@ -1977,7 +2025,12 @@ async function waitForChatGPTProjectUploadConfirmation(page, fileNames) {
             (() => {
                 const expectedFileNames = ${JSON.stringify(expectedFileNames)};
                 const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
-                const root = document.querySelector('[role="dialog"]') || document.body;
+                const root = document.querySelector('[role="dialog"]')
+                    || document.querySelector('[data-project-home-sources-surface="true"]')
+                    || document.querySelector('[role="tabpanel"][data-state="active"]');
+                if (!root) {
+                    return { ok: false, pending: true, reason: 'project knowledge surface was not visible after upload' };
+                }
                 const text = normalize(root?.innerText || root?.textContent || '');
                 const errorNode = Array.from((root || document).querySelectorAll('[role="alert"], [data-testid*="error"], [class*="error"]')).find((node) => {
                     const label = normalize(node.innerText || node.textContent || node.getAttribute('aria-label') || '');

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -211,7 +211,7 @@ function isTrustedChatGPTHost(hostname) {
 }
 
 function projectIdFromPathname(pathname) {
-    const match = String(pathname || '').match(/^\/g\/g-p-([a-f0-9]+)(?:[-/]|$)/i);
+    const match = String(pathname || '').match(/^\/g\/g-p-([a-f0-9]{8,})(?:[-/]|$)/i);
     return match ? match[1].toLowerCase() : '';
 }
 
@@ -772,7 +772,7 @@ export function parseChatGPTProjectId(value) {
         );
     }
     // Accept project slug pattern: g-p-{hex_id}-{slug} or just hex id
-    const slugMatch = raw.match(/^g-p-([a-f0-9]+)/i);
+    const slugMatch = raw.match(/^g-p-([a-f0-9]{8,})/i);
     if (slugMatch) return slugMatch[1].toLowerCase();
     if (/^[a-f0-9]{8,}$/i.test(raw)) return raw.toLowerCase();
     throw new ArgumentError(
@@ -1641,7 +1641,7 @@ async function extractProjectLinks(page) {
         const cleanText = (value) => String(value || '').replace(new RegExp('\\\\s+', 'g'), ' ').trim();
         const trustedHost = (hostname) => hostname === '${CHATGPT_DOMAIN}' || hostname.endsWith('.${CHATGPT_DOMAIN}');
         const projectIdFromPathname = (pathname) => {
-            const match = String(pathname || '').match(new RegExp('^/g/g-p-([a-f0-9]+)(?:[-/]|$)', 'i'));
+            const match = String(pathname || '').match(new RegExp('^/g/g-p-([a-f0-9]{8,})(?:[-/]|$)', 'i'));
             return match ? match[1].toLowerCase() : '';
         };
         const parseProjectId = (value) => {
@@ -1655,7 +1655,7 @@ async function extractProjectLinks(page) {
                     return '';
                 }
             }
-            const slugMatch = raw.match(new RegExp('^g-p-([a-f0-9]+)', 'i'));
+            const slugMatch = raw.match(new RegExp('^g-p-([a-f0-9]{8,})', 'i'));
             if (slugMatch) return slugMatch[1].toLowerCase();
             if (new RegExp('^[a-f0-9]{8,}$', 'i').test(raw)) return raw.toLowerCase();
             return '';
@@ -1723,8 +1723,9 @@ async function extractProjectLinks(page) {
                     if (props && props.gizmo) {
                         var g = props.gizmo;
                         var gId = g.gizmo && g.gizmo.id ? g.gizmo.id : g.id;
-                        if (gId) {
-                            projectId = String(gId).replace(/^g-p-/, '').toLowerCase();
+                        var gIdMatch = String(gId || '').match(new RegExp('^g-p-([a-f0-9]{8,})(?:-|$)', 'i'));
+                        if (gIdMatch) {
+                            projectId = gIdMatch[1].toLowerCase();
                             shortUrl = String(g.short_url || g.gizmo && g.gizmo.short_url || '');
                             break;
                         }

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -96,7 +96,9 @@ describe('chatgpt conversation id parsing', () => {
         expect(__test__.parseChatGPTConversationId('abc_123-def')).toBe('abc_123-def');
         expect(__test__.parseChatGPTConversationId('https://chatgpt.com/c/abc_123-def?model=gpt-5')).toBe('abc_123-def');
         expect(__test__.parseChatGPTConversationId('https://chat.openai.chatgpt.com/c/abc_123-def')).toBe('abc_123-def');
+        expect(__test__.parseChatGPTConversationId('https://chatgpt.com/g/g-p-12345678-demo/c/abc_123-def')).toBe('abc_123-def');
         expect(__test__.parseChatGPTConversationId('/c/abc_123-def')).toBe('abc_123-def');
+        expect(__test__.parseChatGPTConversationId('/g/g-p-12345678-demo/c/abc_123-def')).toBe('abc_123-def');
     });
 
     it('rejects invalid detail ids', () => {

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -3,8 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairCounts, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairCounts, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, navigateToProject, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
 
 const tempDirs = [];
 
@@ -1147,6 +1147,42 @@ describe('chatgpt project id parsing', () => {
     it('rejects invalid project ids', () => {
         expect(() => __test__.parseChatGPTProjectId('')).toThrow(/project/);
         expect(() => __test__.parseChatGPTProjectId('https://chatgpt.com/')).toThrow(/project/);
+        expect(() => __test__.parseChatGPTProjectId('https://evil.test/g/g-p-12345678')).toThrow(/project/);
+        expect(() => __test__.parseChatGPTProjectId('http://chatgpt.com/g/g-p-12345678')).toThrow(/project/);
+    });
+});
+
+describe('chatgpt project navigation', () => {
+    it('verifies the current URL stays bound to the requested project', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                url: 'https://chatgpt.com/g/g-p-deadbeef',
+                title: 'Other Project',
+                hasComposer: true,
+                isLoggedIn: true,
+                hasLoginGate: false,
+            }),
+        };
+
+        await expect(navigateToProject(page, '12345678')).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps project login redirects to AuthRequiredError', async () => {
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                url: 'https://chatgpt.com/auth/login',
+                title: 'Log in',
+                hasComposer: false,
+                isLoggedIn: false,
+                hasLoginGate: true,
+            }),
+        };
+
+        await expect(navigateToProject(page, '12345678')).rejects.toBeInstanceOf(AuthRequiredError);
     });
 });
 
@@ -1197,6 +1233,10 @@ describe('chatgpt project file upload helper', () => {
             <a data-sidebar-item="true" href="/g/g-p-abcdef90">
               <span data-testid="project-folder-icon"></span>
               Project Beta
+            </a>
+            <a data-sidebar-item="true" href="https://evil.test/g/g-p-badbadbad">
+              <span data-testid="project-folder-icon"></span>
+              Evil Project
             </a>
         `, {
             url: 'https://chatgpt.com/',
@@ -1308,11 +1348,11 @@ describe('chatgpt project file upload helper', () => {
                 if (s.includes('expectedFileNames')) {
                     return Promise.resolve({ ok: true });
                 }
-                if (s.includes('Add files')) return Promise.resolve(true);
-                if (s.includes('role="dialog"')) return Promise.resolve(true);
                 if (s.includes('new DataTransfer()')) {
                     return Promise.resolve({ ok: true });
                 }
+                if (s.includes('Add files')) return Promise.resolve(true);
+                if (s.includes('role="dialog"')) return Promise.resolve(true);
                 return Promise.resolve(undefined);
             }),
         };
@@ -1356,6 +1396,52 @@ describe('chatgpt project file upload helper', () => {
         expect(result).toMatchObject({
             ok: false,
             reason: expect.stringContaining('uploaded file did not appear'),
+        });
+    });
+
+    it('does not treat composer/body filename text as project knowledge confirmation', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'composer-only.pdf');
+        fs.writeFileSync(filePath, 'fake-pdf');
+
+        const dom = new JSDOM(`
+            <!doctype html>
+            <main>
+              <form data-type="unified-composer">
+                <input id="upload-files" type="file">
+                <span>composer-only.pdf</span>
+              </form>
+            </main>
+        `, {
+            url: 'https://chatgpt.com/g/g-p-12345678',
+            runScripts: 'outside-only',
+        });
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            setFileInput: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                if (s.includes('isVisible') && s.includes('hasComposer') && s.includes('isLoggedIn')) {
+                    return Promise.resolve({ session: 'test', data: { url: 'https://chatgpt.com/g/g-p-12345678', title: 'Project', hasComposer: true, isLoggedIn: true, hasLoginGate: false } });
+                }
+                if (s.includes('expectedFileNames')) {
+                    return Promise.resolve(dom.window.eval(s));
+                }
+                if (s.includes('Add files')) return Promise.resolve(true);
+                if (s.includes('role="dialog"')) return Promise.resolve(true);
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        const { uploadChatGPTProjectFiles } = await import('./utils.js');
+        const result = await uploadChatGPTProjectFiles(page, '12345678', [filePath]);
+
+        expect(result).toMatchObject({
+            ok: false,
+            reason: expect.stringContaining('project knowledge surface'),
         });
     });
 });

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1130,3 +1130,230 @@ describe('chatgpt image upload helper', () => {
         expect(__test__.imageMimeFromPath('/tmp/a.jpg')).toBe('image/jpeg');
     });
 });
+
+describe('chatgpt project id parsing', () => {
+    it('accepts project hex ids and /g/g-p- URLs', () => {
+        expect(__test__.parseChatGPTProjectId('12345678abcdef90')).toBe('12345678abcdef90');
+        expect(__test__.parseChatGPTProjectId('https://chatgpt.com/g/g-p-12345678abcdef90')).toBe('12345678abcdef90');
+        expect(__test__.parseChatGPTProjectId('/g/g-p-abcdef0123456789')).toBe('abcdef0123456789');
+    });
+
+    it('accepts g-p-{hex_id}-{slug} pattern', () => {
+        expect(__test__.parseChatGPTProjectId('g-p-12345678-my-project')).toBe('12345678');
+    });
+
+    it('rejects invalid project ids', () => {
+        expect(() => __test__.parseChatGPTProjectId('')).toThrow(/project/);
+        expect(() => __test__.parseChatGPTProjectId('https://chatgpt.com/')).toThrow(/project/);
+    });
+});
+
+describe('chatgpt file path validation', () => {
+    it('validates local files for project upload (any type)', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const pdfPath = path.join(dir, 'report.pdf');
+        fs.writeFileSync(pdfPath, 'fake-pdf');
+        const docxPath = path.join(dir, 'notes.docx');
+        fs.writeFileSync(docxPath, 'fake-docx');
+
+        const { prepareChatGPTFilePaths } = await import('./utils.js');
+        await expect(prepareChatGPTFilePaths([pdfPath])).resolves.toEqual({ ok: true, paths: [pdfPath] });
+        await expect(prepareChatGPTFilePaths([pdfPath, docxPath])).resolves.toEqual({ ok: true, paths: [pdfPath, docxPath] });
+        await expect(prepareChatGPTFilePaths([path.join(dir, 'missing.txt')])).resolves.toMatchObject({
+            ok: false,
+            reason: expect.stringContaining('File not found'),
+        });
+    });
+});
+
+describe('chatgpt project file upload helper', () => {
+    it('exposes mimeFromFilePath for fallback upload', () => {
+        expect(__test__.mimeFromFilePath('/tmp/report.pdf')).toBe('application/pdf');
+        expect(__test__.mimeFromFilePath('/tmp/notes.docx')).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+        expect(__test__.mimeFromFilePath('/tmp/data.csv')).toBe('text/csv');
+        expect(__test__.mimeFromFilePath('/tmp/code.py')).toBe('text/x-python');
+        expect(__test__.mimeFromFilePath('/tmp/image.png')).toBe('image/png');
+        expect(__test__.mimeFromFilePath('/tmp/unknown.xyz')).toBe('application/octet-stream');
+    });
+
+    it('exposes PROJECT_LINK_SELECTOR for project link extraction', () => {
+        expect(__test__.PROJECT_LINK_SELECTOR).toBe('a[href*="/g/g-p-"]');
+    });
+
+    it('extracts visible project anchors from the sidebar without React Fiber internals', async () => {
+        const dom = new JSDOM(`
+            <!doctype html>
+            <a data-sidebar-item="true" href="/g/g-p-12345678-alpha">
+              <span data-testid="project-folder-icon"></span>
+              Project Alpha
+            </a>
+            <a data-sidebar-item="true" href="https://chatgpt.com/g/g-p-12345678-alpha?model=gpt-5">
+              <span data-testid="project-folder-icon"></span>
+              Duplicate Alpha
+            </a>
+            <a data-sidebar-item="true" href="/g/g-p-abcdef90">
+              <span data-testid="project-folder-icon"></span>
+              Project Beta
+            </a>
+        `, {
+            url: 'https://chatgpt.com/',
+            runScripts: 'outside-only',
+        });
+        for (const el of dom.window.document.querySelectorAll('[data-sidebar-item="true"]')) {
+            el.getBoundingClientRect = () => ({ width: 240, height: 32 });
+        }
+
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
+        };
+
+        const { getProjectList } = await import('./utils.js');
+        await expect(getProjectList(page)).resolves.toEqual([
+            {
+                Index: 1,
+                Id: '12345678',
+                Title: 'Project Alpha',
+                Url: 'https://chatgpt.com/g/g-p-12345678-alpha',
+            },
+            {
+                Index: 2,
+                Id: 'abcdef90',
+                Title: 'Project Beta',
+                Url: 'https://chatgpt.com/g/g-p-abcdef90',
+            },
+        ]);
+    });
+
+    it('opens project knowledge dialog by finding an "Add files" button', async () => {
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            setFileInput: vi.fn(),
+            evaluate: vi.fn((script) => {
+                if (String(script).includes('Add files')) {
+                    return Promise.resolve(true);
+                }
+                if (String(script).includes('role="dialog"')) {
+                    return Promise.resolve(true);
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        const { openProjectKnowledgeDialog } = await import('./utils.js');
+        const result = await openProjectKnowledgeDialog(page);
+        expect(result).toBe(true);
+    });
+
+    it('reports failure when no Add files button is found', async () => {
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            setFileInput: vi.fn(),
+            evaluate: vi.fn().mockResolvedValue(false),
+        };
+
+        const { openProjectKnowledgeDialog } = await import('./utils.js');
+        const result = await openProjectKnowledgeDialog(page);
+        expect(result).toBe(false);
+    });
+
+    it('opens the live project Sources tab upload surface when no Add files dialog exists', async () => {
+        const dom = new JSDOM(`
+            <!doctype html>
+            <button role="tab" aria-selected="true">Chats</button>
+            <button role="tab" aria-selected="false" id="project-home-tabs-demo-sources">Sources</button>
+            <div role="tabpanel" data-state="inactive"></div>
+        `, {
+            url: 'https://chatgpt.com/g/g-p-12345678-demo/project',
+            runScripts: 'outside-only',
+        });
+        const sourcesTab = dom.window.document.querySelector('#project-home-tabs-demo-sources');
+        sourcesTab.getBoundingClientRect = () => ({ width: 96, height: 32 });
+        sourcesTab.addEventListener('click', () => {
+            sourcesTab.setAttribute('aria-selected', 'true');
+            sourcesTab.dataset.clicked = 'true';
+        });
+
+        const page = {
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
+        };
+
+        const { openProjectKnowledgeDialog } = await import('./utils.js');
+        await expect(openProjectKnowledgeDialog(page)).resolves.toBe(true);
+        expect(sourcesTab.dataset.clicked).toBe('true');
+    });
+
+    it('projects file upload uses dialog file input selectors and waits for filename confirmation', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'report.pdf');
+        fs.writeFileSync(filePath, 'fake-pdf');
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            nativeType: vi.fn(),
+            setFileInput: vi.fn().mockRejectedValue(new Error('No element found')),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                // getPageState returns a specific object
+                if (s.includes('isVisible') && s.includes('hasComposer') && s.includes('isLoggedIn')) {
+                    return Promise.resolve({ session: 'test', data: { url: 'https://chatgpt.com/g/g-p-12345678', title: 'Project', hasComposer: true, isLoggedIn: true, hasLoginGate: false } });
+                }
+                if (s.includes('expectedFileNames')) {
+                    return Promise.resolve({ ok: true });
+                }
+                if (s.includes('Add files')) return Promise.resolve(true);
+                if (s.includes('role="dialog"')) return Promise.resolve(true);
+                if (s.includes('new DataTransfer()')) {
+                    return Promise.resolve({ ok: true });
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        const { uploadChatGPTProjectFiles } = await import('./utils.js');
+        const result = await uploadChatGPTProjectFiles(page, '12345678', [filePath]);
+
+        expect(result).toEqual({ ok: true, files: [filePath] });
+        expect(page.goto).toHaveBeenCalledWith(
+            expect.stringContaining('/g/g-p-12345678'),
+            expect.any(Object),
+        );
+        expect(page.evaluate.mock.calls.some(([script]) => String(script).includes('expectedFileNames'))).toBe(true);
+    });
+
+    it('returns failure when project upload confirmation does not appear', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'missing-confirmation.pdf');
+        fs.writeFileSync(filePath, 'fake-pdf');
+
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            setFileInput: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                if (s.includes('isVisible') && s.includes('hasComposer') && s.includes('isLoggedIn')) {
+                    return Promise.resolve({ session: 'test', data: { url: 'https://chatgpt.com/g/g-p-12345678', title: 'Project', hasComposer: true, isLoggedIn: true, hasLoginGate: false } });
+                }
+                if (s.includes('expectedFileNames')) return Promise.resolve({ ok: false, reason: 'uploaded file did not appear in project knowledge' });
+                if (s.includes('Add files')) return Promise.resolve(true);
+                if (s.includes('role="dialog"')) return Promise.resolve(true);
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        const { uploadChatGPTProjectFiles } = await import('./utils.js');
+        const result = await uploadChatGPTProjectFiles(page, '12345678', [filePath]);
+
+        expect(result).toMatchObject({
+            ok: false,
+            reason: expect.stringContaining('uploaded file did not appear'),
+        });
+    });
+});

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1149,6 +1149,8 @@ describe('chatgpt project id parsing', () => {
         expect(() => __test__.parseChatGPTProjectId('https://chatgpt.com/')).toThrow(/project/);
         expect(() => __test__.parseChatGPTProjectId('https://evil.test/g/g-p-12345678')).toThrow(/project/);
         expect(() => __test__.parseChatGPTProjectId('http://chatgpt.com/g/g-p-12345678')).toThrow(/project/);
+        expect(() => __test__.parseChatGPTProjectId('g-p-a-short')).toThrow(/project/);
+        expect(() => __test__.parseChatGPTProjectId('https://chatgpt.com/g/g-p-a-short')).toThrow(/project/);
     });
 });
 
@@ -1237,6 +1239,10 @@ describe('chatgpt project file upload helper', () => {
             <a data-sidebar-item="true" href="https://evil.test/g/g-p-badbadbad">
               <span data-testid="project-folder-icon"></span>
               Evil Project
+            </a>
+            <a data-sidebar-item="true" href="/g/g-p-a-short">
+              <span data-testid="project-folder-icon"></span>
+              Short Bait
             </a>
         `, {
             url: 'https://chatgpt.com/',


### PR DESCRIPTION
## Summary
- add `chatgpt/project-list` to list visible ChatGPT projects from the sidebar
- add `chatgpt/project-file-add` to upload local files into project knowledge
- add `--project` routing to `chatgpt ask`, `send`, `new`, `image`, and `model`
- add project id parsing, robust project link extraction, Sources-tab upload handling, project conversation URL parsing, upload confirmation, and focused adapter tests

## Test Plan
- `pnpm exec vitest run --project adapter clis/chatgpt/commands.test.js clis/chatgpt/envelope.test.js clis/chatgpt/image.test.js clis/chatgpt/model.test.js clis/chatgpt/utils.test.js` → 121 passed
- `pnpm exec tsc --noEmit`
- `pnpm run build-manifest` → `1240 entries`
- `pnpm exec tsx src/main.ts chatgpt ask --help` / `send --help` / `new --help` / `image --help` / `model --help` → expose `--project` where expected
- `pnpm exec tsx src/main.ts chatgpt project-list -f json --trace retain-on-failure --window foreground --keep-tab true` → live authenticated local session returned visible projects
- `pnpm exec tsx src/main.ts chatgpt project-file-add /tmp/opencli-chatgpt-project-upload-validation-pointer-20260621215147.txt --id 6a1791df8fa88191afb5a016ce1f497e -f json --trace retain-on-failure --window foreground --keep-tab true` → live authenticated local session uploaded one text file to project knowledge

## Notes
- The branch was updated against latest `origin/main` before opening this PR.
- `project-file-add` targets the current ChatGPT project `Sources` tab upload surface and avoids the chat composer attachment input.
- `ask/send --project` rejects `--conversation` because project routing starts a new project chat, while conversation routing continues an existing chat.
- `new/image/model --project` use the same project id or `/g/g-p-...` URL parsing as the project file upload command.
