### PR TITLE
chore(release): bump version to 1.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- bump @jackwener/opencli from 1.8.4 to 1.8.5 in package.json and package-lock.json

## Release gate
- main CI green on 616cc886
- main Security Audit green on 616cc886
- main E2E Headed Chrome green on 616cc886 (Ubuntu + macOS)
- npm latest is currently 1.8.4

## Verification
- npm run build
- npm run typecheck
- HOME=$(mktemp -d) npm test