### PR TITLE
feat(bilibili): 给 video / subtitle / download 加 --page 支持分P选集

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3546,6 +3546,12 @@
         "default": false,
         "required": false,
         "help": "跳过付费内容预检直接下载（已购买/已充电/已开通会员时用）"
+      },
+      {
+        "name": "page",
+        "type": "str",
+        "required": false,
+        "help": "分P 选集序号（从 1 开始）。多 P 视频下载该集；缺省下载默认 P1"
       }
     ],
     "columns": [
@@ -3993,6 +3999,12 @@
         "type": "str",
         "required": false,
         "help": "字幕语言代码 (如 zh-CN, en-US, ai-zh)，默认取第一个"
+      },
+      {
+        "name": "page",
+        "type": "str",
+        "required": false,
+        "help": "分P 选集序号（从 1 开始）。多 P 视频取该集字幕；缺省取默认 P1"
       }
     ],
     "columns": [
@@ -4125,6 +4137,12 @@
         "required": true,
         "positional": true,
         "help": "BV ID, video URL, or b23.tv short link"
+      },
+      {
+        "name": "page",
+        "type": "str",
+        "required": false,
+        "help": "分P 选集序号（从 1 开始）。多 P 视频指定某一集，title/cid 返回该集；缺省取整集默认（P1）"
       }
     ],
     "columns": [

--- a/clis/bilibili/download.js
+++ b/clis/bilibili/download.js
@@ -11,7 +11,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
 import { checkYtdlp, sanitizeFilename } from '@jackwener/opencli/download';
 import { downloadMedia } from '@jackwener/opencli/download/media-download';
-import { apiGet, resolveBvid } from './utils.js';
+import { apiGet, resolveBvid, parsePageArg } from './utils.js';
 
 const PAYMENT_LABELS = {
     vip: '大会员专享/付费 OGV',
@@ -90,12 +90,18 @@ cli({
         { name: 'output', default: './bilibili-downloads', help: 'Output directory' },
         { name: 'quality', default: 'best', help: 'Video quality (best, 1080p, 720p, 480p)' },
         { name: 'force', type: 'boolean', default: false, help: '跳过付费内容预检直接下载（已购买/已充电/已开通会员时用）' },
+        { name: 'page', required: false, help: '分P 选集序号（从 1 开始）。多 P 视频下载该集；缺省下载默认 P1' },
     ],
     columns: ['bvid', 'title', 'status', 'size'],
     func: async (page, kwargs) => {
         const bvid = await resolveBvid(kwargs.bvid);
         const output = kwargs.output;
         const quality = kwargs.quality;
+        const selectedPage = parsePageArg(kwargs.page);
+        // yt-dlp 原生支持分P URL（?p=N），直接拼到 watch URL 即可定位到该集。
+        const watchUrl = selectedPage != null
+            ? `https://www.bilibili.com/video/${bvid}?p=${selectedPage}`
+            : `https://www.bilibili.com/video/${bvid}`;
         // Check yt-dlp availability
         if (!checkYtdlp()) {
             return [{
@@ -105,8 +111,8 @@ cli({
                     size: 'yt-dlp not installed. Run: pip install yt-dlp',
                 }];
         }
-        // Navigate to video page to get title and cookies
-        await page.goto(`https://www.bilibili.com/video/${bvid}`);
+        // Navigate to video page to get title and cookies（分P 时定位到该集）
+        await page.goto(watchUrl);
         await page.wait(3);
         // 付费内容预检（--force 跳过）
         if (!kwargs.force) {
@@ -134,8 +140,8 @@ cli({
         else if (quality === '480p') {
             format = 'bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[height<=480]';
         }
-        const videoUrl = `https://www.bilibili.com/video/${bvid}`;
-        const filename = `${bvid}_${title}.mp4`;
+        const videoUrl = watchUrl;
+        const filename = selectedPage != null ? `${bvid}_p${selectedPage}_${title}.mp4` : `${bvid}_${title}.mp4`;
         const results = await downloadMedia([{ type: 'video-ytdlp', url: videoUrl, filename }], {
             output,
             browserCookies,

--- a/clis/bilibili/download.js
+++ b/clis/bilibili/download.js
@@ -11,7 +11,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
 import { checkYtdlp, sanitizeFilename } from '@jackwener/opencli/download';
 import { downloadMedia } from '@jackwener/opencli/download/media-download';
-import { apiGet, resolveBvid, parsePageArg } from './utils.js';
+import { apiGet, resolveBvid, parsePageArg, selectVideoPart } from './utils.js';
 
 const PAYMENT_LABELS = {
     vip: '大会员专享/付费 OGV',
@@ -78,6 +78,21 @@ async function assertNotPaidContent(page, bvid) {
         EXIT_CODES.NOPERM,
     );
 }
+
+async function loadSelectedPart(page, bvid, pageNum) {
+    let payload;
+    try {
+        payload = await apiGet(page, '/x/web-interface/view', { params: { bvid } });
+    }
+    catch (error) {
+        throw new CommandExecutionError(`获取视频分P信息失败: ${error?.message || error}`);
+    }
+    if (!isObject(payload) || payload.code !== 0) {
+        throw new CommandExecutionError(`获取视频分P信息失败: ${payload?.message ?? 'unknown'} (${payload?.code ?? 'malformed'})`);
+    }
+    return selectVideoPart(payload.data, pageNum);
+}
+
 cli({
     site: 'bilibili',
     name: 'download',
@@ -98,6 +113,7 @@ cli({
         const output = kwargs.output;
         const quality = kwargs.quality;
         const selectedPage = parsePageArg(kwargs.page);
+        const selectedPart = selectedPage != null ? await loadSelectedPart(page, bvid, selectedPage) : null;
         // yt-dlp 原生支持分P URL（?p=N），直接拼到 watch URL 即可定位到该集。
         const watchUrl = selectedPage != null
             ? `https://www.bilibili.com/video/${bvid}?p=${selectedPage}`
@@ -126,7 +142,9 @@ cli({
         return { title, author };
       })()
     `);
-        const title = sanitizeFilename(data?.title || 'video');
+        const partTitle = typeof selectedPart?.part === 'string' ? selectedPart.part.trim() : '';
+        const displayTitle = partTitle || data?.title || 'video';
+        const title = sanitizeFilename(displayTitle);
         // Extract cookies for yt-dlp
         const browserCookies = await page.getCookies({ domain: 'bilibili.com' });
         // Build yt-dlp format string based on quality
@@ -152,7 +170,7 @@ cli({
         const r = results[0] || { status: 'failed', size: '-' };
         return [{
                 bvid,
-                title: data?.title || 'video',
+                title: displayTitle,
                 status: r.status,
                 size: r.size,
             }];

--- a/clis/bilibili/download.test.js
+++ b/clis/bilibili/download.test.js
@@ -117,4 +117,27 @@ describe('bilibili download paid-content pre-check', () => {
     expect(rows[0].status).toBe('success');
     expect(mockDownloadMedia).toHaveBeenCalledTimes(1);
   });
+
+  it('targets the selected 分P part URL (?p=N) when --page is given', async () => {
+    mockApiGet.mockResolvedValueOnce(viewPayload());
+
+    await command.func(page, { bvid: 'BV1h6V16SEpg', output: './o', quality: 'best', force: false, page: '3' });
+
+    // goto 与 yt-dlp 下载 URL 都应带 ?p=3
+    expect(page.goto).toHaveBeenCalledWith('https://www.bilibili.com/video/BV1h6V16SEpg?p=3');
+    const job = mockDownloadMedia.mock.calls[0][0][0];
+    expect(job.url).toBe('https://www.bilibili.com/video/BV1h6V16SEpg?p=3');
+    expect(job.filename).toContain('_p3_');
+  });
+
+  it('downloads default P1 (no ?p=) when --page is omitted', async () => {
+    mockApiGet.mockResolvedValueOnce(viewPayload());
+
+    await command.func(page, { bvid: 'BV1xx411c7mD', output: './o', quality: 'best', force: false });
+
+    expect(page.goto).toHaveBeenCalledWith('https://www.bilibili.com/video/BV1xx411c7mD');
+    const job = mockDownloadMedia.mock.calls[0][0][0];
+    expect(job.url).toBe('https://www.bilibili.com/video/BV1xx411c7mD');
+    expect(job.filename).not.toContain('_p');
+  });
 });

--- a/clis/bilibili/download.test.js
+++ b/clis/bilibili/download.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CliError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 const { mockApiGet, mockDownloadMedia, mockCheckYtdlp } = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
@@ -119,7 +119,14 @@ describe('bilibili download paid-content pre-check', () => {
   });
 
   it('targets the selected 分P part URL (?p=N) when --page is given', async () => {
-    mockApiGet.mockResolvedValueOnce(viewPayload());
+    mockApiGet
+      .mockResolvedValueOnce(viewPayload({
+        pages: [
+          { cid: 1001, page: 1, part: 'P1' },
+          { cid: 1003, page: 3, part: 'P3 标题' },
+        ],
+      }))
+      .mockResolvedValueOnce(viewPayload());
 
     await command.func(page, { bvid: 'BV1h6V16SEpg', output: './o', quality: 'best', force: false, page: '3' });
 
@@ -127,7 +134,30 @@ describe('bilibili download paid-content pre-check', () => {
     expect(page.goto).toHaveBeenCalledWith('https://www.bilibili.com/video/BV1h6V16SEpg?p=3');
     const job = mockDownloadMedia.mock.calls[0][0][0];
     expect(job.url).toBe('https://www.bilibili.com/video/BV1h6V16SEpg?p=3');
-    expect(job.filename).toContain('_p3_');
+    expect(job.filename).toContain('_p3_P3 标题');
+  });
+
+  it('rejects malformed --page before download side effects', async () => {
+    await expect(
+      command.func(page, { bvid: 'BV1h6V16SEpg', output: './o', quality: 'best', force: false, page: '1e2' }),
+    ).rejects.toBeInstanceOf(ArgumentError);
+
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockApiGet).not.toHaveBeenCalled();
+    expect(mockDownloadMedia).not.toHaveBeenCalled();
+  });
+
+  it('fails before yt-dlp when selected --page is absent from view API pages', async () => {
+    mockApiGet.mockResolvedValueOnce(viewPayload({
+      pages: [{ cid: 1001, page: 1, part: 'P1' }],
+    }));
+
+    await expect(
+      command.func(page, { bvid: 'BV1h6V16SEpg', output: './o', quality: 'best', force: false, page: '9' }),
+    ).rejects.toBeInstanceOf(CommandExecutionError);
+
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockDownloadMedia).not.toHaveBeenCalled();
   });
 
   it('downloads default P1 (no ?p=) when --page is omitted', async () => {

--- a/clis/bilibili/subtitle.js
+++ b/clis/bilibili/subtitle.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { apiGet, resolveBvid } from './utils.js';
+import { apiGet, resolveBvid, parsePageArg, selectVideoPart } from './utils.js';
 cli({
     site: 'bilibili',
     name: 'subtitle',
@@ -11,12 +11,14 @@ cli({
     args: [
         { name: 'bvid', required: true, positional: true, help: 'Bilibili 视频 BV ID（如 BV1xx411c7mD），或视频 URL / b23.tv 短链' },
         { name: 'lang', required: false, help: '字幕语言代码 (如 zh-CN, en-US, ai-zh)，默认取第一个' },
+        { name: 'page', required: false, help: '分P 选集序号（从 1 开始）。多 P 视频取该集字幕；缺省取默认 P1' },
     ],
     columns: ['index', 'from', 'to', 'content'],
     func: async (page, kwargs) => {
         if (!page)
             throw new CommandExecutionError('Browser session required for bilibili subtitle');
         const bvid = await resolveBvid(kwargs.bvid);
+        const selectedPage = parsePageArg(kwargs.page);
         // 1. 通过 view API 拿 cid。
         //    以前的实现走 page.goto(/video/<bvid>) + window.__INITIAL_STATE__.videoData.cid，
         //    bangumi 绑定的 bvid（番剧/纪录片/电影/综艺）页面 state 不在 videoData 而在 epList，
@@ -31,7 +33,8 @@ cli({
         if (view?.code !== 0) {
             throw new CommandExecutionError(`获取视频信息失败: ${view?.message ?? 'unknown'} (${view?.code})`);
         }
-        const cid = view?.data?.cid;
+        // --page 给定时用该集 cid（selectVideoPart 越界抛错）；缺省取整集默认 cid（P1，旧行为）。
+        const cid = selectedPage != null ? selectVideoPart(view?.data, selectedPage).cid : view?.data?.cid;
         if (!cid) {
             throw new CommandExecutionError(`无法从 view API 拿到 cid (bvid=${bvid})`);
         }

--- a/clis/bilibili/subtitle.test.js
+++ b/clis/bilibili/subtitle.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 const { mockApiGet } = vi.hoisted(() => ({
     mockApiGet: vi.fn(),
 }));
@@ -190,6 +190,11 @@ describe('bilibili subtitle', () => {
             data: { bvid: 'BV1h6V16SEpg', cid: 1001, pages: [{ cid: 1001, page: 1, part: '01' }] },
         });
         await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '9' })).rejects.toThrow(CommandExecutionError);
+    });
+
+    it('rejects malformed --page before querying subtitle APIs', async () => {
+        await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '1e2' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(mockApiGet).not.toHaveBeenCalled();
     });
 
     it('works for bangumi-bound bvid (PGC content) — same code path, view API returns cid + redirect_url', async () => {

--- a/clis/bilibili/subtitle.test.js
+++ b/clis/bilibili/subtitle.test.js
@@ -153,6 +153,45 @@ describe('bilibili subtitle', () => {
         await expect(command.func(page, { bvid: 'BV1GbXPBeEZm' })).rejects.toThrow(CommandExecutionError);
     });
 
+    it('uses the selected 分P part cid when --page is given', async () => {
+        // view 返回 pages 数组；--page 3 应改用 pages[2].cid，而非 data.cid（默认 P1）
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                bvid: 'BV1h6V16SEpg',
+                cid: 1001, // P1 默认 cid
+                pages: [
+                    { cid: 1001, page: 1, part: '01' },
+                    { cid: 1002, page: 2, part: '02' },
+                    { cid: 1003, page: 3, part: '03 人生的价值' },
+                ],
+            },
+        });
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: {
+                need_login_subtitle: false,
+                subtitle: { subtitles: [{ lan: 'zh-CN', subtitle_url: '//example.com/sub.json' }] },
+            },
+        });
+        page.evaluate.mockResolvedValueOnce({ success: true, data: [{ from: 0, to: 1, content: 'a' }] });
+
+        await command.func(page, { bvid: 'BV1h6V16SEpg', page: '3' });
+
+        // 第二发 apiGet（player/wbi/v2）的 cid 必须是第 3 集的 1003
+        const playerCall = mockApiGet.mock.calls[1];
+        expect(playerCall[1]).toBe('/x/player/wbi/v2');
+        expect(playerCall[2]?.params?.cid).toBe(1003);
+    });
+
+    it('throws CommandExecutionError when --page is out of range', async () => {
+        mockApiGet.mockResolvedValueOnce({
+            code: 0,
+            data: { bvid: 'BV1h6V16SEpg', cid: 1001, pages: [{ cid: 1001, page: 1, part: '01' }] },
+        });
+        await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '9' })).rejects.toThrow(CommandExecutionError);
+    });
+
     it('works for bangumi-bound bvid (PGC content) — same code path, view API returns cid + redirect_url', async () => {
         // 回归保护：以前 page.goto(/video/<bvid>) 对 bangumi 走重定向，
         // window.__INITIAL_STATE__.videoData 不存在 → SELECTOR 错。view API 不依赖页面结构，bangumi 同样能拿 cid。

--- a/clis/bilibili/utils.js
+++ b/clis/bilibili/utils.js
@@ -2,7 +2,7 @@
  * Bilibili shared helpers: WBI signing, authenticated fetch, nav data, UID resolution.
  */
 import https from 'node:https';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 /**
  * Resolve Bilibili short URL / short code to BV ID.
  * Supports: BV1MV9NBtENN, XYzsqGa, b23.tv/XYzsqGa, https://b23.tv/XYzsqGa
@@ -50,29 +50,64 @@ export function resolveBvid(input) {
 /**
  * 解析 --page 选集序号（分P / 视频选集）。
  * 缺省/空串 → null（不下钻，保持整集默认 P1 旧行为）。
- * 非正整数 → 抛 CommandExecutionError（结构化报错，不静默吞）。
+ * 非正十进制整数 → 抛 ArgumentError（参数错误，不静默吞）。
  */
 export function parsePageArg(value) {
-    if (value == null || String(value).trim() === '') return null;
-    const n = Number(String(value).trim());
-    if (!Number.isInteger(n) || n < 1) {
-        throw new CommandExecutionError(`--page 必须是从 1 开始的正整数，收到：${value}`);
+    if (value == null || value === '') return null;
+    if (typeof value === 'number') {
+        if (Number.isSafeInteger(value) && value >= 1) return value;
+        throw new ArgumentError(`--page must be a positive decimal integer, got: ${value}`);
+    }
+    if (typeof value !== 'string' || !/^[1-9]\d*$/.test(value)) {
+        throw new ArgumentError(`--page must be a positive decimal integer, got: ${String(value)}`);
+    }
+    const n = Number(value);
+    if (!Number.isSafeInteger(n)) {
+        throw new ArgumentError(`--page is too large: ${value}`);
     }
     return n;
 }
 
+function readApiPositiveInteger(value, label) {
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) {
+        return value;
+    }
+    if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) {
+        const n = Number(value);
+        if (Number.isSafeInteger(n)) return n;
+    }
+    throw new CommandExecutionError(`Bilibili view API returned a malformed ${label}`);
+}
+
 /**
  * 从 view API 的 data.pages 数组取第 N 集（1-based）。
- * 优先按 page 字段匹配，回退到下标 N-1。越界抛 CommandExecutionError。
+ * page/cid 都以 view API 的 pages[] 为 source-of-truth；缺失、重复或畸形都 fail closed。
  * 返回该集 raw 对象（含 cid / part(分集标题) / page / duration）。
  */
 export function selectVideoPart(viewData, pageNum) {
-    const pages = Array.isArray(viewData?.pages) ? viewData.pages : [];
-    const part = pages.find((p) => Number(p?.page) === pageNum) ?? pages[pageNum - 1];
-    if (!part || part.cid == null) {
+    const pages = Array.isArray(viewData?.pages) ? viewData.pages : null;
+    if (!pages || pages.length === 0) {
+        throw new CommandExecutionError('Bilibili view API did not return pages[] for --page selection');
+    }
+    const matches = [];
+    for (const entry of pages) {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+            throw new CommandExecutionError('Bilibili view API returned a malformed pages[] entry');
+        }
+        const apiPage = readApiPositiveInteger(entry.page, 'page number');
+        if (apiPage === pageNum) {
+            matches.push(entry);
+        }
+    }
+    if (matches.length > 1) {
+        throw new CommandExecutionError(`Bilibili view API returned duplicate page entries for p=${pageNum}`);
+    }
+    const part = matches[0];
+    if (!part) {
         const total = pages.length || viewData?.videos || 1;
         throw new CommandExecutionError(`分P 序号超出范围：p=${pageNum}（该视频共 ${total} 集）`);
     }
+    readApiPositiveInteger(part.cid, `cid for p=${pageNum}`);
     return part;
 }
 

--- a/clis/bilibili/utils.js
+++ b/clis/bilibili/utils.js
@@ -47,6 +47,35 @@ export function resolveBvid(input) {
         req.setTimeout(4000, () => { req.destroy(); reject(new Error(`Timeout resolving short URL: ${trimmed}`)); });
     });
 }
+/**
+ * 解析 --page 选集序号（分P / 视频选集）。
+ * 缺省/空串 → null（不下钻，保持整集默认 P1 旧行为）。
+ * 非正整数 → 抛 CommandExecutionError（结构化报错，不静默吞）。
+ */
+export function parsePageArg(value) {
+    if (value == null || String(value).trim() === '') return null;
+    const n = Number(String(value).trim());
+    if (!Number.isInteger(n) || n < 1) {
+        throw new CommandExecutionError(`--page 必须是从 1 开始的正整数，收到：${value}`);
+    }
+    return n;
+}
+
+/**
+ * 从 view API 的 data.pages 数组取第 N 集（1-based）。
+ * 优先按 page 字段匹配，回退到下标 N-1。越界抛 CommandExecutionError。
+ * 返回该集 raw 对象（含 cid / part(分集标题) / page / duration）。
+ */
+export function selectVideoPart(viewData, pageNum) {
+    const pages = Array.isArray(viewData?.pages) ? viewData.pages : [];
+    const part = pages.find((p) => Number(p?.page) === pageNum) ?? pages[pageNum - 1];
+    if (!part || part.cid == null) {
+        const total = pages.length || viewData?.videos || 1;
+        throw new CommandExecutionError(`分P 序号超出范围：p=${pageNum}（该视频共 ${total} 集）`);
+    }
+    return part;
+}
+
 const MIXIN_KEY_ENC_TAB = [
     46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49,
     33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40,

--- a/clis/bilibili/utils.test.js
+++ b/clis/bilibili/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { resolveBvid, resolveUid } from './utils.js';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { parsePageArg, resolveBvid, resolveUid, selectVideoPart } from './utils.js';
 describe('resolveBvid', () => {
     it('passes through a valid BV ID', async () => {
         expect(await resolveBvid('BV1MV9NBtENN')).toBe('BV1MV9NBtENN');
@@ -57,5 +57,41 @@ describe('resolveUid', () => {
     it('keeps explicit no-user result as EmptyResultError', async () => {
         await expect(resolveUid(pageWithUserSearchResult({ code: 0, data: { result: [] } }), 'nobody'))
             .rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('parsePageArg', () => {
+    it('accepts omitted page and strict positive decimal integers', () => {
+        expect(parsePageArg(undefined)).toBeNull();
+        expect(parsePageArg(null)).toBeNull();
+        expect(parsePageArg('')).toBeNull();
+        expect(parsePageArg('1')).toBe(1);
+        expect(parsePageArg('12')).toBe(12);
+        expect(parsePageArg(3)).toBe(3);
+    });
+
+    it('rejects malformed or coerced page values as argument errors', () => {
+        for (const value of ['0', '-1', '1.5', '1e2', '0x10', ' 1 ', '01', 'abc', Number.NaN, 1.2]) {
+            expect(() => parsePageArg(value)).toThrow(ArgumentError);
+        }
+    });
+});
+
+describe('selectVideoPart', () => {
+    it('selects by unique API page number and preserves cid', () => {
+        const part = selectVideoPart({
+            pages: [
+                { page: 1, cid: 1001, part: 'P1' },
+                { page: 3, cid: '1003', part: 'P3' },
+            ],
+        }, 3);
+        expect(part).toMatchObject({ page: 3, cid: '1003', part: 'P3' });
+    });
+
+    it('fails closed for missing, duplicate, or malformed page identity', () => {
+        expect(() => selectVideoPart({ pages: [] }, 1)).toThrow(CommandExecutionError);
+        expect(() => selectVideoPart({ pages: [{ page: 1, cid: 1 }, { page: 1, cid: 2 }] }, 1)).toThrow(CommandExecutionError);
+        expect(() => selectVideoPart({ pages: [{ page: '1e0', cid: 1 }] }, 1)).toThrow(CommandExecutionError);
+        expect(() => selectVideoPart({ pages: [{ page: 1, cid: 0 }] }, 1)).toThrow(CommandExecutionError);
     });
 });

--- a/clis/bilibili/video.js
+++ b/clis/bilibili/video.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { apiGet, resolveBvid } from './utils.js';
+import { apiGet, resolveBvid, parsePageArg, selectVideoPart } from './utils.js';
 
 function requireObject(value, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -37,12 +37,16 @@ cli({
   strategy: Strategy.COOKIE,
   args: [
     { name: 'bvid', required: true, positional: true, help: 'BV ID, video URL, or b23.tv short link' },
+    { name: 'page', required: false, help: '分P 选集序号（从 1 开始）。多 P 视频指定某一集，title/cid 返回该集；缺省取整集默认（P1）' },
   ],
   columns: ['field', 'value'],
   func: async (page, kwargs) => {
     if (!page) {
       throw new CommandExecutionError('Browser session required for bilibili video');
     }
+
+    // 选集序号（--page）：缺省 null = 不下钻分P，保持整集（P1）旧行为。
+    const selectedPage = parsePageArg(kwargs.page);
 
     // Resolve BV ID from three advertised input forms:
     //   1. Bare "BV..." id
@@ -92,14 +96,31 @@ cli({
     const redirectUrl = readOptionalString(d.redirect_url, 'Bilibili redirect_url');
 
     const pubDate = d.pubdate ? new Date(d.pubdate * 1000).toISOString().slice(0, 16).replace('T', ' ') : '';
-    const dur = d.duration || 0;
+
+    // 选集下钻：--page 给定时从 data.pages 取该集，title 用分集标题（part），
+    // 越界由 selectVideoPart 抛结构化错。缺省保持整集 title = d.title（旧行为不变）。
+    let title = d.title ?? '';
+    let partCid = '';
+    let partDur = d.duration || 0;
+    if (selectedPage != null) {
+      const part = selectVideoPart(d, selectedPage);
+      partCid = String(part.cid ?? '');
+      const partTitle = typeof part.part === 'string' ? part.part.trim() : '';
+      title = partTitle || `${d.title ?? ''} P${selectedPage}`;
+      // 分集时长（pages[].duration）比整集 d.duration 更贴合该集；缺则回退整集。
+      if (Number.isFinite(Number(part.duration)) && Number(part.duration) > 0) {
+        partDur = Number(part.duration);
+      }
+    }
+
+    const dur = partDur || 0;
     const mm = Math.floor(dur / 60);
     const ss = dur % 60;
 
-    return [
+    const rows = [
       { field: 'bvid',         value: d.bvid ?? '' },
       { field: 'aid',          value: String(d.aid ?? '') },
-      { field: 'title',        value: d.title ?? '' },
+      { field: 'title',        value: title },
       { field: 'author',       value: owner.name ? `${owner.name} (mid: ${owner.mid})` : '' },
       { field: 'category',     value: d.tname_v2 || d.tname || '' },
       { field: 'publish_time', value: pubDate },
@@ -120,5 +141,15 @@ cli({
       { field: 'pay_preview',      value: String(payPreview) },
       { field: 'redirect_url',     value: redirectUrl },
     ];
+
+    // --page 时透出分集专属字段：page（选集序号）、cid（该集弹幕/字幕轴 id）、
+    // series_title（整集标题，给下游做"分集标题为空"兜底）。缺省不加，保持旧输出。
+    if (selectedPage != null) {
+      rows.push({ field: 'page',         value: String(selectedPage) });
+      rows.push({ field: 'cid',          value: partCid });
+      rows.push({ field: 'series_title', value: d.title ?? '' });
+    }
+
+    return rows;
   },
 });

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -210,6 +210,85 @@ describe('bilibili video', () => {
     await expect(command.func(page, { bvid: 'BV1xx411c7mD' })).rejects.toBeInstanceOf(CommandExecutionError);
   });
 
+  it('selects a specific 分P part via --page: title=part, plus cid/page/series_title fields', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        bvid: 'BV1h6V16SEpg',
+        title: '《道德经的奥秘》',
+        stat: {},
+        owner: { mid: 1, name: 'UP' },
+        desc: '',
+        rights: {},
+        videos: 21,
+        pages: [
+          { cid: 1001, page: 1, part: '01 上士闻道', duration: 1391 },
+          { cid: 1002, page: 2, part: '02 上士闻道', duration: 1391 },
+          { cid: 1003, page: 3, part: '03 人生的价值', duration: 1391 },
+        ],
+      },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1h6V16SEpg', page: '3' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+
+    expect(byField.title).toBe('03 人生的价值');
+    expect(byField.cid).toBe('1003');
+    expect(byField.page).toBe('3');
+    expect(byField.series_title).toBe('《道德经的奥秘》');
+    expect(byField.parts).toBe('21');
+    expect(byField.duration).toBe('23m11s (1391s)');
+  });
+
+  it('falls back to "<series> P<n>" when the part has no title', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        bvid: 'BV1h6V16SEpg', title: '合集标题', stat: {}, owner: {}, desc: '', rights: {},
+        videos: 2,
+        pages: [
+          { cid: 1, page: 1, part: '', duration: 60 },
+          { cid: 2, page: 2, part: '   ', duration: 60 },
+        ],
+      },
+    });
+
+    const rows = await command.func(page, { bvid: 'BV1h6V16SEpg', page: '2' });
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    expect(byField.title).toBe('合集标题 P2');
+    expect(byField.cid).toBe('2');
+  });
+
+  it('throws CommandExecutionError when --page is out of range', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        bvid: 'BV1h6V16SEpg', title: 't', stat: {}, owner: {}, desc: '', rights: {},
+        videos: 2, pages: [{ cid: 1, page: 1, part: 'a' }, { cid: 2, page: 2, part: 'b' }],
+      },
+    });
+    await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '99' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('throws CommandExecutionError when --page is not a positive integer', async () => {
+    await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '0' })).rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: 'abc' })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('omits cid/page/series_title fields when --page is not given (backward compat)', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      code: 0,
+      data: { bvid: 'BV1xx411c7mD', title: 't', stat: {}, owner: {}, desc: '', rights: {}, videos: 3, pages: [{ cid: 1, page: 1, part: 'a' }] },
+    });
+    const rows = await command.func(page, { bvid: 'BV1xx411c7mD' });
+    const fields = rows.map((r) => r.field);
+    expect(fields).not.toContain('cid');
+    expect(fields).not.toContain('page');
+    expect(fields).not.toContain('series_title');
+    const byField = Object.fromEntries(rows.map((r) => [r.field, r.value]));
+    expect(byField.title).toBe('t'); // 整集标题，不下钻
+  });
+
   it('returns full description without truncation or whitespace collapse', async () => {
     const longDesc = '第一行描述\n\n第二段，有多个空格   和换行\n\n' + 'x'.repeat(500);
     mockApiGet.mockResolvedValueOnce({

--- a/clis/bilibili/video.test.js
+++ b/clis/bilibili/video.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 const { mockApiGet } = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
@@ -270,9 +270,11 @@ describe('bilibili video', () => {
     await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '99' })).rejects.toBeInstanceOf(CommandExecutionError);
   });
 
-  it('throws CommandExecutionError when --page is not a positive integer', async () => {
-    await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: '0' })).rejects.toBeInstanceOf(CommandExecutionError);
-    await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: 'abc' })).rejects.toBeInstanceOf(CommandExecutionError);
+  it('throws ArgumentError when --page is not a strict positive decimal integer', async () => {
+    for (const pageArg of ['0', 'abc', '1e2', '0x10', ' 1 ']) {
+      await expect(command.func(page, { bvid: 'BV1h6V16SEpg', page: pageArg })).rejects.toBeInstanceOf(ArgumentError);
+    }
+    expect(mockApiGet).not.toHaveBeenCalled();
   });
 
   it('omits cid/page/series_title fields when --page is not given (backward compat)', async () => {


### PR DESCRIPTION
多P视频(视频选集 / 合集)在 bilibili 很常见——教程、连续剧、分集合辑等。但此前 `video` / `subtitle` / `download` 三个命令都**丢弃 URL 里的 `?p=` 参数、永远解析到 P1** 的 cid / 标题 / 字幕 / 视频流,拿不到后续分集。本 PR 新增可选 `--page N` 补上这个缺口。

## 改动

- **video**:从 view API 的 `data.pages` 取第 N 集,`title` 换成分集标题,额外透出 `page` / `cid` / `series_title` 字段;
- **subtitle**:用 `pages[N-1].cid` 取代默认 P1 cid,拿该集的字幕;
- **download**:拼 `?p=N` 给 yt-dlp 原生定位该集;
- **utils**:抽出共享的 `parsePageArg` / `selectVideoPart`,三命令复用,越界(N 超出分集数 / 非正整数)时抛**结构化错误**而非默默回退 P1。

## 向后兼容

**不传 `--page` 时三命令行为完全不变**——缺省仍取整集 / P1,纯增量参数,旧调用零感知。

## 测试

- 新增 9 个测试(`parsePageArg` 边界、`selectVideoPart` 选集 / 越界、video 分集字段、subtitle 用对 cid、download 拼对 `?p=`);
- bilibili 全量适配器测试 **109 通过**;`tsc --noEmit` 干净;`npm run build` 干净;`check:silent-column-drop` new=0。