### PR TITLE
chore(extension): bump version to 1.0.21

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"


### PR DESCRIPTION
## Summary
- bump Chrome extension package/manifest version from 1.0.20 to 1.0.21
- include package-lock version metadata for the extension release

## Why
- extension runtime changed in the 1.8.5 release cycle, but the packaged release asset still used extension version 1.0.20

## Verification
- cd extension && npm run build
- npx vitest run --project extension extension/src/
- cd extension && npm ci
- cd extension && npm run typecheck
- cd extension && npm run package:release -- --out ../extension-package-test