### PR TITLE
fix(twitter): match localized delete menu and poll for late-hydrating article (#2001)

### DIFF
--- a/clis/twitter/delete.js
+++ b/clis/twitter/delete.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
+import { parseTweetUrl, buildTwitterArticleScopeSource, unwrapBrowserResult } from './shared.js';
 
 function buildDeleteScript(tweetId) {
     return `(async () => {
@@ -19,10 +19,11 @@ function buildDeleteScript(tweetId) {
               return { ok: false, message: 'Could not find the tweet card matching the requested URL.' };
           }
 
-          const buttons = Array.from(targetArticle.querySelectorAll('button,[role="button"]'));
+          const belongsToTargetArticle = (el) => el.closest('article') === targetArticle;
+          const buttons = Array.from(targetArticle.querySelectorAll('button,[role="button"]')).filter(belongsToTargetArticle);
           // X localizes the "More" caret aria-label (zh-Hans: 更多), so prefer the
           // language-agnostic data-testid and fall back to a multilingual label match.
-          const moreMenu = Array.from(targetArticle.querySelectorAll('[data-testid="caret"]')).find(visible)
+          const moreMenu = Array.from(targetArticle.querySelectorAll('[data-testid="caret"]')).filter(belongsToTargetArticle).find(visible)
               || buttons.find((el) => visible(el) && /^(More|更多)/.test((el.getAttribute('aria-label') || '').trim()));
           if (!moreMenu) {
               return { ok: false, message: 'Could not find the "More" context menu on the matched tweet. Are you sure you are logged in and looking at a valid tweet?' };
@@ -80,7 +81,7 @@ cli({
         const target = parseTweetUrl(kwargs.url);
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' }); // Wait for tweet to load completely
-        const result = await page.evaluate(buildDeleteScript(target.id));
+        const result = unwrapBrowserResult(await page.evaluate(buildDeleteScript(target.id)));
         if (result.ok) {
             // Wait for the deletion request to be processed
             await page.wait(2);

--- a/clis/twitter/delete.js
+++ b/clis/twitter/delete.js
@@ -7,14 +7,23 @@ function buildDeleteScript(tweetId) {
       try {
           const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
           ${buildTwitterArticleScopeSource(tweetId)}
-          const targetArticle = findTargetArticle();
+          // The article's self-referential /status/<id> link can hydrate late on
+          // slow networks, so poll findTargetArticle() for ~5s before giving up.
+          let targetArticle = findTargetArticle();
+          for (let i = 0; i < 20 && !targetArticle; i++) {
+              await new Promise(r => setTimeout(r, 250));
+              targetArticle = findTargetArticle();
+          }
 
           if (!targetArticle) {
               return { ok: false, message: 'Could not find the tweet card matching the requested URL.' };
           }
 
           const buttons = Array.from(targetArticle.querySelectorAll('button,[role="button"]'));
-          const moreMenu = buttons.find((el) => visible(el) && (el.getAttribute('aria-label') || '').trim() === 'More');
+          // X localizes the "More" caret aria-label (zh-Hans: 更多), so prefer the
+          // language-agnostic data-testid and fall back to a multilingual label match.
+          const moreMenu = Array.from(targetArticle.querySelectorAll('[data-testid="caret"]')).find(visible)
+              || buttons.find((el) => visible(el) && /^(More|更多)/.test((el.getAttribute('aria-label') || '').trim()));
           if (!moreMenu) {
               return { ok: false, message: 'Could not find the "More" context menu on the matched tweet. Are you sure you are logged in and looking at a valid tweet?' };
           }
@@ -25,7 +34,9 @@ function buildDeleteScript(tweetId) {
           const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
           const deleteBtn = items.find((item) => {
               const text = (item.textContent || '').trim();
-              return text.includes('Delete') && !text.includes('List');
+              // X localizes the menu item (zh-Hans: 删除); exclude the "Add/remove
+              // from Lists" item in both languages so we never click the wrong row.
+              return (text.includes('Delete') || text.includes('删除')) && !text.includes('List') && !text.includes('列表');
           });
 
           if (!deleteBtn) {

--- a/clis/twitter/delete.js
+++ b/clis/twitter/delete.js
@@ -29,10 +29,12 @@ function buildDeleteScript(tweetId) {
               return { ok: false, message: 'Could not find the "More" context menu on the matched tweet. Are you sure you are logged in and looking at a valid tweet?' };
           }
 
+          const beforeMenuItems = new Set(document.querySelectorAll('[role="menuitem"]'));
           moreMenu.click();
           await new Promise(r => setTimeout(r, 1000));
 
-          const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+          const items = Array.from(document.querySelectorAll('[role="menuitem"]'))
+              .filter((item) => visible(item) && !beforeMenuItems.has(item));
           const deleteBtn = items.find((item) => {
               const text = (item.textContent || '').trim();
               // X localizes the menu item (zh-Hans: 删除); exclude the "Add/remove

--- a/clis/twitter/delete.test.js
+++ b/clis/twitter/delete.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
-import './delete.js';
+import { __test__ } from './delete.js';
 describe('twitter delete command', () => {
     it('targets the matched tweet article instead of the first More button on the page', async () => {
         const cmd = getRegistry().get('twitter/delete');
@@ -91,6 +92,50 @@ describe('twitter delete command', () => {
             },
         ]);
         expect(page.wait).toHaveBeenNthCalledWith(2, 2);
+    });
+    it('ignores stale non-target delete menu items that existed before opening the matched tweet menu', async () => {
+        const dom = new JSDOM(`
+            <body>
+              <div role="menuitem" data-stale-delete>删除</div>
+              <article>
+                <a href="https://x.com/bob/status/999">wrong tweet</a>
+                <button data-testid="caret" aria-label="更多"></button>
+              </article>
+              <article>
+                <a href="https://x.com/alice/status/2040254679301718161">target tweet</a>
+                <button data-testid="caret" aria-label="更多" data-target-caret></button>
+              </article>
+            </body>
+        `, { runScripts: 'outside-only', url: 'https://x.com/alice/status/2040254679301718161' });
+        dom.window.setTimeout = (handler) => {
+            if (typeof handler === 'function') handler();
+            return 0;
+        };
+        Object.defineProperty(dom.window.HTMLElement.prototype, 'getClientRects', {
+            configurable: true,
+            value() {
+                return [{ bottom: 1, height: 1, left: 0, right: 1, top: 0, width: 1 }];
+            },
+        });
+        let staleDeleteClicked = false;
+        let targetCaretClicked = false;
+        dom.window.document.querySelector('[data-stale-delete]')?.addEventListener('click', () => {
+            staleDeleteClicked = true;
+        });
+        dom.window.document.querySelector('[data-target-caret]')?.addEventListener('click', () => {
+            targetCaretClicked = true;
+            const item = dom.window.document.createElement('div');
+            item.setAttribute('role', 'menuitem');
+            item.textContent = 'Pin to your profile';
+            dom.window.document.body.appendChild(item);
+        });
+        const result = await dom.window.eval(__test__.buildDeleteScript('2040254679301718161'));
+        expect(targetCaretClicked).toBe(true);
+        expect(staleDeleteClicked).toBe(false);
+        expect(result).toEqual({
+            ok: false,
+            message: 'The matched tweet menu did not contain Delete. This tweet may not belong to you.',
+        });
     });
     it('rejects malformed or off-domain URLs with ArgumentError before navigation', async () => {
         const cmd = getRegistry().get('twitter/delete');

--- a/clis/twitter/delete.test.js
+++ b/clis/twitter/delete.test.js
@@ -27,6 +27,8 @@ describe('twitter delete command', () => {
         expect(script).toContain('__twGetStatusIdFromHref');
         expect(script).toContain("document.querySelectorAll('article')");
         expect(script).toContain("targetArticle.querySelectorAll('button,[role=\"button\"]')");
+        expect(script).toContain("closest('article') === targetArticle");
+        expect(script).toContain(".filter(belongsToTargetArticle)");
         // Localized "More" caret: prefer the language-agnostic data-testid, fall
         // back to a multilingual aria-label match (zh-Hans 更多), and poll for the
         // late-hydrating target article before giving up.
@@ -67,6 +69,28 @@ describe('twitter delete command', () => {
             },
         ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+    it('unwraps Browser Bridge evaluate envelopes before checking delete success', async () => {
+        const cmd = getRegistry().get('twitter/delete');
+        expect(cmd?.func).toBeTypeOf('function');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                session: 'twitter',
+                data: { ok: true, message: 'Tweet successfully deleted.' },
+            }),
+        };
+        const result = await cmd.func(page, {
+            url: 'https://x.com/alice/status/2040254679301718161',
+        });
+        expect(result).toEqual([
+            {
+                status: 'success',
+                message: 'Tweet successfully deleted.',
+            },
+        ]);
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
     });
     it('rejects malformed or off-domain URLs with ArgumentError before navigation', async () => {
         const cmd = getRegistry().get('twitter/delete');

--- a/clis/twitter/delete.test.js
+++ b/clis/twitter/delete.test.js
@@ -27,6 +27,16 @@ describe('twitter delete command', () => {
         expect(script).toContain('__twGetStatusIdFromHref');
         expect(script).toContain("document.querySelectorAll('article')");
         expect(script).toContain("targetArticle.querySelectorAll('button,[role=\"button\"]')");
+        // Localized "More" caret: prefer the language-agnostic data-testid, fall
+        // back to a multilingual aria-label match (zh-Hans 更多), and poll for the
+        // late-hydrating target article before giving up.
+        expect(script).toContain('[data-testid="caret"]');
+        expect(script).toContain('/^(More|更多)/');
+        expect(script).toContain('i < 20');
+        // Delete menu item is localized (删除) and must exclude the Lists item in
+        // both languages (List / 列表).
+        expect(script).toContain('删除');
+        expect(script).toContain('列表');
         // Substring match must NOT appear — exact-id match only.
         expect(script).not.toContain("'/status/' + tweetId");
         expect(result).toEqual([


### PR DESCRIPTION
## What
`opencli twitter delete` fails on a **Simplified-Chinese X UI** from a tweet **detail page** — two cascading issues plus a localized menu item. Closes #2001.

## Root cause & fix (all inside `buildDeleteScript`)
1. **Localized "More" caret** — the caret was matched by `aria-label === 'More'`, but X localizes it (zh-Hans `更多`), so the exact English match never hit. → Prefer the language-agnostic `[data-testid="caret"]` (kept scoped to the matched `targetArticle`), falling back to a multilingual `/^(More|更多)/` aria-label match.
2. **Late hydration** — `findTargetArticle()` ran right after `primaryColumn` appeared, but the article's self-referential `/status/<id>` link (what the matcher keys on) hydrates later on slow networks. → Poll `findTargetArticle()` for ~5s (20 × 250ms) before giving up.
3. **Localized Delete item** — broaden the menu match to `Delete`/`删除` and exclude the Lists item in **both** languages (`List`/`列表`), so `从列表中删除` / `Remove from Lists` is never clicked.

Article-scoping is preserved (exact-id match via the shared helper), so we still act only on the matched tweet.

## Test
Extended `clis/twitter/delete.test.js` with assertions for the `data-testid="caret"` primary selector, the `/^(More|更多)/` fallback, the poll bound, and the localized Delete/`删除` + `列表` exclusion. `vitest run clis/twitter/delete.test.js` → 4 passed; `check:typed-error-lint` / `check:silent-column-drop` → no new violations.

_Reported by OpenCLI autofix (locally verified); this implements the same repair with tests._