### PR TITLE
fix(twitter): default tweet page delay to two seconds

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -36688,7 +36688,7 @@
       {
         "name": "page-delay",
         "type": "int",
-        "default": 1,
+        "default": 2,
         "required": false,
         "help": "Seconds to wait between paginated timeline requests to reduce rate-limit risk. Use 0 to disable."
       },

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -8,7 +8,7 @@ const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
 const MAX_PAGINATION_PAGES = 100;
 const USER_TWEETS_PAGE_SIZE = 100;
 const MAX_TWEETS_LIMIT = MAX_PAGINATION_PAGES * USER_TWEETS_PAGE_SIZE;
-const DEFAULT_PAGE_DELAY_SECONDS = 1;
+const DEFAULT_PAGE_DELAY_SECONDS = 2;
 
 const USER_TWEETS_FEATURES = {
     rweb_video_screen_enabled: true,
@@ -232,7 +232,7 @@ function normalizePageDelaySeconds(rawDelay) {
     if (!Number.isInteger(delay) || delay < 0 || delay > 60) {
         throw new ArgumentError(
             'twitter tweets --page-delay must be an integer between 0 and 60 seconds',
-            'Example: opencli twitter tweets @jack --limit 250 --page-delay 1'
+            'Example: opencli twitter tweets @jack --limit 250 --page-delay 2'
         );
     }
     return delay;

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -201,7 +201,7 @@ describe('twitter tweets helpers', () => {
             }),
         };
 
-        const rows = await cmd.func(page, { username: 'jakevin7', limit: 250, 'page-delay': 1 });
+        const rows = await cmd.func(page, { username: 'jakevin7', limit: 250 });
 
         expect(rows).toHaveLength(250);
         expect(rows[0]).toMatchObject({ id: '1', text: 'post 1' });
@@ -214,8 +214,8 @@ describe('twitter tweets helpers', () => {
         expect(userTweetsRequests[2]).toContain('"cursor":"cursor-2"');
         expect(userTweetsRequests[2]).toContain('"count":60');
         expect(page.wait).toHaveBeenCalledTimes(2);
-        expect(page.wait).toHaveBeenNthCalledWith(1, 1);
-        expect(page.wait).toHaveBeenNthCalledWith(2, 1);
+        expect(page.wait).toHaveBeenNthCalledWith(1, 2);
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
     });
 
     it('rejects invalid tweet limits before navigation', async () => {


### PR DESCRIPTION
## Summary
- change twitter tweets pagination delay default from 1s to 2s
- update the command example, manifest, and pagination test to assert the implicit 2s default

## Validation
- npm test -- --run clis/twitter/tweets.test.js
- npm run typecheck
- npm run build
- npm run check:typed-error-lint
- git diff --check