### PR TITLE
test(extension): isolate background reconnect timers

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -244,9 +244,13 @@ describe('background tab isolation', () => {
     vi.useRealTimers();
     MockWebSocket.instances = [];
     vi.stubGlobal('WebSocket', MockWebSocket);
+    // Most tests exercise tab/session behavior, not daemon reconnect cadence.
+    // Keep the startup ping pending unless a test explicitly controls it.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
   });
 
   afterEach(() => {
+    vi.clearAllTimers();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Summary
- Keep the default background startup daemon ping pending in tests unless a test explicitly controls it
- Clear pending timers after each background test so reconnect timers cannot leak into later tests

## Verification
- npm run test -- --project extension extension/src/background.test.ts
- npx vitest run --project extension extension/src/
- npm run typecheck
- npm run build
- cd extension && npm run build
- HOME=$(mktemp -d) npm test