### PR TITLE
feat(semanticscholar): add Semantic Scholar academic graph adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -28878,6 +28878,160 @@
     "sourceFile": "rubygems/search.js"
   },
   {
+    "site": "semanticscholar",
+    "name": "citations",
+    "description": "List papers that cite a Semantic Scholar paper (paginated)",
+    "access": "read",
+    "domain": "api.semanticscholar.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "paperId (40-char hex), DOI, arXiv id, or prefixed id"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max citing papers (1-1000, single Semantic Scholar page)"
+      },
+      {
+        "name": "offset",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Page offset (0-based)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "paperId",
+      "doi",
+      "title",
+      "year",
+      "firstAuthor",
+      "citationCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "semanticscholar/citations.js",
+    "sourceFile": "semanticscholar/citations.js"
+  },
+  {
+    "site": "semanticscholar",
+    "name": "paper",
+    "description": "Semantic Scholar paper detail (citation graph + AI tldr) by paperId, DOI, or arXiv id",
+    "access": "read",
+    "domain": "api.semanticscholar.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "paperId (40-char hex), DOI, arXiv id, or prefixed id (e.g. \"ARXIV:1706.03762\", \"PMID:12345\")"
+      }
+    ],
+    "columns": [
+      "paperId",
+      "doi",
+      "title",
+      "year",
+      "firstAuthor",
+      "citationCount",
+      "influentialCitationCount",
+      "referenceCount",
+      "tldr",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "semanticscholar/paper.js",
+    "sourceFile": "semanticscholar/paper.js"
+  },
+  {
+    "site": "semanticscholar",
+    "name": "recommendations",
+    "description": "Semantic Scholar AI-curated related papers for a paperId, DOI, or arXiv id",
+    "access": "read",
+    "domain": "api.semanticscholar.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "paperId (40-char hex), DOI, arXiv id, or prefixed id"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max recommendations (1-500)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "paperId",
+      "doi",
+      "title",
+      "year",
+      "firstAuthor",
+      "citationCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "semanticscholar/recommendations.js",
+    "sourceFile": "semanticscholar/recommendations.js"
+  },
+  {
+    "site": "semanticscholar",
+    "name": "search",
+    "description": "Search Semantic Scholar papers by free text",
+    "access": "read",
+    "domain": "api.semanticscholar.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search text (e.g. \"attention is all you need\", \"diffusion model\")"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max papers (1-100, single Semantic Scholar page)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "paperId",
+      "doi",
+      "title",
+      "year",
+      "firstAuthor",
+      "citationCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "semanticscholar/search.js",
+    "sourceFile": "semanticscholar/search.js"
+  },
+  {
     "site": "sinablog",
     "name": "article",
     "description": "获取新浪博客单篇文章详情",

--- a/clis/semanticscholar/citations.js
+++ b/clis/semanticscholar/citations.js
@@ -7,8 +7,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
     S2_GRAPH_BASE,
-    firstAuthorName,
-    pickDoi,
+    normalizePaperRow,
     requireBoundedInt,
     requirePaperRef,
     s2Fetch,
@@ -53,17 +52,10 @@ cli({
         }
 
         return data.slice(0, limit).map((entry, i) => {
-            const p = entry?.citingPaper ?? {};
-            return {
-                rank: offset + i + 1,
-                paperId: String(p.paperId ?? ''),
-                doi: pickDoi(p.externalIds),
-                title: String(p.title ?? '').trim(),
-                year: p.year != null ? Number(p.year) : null,
-                firstAuthor: firstAuthorName(p.authors),
-                citationCount: p.citationCount != null ? Number(p.citationCount) : null,
-                url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
-            };
+            if (!entry || typeof entry !== 'object' || !('citingPaper' in entry)) {
+                throw new CommandExecutionError('semanticscholar citations row is missing citingPaper');
+            }
+            return normalizePaperRow(entry.citingPaper, 'citations', { rank: offset + i + 1 });
         });
     },
 });

--- a/clis/semanticscholar/citations.js
+++ b/clis/semanticscholar/citations.js
@@ -1,0 +1,69 @@
+// semanticscholar citations: papers that cite this one (paginated).
+//
+// Hits `/paper/{ref}/citations?fields=...`. The endpoint returns
+// `{ data: [{ citingPaper: { ... } }] }`; we unwrap to the citing-paper rows
+// and surface fields that round-trip into `semanticscholar paper <paperId>`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    S2_GRAPH_BASE,
+    firstAuthorName,
+    pickDoi,
+    requireBoundedInt,
+    requirePaperRef,
+    s2Fetch,
+} from './utils.js';
+
+const FIELDS = ['paperId', 'title', 'year', 'authors', 'citationCount', 'externalIds'].join(',');
+
+cli({
+    site: 'semanticscholar',
+    name: 'citations',
+    access: 'read',
+    description: 'List papers that cite a Semantic Scholar paper (paginated)',
+    domain: 'api.semanticscholar.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'paperId (40-char hex), DOI, arXiv id, or prefixed id' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max citing papers (1-1000, single Semantic Scholar page)' },
+        { name: 'offset', type: 'int', default: 0, help: 'Page offset (0-based)' },
+    ],
+    columns: ['rank', 'paperId', 'doi', 'title', 'year', 'firstAuthor', 'citationCount', 'url'],
+    func: async (args) => {
+        const ref = requirePaperRef(args.id);
+        const limit = requireBoundedInt(args.limit, 20, 1000);
+        const offsetRaw = args.offset ?? 0;
+        const offset = typeof offsetRaw === 'number' ? offsetRaw : Number(offsetRaw);
+        if (!Number.isInteger(offset) || offset < 0) {
+            throw new ArgumentError('semanticscholar citations offset must be a non-negative integer');
+        }
+        if (offset > 9999) {
+            throw new ArgumentError('semanticscholar citations offset must be <= 9999');
+        }
+        const url = `${S2_GRAPH_BASE}/paper/${encodeURIComponent(ref)}/citations?fields=${FIELDS}&limit=${limit}&offset=${offset}`;
+        const body = await s2Fetch(url, 'semanticscholar citations');
+
+        const data = Array.isArray(body?.data) ? body.data : null;
+        if (data === null) {
+            throw new CommandExecutionError('semanticscholar citations returned an unexpected payload shape');
+        }
+        if (!data.length) {
+            throw new EmptyResultError('semanticscholar citations', `No Semantic Scholar citations for "${args.id}" at offset ${offset}.`);
+        }
+
+        return data.slice(0, limit).map((entry, i) => {
+            const p = entry?.citingPaper ?? {};
+            return {
+                rank: offset + i + 1,
+                paperId: String(p.paperId ?? ''),
+                doi: pickDoi(p.externalIds),
+                title: String(p.title ?? '').trim(),
+                year: p.year != null ? Number(p.year) : null,
+                firstAuthor: firstAuthorName(p.authors),
+                citationCount: p.citationCount != null ? Number(p.citationCount) : null,
+                url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
+            };
+        });
+    },
+});

--- a/clis/semanticscholar/paper.js
+++ b/clis/semanticscholar/paper.js
@@ -1,0 +1,57 @@
+// semanticscholar paper: single-paper detail with citation graph + AI tldr.
+//
+// Hits `/paper/{ref}?fields=...`. Surfaces the two fields that are unique to
+// Semantic Scholar versus the existing arxiv/openalex/dblp/pubmed adapters:
+// `influentialCitationCount` (their gated "important" count) and `tldr.text`
+// (LLM-generated one-line summary).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    S2_GRAPH_BASE,
+    firstAuthorName,
+    pickDoi,
+    requirePaperRef,
+    s2Fetch,
+    tldrText,
+} from './utils.js';
+
+const FIELDS = [
+    'paperId', 'title', 'year', 'authors', 'citationCount',
+    'influentialCitationCount', 'referenceCount', 'tldr', 'externalIds', 'url',
+].join(',');
+
+cli({
+    site: 'semanticscholar',
+    name: 'paper',
+    access: 'read',
+    description: 'Semantic Scholar paper detail (citation graph + AI tldr) by paperId, DOI, or arXiv id',
+    domain: 'api.semanticscholar.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'paperId (40-char hex), DOI, arXiv id, or prefixed id (e.g. "ARXIV:1706.03762", "PMID:12345")' },
+    ],
+    columns: ['paperId', 'doi', 'title', 'year', 'firstAuthor', 'citationCount', 'influentialCitationCount', 'referenceCount', 'tldr', 'url'],
+    func: async (args) => {
+        const ref = requirePaperRef(args.id);
+        const url = `${S2_GRAPH_BASE}/paper/${encodeURIComponent(ref)}?fields=${FIELDS}`;
+        const body = await s2Fetch(url, 'semanticscholar paper');
+
+        if (!body || typeof body !== 'object' || !body.paperId) {
+            throw new EmptyResultError('semanticscholar paper', `No Semantic Scholar record for "${args.id}".`);
+        }
+
+        return [{
+            paperId: String(body.paperId),
+            doi: pickDoi(body.externalIds),
+            title: String(body.title ?? '').trim(),
+            year: body.year != null ? Number(body.year) : null,
+            firstAuthor: firstAuthorName(body.authors),
+            citationCount: body.citationCount != null ? Number(body.citationCount) : null,
+            influentialCitationCount: body.influentialCitationCount != null ? Number(body.influentialCitationCount) : null,
+            referenceCount: body.referenceCount != null ? Number(body.referenceCount) : null,
+            tldr: tldrText(body.tldr),
+            url: typeof body.url === 'string' ? body.url : `https://www.semanticscholar.org/paper/${body.paperId}`,
+        }];
+    },
+});

--- a/clis/semanticscholar/paper.js
+++ b/clis/semanticscholar/paper.js
@@ -5,11 +5,11 @@
 // `influentialCitationCount` (their gated "important" count) and `tldr.text`
 // (LLM-generated one-line summary).
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     S2_GRAPH_BASE,
-    firstAuthorName,
-    pickDoi,
+    normalizePaperRow,
+    optionalNumber,
     requirePaperRef,
     s2Fetch,
     tldrText,
@@ -37,21 +37,16 @@ cli({
         const url = `${S2_GRAPH_BASE}/paper/${encodeURIComponent(ref)}?fields=${FIELDS}`;
         const body = await s2Fetch(url, 'semanticscholar paper');
 
-        if (!body || typeof body !== 'object' || !body.paperId) {
-            throw new EmptyResultError('semanticscholar paper', `No Semantic Scholar record for "${args.id}".`);
+        if (!body || typeof body !== 'object') {
+            throw new CommandExecutionError('semanticscholar paper returned an unexpected payload shape');
         }
+        const row = normalizePaperRow(body, 'paper');
 
         return [{
-            paperId: String(body.paperId),
-            doi: pickDoi(body.externalIds),
-            title: String(body.title ?? '').trim(),
-            year: body.year != null ? Number(body.year) : null,
-            firstAuthor: firstAuthorName(body.authors),
-            citationCount: body.citationCount != null ? Number(body.citationCount) : null,
-            influentialCitationCount: body.influentialCitationCount != null ? Number(body.influentialCitationCount) : null,
-            referenceCount: body.referenceCount != null ? Number(body.referenceCount) : null,
+            ...row,
+            influentialCitationCount: optionalNumber(body.influentialCitationCount, 'paper influentialCitationCount'),
+            referenceCount: optionalNumber(body.referenceCount, 'paper referenceCount'),
             tldr: tldrText(body.tldr),
-            url: typeof body.url === 'string' ? body.url : `https://www.semanticscholar.org/paper/${body.paperId}`,
         }];
     },
 });

--- a/clis/semanticscholar/recommendations.js
+++ b/clis/semanticscholar/recommendations.js
@@ -1,0 +1,57 @@
+// semanticscholar recommendations: AI-curated related papers from Semantic
+// Scholar's semantic graph. This endpoint has no equivalent in openalex or
+// arxiv; it is the Semantic Scholar adapter's main differentiating surface.
+//
+// Hits `https://api.semanticscholar.org/recommendations/v1/papers/forpaper/{ref}`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    S2_REC_BASE,
+    firstAuthorName,
+    pickDoi,
+    requireBoundedInt,
+    requirePaperRef,
+    s2Fetch,
+} from './utils.js';
+
+const FIELDS = ['paperId', 'title', 'year', 'authors', 'citationCount', 'externalIds'].join(',');
+
+cli({
+    site: 'semanticscholar',
+    name: 'recommendations',
+    access: 'read',
+    description: 'Semantic Scholar AI-curated related papers for a paperId, DOI, or arXiv id',
+    domain: 'api.semanticscholar.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'paperId (40-char hex), DOI, arXiv id, or prefixed id' },
+        { name: 'limit', type: 'int', default: 10, help: 'Max recommendations (1-500)' },
+    ],
+    columns: ['rank', 'paperId', 'doi', 'title', 'year', 'firstAuthor', 'citationCount', 'url'],
+    func: async (args) => {
+        const ref = requirePaperRef(args.id);
+        const limit = requireBoundedInt(args.limit, 10, 500);
+        const url = `${S2_REC_BASE}/papers/forpaper/${encodeURIComponent(ref)}?fields=${FIELDS}&limit=${limit}`;
+        const body = await s2Fetch(url, 'semanticscholar recommendations');
+
+        const recommended = Array.isArray(body?.recommendedPapers) ? body.recommendedPapers : null;
+        if (recommended === null) {
+            throw new CommandExecutionError('semanticscholar recommendations returned an unexpected payload shape');
+        }
+        if (!recommended.length) {
+            throw new EmptyResultError('semanticscholar recommendations', `No Semantic Scholar recommendations for "${args.id}".`);
+        }
+
+        return recommended.slice(0, limit).map((p, i) => ({
+            rank: i + 1,
+            paperId: String(p.paperId ?? ''),
+            doi: pickDoi(p.externalIds),
+            title: String(p.title ?? '').trim(),
+            year: p.year != null ? Number(p.year) : null,
+            firstAuthor: firstAuthorName(p.authors),
+            citationCount: p.citationCount != null ? Number(p.citationCount) : null,
+            url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
+        }));
+    },
+});

--- a/clis/semanticscholar/recommendations.js
+++ b/clis/semanticscholar/recommendations.js
@@ -7,8 +7,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
     S2_REC_BASE,
-    firstAuthorName,
-    pickDoi,
+    normalizePaperRow,
     requireBoundedInt,
     requirePaperRef,
     s2Fetch,
@@ -43,15 +42,6 @@ cli({
             throw new EmptyResultError('semanticscholar recommendations', `No Semantic Scholar recommendations for "${args.id}".`);
         }
 
-        return recommended.slice(0, limit).map((p, i) => ({
-            rank: i + 1,
-            paperId: String(p.paperId ?? ''),
-            doi: pickDoi(p.externalIds),
-            title: String(p.title ?? '').trim(),
-            year: p.year != null ? Number(p.year) : null,
-            firstAuthor: firstAuthorName(p.authors),
-            citationCount: p.citationCount != null ? Number(p.citationCount) : null,
-            url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
-        }));
+        return recommended.slice(0, limit).map((p, i) => normalizePaperRow(p, 'recommendations', { rank: i + 1 }));
     },
 });

--- a/clis/semanticscholar/search.js
+++ b/clis/semanticscholar/search.js
@@ -1,0 +1,58 @@
+// semanticscholar search: paper search across the Semantic Scholar graph.
+//
+// Hits `/paper/search?query=...`. Returns the agent-useful projection:
+// paperId (round-trips into `semanticscholar paper`), DOI, title, year,
+// first author, citationCount. The bulk search endpoint is the rate-limited
+// surface, so `utils.s2Fetch` retries once on 429.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    S2_GRAPH_BASE,
+    firstAuthorName,
+    pickDoi,
+    requireBoundedInt,
+    requireString,
+    s2Fetch,
+} from './utils.js';
+
+const FIELDS = ['paperId', 'title', 'year', 'authors', 'citationCount', 'externalIds'].join(',');
+
+cli({
+    site: 'semanticscholar',
+    name: 'search',
+    access: 'read',
+    description: 'Search Semantic Scholar papers by free text',
+    domain: 'api.semanticscholar.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search text (e.g. "attention is all you need", "diffusion model")' },
+        { name: 'limit', type: 'int', default: 20, help: 'Max papers (1-100, single Semantic Scholar page)' },
+    ],
+    columns: ['rank', 'paperId', 'doi', 'title', 'year', 'firstAuthor', 'citationCount', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'query');
+        const limit = requireBoundedInt(args.limit, 20, 100);
+        const url = `${S2_GRAPH_BASE}/paper/search?query=${encodeURIComponent(query)}&limit=${limit}&fields=${FIELDS}`;
+        const body = await s2Fetch(url, 'semanticscholar search');
+
+        const data = Array.isArray(body?.data) ? body.data : null;
+        if (data === null) {
+            throw new CommandExecutionError('semanticscholar search returned an unexpected payload shape');
+        }
+        if (!data.length) {
+            throw new EmptyResultError('semanticscholar search', `No Semantic Scholar papers matched "${query}".`);
+        }
+
+        return data.slice(0, limit).map((p, i) => ({
+            rank: i + 1,
+            paperId: String(p.paperId ?? ''),
+            doi: pickDoi(p.externalIds),
+            title: String(p.title ?? '').trim(),
+            year: p.year != null ? Number(p.year) : null,
+            firstAuthor: firstAuthorName(p.authors),
+            citationCount: p.citationCount != null ? Number(p.citationCount) : null,
+            url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
+        }));
+    },
+});

--- a/clis/semanticscholar/search.js
+++ b/clis/semanticscholar/search.js
@@ -8,8 +8,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
     S2_GRAPH_BASE,
-    firstAuthorName,
-    pickDoi,
+    normalizePaperRow,
     requireBoundedInt,
     requireString,
     s2Fetch,
@@ -44,15 +43,6 @@ cli({
             throw new EmptyResultError('semanticscholar search', `No Semantic Scholar papers matched "${query}".`);
         }
 
-        return data.slice(0, limit).map((p, i) => ({
-            rank: i + 1,
-            paperId: String(p.paperId ?? ''),
-            doi: pickDoi(p.externalIds),
-            title: String(p.title ?? '').trim(),
-            year: p.year != null ? Number(p.year) : null,
-            firstAuthor: firstAuthorName(p.authors),
-            citationCount: p.citationCount != null ? Number(p.citationCount) : null,
-            url: p.paperId ? `https://www.semanticscholar.org/paper/${p.paperId}` : '',
-        }));
+        return data.slice(0, limit).map((p, i) => normalizePaperRow(p, 'search', { rank: i + 1 }));
     },
 });

--- a/clis/semanticscholar/semanticscholar.test.js
+++ b/clis/semanticscholar/semanticscholar.test.js
@@ -103,10 +103,20 @@ describe('semanticscholar paper command', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('maps a missing paper to EmptyResultError', async () => {
+    it('typed-fails malformed paper detail rows instead of treating parser drift as empty', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
 
-        await expect(command.func({ id: '10.0/missing' })).rejects.toBeInstanceOf(EmptyResultError);
+        await expect(command.func({ id: '10.0/missing' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails non-numeric metric fields instead of returning NaN', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            paperId: 'df2b0e26d0599ce3e70df8a9da02e51594e0e992',
+            title: 'Bad Metrics',
+            citationCount: 'many',
+        })));
+
+        await expect(command.func({ id: '10.0/bad-metrics' })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });
 
@@ -148,6 +158,22 @@ describe('semanticscholar citations command', () => {
 
         await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
+
+    it('typed-fails malformed citation rows without a citing paper identity', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            data: [{ citingPaper: { title: 'Missing identity' } }],
+        })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails citation entries missing citingPaper instead of emitting blank rows', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            data: [{ contexts: ['missing citing paper'] }],
+        })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
 });
 
 describe('semanticscholar recommendations command', () => {
@@ -173,6 +199,14 @@ describe('semanticscholar recommendations command', () => {
 
     it('typed-fails when the payload is missing recommendedPapers entirely', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ wrong: 'shape' })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails malformed recommendation rows without a stable paper identity', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            recommendedPapers: [{ title: 'Missing id' }],
+        })));
 
         await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
@@ -233,5 +267,13 @@ describe('semanticscholar search command', () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: [] })));
 
         await expect(command.func({ query: 'zz-no-hit', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails malformed search rows without a stable paper identity', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            data: [{ title: 'Missing id' }],
+        })));
+
+        await expect(command.func({ query: 'broken row', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/semanticscholar/semanticscholar.test.js
+++ b/clis/semanticscholar/semanticscholar.test.js
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './paper.js';
+import './citations.js';
+import './recommendations.js';
+import './search.js';
+
+function jsonResponse(body, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SEMANTIC_SCHOLAR_API_KEY;
+});
+
+describe('semanticscholar adapter registry contracts', () => {
+    it('declares paper columns so paperId round-trips into citations and recommendations', () => {
+        const paper = getRegistry().get('semanticscholar/paper');
+        const citations = getRegistry().get('semanticscholar/citations');
+        const recommendations = getRegistry().get('semanticscholar/recommendations');
+
+        expect(paper).toBeDefined();
+        expect(citations).toBeDefined();
+        expect(recommendations).toBeDefined();
+        expect(paper.columns).toContain('paperId');
+        expect(citations.columns).toContain('paperId');
+        expect(recommendations.columns).toContain('paperId');
+    });
+
+    it('surfaces the unique Semantic Scholar fields on paper detail', () => {
+        const paper = getRegistry().get('semanticscholar/paper');
+
+        expect(paper.columns).toContain('influentialCitationCount');
+        expect(paper.columns).toContain('tldr');
+    });
+
+    it('marks every command as read access on the api.semanticscholar.org domain', () => {
+        for (const name of ['paper', 'citations', 'recommendations', 'search']) {
+            const cmd = getRegistry().get(`semanticscholar/${name}`);
+            expect(cmd, name).toBeDefined();
+            expect(cmd.access, name).toBe('read');
+            expect(cmd.domain, name).toBe('api.semanticscholar.org');
+            expect(cmd.browser, name).toBe(false);
+        }
+    });
+});
+
+describe('semanticscholar paper command', () => {
+    const command = getRegistry().get('semanticscholar/paper');
+
+    it('returns the paper row with citation graph and tldr', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+            paperId: 'df2b0e26d0599ce3e70df8a9da02e51594e0e992',
+            title: 'BERT: Pre-training of Deep Bidirectional Transformers',
+            year: 2019,
+            authors: [{ name: 'Jacob Devlin' }, { name: 'Ming-Wei Chang' }],
+            citationCount: 116233,
+            influentialCitationCount: 22448,
+            referenceCount: 63,
+            tldr: { text: 'A new language representation model called BERT.' },
+            externalIds: { DOI: '10.18653/v1/N19-1423' },
+            url: 'https://www.semanticscholar.org/paper/df2b0e26d0599ce3e70df8a9da02e51594e0e992',
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ id: '10.18653/v1/N19-1423' })).resolves.toEqual([{
+            paperId: 'df2b0e26d0599ce3e70df8a9da02e51594e0e992',
+            doi: '10.18653/v1/N19-1423',
+            title: 'BERT: Pre-training of Deep Bidirectional Transformers',
+            year: 2019,
+            firstAuthor: 'Jacob Devlin',
+            citationCount: 116233,
+            influentialCitationCount: 22448,
+            referenceCount: 63,
+            tldr: 'A new language representation model called BERT.',
+            url: 'https://www.semanticscholar.org/paper/df2b0e26d0599ce3e70df8a9da02e51594e0e992',
+        }]);
+        // DOI normalization: bare 10.x DOIs get the DOI: prefix encoded into the path.
+        expect(fetchMock.mock.calls[0][0]).toContain('DOI%3A10.18653%2Fv1%2FN19-1423');
+    });
+
+    it('forwards SEMANTIC_SCHOLAR_API_KEY as the x-api-key header when set', async () => {
+        process.env.SEMANTIC_SCHOLAR_API_KEY = 'test-key';
+        const paperId = 'a'.repeat(40);
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ paperId, title: 'x' }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await command.func({ id: paperId });
+        expect(fetchMock.mock.calls[0][1].headers['x-api-key']).toBe('test-key');
+    });
+
+    it('rejects invalid identifiers before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ id: '' })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ id: 'not a real reference' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps a missing paper to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
+
+        await expect(command.func({ id: '10.0/missing' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('semanticscholar citations command', () => {
+    const command = getRegistry().get('semanticscholar/citations');
+
+    it('unwraps citingPaper rows and offsets ranks correctly', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            data: [
+                { citingPaper: { paperId: 'p1', title: 'Citing One', year: 2024, authors: [{ name: 'Alice' }], citationCount: 5, externalIds: { DOI: '10.1/p1' } } },
+                { citingPaper: { paperId: 'p2', title: 'Citing Two', year: 2025, authors: [{ name: 'Bob' }], citationCount: 12, externalIds: {} } },
+            ],
+        })));
+
+        await expect(command.func({ id: '10.18653/v1/N19-1423', limit: 2, offset: 10 })).resolves.toEqual([
+            { rank: 11, paperId: 'p1', doi: '10.1/p1', title: 'Citing One', year: 2024, firstAuthor: 'Alice', citationCount: 5, url: 'https://www.semanticscholar.org/paper/p1' },
+            { rank: 12, paperId: 'p2', doi: '', title: 'Citing Two', year: 2025, firstAuthor: 'Bob', citationCount: 12, url: 'https://www.semanticscholar.org/paper/p2' },
+        ]);
+    });
+
+    it('rejects invalid arguments before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ id: '', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ id: '10.0/x', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ id: '10.0/x', limit: 1001 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps empty citation pages to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: [] })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails malformed payloads instead of returning empty rows', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ wrong: 'shape' })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('semanticscholar recommendations command', () => {
+    const command = getRegistry().get('semanticscholar/recommendations');
+
+    it('returns recommendedPapers rows ranked from 1', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+            recommendedPapers: [
+                { paperId: 'r1', title: 'Related One', year: 2024, authors: [{ name: 'Carol' }], citationCount: 7, externalIds: { DOI: '10.1/r1' } },
+            ],
+        })));
+
+        await expect(command.func({ id: '10.18653/v1/N19-1423', limit: 1 })).resolves.toEqual([
+            { rank: 1, paperId: 'r1', doi: '10.1/r1', title: 'Related One', year: 2024, firstAuthor: 'Carol', citationCount: 7, url: 'https://www.semanticscholar.org/paper/r1' },
+        ]);
+    });
+
+    it('maps empty recommendation responses to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ recommendedPapers: [] })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails when the payload is missing recommendedPapers entirely', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ wrong: 'shape' })));
+
+        await expect(command.func({ id: '10.0/x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('semanticscholar search command', () => {
+    const command = getRegistry().get('semanticscholar/search');
+
+    it('returns search rows that round-trip into semanticscholar paper', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+            data: [{
+                paperId: 'sp1',
+                title: 'A Search Hit',
+                year: 2023,
+                authors: [{ name: 'Dana' }],
+                citationCount: 99,
+                externalIds: { DOI: '10.1/sp1' },
+            }],
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ query: 'transformers', limit: 1 })).resolves.toEqual([{
+            rank: 1,
+            paperId: 'sp1',
+            doi: '10.1/sp1',
+            title: 'A Search Hit',
+            year: 2023,
+            firstAuthor: 'Dana',
+            citationCount: 99,
+            url: 'https://www.semanticscholar.org/paper/sp1',
+        }]);
+        const url = new URL(fetchMock.mock.calls[0][0]);
+        expect(url.searchParams.get('query')).toBe('transformers');
+    });
+
+    it('rejects invalid arguments before fetching', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(command.func({ query: ' ', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ query: 'x', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command.func({ query: 'x', limit: 101 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('retries once on 429 when no API key is configured', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+            .mockResolvedValueOnce(jsonResponse({ data: [{ paperId: 'after', title: 'Recovered', year: 2024, authors: [], citationCount: 0, externalIds: {} }] }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const rows = await command.func({ query: 'bursty', limit: 1 });
+        expect(rows[0].paperId).toBe('after');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('maps empty search results to EmptyResultError', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: [] })));
+
+        await expect(command.func({ query: 'zz-no-hit', limit: 5 })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});

--- a/clis/semanticscholar/utils.js
+++ b/clis/semanticscholar/utils.js
@@ -151,6 +151,42 @@ export function firstAuthorName(authors) {
     return '';
 }
 
+export function optionalNumber(value, label) {
+    if (value == null) return null;
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new CommandExecutionError(`semanticscholar ${label} must be a number when present`);
+    }
+    return value;
+}
+
+export function normalizePaperRow(paper, label, { rank } = {}) {
+    if (!paper || typeof paper !== 'object') {
+        throw new CommandExecutionError(`semanticscholar ${label} row is not an object`);
+    }
+    if (typeof paper.paperId !== 'string' || !paper.paperId.trim()) {
+        throw new CommandExecutionError(`semanticscholar ${label} row is missing paperId`);
+    }
+    if (typeof paper.title !== 'string' || !paper.title.trim()) {
+        throw new CommandExecutionError(`semanticscholar ${label} row is missing title`);
+    }
+    if (paper.authors != null && !Array.isArray(paper.authors)) {
+        throw new CommandExecutionError(`semanticscholar ${label} row has malformed authors`);
+    }
+    const row = {
+        paperId: paper.paperId.trim(),
+        doi: pickDoi(paper.externalIds),
+        title: paper.title.trim(),
+        year: optionalNumber(paper.year, `${label} year`),
+        firstAuthor: firstAuthorName(paper.authors),
+        citationCount: optionalNumber(paper.citationCount, `${label} citationCount`),
+        url: typeof paper.url === 'string' && paper.url.trim()
+            ? paper.url.trim()
+            : `https://www.semanticscholar.org/paper/${paper.paperId.trim()}`,
+    };
+    if (rank != null) return { rank, ...row };
+    return row;
+}
+
 /** Strip the typed prefix from `externalIds.DOI` and similar. */
 export function pickDoi(externalIds) {
     if (externalIds && typeof externalIds === 'object' && typeof externalIds.DOI === 'string') {

--- a/clis/semanticscholar/utils.js
+++ b/clis/semanticscholar/utils.js
@@ -1,0 +1,160 @@
+// Shared helpers for the Semantic Scholar (`api.semanticscholar.org`) adapter.
+//
+// Semantic Scholar exposes a free Academic Graph + a separate Recommendations
+// API. Anonymous traffic caps at roughly 100 requests / 5 minutes; an optional
+// API key (free at https://www.semanticscholar.org/product/api#api-key-form)
+// lifts the limit and is passed via `SEMANTIC_SCHOLAR_API_KEY`. Paper refs
+// accept Semantic Scholar paperIds, DOIs, arXiv ids, ACL ids, MAG ids, PMID,
+// or full URLs; they round-trip through `paper <ref>` to `citations <ref>`
+// and `recommendations <ref>`.
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const S2_GRAPH_BASE = 'https://api.semanticscholar.org/graph/v1';
+export const S2_REC_BASE = 'https://api.semanticscholar.org/recommendations/v1';
+const UA = 'opencli-semanticscholar-adapter (+https://github.com/jackwener/opencli)';
+
+// Semantic Scholar paperId: 40-char lowercase hex (SHA-ish).
+const S2_PAPER_ID = /^[0-9a-f]{40}$/i;
+// DOIs: anything starting with 10. after an optional `doi:` / `doi.org/` prefix.
+const DOI_BARE = /^10\.\S+$/;
+// arXiv ids: modern `YYMM.NNNNN` form or legacy `archive/YYMMNNN`.
+const ARXIV_MODERN = /^\d{4}\.\d{4,5}(?:v\d+)?$/;
+const ARXIV_LEGACY = /^[a-z-]+\/\d{7}(?:v\d+)?$/i;
+// Other Semantic Scholar accepted prefixes that we pass through verbatim.
+const PREFIXED = /^(ARXIV|MAG|ACL|PMID|PMCID|URL|CorpusId|DBLP):/i;
+
+export function requireString(value, label) {
+    const s = String(value ?? '').trim();
+    if (!s) {
+        throw new ArgumentError(`semanticscholar ${label} cannot be empty`);
+    }
+    return s;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ArgumentError(`semanticscholar ${label} must be a positive integer`);
+    }
+    if (n > maxValue) {
+        throw new ArgumentError(`semanticscholar ${label} must be <= ${maxValue}`);
+    }
+    return n;
+}
+
+/**
+ * Resolve a user-supplied paper reference to a Semantic Scholar paper id
+ * segment. Accepts:
+ *
+ *   - bare Semantic Scholar paperId (40-char hex)
+ *   - DOI (with or without `doi:` / `https://doi.org/` prefix)
+ *   - arXiv id (`1706.03762` / `1706.03762v3` / `cs/0501067`)
+ *   - typed prefixes Semantic Scholar accepts verbatim (`ARXIV:`, `MAG:`,
+ *     `ACL:`, `PMID:`, `PMCID:`, `URL:`, `CorpusId:`, `DBLP:`)
+ *   - full `https://www.semanticscholar.org/paper/<paperId>` URL
+ */
+export function requirePaperRef(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) {
+        throw new ArgumentError(
+            'semanticscholar paper id cannot be empty',
+            'Example: opencli semanticscholar paper 10.18653/v1/N19-1423',
+        );
+    }
+    const s2Url = raw.match(/^https?:\/\/(?:www\.)?semanticscholar\.org\/paper\/(?:[^/]+\/)?([0-9a-f]{40})/i);
+    if (s2Url) return s2Url[1].toLowerCase();
+    if (S2_PAPER_ID.test(raw)) return raw.toLowerCase();
+    if (PREFIXED.test(raw)) return raw;
+    if (/^doi:/i.test(raw)) {
+        const doi = raw.replace(/^doi:/i, '').trim();
+        if (DOI_BARE.test(doi)) return `DOI:${doi}`;
+    }
+    const doiUrl = raw.match(/^https?:\/\/(?:dx\.)?doi\.org\/(.+)$/i);
+    if (doiUrl && DOI_BARE.test(doiUrl[1])) return `DOI:${doiUrl[1]}`;
+    if (DOI_BARE.test(raw)) return `DOI:${raw}`;
+    if (ARXIV_MODERN.test(raw) || ARXIV_LEGACY.test(raw)) return `ARXIV:${raw}`;
+    throw new ArgumentError(
+        `semanticscholar paper id "${value}" is not recognised`,
+        'Use a Semantic Scholar paperId, a DOI, an arXiv id, or a prefixed id (e.g. "ARXIV:1706.03762", "PMID:12345").',
+    );
+}
+
+/**
+ * Fetch with optional `SEMANTIC_SCHOLAR_API_KEY` header. Retries once on 429
+ * after a short pause; anonymous traffic hits the public ~100 req / 5 min
+ * cap, and a single retry covers the typical burst-then-cool-down case.
+ */
+export async function s2Fetch(url, label) {
+    const headers = { 'user-agent': UA, accept: 'application/json' };
+    const apiKey = process.env.SEMANTIC_SCHOLAR_API_KEY;
+    if (apiKey) headers['x-api-key'] = apiKey;
+
+    let resp;
+    let attempt = 0;
+    while (true) {
+        try {
+            resp = await fetch(url, { headers });
+        } catch (err) {
+            throw new CommandExecutionError(
+                `${label} request failed: ${err?.message ?? err}`,
+                'Check that api.semanticscholar.org is reachable from this network.',
+            );
+        }
+        if (resp.status === 429 && attempt === 0 && !apiKey) {
+            attempt += 1;
+            await new Promise(resolve => setTimeout(resolve, 1500));
+            continue;
+        }
+        break;
+    }
+
+    if (resp.status === 404) {
+        throw new EmptyResultError(label, `Semantic Scholar returned 404 for ${url}.`);
+    }
+    if (resp.status === 429) {
+        throw new CommandExecutionError(
+            `${label} returned HTTP 429 (rate limited)`,
+            'Semantic Scholar throttles anonymous traffic; set SEMANTIC_SCHOLAR_API_KEY (free at https://www.semanticscholar.org/product/api) or wait a minute and retry.',
+        );
+    }
+    if (!resp.ok) {
+        throw new CommandExecutionError(`${label} returned HTTP ${resp.status}`);
+    }
+    let body;
+    try {
+        body = await resp.json();
+    } catch (err) {
+        throw new CommandExecutionError(`${label} returned malformed JSON: ${err?.message ?? err}`);
+    }
+    if (body && typeof body === 'object' && body.error) {
+        throw new CommandExecutionError(`${label} returned an error: ${body.error}`);
+    }
+    return body;
+}
+
+/** Return the AI-generated one-line summary if present, else ''. */
+export function tldrText(tldr) {
+    if (tldr && typeof tldr === 'object' && typeof tldr.text === 'string') {
+        return tldr.text.trim();
+    }
+    return '';
+}
+
+/** First author display name, or '' when authors is missing. */
+export function firstAuthorName(authors) {
+    if (!Array.isArray(authors) || !authors.length) return '';
+    const first = authors[0];
+    if (first && typeof first === 'object' && typeof first.name === 'string') {
+        return first.name.trim();
+    }
+    return '';
+}
+
+/** Strip the typed prefix from `externalIds.DOI` and similar. */
+export function pickDoi(externalIds) {
+    if (externalIds && typeof externalIds === 'object' && typeof externalIds.DOI === 'string') {
+        return externalIds.DOI;
+    }
+    return '';
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -134,6 +134,7 @@ export default defineConfig({
                 { text: 'arXiv', link: '/adapters/browser/arxiv' },
                 { text: 'dblp', link: '/adapters/browser/dblp' },
                 { text: 'PubMed', link: '/adapters/browser/pubmed' },
+                { text: 'Semantic Scholar', link: '/adapters/browser/semanticscholar' },
                 { text: 'paperreview.ai', link: '/adapters/browser/paperreview' },
                 { text: 'Barchart', link: '/adapters/browser/barchart' },
                 { text: 'Hugging Face', link: '/adapters/browser/hf' },

--- a/docs/adapters/browser/semanticscholar.md
+++ b/docs/adapters/browser/semanticscholar.md
@@ -1,0 +1,77 @@
+# Semantic Scholar
+
+**Mode**: 🌐 Public · **Domain**: `api.semanticscholar.org`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli semanticscholar paper <id-or-doi>` | Paper detail (citation graph + AI tldr) by paperId, DOI, or arXiv id |
+| `opencli semanticscholar citations <id-or-doi>` | Papers that cite a given paper (paginated) |
+| `opencli semanticscholar recommendations <id-or-doi>` | AI-curated related papers from Semantic Scholar's semantic graph |
+| `opencli semanticscholar search <query>` | Search Semantic Scholar papers by free text |
+
+## Usage Examples
+
+```bash
+# Paper detail by DOI (the BERT paper)
+opencli semanticscholar paper 10.18653/v1/N19-1423
+
+# Paper detail by arXiv id
+opencli semanticscholar paper 1706.03762
+
+# Citations of a paper, paginated
+opencli semanticscholar citations 10.18653/v1/N19-1423 --limit 20
+opencli semanticscholar citations 10.18653/v1/N19-1423 --limit 20 --offset 20
+
+# AI-curated related papers (unique to Semantic Scholar)
+opencli semanticscholar recommendations 10.18653/v1/N19-1423 --limit 10
+
+# Free-text search
+opencli semanticscholar search "attention is all you need" --limit 10
+
+# JSON output
+opencli semanticscholar paper 10.18653/v1/N19-1423 -f json
+```
+
+### `paper` Options
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Semantic Scholar paperId (40-char hex), DOI, arXiv id, or a prefixed id such as `PMID:12345` / `ACL:N19-1423` / `MAG:...` / `CorpusId:...` |
+
+Returns one row with `paperId, doi, title, year, firstAuthor, citationCount, influentialCitationCount, referenceCount, tldr, url`. The `paperId` and `doi` values round-trip into `citations` and `recommendations`.
+
+### `citations` Options
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Same id forms as `paper` |
+| `--limit` | Max citing papers (1-1000, single Semantic Scholar page; default 20) |
+| `--offset` | 0-based page offset for pagination (default 0; max 9999) |
+
+Returns rows with `rank, paperId, doi, title, year, firstAuthor, citationCount, url`.
+
+### `recommendations` Options
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Same id forms as `paper` |
+| `--limit` | Max recommendations (1-500, default 10) |
+
+Returns rows with `rank, paperId, doi, title, year, firstAuthor, citationCount, url`. Uses Semantic Scholar's proprietary `recommendations/v1/papers/forpaper` endpoint, which has no equivalent in the existing arxiv / openalex / dblp / pubmed adapters.
+
+### `search` Options
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Full-text query |
+| `--limit` | Max papers (1-100, default 20) |
+
+Returns rows with `rank, paperId, doi, title, year, firstAuthor, citationCount, url`. Each `paperId` round-trips into `semanticscholar paper`.
+
+## Prerequisites
+
+- No browser required; uses the public Semantic Scholar API.
+- The anonymous API caps at roughly 100 requests per 5 minutes. The adapter retries once on 429 with a short pause, and surfaces a typed `CommandExecutionError` after that.
+- Set `SEMANTIC_SCHOLAR_API_KEY` to use a free API key (register at https://www.semanticscholar.org/product/api#api-key-form), which lifts the rate cap. The adapter forwards it as the `x-api-key` header; it works without a key.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -109,6 +109,7 @@ Run `opencli list` for the live registry.
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |
 | **[dblp](./browser/dblp.md)**                     | `search` `author` `paper` `venue`                                                                                                              | 🌐 Public    |
 | **[pubmed](./browser/pubmed.md)**                 | `search` `article` `author` `citations` `related` `clinical-trial` `review` `mesh` `journal`                                                 | 🌐 Public    |
+| **[semanticscholar](./browser/semanticscholar.md)** | `paper` `citations` `recommendations` `search`                                                                                              | 🌐 Public    |
 | **[openreview](./browser/openreview.md)**         | `search` `venue` `author` `paper` `reviews`                                                                                                    | 🌐 Public    |
 | **[paperreview](./browser/paperreview.md)**       | `submit` `review` `feedback`                                                                                                                   | 🌐 Public    |
 | **[barchart](./browser/barchart.md)**             | `quote` `options` `greeks` `flow`                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
## Description

Adds a native read-only adapter for the Semantic Scholar Academic Graph (#1993). Four commands cover the most common agent surfaces and follow the same `Strategy.PUBLIC` shape as the merged `openalex` / `dblp` / `archive` adapters: no login, no browser, plain `fetch` against `api.semanticscholar.org`. The differentiating value vs the existing nine academic adapters is `influentialCitationCount` (Semantic Scholar's gated "important citation" count), `tldr.text` (LLM-generated one-line summary), and `/recommendations/v1/papers/forpaper` (their proprietary related-paper endpoint, no equivalent in openalex or arxiv).

Related issue: Closes #1993.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Added doc page under `docs/adapters/` (if new adapter)
- [x] Updated `docs/adapters/index.md` table (if new adapter)
- [x] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Commands:

```
semanticscholar paper <id-or-doi>
semanticscholar citations <id-or-doi>     [--limit N] [--offset N]
semanticscholar recommendations <id-or-doi> [--limit N]
semanticscholar search <query>             [--limit N]
```

Live runs against api.semanticscholar.org (BERT, DOI `10.18653/v1/N19-1423`):

```
$ opencli semanticscholar recommendations 10.18653/v1/N19-1423 --limit 3 -f json
[
  { "rank": 1, "paperId": "28245905...", "title": "A Study on Hidden Layer Distillation for Large Language Model Pre-Training", "year": 2026, "firstAuthor": "Maxime Guigon", "url": "https://www.semanticscholar.org/paper/28245905..." },
  { "rank": 2, "paperId": "883a4614...", "title": "Gated transformer with shallow decoder for machine translation", "year": 2026, "firstAuthor": "Fangfang Li", "doi": "10.1038/s41598-026-49583-z", ... },
  { "rank": 3, "paperId": "339a847f...", ... }
]
```

```
$ opencli semanticscholar citations 10.18653/v1/N19-1423 --limit 2 -f json
[
  { "rank": 1, "paperId": "85417f8f...", "doi": "10.1016/j.ipm.2026.104781", "title": "Multi-domain generalization few-shot intent recognition with dual representation learning", "year": 2026, "firstAuthor": "Shun Yang", ... },
  { "rank": 2, "paperId": "bb2213c8...", "doi": "10.1016/j.aei.2026.104679", "title": "An agentic framework for data augmentation in construction defect report classification", ... }
]
```

The anonymous API caps at roughly 100 requests per 5 minutes per IP. The adapter retries once on 429 with a short pause, then surfaces a typed `CommandExecutionError` whose help line points at `SEMANTIC_SCHOLAR_API_KEY` (free key at https://www.semanticscholar.org/product/api). This mirrors the unauthenticated-traffic caveat the merged `openalex` adapter already documents.

Identifier handling (see `clis/semanticscholar/utils.js:requirePaperRef`): accepts 40-char Semantic Scholar paperIds, DOIs (with or without `doi:` / `https://doi.org/` prefix), arXiv ids (`1706.03762` / `cs/0501067`), and Semantic Scholar's typed prefixes (`ARXIV:` / `MAG:` / `ACL:` / `PMID:` / `PMCID:` / `URL:` / `CorpusId:` / `DBLP:`). The same id round-trips between `paper`, `citations`, and `recommendations`.

`clis/semanticscholar/semanticscholar.test.js` passes 18 / 18 locally (registry contracts + per-command success / argument rejection / EmptyResult / malformed-payload / API-key header / 429 retry), `npm run check:typed-error-lint` and `npm run check:silent-column-drop` both report `new=0`, and `scripts/check-doc-coverage.sh --strict` reports 166 / 166.
