### PR TITLE
feat(cli): split `opencli list` table into App vs Site sections

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -8,6 +8,7 @@ import { BrowserCommandError } from './browser/daemon-client.js';
 import type { IPage } from './types.js';
 import { TargetError } from './browser/target-errors.js';
 import { PKG_VERSION } from './version.js';
+import { classifyAdapter } from './help.js';
 
 const {
   mockBrowserConnect,
@@ -186,6 +187,115 @@ describe('createProgram root help descriptions', () => {
       // App adapters appear before Site adapters (External CLIs are absent here)
       expect(help.indexOf('App adapters')).toBeLessThan(help.indexOf('Site adapters'));
     } finally {
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
+  it('classifies local IP domains as app adapters', () => {
+    expect(classifyAdapter('localhost')).toBe('app');
+    expect(classifyAdapter('127.0.0.1')).toBe('app');
+    expect(classifyAdapter('::1')).toBe('app');
+    expect(classifyAdapter('www.bilibili.com')).toBe('site');
+  });
+
+  it('splits list table output into App and Site sections without changing per-site rows', async () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const restoreStdoutSpy = () => stdoutSpy.mockImplementation(() => {});
+    registry.clear();
+    try {
+      cli({
+        site: 'antigravity',
+        name: 'history',
+        access: 'read',
+        description: 'Read Antigravity history',
+        domain: '127.0.0.1',
+        strategy: Strategy.UI,
+        browser: true,
+      });
+      cli({
+        site: 'chatwise',
+        name: 'ask',
+        access: 'write',
+        description: 'Ask Chatwise desktop app',
+        domain: 'localhost',
+        strategy: Strategy.UI,
+        browser: true,
+      });
+      cli({
+        site: 'bilibili',
+        name: 'hot',
+        access: 'read',
+        description: 'Bilibili hot videos',
+        domain: 'www.bilibili.com',
+        strategy: Strategy.PUBLIC,
+        browser: false,
+      });
+
+      const program = createProgram('', '');
+      await program.parseAsync(['node', 'opencli', 'list']);
+      const output = stdoutSpy.mock.calls.flat().join('\n');
+
+      expect(output).toContain('App adapters');
+      expect(output).toContain('Site adapters');
+      expect(output.indexOf('App adapters')).toBeLessThan(output.indexOf('Site adapters'));
+      expect(output).toMatch(/App adapters[\s\S]*antigravity[\s\S]*history \[ui\] — Read Antigravity history/);
+      expect(output).toMatch(/App adapters[\s\S]*chatwise[\s\S]*ask \[ui\] — Ask Chatwise desktop app/);
+      expect(output).toMatch(/Site adapters[\s\S]*bilibili[\s\S]*hot \[public\] — Bilibili hot videos/);
+      expect(output).toContain('3 built-in commands across 2 apps + 1 sites,');
+    } finally {
+      restoreStdoutSpy();
+      stdoutSpy.mockClear();
+      registry.clear();
+      for (const [key, value] of snapshot) registry.set(key, value);
+    }
+  });
+
+  it('omits empty list table sections and leaves structured list rows unchanged', async () => {
+    const registry = getRegistry();
+    const snapshot = new Map(registry);
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const restoreStdoutSpy = () => stdoutSpy.mockImplementation(() => {});
+    registry.clear();
+    try {
+      cli({
+        site: 'bilibili',
+        name: 'hot',
+        access: 'read',
+        description: 'Bilibili hot videos',
+        domain: 'www.bilibili.com',
+        strategy: Strategy.PUBLIC,
+        browser: false,
+        columns: ['title', 'url'],
+      });
+
+      const tableProgram = createProgram('', '');
+      await tableProgram.parseAsync(['node', 'opencli', 'list']);
+      const tableOutput = stdoutSpy.mock.calls.flat().join('\n');
+      expect(tableOutput).not.toContain('App adapters');
+      expect(tableOutput).toContain('Site adapters');
+      expect(tableOutput).toContain('1 built-in commands across 0 apps + 1 sites,');
+
+      stdoutSpy.mockClear();
+      const jsonProgram = createProgram('', '');
+      await jsonProgram.parseAsync(['node', 'opencli', 'list', '-f', 'json']);
+      const jsonOutput = stdoutSpy.mock.calls.flat().join('\n');
+      const rows = JSON.parse(jsonOutput);
+      expect(rows).toMatchObject([
+        {
+          site: 'bilibili',
+          name: 'hot',
+          domain: 'www.bilibili.com',
+          columns: ['title', 'url'],
+        },
+      ]);
+      expect(rows[0]).not.toHaveProperty('adapterKind');
+      expect(rows[0]).not.toHaveProperty('section');
+    } finally {
+      restoreStdoutSpy();
+      stdoutSpy.mockClear();
       registry.clear();
       for (const [key, value] of snapshot) registry.set(key, value);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -737,8 +737,8 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
       }
 
       // Table (default) — grouped by adapter kind (app vs site), then by site name.
-      // classifyAdapter() reads the `domain` field: DNS-style domains (containing
-      // a dot) are sites; everything else (localhost, IPs, bare names) is an app.
+      // classifyAdapter() reads the `domain` field: DNS-style domains are sites;
+      // localhost/loopback endpoints and bare app names are apps.
       const appsBySite = new Map<string, CliCommand[]>();
       const sitesBySite = new Map<string, CliCommand[]>();
       for (const cmd of commands) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -736,18 +736,19 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         return;
       }
 
-      // Table (default) — grouped by site
-      const sites = new Map<string, CliCommand[]>();
+      // Table (default) — grouped by adapter kind (app vs site), then by site name.
+      // classifyAdapter() reads the `domain` field: DNS-style domains (containing
+      // a dot) are sites; everything else (localhost, IPs, bare names) is an app.
+      const appsBySite = new Map<string, CliCommand[]>();
+      const sitesBySite = new Map<string, CliCommand[]>();
       for (const cmd of commands) {
-        const g = sites.get(cmd.site) ?? [];
+        const target = classifyAdapter(cmd.domain) === 'app' ? appsBySite : sitesBySite;
+        const g = target.get(cmd.site) ?? [];
         g.push(cmd);
-        sites.set(cmd.site, g);
+        target.set(cmd.site, g);
       }
 
-      console.log();
-      console.log('  opencli' + ' — available commands');
-      console.log();
-      for (const [site, cmds] of sites) {
+      const renderSiteGroup = (site: string, cmds: CliCommand[]): void => {
         console.log(`  ${site}`);
         for (const cmd of cmds) {
           const label = strategyLabel(cmd);
@@ -758,6 +759,22 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
           console.log(`    ${cmd.name} ${tag}${aliases}${cmd.description ? ` — ${cmd.description}` : ''}`);
         }
         console.log();
+      };
+
+      console.log();
+      console.log('  opencli' + ' — available commands');
+      console.log();
+
+      if (appsBySite.size > 0) {
+        console.log('  App adapters');
+        console.log();
+        for (const [site, cmds] of appsBySite) renderSiteGroup(site, cmds);
+      }
+
+      if (sitesBySite.size > 0) {
+        console.log('  Site adapters');
+        console.log();
+        for (const [site, cmds] of sitesBySite) renderSiteGroup(site, cmds);
       }
 
       const externalClis = loadExternalClis();
@@ -771,7 +788,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
         console.log();
       }
 
-      console.log(`  ${commands.length} built-in commands across ${sites.size} sites, ${externalClis.length} external CLIs`);
+      console.log(`  ${commands.length} built-in commands across ${appsBySite.size} apps + ${sitesBySite.size} sites, ${externalClis.length} external CLIs`);
       console.log();
     });
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -132,7 +132,7 @@ export function wrapCommaList(
  *
  * - `site`: web site adapter (real DNS-style domain, e.g. `www.bilibili.com`)
  * - `app`: desktop app adapter (Electron/osascript, signaled by `domain: 'localhost'`
- *   or other non-DNS string like `'doubao-app'`)
+ *   or other non-DNS/local endpoint string like `'127.0.0.1'` / `'doubao-app'`)
  *
  * Classification is derived from the adapter's `domain` field — no new schema
  * required. Adapters without a `domain` field default to `site` (most are
@@ -140,8 +140,17 @@ export function wrapCommaList(
  */
 export type AdapterKind = 'site' | 'app';
 
+function isLocalIpDomain(domain: string): boolean {
+  if (domain === '::1' || domain === '[::1]') return true;
+  const parts = domain.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every(part => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255)
+    && Number(parts[0]) === 127;
+}
+
 export function classifyAdapter(domain: string | undefined): AdapterKind {
   if (!domain) return 'site';
+  if (isLocalIpDomain(domain)) return 'app';
   return domain.includes('.') ? 'site' : 'app';
 }
 


### PR DESCRIPTION
## Summary

Per @WAWQAQ: `opencli list` (default table format) grouped every adapter under a flat `site:` heading. Desktop-app adapters like `trae-cn` / `cursor` / `codex` looked identical to web-site adapters like `bilibili` or `twitter` — a user couldn't tell apart "drives a real browser session" from "Electron app via CDP".

`opencli --help` already classifies adapters via `classifyAdapter(domain)` (from `src/help.ts`), splitting into **App adapters** and **Site adapters** sections. `opencli list` was the lone outlier still using the flat layout.

## What changed

Mirror that classification in the `list` table renderer:

- Partition commands by `classifyAdapter(cmd.domain)` into `appsBySite` vs `sitesBySite`.
- Render section headers (`App adapters` / `Site adapters`) before each group; per-site layout under each header is unchanged.
- Update the footer from `... across N sites, M external CLIs` to `... across X apps + Y sites, M external CLIs` so the split is visible numerically.
- Skip empty sections — a user with no Electron apps registered won't see a stray "App adapters" header.

Non-table formats (`json` / `yaml` / `md` / `csv`) are unchanged; structured consumers already get the `domain` field per row and can re-classify themselves.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [x] ♻️ Refactor (UX-level: reorganizes existing data)

## Tests

- `npx tsc --noEmit` — clean.
- `npx vitest run --project unit src/cli.test.ts` — 157/163 same as `main`. The 6 failing browser-tab targeting tests are unrelated and pre-existing on `main` at `7af50abd`.
- `classifyAdapter()` itself has dedicated coverage in `src/help.test.ts` (`'localhost' → 'app'`, `'www.bilibili.com' → 'site'`, etc.).

## Adjacent note (not in this PR)

`classifyAdapter` uses `domain.includes('.')` as the site heuristic. That misclassifies IP-address domains (e.g. `antigravity` ships `domain: '127.0.0.1'`) as `site` even though they're Electron apps over CDP. Worth a follow-up PR to tighten the classifier — out of scope here to keep the diff focused on the list-table presentation.