### PR TITLE
fix(twitter): fall back to CreateTweet for text posts

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -1,8 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { isRecoverableFileInputError } from './utils.js';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { describeTwitterApiError, resolveTwitterOperationMetadata, unwrapBrowserResult } from './shared.js';
+import { isRecoverableFileInputError, TWITTER_BEARER_TOKEN } from './utils.js';
 
 const MAX_IMAGES = 4;
 const UPLOAD_POLL_MS = 500;
@@ -12,8 +13,53 @@ const COMPOSER_TIMEOUT_MS = 10_000;
 const SUBMIT_POLL_MS = 500;
 const SUBMIT_TIMEOUT_MS = 15_000;
 const COMPOSE_URL = 'https://x.com/compose/post';
+const API_CONTEXT_URL = 'https://x.com/home';
 const FILE_INPUT_SELECTOR = 'input[type="file"][data-testid="fileInput"]';
 const SUPPORTED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+// Baked fallback for resolveTwitterOperationMetadata(); runtime lookup still wins
+// when twitter-openapi or the loaded X bundle has newer CreateTweet metadata.
+const CREATE_TWEET_OPERATION = {
+    queryId: '5CdvsV_zjv4L64XFifAglw',
+    features: {
+        premium_content_api_read_enabled: false,
+        communities_web_enable_tweet_community_results_fetch: true,
+        c9s_tweet_anatomy_moderator_badge_enabled: true,
+        responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+        responsive_web_grok_analyze_post_followups_enabled: true,
+        rweb_cashtags_composer_attachment_enabled: true,
+        responsive_web_jetfuel_frame: true,
+        responsive_web_grok_share_attachment_enabled: true,
+        responsive_web_grok_annotations_enabled: true,
+        responsive_web_edit_tweet_api_enabled: true,
+        rweb_conversational_replies_downvote_enabled: false,
+        graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+        view_counts_everywhere_api_enabled: true,
+        longform_notetweets_consumption_enabled: true,
+        responsive_web_twitter_article_tweet_consumption_enabled: true,
+        content_disclosure_indicator_enabled: true,
+        content_disclosure_ai_generated_indicator_enabled: true,
+        responsive_web_grok_show_grok_translated_post: true,
+        responsive_web_grok_analysis_button_from_backend: true,
+        post_ctas_fetch_enabled: true,
+        longform_notetweets_rich_text_read_enabled: true,
+        longform_notetweets_inline_media_enabled: false,
+        profile_label_improvements_pcf_label_in_post_enabled: true,
+        responsive_web_profile_redirect_enabled: false,
+        rweb_tipjar_consumption_enabled: false,
+        verified_phone_label_enabled: false,
+        articles_preview_enabled: true,
+        rweb_cashtags_enabled: true,
+        responsive_web_grok_community_note_auto_translation_is_enabled: true,
+        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+        freedom_of_speech_not_reach_fetch_enabled: true,
+        standardized_nudges_misinfo: true,
+        tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+        responsive_web_grok_image_annotation_enabled: true,
+        responsive_web_grok_imagine_annotation_enabled: true,
+        responsive_web_graphql_timeline_navigation_enabled: true,
+    },
+    fieldToggles: {},
+};
 
 function validateImagePaths(raw) {
     const paths = raw.split(',').map(s => s.trim()).filter(Boolean);
@@ -248,6 +294,94 @@ async function submitTweet(page, text) {
     })()`);
 }
 
+function formatGraphqlErrors(bodyJson) {
+    const errors = Array.isArray(bodyJson?.errors) ? bodyJson.errors : [];
+    if (errors.length === 0) return '';
+    return errors
+        .map((error) => error?.message || JSON.stringify(error))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 300);
+}
+
+function extractCreatedTweet(bodyJson) {
+    const result = bodyJson?.data?.create_tweet?.tweet_results?.result;
+    const tweet = result?.tweet || result;
+    if (!tweet || typeof tweet !== 'object') return null;
+    const id = String(tweet.rest_id || tweet.legacy?.id_str || '').trim();
+    if (!/^\d+$/.test(id)) return null;
+    const user = tweet.core?.user_results?.result;
+    const screenName = String(user?.core?.screen_name || user?.legacy?.screen_name || '').trim();
+    return {
+        id,
+        url: screenName ? `https://x.com/${screenName}/status/${id}` : `https://x.com/i/status/${id}`,
+    };
+}
+
+async function postTextViaCreateTweet(page, text) {
+    await page.goto(API_CONTEXT_URL, { waitUntil: 'load', settleMs: 1000 });
+    const cookies = await page.getCookies({ url: 'https://x.com' });
+    const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
+    if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+
+    const operation = await resolveTwitterOperationMetadata(page, 'CreateTweet', CREATE_TWEET_OPERATION);
+    const payload = {
+        variables: {
+            tweet_text: text,
+            dark_request: false,
+            media: { media_entities: [], possibly_sensitive: false },
+            semantic_annotation_ids: [],
+        },
+        features: operation.features,
+        queryId: operation.queryId,
+    };
+    if (operation.fieldToggles && Object.keys(operation.fieldToggles).length > 0) {
+        payload.fieldToggles = operation.fieldToggles;
+    }
+
+    const headers = JSON.stringify({
+        'Authorization': `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
+        'X-Csrf-Token': ct0,
+        'X-Twitter-Auth-Type': 'OAuth2Session',
+        'X-Twitter-Active-User': 'yes',
+        'Content-Type': 'application/json',
+    });
+    const apiUrl = `/i/api/graphql/${operation.queryId}/CreateTweet`;
+    const body = JSON.stringify(payload);
+    const result = unwrapBrowserResult(await page.evaluate(`async () => {
+        const r = await fetch(${JSON.stringify(apiUrl)}, {
+            method: 'POST',
+            headers: ${headers},
+            credentials: 'include',
+            body: ${JSON.stringify(body)},
+        });
+        const bodyText = await r.text();
+        let bodyJson = null;
+        try { bodyJson = JSON.parse(bodyText); } catch {}
+        return { ok: r.ok, httpStatus: r.status, bodyJson, bodyText };
+    }`));
+
+    if (result?.httpStatus === 401 || result?.httpStatus === 403) {
+        throw new AuthRequiredError('x.com', `Twitter CreateTweet returned HTTP ${result.httpStatus}`);
+    }
+    if (!result?.ok) {
+        const hint = formatGraphqlErrors(result?.bodyJson);
+        const message = describeTwitterApiError('CreateTweet', result?.httpStatus ?? 0, hint || undefined);
+        return { ok: false, message };
+    }
+
+    const created = extractCreatedTweet(result.bodyJson);
+    if (!created) {
+        const error = formatGraphqlErrors(result.bodyJson);
+        return {
+            ok: false,
+            message: error ? `CreateTweet failed: ${error}` : 'CreateTweet returned no created tweet id.',
+        };
+    }
+
+    return { ok: true, message: 'Tweet posted successfully.', ...created };
+}
+
 cli({
     site: 'twitter',
     name: 'post',
@@ -269,10 +403,25 @@ cli({
         const absPaths = kwargs.images ? validateImagePaths(String(kwargs.images)) : [];
         const text = String(kwargs.text ?? '');
 
-        // The current X standalone composer is /compose/post. It keeps a single,
-        // visible composer and is the same route used by the reply command.
-        await page.goto(COMPOSE_URL, { waitUntil: 'load', settleMs: 2500 });
-        await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+        try {
+            // The current X standalone composer is /compose/post. It keeps a single,
+            // visible composer and is the same route used by the reply command.
+            await page.goto(COMPOSE_URL, { waitUntil: 'load', settleMs: 2500 });
+            await page.wait({ selector: '[data-testid="tweetTextarea_0"]', timeout: 15 });
+        } catch (err) {
+            if (absPaths.length > 0) throw err;
+            // This runs before any text insertion or submit click, so the API
+            // fallback cannot duplicate a post. Media posts still need the UI
+            // composer because this path does not upload media entities.
+            const result = await postTextViaCreateTweet(page, text);
+            return [{
+                status: result?.ok ? 'success' : 'failed',
+                message: result?.message ?? 'Tweet failed to post.',
+                text,
+                ...(result?.id ? { id: result.id } : {}),
+                ...(result?.url ? { url: result.url } : {}),
+            }];
+        }
 
         // Attach media before inserting text. Uploading media after Draft.js has
         // text can re-render/reset the editor, causing image-only posts.

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -69,6 +69,65 @@ describe('twitter post command', () => {
         expect(page.insertText).toHaveBeenCalledWith('hello world');
     });
 
+    it('falls back to CreateTweet when the standalone composer does not render for text-only posts', async () => {
+        const command = getCommand();
+        const wait = vi.fn()
+            .mockRejectedValueOnce(new Error('Selector not found: [data-testid="tweetTextarea_0"]'));
+        const page = makePage([
+            {
+                queryId: 'createTweetQueryId',
+                features: { responsive_web_edit_tweet_api_enabled: true },
+                fieldToggles: {},
+            },
+            {
+                session: 'browser:default',
+                data: {
+                    ok: true,
+                    httpStatus: 200,
+                    bodyText: '{}',
+                    bodyJson: {
+                        data: {
+                            create_tweet: {
+                                tweet_results: {
+                                    result: {
+                                        rest_id: '2054239044884693381',
+                                        core: {
+                                            user_results: {
+                                                result: {
+                                                    core: { screen_name: 'mock_user' },
+                                                },
+                                            },
+                                        },
+                                        legacy: { full_text: 'fallback via api' },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ], {
+            wait,
+            getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf-token' }]),
+        });
+
+        const result = await command.func(page, { text: 'fallback via api' });
+
+        expect(result).toEqual([{
+            status: 'success',
+            message: 'Tweet posted successfully.',
+            text: 'fallback via api',
+            id: '2054239044884693381',
+            url: 'https://x.com/mock_user/status/2054239044884693381',
+        }]);
+        expect(page.goto).toHaveBeenNthCalledWith(1, 'https://x.com/compose/post', { waitUntil: 'load', settleMs: 2500 });
+        expect(page.goto).toHaveBeenNthCalledWith(2, 'https://x.com/home', { waitUntil: 'load', settleMs: 1000 });
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
+        expect(page.insertText).not.toHaveBeenCalled();
+        expect(page.evaluate.mock.calls[1][0]).toContain('/i/api/graphql/createTweetQueryId/CreateTweet');
+        expect(page.evaluate.mock.calls[1][0]).toContain('\\"tweet_text\\":\\"fallback via api\\"');
+    });
+
     it('returns the created tweet URL from the success toast when available', async () => {
         const command = getCommand();
         const page = makePage([


### PR DESCRIPTION
## Summary
- Add a text-only CreateTweet fallback for twitter post when /compose/post does not render the composer.
- Keep the existing UI composer path for successful DOM loads and image posts.

## Why
- Fixes #2024: X can load only the static shell in the automation browser, leaving no [data-testid="tweetTextarea_0"] for twitter post.

## Validation
- npm run test:adapter -- clis/twitter/post.test.js passed (18 tests)
- npm run test:adapter -- clis/twitter/post.test.js clis/twitter/reply.test.js clis/twitter/search.test.js clis/twitter/list-create.test.js clis/twitter/shared.test.js passed (155 tests)
- npm run test:adapter passed (460 files, 4459 tests)
- npm run typecheck passed
- Live: node dist/src/main.js twitter post "OpenCLI live adapter test 2026-06-25; deleting shortly." -f json --trace retain-on-failure returned success with id 2069960917824274867
- Cleanup: node dist/src/main.js twitter delete "https://x.com/murongg_/status/2069960917824274867" -f json --trace retain-on-failure returned success

## Risk
- The fallback uses Twitter/X internal CreateTweet GraphQL metadata. Runtime metadata lookup still wins before the baked fallback, matching the existing Twitter API adapters.
- Image posts still require the UI composer because this change does not implement media upload through the API path.

Closes #2024