### PR TITLE
test(e2e): isolate fixed-port browser tab tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:bun": "bun vitest run --project unit --project extension --project adapter",
     "test:adapter": "vitest run --project adapter",
     "test:all": "vitest run",
-    "test:e2e": "vitest run --project e2e",
+    "test:e2e": "vitest run --project e2e-fixed-port --project e2e",
     "advise:listing-id-pairing": "node scripts/check-listing-id-pairing.mjs",
     "check:silent-column-drop": "node scripts/check-silent-column-drop.mjs",
     "check:typed-error-lint": "node scripts/check-typed-error-lint.mjs",

--- a/tests/e2e/browser-tabs.test.ts
+++ b/tests/e2e/browser-tabs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createServer, request, type IncomingMessage, type ServerResponse } from 'node:http';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -35,6 +35,42 @@ type FakeDaemon = {
 
 const DAEMON_PORT = 19825;
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function shutdownExistingDaemon(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+
+    const req = request({
+      host: '127.0.0.1',
+      port: DAEMON_PORT,
+      path: '/shutdown',
+      method: 'POST',
+      headers: { 'X-OpenCLI': '1' },
+      timeout: 500,
+    }, (res) => {
+      res.resume();
+      res.on('end', finish);
+      res.on('close', finish);
+    });
+
+    req.on('timeout', () => req.destroy());
+    req.on('error', finish);
+    req.on('close', finish);
+    req.end();
+  });
+
+  await sleep(100);
+}
+
 async function readBody(req: IncomingMessage): Promise<string> {
   return await new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -50,6 +86,8 @@ function json(res: ServerResponse, status: number, payload: unknown): void {
 }
 
 async function startFakeDaemon(): Promise<FakeDaemon> {
+  await shutdownExistingDaemon();
+
   const tabs = new Map<string, FakeTab>([
     ['tab-1', { page: 'tab-1', url: 'https://one.example/', title: 'tab-one', active: true }],
     ['tab-2', { page: 'tab-2', url: 'https://two.example/', title: 'tab-two', active: false }],
@@ -184,13 +222,31 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
     }
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(DAEMON_PORT, '127.0.0.1', () => {
-      server.off('error', reject);
-      resolve();
-    });
-  });
+  let lastBindError: unknown;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(DAEMON_PORT, '127.0.0.1', () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
+      lastBindError = undefined;
+      break;
+    } catch (err: any) {
+      lastBindError = err;
+      if (err?.code !== 'EADDRINUSE') {
+        break;
+      }
+      await shutdownExistingDaemon();
+      await sleep(100);
+    }
+  }
+
+  if (lastBindError) {
+    throw lastBindError;
+  }
 
   const address = server.address();
   if (!address || typeof address !== 'object') {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,14 @@ export default defineConfig({
       },
       {
         test: {
+          name: 'e2e-fixed-port',
+          include: ['tests/e2e/browser-tabs.test.ts'],
+          fileParallelism: false,
+          sequence: { groupOrder: 2 },
+        },
+      },
+      {
+        test: {
           name: 'e2e',
           include: [
             'tests/e2e/browser-public.test.ts',
@@ -38,7 +46,6 @@ export default defineConfig({
             'tests/e2e/management.test.ts',
             'tests/e2e/output-formats.test.ts',
             'tests/e2e/plugin-management.test.ts',
-            'tests/e2e/browser-tabs.test.ts',
             'tests/e2e/article-download-pipeline.test.ts',
             ...(includeAxChromeE2e ? ['tests/e2e/browser-ax-chrome.test.ts'] : []),
             // Extended browser tests (20+ sites) — opt-in only:
@@ -46,14 +53,14 @@ export default defineConfig({
             ...(includeExtendedE2e ? ['tests/e2e/browser-public-extended.test.ts', 'tests/e2e/browser-auth.test.ts', 'tests/e2e/douban.test.ts'] : []),
           ],
           maxWorkers: 2,
-          sequence: { groupOrder: 2 },
+          sequence: { groupOrder: 3 },
         },
       },
       {
         test: {
           name: 'smoke',
           include: ['tests/smoke/**/*.test.ts'],
-          sequence: { groupOrder: 3 },
+          sequence: { groupOrder: 4 },
         },
       },
     ],


### PR DESCRIPTION
## Summary
- move browser-tabs E2E into a dedicated e2e-fixed-port Vitest project that runs before the normal E2E group
- keep the rest of headed E2E parallel so the release gate does not slow down unnecessarily
- have browser-tabs shut down any stale OpenCLI daemon before binding the fixed bridge port 19825

## Verification
- npx vitest run --project e2e-fixed-port tests/e2e/browser-tabs.test.ts --reporter=verbose
- npx vitest run tests/e2e/browser-tabs.test.ts tests/e2e/article-download-pipeline.test.ts --reporter=verbose
- npm run typecheck
- npm run build