### PR TITLE
fix(twitter): allow paginated tweet backfills

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -36683,7 +36683,14 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Max tweets to return"
+        "help": "Max tweets to return (1-10000; fetched across cursor pages)"
+      },
+      {
+        "name": "page-delay",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Seconds to wait between paginated timeline requests to reduce rate-limit risk. Use 0 to disable."
       },
       {
         "name": "top-by-engagement",

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -6,6 +6,9 @@ import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const USER_TWEETS_QUERY_ID = 'lrMzG9qPQHpqJdP3AbM-bQ';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
 const MAX_PAGINATION_PAGES = 100;
+const USER_TWEETS_PAGE_SIZE = 100;
+const MAX_TWEETS_LIMIT = MAX_PAGINATION_PAGES * USER_TWEETS_PAGE_SIZE;
+const DEFAULT_PAGE_DELAY_SECONDS = 1;
 
 const USER_TWEETS_FEATURES = {
     rweb_video_screen_enabled: true,
@@ -213,6 +216,28 @@ function parseUserTweets(data, seen) {
     return { tweets, nextCursor };
 }
 
+function normalizeLimit(rawLimit) {
+    const limit = rawLimit ?? 20;
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_TWEETS_LIMIT) {
+        throw new ArgumentError(
+            `twitter tweets --limit must be an integer between 1 and ${MAX_TWEETS_LIMIT}`,
+            `Example: opencli twitter tweets @jack --limit 250`
+        );
+    }
+    return limit;
+}
+
+function normalizePageDelaySeconds(rawDelay) {
+    const delay = rawDelay ?? DEFAULT_PAGE_DELAY_SECONDS;
+    if (!Number.isInteger(delay) || delay < 0 || delay > 60) {
+        throw new ArgumentError(
+            'twitter tweets --page-delay must be an integer between 0 and 60 seconds',
+            'Example: opencli twitter tweets @jack --limit 250 --page-delay 1'
+        );
+    }
+    return delay;
+}
+
 cli({
     site: 'twitter',
     name: 'tweets',
@@ -223,12 +248,14 @@ cli({
     browser: true,
     args: [
         { name: 'username', type: 'string', positional: true, help: 'Twitter screen name (with or without @). Defaults to the logged-in user when omitted.' },
-        { name: 'limit', type: 'int', default: 20, help: 'Max tweets to return' },
+        { name: 'limit', type: 'int', default: 20, help: `Max tweets to return (1-${MAX_TWEETS_LIMIT}; fetched across cursor pages)` },
+        { name: 'page-delay', type: 'int', default: DEFAULT_PAGE_DELAY_SECONDS, help: 'Seconds to wait between paginated timeline requests to reduce rate-limit risk. Use 0 to disable.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the chronological ordering.' },
     ],
     columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet'],
     func: async (page, kwargs) => {
-        const limit = Math.max(1, Math.min(200, kwargs.limit || 20));
+        const limit = normalizeLimit(kwargs.limit);
+        const pageDelaySeconds = normalizePageDelaySeconds(kwargs['page-delay']);
         const rawUsername = String(kwargs.username ?? '').trim();
         let username = normalizeTwitterScreenName(rawUsername);
         if (rawUsername && !username) {
@@ -283,7 +310,10 @@ cli({
         let cursor = null;
         // Runaway guard only; --limit and cursor exhaustion control normal pagination.
         for (let i = 0; i < MAX_PAGINATION_PAGES && all.length < limit; i++) {
-            const fetchCount = Math.min(100, limit - all.length + 10);
+            if (i > 0 && pageDelaySeconds > 0) {
+                await page.wait(pageDelaySeconds);
+            }
+            const fetchCount = Math.min(USER_TWEETS_PAGE_SIZE, limit - all.length + 10);
             const url = buildUserTweetsUrl(userTweetsOperation, userId, fetchCount, cursor);
             const data = normalizeTwitterGraphqlPayload(await page.evaluate(`async () => {
         const r = await fetch("${url}", { headers: ${headers}, credentials: 'include' });
@@ -306,9 +336,12 @@ cli({
 });
 
 export const __test__ = {
+    MAX_TWEETS_LIMIT,
     sanitizeQueryId,
     buildUserTweetsUrl,
     buildUserByScreenNameUrl,
     extractTweet,
     parseUserTweets,
+    normalizeLimit,
+    normalizePageDelaySeconds,
 };

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -3,6 +3,58 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
 import { __test__ } from './tweets.js';
 
+function makeTweetEntry(id, author = 'jakevin7') {
+    return {
+        entryId: `tweet-${id}`,
+        content: {
+            itemContent: {
+                tweet_results: {
+                    result: {
+                        rest_id: String(id),
+                        legacy: {
+                            full_text: `post ${id}`,
+                            favorite_count: 0,
+                            retweet_count: 0,
+                            reply_count: 0,
+                            created_at: 'now',
+                        },
+                        core: {
+                            user_results: {
+                                result: {
+                                    legacy: { screen_name: author, name: author },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function makeTimelinePayload(startId, count, nextCursor = null) {
+    const entries = Array.from({ length: count }, (_, index) => makeTweetEntry(startId + index));
+    if (nextCursor) {
+        entries.push({
+            entryId: `cursor-bottom-${nextCursor}`,
+            content: { entryType: 'TimelineTimelineCursor', cursorType: 'Bottom', value: nextCursor },
+        });
+    }
+    return {
+        data: {
+            user: {
+                result: {
+                    timeline_v2: {
+                        timeline: {
+                            instructions: [{ entries }],
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
 describe('twitter tweets helpers', () => {
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
@@ -120,6 +172,79 @@ describe('twitter tweets helpers', () => {
         };
 
         await expect(cmd.func(page, { username: 'viewer/extra' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.getCookies).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('fetches limits above 200 across cursor pages with a delay between pages', async () => {
+        const cmd = getRegistry().get('twitter/tweets');
+        const userTweetsRequests = [];
+        const pages = [
+            makeTimelinePayload(1, 100, 'cursor-1'),
+            makeTimelinePayload(101, 100, 'cursor-2'),
+            makeTimelinePayload(201, 60, null),
+        ];
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn(async (script) => {
+                const text = typeof script === 'function' ? script.toString() : String(script);
+                if (text.includes('operationName')) return null;
+                if (text.includes('/UserByScreenName')) return '42';
+                if (text.includes('/UserTweets')) {
+                    userTweetsRequests.push(decodeURIComponent(text));
+                    return pages[userTweetsRequests.length - 1];
+                }
+                return null;
+            }),
+        };
+
+        const rows = await cmd.func(page, { username: 'jakevin7', limit: 250, 'page-delay': 1 });
+
+        expect(rows).toHaveLength(250);
+        expect(rows[0]).toMatchObject({ id: '1', text: 'post 1' });
+        expect(rows[249]).toMatchObject({ id: '250', text: 'post 250' });
+        expect(userTweetsRequests).toHaveLength(3);
+        expect(userTweetsRequests[0]).toContain('"count":100');
+        expect(userTweetsRequests[0]).not.toContain('"cursor"');
+        expect(userTweetsRequests[1]).toContain('"cursor":"cursor-1"');
+        expect(userTweetsRequests[1]).toContain('"count":100');
+        expect(userTweetsRequests[2]).toContain('"cursor":"cursor-2"');
+        expect(userTweetsRequests[2]).toContain('"count":60');
+        expect(page.wait).toHaveBeenCalledTimes(2);
+        expect(page.wait).toHaveBeenNthCalledWith(1, 1);
+        expect(page.wait).toHaveBeenNthCalledWith(2, 1);
+    });
+
+    it('rejects invalid tweet limits before navigation', async () => {
+        const cmd = getRegistry().get('twitter/tweets');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        await expect(cmd.func(page, { username: 'jakevin7', limit: __test__.MAX_TWEETS_LIMIT + 1 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func(page, { username: 'jakevin7', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.getCookies).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid pagination delays before navigation', async () => {
+        const cmd = getRegistry().get('twitter/tweets');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            getCookies: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        await expect(cmd.func(page, { username: 'jakevin7', limit: 20, 'page-delay': -1 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(cmd.func(page, { username: 'jakevin7', limit: 20, 'page-delay': 61 })).rejects.toBeInstanceOf(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
         expect(page.getCookies).not.toHaveBeenCalled();
         expect(page.evaluate).not.toHaveBeenCalled();

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -97,14 +97,6 @@
   },
   {
     "rule": "silent-clamp",
-    "command": "bilibili/comments",
-    "file": "clis/bilibili/comments.js",
-    "line": 21,
-    "text": "const limit = Math.min(Number(kwargs.limit) || 20, 50);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
     "command": "bilibili/favorite",
     "file": "clis/bilibili/favorite.js",
     "line": 35,
@@ -419,7 +411,7 @@
     "rule": "silent-clamp",
     "command": "linkedin/timeline",
     "file": "clis/linkedin/timeline.js",
-    "line": 473,
+    "line": 479,
     "text": "const limit = Math.max(1, Math.min(kwargs.limit ?? 20, 100));",
     "occurrence": 0
   },
@@ -483,7 +475,7 @@
     "rule": "silent-clamp",
     "command": "reddit/read",
     "file": "clis/reddit/read.js",
-    "line": 479,
+    "line": 531,
     "text": "for (var i = 0; i < Math.min(t1TopLevel.length, limit); i++) {",
     "occurrence": 0
   },
@@ -635,7 +627,7 @@
     "rule": "silent-clamp",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 227,
+    "line": 232,
     "text": "const fetchCount = Math.min(50, limit - allUsers.length + 10);",
     "occurrence": 0
   },
@@ -643,7 +635,7 @@
     "rule": "silent-clamp",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 207,
+    "line": 208,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -651,7 +643,7 @@
     "rule": "silent-clamp",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 176,
+    "line": 179,
     "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
@@ -659,7 +651,7 @@
     "rule": "silent-clamp",
     "command": "twitter/timeline",
     "file": "clis/twitter/timeline.js",
-    "line": 183,
+    "line": 185,
     "text": "const fetchCount = Math.min(40, limit - allTweets.length + 5); // over-fetch slightly for promoted filtering",
     "occurrence": 0
   },
@@ -667,16 +659,8 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 287,
-    "text": "const fetchCount = Math.min(100, limit - all.length + 10);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "twitter/tweets",
-    "file": "clis/twitter/tweets.js",
-    "line": 232,
-    "text": "const limit = Math.max(1, Math.min(200, kwargs.limit || 20));",
+    "line": 316,
+    "text": "const fetchCount = Math.min(USER_TWEETS_PAGE_SIZE, limit - all.length + 10);",
     "occurrence": 0
   },
   {
@@ -731,7 +715,7 @@
     "rule": "silent-clamp",
     "command": "xianyu/search",
     "file": "clis/xianyu/search.js",
-    "line": 8,
+    "line": 9,
     "text": "return Math.min(MAX_LIMIT, Math.max(1, Math.floor(n)));",
     "occurrence": 0
   },
@@ -747,7 +731,7 @@
     "rule": "silent-clamp",
     "command": "youtube/channel",
     "file": "clis/youtube/channel.js",
-    "line": 35,
+    "line": 81,
     "text": "const limit = Math.min(kwargs.limit || 10, 30);",
     "occurrence": 0
   },
@@ -819,7 +803,7 @@
     "rule": "silent-clamp",
     "command": "zhihu/collection",
     "file": "clis/zhihu/collection.js",
-    "line": 154,
+    "line": 142,
     "text": "const currentFetchLimit = Math.min(pageLimit, requestedLimit - collected.length);",
     "occurrence": 0
   },
@@ -827,7 +811,7 @@
     "rule": "silent-clamp",
     "command": "zhihu/collection",
     "file": "clis/zhihu/collection.js",
-    "line": 143,
+    "line": 131,
     "text": "const pageLimit = Math.min(requestedLimit, 20); // 知乎 API 限制每页最大 20",
     "occurrence": 0
   },
@@ -859,7 +843,7 @@
     "rule": "silent-sentinel",
     "command": "bilibili/download",
     "file": "clis/bilibili/download.js",
-    "line": 47,
+    "line": 141,
     "text": "const author = document.querySelector('.up-name, .username')?.textContent?.trim() || 'unknown';",
     "occurrence": 0
   },
@@ -937,22 +921,6 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "twitter/following",
-    "file": "clis/twitter/following.js",
-    "line": 95,
-    "text": "name: core.name || legacy.name || 'unknown',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "twitter/following",
-    "file": "clis/twitter/following.js",
-    "line": 94,
-    "text": "screen_name: core.screen_name || legacy.screen_name || 'unknown',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
     "line": 91,
@@ -963,33 +931,9 @@
     "rule": "silent-sentinel",
     "command": "twitter/list-tweets",
     "file": "clis/twitter/list-tweets.js",
-    "line": 62,
+    "line": 63,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "twitter/notifications",
-    "file": "clis/twitter/notifications.js",
-    "line": 82,
-    "text": "author = fromUser?.core?.screen_name || fromUser?.legacy?.screen_name || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "twitter/notifications",
-    "file": "clis/twitter/notifications.js",
-    "line": 104,
-    "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
-    "command": "twitter/notifications",
-    "file": "clis/twitter/notifications.js",
-    "line": 97,
-    "text": "author = tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown';",
-    "occurrence": 1
   },
   {
     "rule": "silent-sentinel",
@@ -1001,17 +945,9 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "twitter/search",
-    "file": "clis/twitter/search.js",
-    "line": 217,
-    "text": "author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || 'unknown',",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "twitter/thread",
     "file": "clis/twitter/thread.js",
-    "line": 48,
+    "line": 49,
     "text": "const screenName = u?.legacy?.screen_name || u?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -1027,7 +963,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 161,
+    "line": 163,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },


### PR DESCRIPTION
## Summary
- remove the silent 200-row cap from twitter tweets and validate an explicit 1-10000 range
- add --page-delay to wait between cursor pages and reduce rate-limit risk
- cover >200-row cursor pagination in twitter adapter tests

## Validation
- npm test -- --run clis/twitter/tweets.test.js
- npm run typecheck
- npm run build
- npm run check:typed-error-lint
- git diff --check