### PR TITLE
fix(browser): enforce fixed daemon bridge port

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ When the site you need is not yet covered, use the `opencli-adapter-author` skil
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENCLI_DAEMON_PORT` | `19825` | HTTP port for the daemon-extension bridge |
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW` | command default | Set to `foreground` or `background` to override Browser Bridge window placement. Browser-backed commands also accept `--window <foreground\|background>`. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for browser connection |

--- a/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/plans/2026-03-31-daemon-lifecycle-redesign.md
@@ -173,7 +173,7 @@ Replace the `IDLE_TIMEOUT` constant (line 27):
 ```typescript
 import { DEFAULT_DAEMON_PORT, DEFAULT_DAEMON_IDLE_TIMEOUT } from './constants.js';
 
-const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const PORT = DEFAULT_DAEMON_PORT;
 const IDLE_TIMEOUT = DEFAULT_DAEMON_IDLE_TIMEOUT;
 ```
 
@@ -425,7 +425,7 @@ Create `src/commands/daemon.ts`:
 import chalk from 'chalk';
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 
-const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const DAEMON_PORT = DEFAULT_DAEMON_PORT;
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 
 interface DaemonStatus {

--- a/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
+++ b/docs/superpowers/specs/2026-03-31-daemon-lifecycle-redesign.md
@@ -184,7 +184,7 @@ and shows:
 ## Backward Compatibility
 
 - No breaking changes to CLI commands or Extension protocol
-- Existing `OPENCLI_DAEMON_PORT` environment variable continues to work
+- The daemon and extension use the fixed Browser Bridge port.
 - The only observable behavior change: daemon stays alive longer
 - New `daemon` subcommands are additive
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "copy-yaml": "node scripts/copy-yaml.cjs",
     "start": "node dist/src/main.js",
     "start:bun": "bun dist/src/main.js",
-    "preuninstall": "node -e \"fetch('http://127.0.0.1:'+(process.env.OPENCLI_DAEMON_PORT||'19825')+'/shutdown',{method:'POST',headers:{'X-OpenCLI':'1'},signal:AbortSignal.timeout(3000)}).catch(()=>{})\" || true",
+    "preuninstall": "node -e \"fetch('http://127.0.0.1:19825/shutdown',{method:'POST',headers:{'X-OpenCLI':'1'},signal:AbortSignal.timeout(3000)}).catch(()=>{})\" || true",
     "postinstall": "node scripts/postinstall.js || true; node scripts/fetch-adapters.js || true",
     "typecheck": "tsc --noEmit",
     "prepare": "[ -d src ] && npm run build || true",

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -77,7 +77,6 @@ A few commands override the default via `cmd.defaultFormat` (e.g. chat commands 
 
 | variable | default | purpose |
 |----------|---------|---------|
-| `OPENCLI_DAEMON_PORT` | `19825` | Daemon ↔ extension bridge port. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `30` | Seconds to wait for the browser bridge. |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Per-command timeout. |
 | `OPENCLI_CDP_ENDPOINT` | — | Manual CDP endpoint override (dev / remote Chrome / Electron). |

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -149,6 +149,28 @@ describe('daemon-client', () => {
     expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work$/);
   });
 
+  it('rejects OPENCLI_DAEMON_PORT so CLI and extension cannot split bridge ports', async () => {
+    vi.resetModules();
+    vi.stubEnv('OPENCLI_DAEMON_PORT', '19999');
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        extensionConnected: true,
+        pending: 0,
+        memoryMB: 1,
+        port: 19825,
+      }),
+    } as Response);
+
+    const freshClient = await import('./daemon-client.js');
+    await expect(freshClient.fetchDaemonStatus()).rejects.toThrow('OPENCLI_DAEMON_PORT is no longer supported');
+
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
   it('sendCommand includes the current pid in generated command ids', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
     vi.mocked(fetch).mockResolvedValue({

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -4,12 +4,12 @@
  * Provides a typed send() function that posts a Command and returns a Result.
  */
 
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
+import { DEFAULT_DAEMON_PORT, unsupportedDaemonPortEnvMessage } from '../constants.js';
 import { sleep } from '../utils.js';
 import { classifyBrowserError } from './errors.js';
 import { resolveProfileContextId } from './profile.js';
 
-const DAEMON_PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const DAEMON_PORT = DEFAULT_DAEMON_PORT;
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
 const OPENCLI_HEADERS = { 'X-OpenCLI': '1' };
 
@@ -81,6 +81,18 @@ export class BrowserCommandError extends Error {
   }
 }
 
+class UnsupportedDaemonPortEnvError extends Error {
+  constructor(value: string) {
+    super(unsupportedDaemonPortEnvMessage(value));
+    this.name = 'UnsupportedDaemonPortEnvError';
+  }
+}
+
+function assertSupportedDaemonPortEnv(): void {
+  const value = process.env.OPENCLI_DAEMON_PORT;
+  if (value !== undefined && value !== '') throw new UnsupportedDaemonPortEnvError(value);
+}
+
 export interface DaemonStatus {
   ok: boolean;
   pid: number;
@@ -109,6 +121,7 @@ export interface BrowserProfileStatus {
 }
 
 async function requestDaemon(pathname: string, init?: RequestInit & { timeout?: number }): Promise<Response> {
+  assertSupportedDaemonPortEnv();
   const { timeout = 2000, headers, ...rest } = init ?? {};
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
@@ -129,7 +142,8 @@ export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: s
     const res = await requestDaemon(`/status${params}`, { timeout: opts?.timeout ?? 2000 });
     if (!res.ok) return null;
     return await res.json() as DaemonStatus;
-  } catch {
+  } catch (err) {
+    if (err instanceof UnsupportedDaemonPortEnvError) throw err;
     return null;
   }
 }
@@ -158,7 +172,8 @@ export async function requestDaemonShutdown(opts?: { timeout?: number }): Promis
   try {
     const res = await requestDaemon('/shutdown', { method: 'POST', timeout: opts?.timeout ?? 5000 });
     return res.ok;
-  } catch {
+  } catch (err) {
+    if (err instanceof UnsupportedDaemonPortEnvError) throw err;
     return false;
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,12 @@
 /** Default daemon port for HTTP/WebSocket communication with browser extension */
 export const DEFAULT_DAEMON_PORT = 19825;
 
+export function unsupportedDaemonPortEnvMessage(value?: string): string {
+  const suffix = value ? ` (received ${value})` : '';
+  return `OPENCLI_DAEMON_PORT is no longer supported${suffix}. ` +
+    `The OpenCLI Chrome extension can only connect to localhost:${DEFAULT_DAEMON_PORT}. ` +
+    'Unset OPENCLI_DAEMON_PORT and rerun opencli.';
+}
 
 /** URL query params that are volatile/ephemeral and should be stripped from patterns */
 export const VOLATILE_PARAMS = new Set([

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,7 +22,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
-import { DEFAULT_DAEMON_PORT } from './constants.js';
+import { DEFAULT_DAEMON_PORT, unsupportedDaemonPortEnvMessage } from './constants.js';
 import { EXIT_CODES } from './errors.js';
 import { log } from './logger.js';
 import { PKG_VERSION } from './version.js';
@@ -34,7 +34,11 @@ import {
   getResponseCorsHeaders,
 } from './daemon-utils.js';
 
-const PORT = parseInt(process.env.OPENCLI_DAEMON_PORT ?? String(DEFAULT_DAEMON_PORT), 10);
+const PORT = DEFAULT_DAEMON_PORT;
+if (process.env.OPENCLI_DAEMON_PORT) {
+  log.error(unsupportedDaemonPortEnvMessage(process.env.OPENCLI_DAEMON_PORT));
+  process.exit(EXIT_CODES.USAGE_ERROR);
+}
 
 // ─── State ───────────────────────────────────────────────────────────
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
 import { isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-detect.js';
+import { unsupportedDaemonPortEnvMessage } from './constants.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,6 +44,11 @@ if (typeof (globalThis as { Bun?: unknown }).Bun === 'undefined' && !isSupported
       '',
     ].join('\n'),
   );
+  process.exit(EXIT_CODES.CONFIG_ERROR);
+}
+
+if (process.env.OPENCLI_DAEMON_PORT) {
+  process.stderr.write(`error: ${unsupportedDaemonPortEnvMessage(process.env.OPENCLI_DAEMON_PORT)}\n`);
   process.exit(EXIT_CODES.CONFIG_ERROR);
 }
 


### PR DESCRIPTION
## Summary
- remove the user-facing daemon port override from docs and scripts
- make CLI/daemon always use the fixed Browser Bridge port 19825, matching the Chrome extension
- fail fast with an actionable error when OPENCLI_DAEMON_PORT is set so users do not get a split CLI/extension bridge

## Verification
- npx vitest run --project unit src/browser/daemon-client.test.ts src/commands/daemon.test.ts src/doctor.test.ts
- npm run typecheck
- npm run build
- OPENCLI_DAEMON_PORT=19999 node dist/src/main.js daemon status
- OPENCLI_DAEMON_PORT=19999 node dist/src/daemon.js
- HOME=$(mktemp -d) npm test