### PR TITLE
docs(readme): recommend OpenCLIApp install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ It also works as a **CLI hub** for local tools such as `gh`, `docker`, `longbrid
 
 ### 1. Install OpenCLI
 
-OpenCLI requires **Node.js >= 20**.
+For desktop use, start with **OpenCLIApp**. It bundles the OpenCLI runtime,
+keeps the managed `opencli` command installed, and gives you a system tray UI
+for setup, diagnostics, updates, browser-login keepalive, and Web → Markdown.
+
+**Option A — OpenCLIApp (recommended for macOS / Windows):**
+Download the latest app from <https://opencli.info/download>, install it, then
+open the app once and use the System page to install or repair the `opencli`
+command.
+
+**Option B — npm global install (CLI-only / CI / servers):**
+OpenCLI requires **Node.js >= 20** when installed through npm.
 
 ```bash
 node --version

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,16 @@ OpenCLI 可以用同一套 CLI 做三类事情：
 
 ### 1. 安装 OpenCLI
 
-OpenCLI 要求 **Node.js >= 20**。
+如果你是在自己的电脑上使用，优先安装 **OpenCLIApp**。它会内置
+OpenCLI runtime，帮你安装 / 修复受管理的 `opencli` 命令，并提供系统托盘
+UI 来做环境诊断、更新、浏览器登录态保活和网页转 Markdown。
+
+**方式 A — OpenCLIApp（macOS / Windows 推荐）：**
+从 <https://opencli.info/download> 下载最新版 App，安装后打开一次，在
+System 页面安装或修复 `opencli` 命令。
+
+**方式 B — npm 全局安装（纯 CLI / CI / 服务器）：**
+通过 npm 安装时，OpenCLI 要求 **Node.js >= 20**。
 
 ```bash
 node --version


### PR DESCRIPTION
## Summary
- Add OpenCLIApp as the recommended desktop install path in the English README
- Mirror the same guidance in README.zh-CN
- Keep npm global install as the CLI-only / CI / server path

## Rationale
Desktop users should not have to discover the App only after reading npm-first setup. The App bundles the OpenCLI runtime, manages the local opencli command, and provides diagnostics/updates/browser-login keepalive/Web Markdown UI. npm remains the right path for pure CLI and automation environments.

## Validation
- git diff --check
- npm run docs:build