### PR TITLE
fix(12306): handle endpoint rotation via 302 redirects

### DIFF
--- a/clis/12306/trains.js
+++ b/clis/12306/trains.js
@@ -37,11 +37,27 @@ async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
     };
     const queryParams = `leftTicketDTO.train_date=${date}&leftTicketDTO.from_station=${fromCode}&leftTicketDTO.to_station=${toCode}&purpose_codes=ADULT`;
     let lastResponseText = '';
-    for (const endpoint of QUERY_ENDPOINTS) {
+    const queue = [...QUERY_ENDPOINTS];
+    const tried = new Set();
+    while (queue.length > 0) {
+        const endpoint = queue.shift();
+        if (tried.has(endpoint)) continue;
+        tried.add(endpoint);
         const url = `https://kyfw.12306.cn/otn/leftTicket/${endpoint}?${queryParams}`;
-        const resp = await fetch(url, { headers });
+        const resp = await fetch(url, { headers, redirect: 'manual' });
         if (!resp.ok) {
-            if (resp.status === 302) continue;
+            if (resp.status === 302) {
+                const body = await resp.text();
+                let json;
+                try { json = JSON.parse(body); } catch { /* ignore */ }
+                if (json?.c_url && typeof json.c_url === 'string') {
+                    const rotated = json.c_url.replace('leftTicket/', '').trim();
+                    if (rotated && !tried.has(rotated)) {
+                        queue.unshift(rotated);
+                    }
+                }
+                continue;
+            }
             throw new CommandExecutionError(`12306 ${endpoint} returned HTTP ${resp.status}`);
         }
         const text = await resp.text();
@@ -52,8 +68,8 @@ async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
         }
         if (json?.c_url && typeof json.c_url === 'string') {
             const rotated = json.c_url.replace('leftTicket/', '').trim();
-            if (rotated && !QUERY_ENDPOINTS.includes(rotated)) {
-                QUERY_ENDPOINTS.unshift(rotated);
+            if (rotated && !tried.has(rotated)) {
+                queue.unshift(rotated);
             }
             continue;
         }

--- a/clis/12306/trains.js
+++ b/clis/12306/trains.js
@@ -16,6 +16,7 @@ import { fetchStationBundle, mintSession, resolveStation, validateDate, parseTra
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
 const QUERY_ENDPOINTS = ['queryG', 'queryO', 'queryZ', 'queryA'];
 const MAX_LIMIT = 100;
+const QUERY_ENDPOINT_RE = /^query[A-Z]$/;
 
 function normalizeLimit(value, defaultValue, max) {
     if (value === undefined || value === null || value === '') return defaultValue;
@@ -27,6 +28,40 @@ function normalizeLimit(value, defaultValue, max) {
         throw new ArgumentError(`limit must be <= ${max}`);
     }
     return n;
+}
+
+function extractQueryEndpoint(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) return '';
+    const direct = raw.replace(/^leftTicket\//, '').trim();
+    if (QUERY_ENDPOINT_RE.test(direct)) return direct;
+    try {
+        const url = new URL(raw, 'https://kyfw.12306.cn');
+        if (url.hostname !== 'kyfw.12306.cn') return '';
+        const match = url.pathname.match(/\/leftTicket\/(query[A-Z])$/);
+        return match ? match[1] : '';
+    }
+    catch {
+        return '';
+    }
+}
+
+async function parseRotationEndpoint(resp, endpoint, bodyText) {
+    let json;
+    if (bodyText) {
+        try { json = JSON.parse(bodyText); } catch { /* body may be HTML on non-rotation redirects */ }
+    }
+    const bodyEndpoint = extractQueryEndpoint(json?.c_url);
+    if (bodyEndpoint) return bodyEndpoint;
+    const locationEndpoint = extractQueryEndpoint(resp.headers?.get?.('location'));
+    if (locationEndpoint) return locationEndpoint;
+    if (resp.status === 302) {
+        throw new CommandExecutionError(`12306 ${endpoint} redirected without a leftTicket query endpoint`);
+    }
+    if (json?.c_url) {
+        throw new CommandExecutionError(`12306 ${endpoint} returned an invalid rotation endpoint`);
+    }
+    return '';
 }
 
 async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
@@ -48,13 +83,9 @@ async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
         if (!resp.ok) {
             if (resp.status === 302) {
                 const body = await resp.text();
-                let json;
-                try { json = JSON.parse(body); } catch { /* ignore */ }
-                if (json?.c_url && typeof json.c_url === 'string') {
-                    const rotated = json.c_url.replace('leftTicket/', '').trim();
-                    if (rotated && !tried.has(rotated)) {
-                        queue.unshift(rotated);
-                    }
+                const rotated = await parseRotationEndpoint(resp, endpoint, body);
+                if (rotated && !tried.has(rotated)) {
+                    queue.unshift(rotated);
                 }
                 continue;
             }
@@ -67,7 +98,7 @@ async function queryLeftTickets(cookieHeader, fromCode, toCode, date) {
             throw new CommandExecutionError(`12306 ${endpoint} returned non-JSON body`);
         }
         if (json?.c_url && typeof json.c_url === 'string') {
-            const rotated = json.c_url.replace('leftTicket/', '').trim();
+            const rotated = await parseRotationEndpoint(resp, endpoint, text);
             if (rotated && !tried.has(rotated)) {
                 queue.unshift(rotated);
             }
@@ -132,4 +163,4 @@ cli({
     },
 });
 
-export const __test__ = { normalizeLimit, queryLeftTickets };
+export const __test__ = { normalizeLimit, extractQueryEndpoint, queryLeftTickets };

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,14 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './utils.js';
 import { __test__ as priceTest } from './price.js';
 import { __test__ as trainTest } from './train.js';
+import { __test__ as trainsTest } from './trains.js';
 import './orders.js';
 
 const { parseStationBundle, resolveStation, validateDate, buildCookieHeader, parseTrainRecord, maskEmail, maskMobile, maskChineseName, unwrapEvaluateResult, requireEvaluateObject, isAuthLikePayload } = __test__;
 const { parsePriceData, queryStopsForPrice, queryPrice, TRAIN_NO_RE: PRICE_TRAIN_NO_RE } = priceTest;
 const { queryStops, TRAIN_NO_RE: TRAIN_TRAIN_NO_RE } = trainTest;
+const { queryLeftTickets, extractQueryEndpoint } = trainsTest;
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe('12306 utils - parseStationBundle', () => {
     it('parses the `@`-delimited station bundle into structured records', () => {
@@ -271,6 +277,69 @@ describe('12306 public API typed boundaries', () => {
             .rejects.toBeInstanceOf(CommandExecutionError);
         await expect(queryPrice('cookie=1', '24000000G10L', '01', '02', 'OM9', '2026-05-22', nonJsonFetch))
             .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});
+
+describe('12306 trains endpoint rotation', () => {
+    const successBody = { data: { result: ['row|payload'] } };
+
+    it('extracts only leftTicket query endpoints from rotation hints', () => {
+        expect(extractQueryEndpoint('leftTicket/queryB')).toBe('queryB');
+        expect(extractQueryEndpoint('/otn/leftTicket/queryC')).toBe('queryC');
+        expect(extractQueryEndpoint('https://kyfw.12306.cn/otn/leftTicket/queryD')).toBe('queryD');
+        expect(extractQueryEndpoint('/otn/error.html')).toBe('');
+        expect(extractQueryEndpoint('https://example.com/leftTicket/queryB')).toBe('');
+        expect(extractQueryEndpoint('leftTicket/querybad')).toBe('');
+    });
+
+    it('follows a 302 JSON c_url rotation signal before trying fallback endpoints', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response(JSON.stringify({ c_url: 'leftTicket/queryB' }), { status: 302 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify(successBody), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(queryLeftTickets('cookie=1', 'BJP', 'AOH', '2026-05-22')).resolves.toEqual(['row|payload']);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[0][0]).toContain('/leftTicket/queryG?');
+        expect(fetchMock.mock.calls[1][0]).toContain('/leftTicket/queryB?');
+    });
+
+    it('follows a 302 Location header rotation signal when the body is not JSON', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response('<html>redirect</html>', {
+                status: 302,
+                headers: { location: '/otn/leftTicket/queryB' },
+            }))
+            .mockResolvedValueOnce(new Response(JSON.stringify(successBody), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(queryLeftTickets('cookie=1', 'BJP', 'AOH', '2026-05-22')).resolves.toEqual(['row|payload']);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1][0]).toContain('/leftTicket/queryB?');
+    });
+
+    it('typed-fails a 302 that does not identify a leftTicket query endpoint', async () => {
+        const fetchMock = vi.fn().mockResolvedValueOnce(new Response('<html>error</html>', {
+            status: 302,
+            headers: { location: '/otn/error.html' },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(queryLeftTickets('cookie=1', 'BJP', 'AOH', '2026-05-22'))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates rotation endpoints request-locally and keeps fallback bounded', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response(JSON.stringify({ c_url: 'leftTicket/queryG' }), { status: 302 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify(successBody), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(queryLeftTickets('cookie=1', 'BJP', 'AOH', '2026-05-22')).resolves.toEqual(['row|payload']);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[0][0]).toContain('/leftTicket/queryG?');
+        expect(fetchMock.mock.calls[1][0]).toContain('/leftTicket/queryO?');
     });
 });
 


### PR DESCRIPTION
## Problem

   The `opencli 12306 trains` command fails with `non-JSON body` error because:

   1. Node.js `fetch` defaults to `redirect: 'follow'`, silently following
 12306's HTTP 302 to `error.html` — returning HTML instead of JSON
   2. 12306 now returns endpoint rotation info in the **302 response body**
 (`{"c_url":"leftTicket/queryB"}`), which was never read because 302 triggered
 `continue` before reading the body
   3. Mutating `QUERY_ENDPOINTS` via `unshift()` during `for...of` iteration
 caused infinite loops

   ## Fix

   - Add `redirect: 'manual'` to prevent automatic redirect following
   - Parse `c_url` from 302 response body and enqueue the rotated endpoint
   - Replace `for...of` with a `while` queue + `Set`-based dedup

   ## Testing

 ```

 $ opencli 12306 trains 上海 南昌 --date 2026-06-25 -f plain

 Returns 72 trains successfully

 ```