### PR TITLE
fix(plugin): declare esbuild so plugin install can compile TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "esbuild": "^0.28.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -654,7 +657,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -671,7 +673,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -688,7 +689,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,7 +705,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,7 +721,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -739,7 +737,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -756,7 +753,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -773,7 +769,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -790,7 +785,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -807,7 +801,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -824,7 +817,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -841,7 +833,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -858,7 +849,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -875,7 +865,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -892,7 +881,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,7 +897,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -926,7 +913,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -943,7 +929,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,7 +945,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -977,7 +961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -994,7 +977,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1011,7 +993,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1028,7 +1009,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,7 +1025,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,7 +1041,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,7 +1057,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2750,7 +2727,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.1.0"
   },
+  "optionalDependencies": {
+    "esbuild": "^0.28.0"
+  },
   "overrides": {
     "postcss": "^8.5.10",
     "vitepress": {

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -400,6 +400,20 @@ describe('resolveEsbuildBin', () => {
     expect(fs.existsSync(binPath!)).toBe(true);
     expect(binPath).toMatch(/esbuild(\.cmd)?$/);
   });
+
+  it('declares esbuild as a production-installable dependency', () => {
+    // transpilePluginTs() needs esbuild at runtime to compile TypeScript
+    // plugins created by `opencli plugin create`. A production install only
+    // pulls `dependencies` + `optionalDependencies`, so esbuild must be
+    // declared in one of those — a transitive devDependency is not installed
+    // by `npm i -g @jackwener/opencli`.
+    const pkg = JSON.parse(
+      fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+    );
+    const declared =
+      Boolean(pkg.dependencies?.esbuild) || Boolean(pkg.optionalDependencies?.esbuild);
+    expect(declared).toBe(true);
+  });
 });
 
 describe('resolveHostOpencliRoot', () => {


### PR DESCRIPTION
## Description

`opencli plugin create` scaffolds a **TypeScript** plugin. Installing it with `opencli plugin install file://<dir>` runs `transpilePluginTs` (`src/plugin.ts`) to compile the source to `.js` via `resolveEsbuildBin`. That resolver only finds esbuild when it happens to be present — and in this repo esbuild is a **purely transitive devDependency** (it's in neither `dependencies` nor `devDependencies`; `package-lock.json` flags it `"dev": true`). So a production install (`npm i -g @jackwener/opencli`) ships no esbuild at all. The transpile then no-ops with a warning, no `.js` is produced, and `discoverPluginDir` (`src/discovery.ts`) aborts with `no compiled .js found` — breaking the documented `create` → `install` flow.

This declares esbuild as an **`optionalDependency`** so it installs alongside the CLI on supported platforms, while preserving the existing graceful degradation in `resolveEsbuildBin` / `transpilePluginTs` for platforms where the optional binary can't be installed. `optionalDependencies` is the idiomatic fit here (it mirrors how esbuild itself ships its platform binaries) and keeps the lean production-dependency footprint — esbuild is installed by default but never hard-fails the install.

Tradeoff for your call: if you'd rather guarantee the transpiler is always present, this could be a hard `dependencies` entry instead; `optionalDependencies` is the lighter promise that matches the code's already-graceful behaviour when esbuild is absent.

Related issue: Closes #1959

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Added a regression test next to the existing `resolveEsbuildBin` test. The existing test passes today only because esbuild is present transitively in dev, which masks the production gap; the new test asserts esbuild is a declared production-installable dependency.

Red on `main` (no declaration):

```
 FAIL  src/plugin.test.ts > resolveEsbuildBin > declares esbuild as a production-installable dependency
   expect(declared).toBe(true)  ->  received false
```

Green with this change:

```
 Test Files  1 passed (1)
      Tests  73 passed (73)
```

`npx tsc --noEmit` exits 0. `package.json` and `package-lock.json` stay in sync (regenerated with `npm install --package-lock-only`), so `npm ci` is unaffected.