### PR TITLE
feat(gemini): add model and thinking selection

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13663,6 +13663,12 @@
         "help": "Prompt to send"
       },
       {
+        "name": "model",
+        "type": "string",
+        "required": false,
+        "help": "Gemini model to use (e.g. \"2.5-flash\"). Use \"opencli gemini models\" to list available values."
+      },
+      {
         "name": "timeout",
         "type": "int",
         "default": 60,
@@ -13675,6 +13681,13 @@
         "default": "false",
         "required": false,
         "help": "Start a new chat first (true/false, default: false)"
+      },
+      {
+        "name": "thinking",
+        "type": "str",
+        "default": null,
+        "required": false,
+        "help": "Thinking level: standard or extended (omitted = leave unchanged)"
       }
     ],
     "columns": [
@@ -13929,6 +13942,25 @@
     "navigateBefore": false,
     "siteSession": "persistent",
     "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "gemini",
+    "name": "models",
+    "description": "List available Gemini models from the web UI",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "model",
+      "thinkingValues"
+    ],
+    "type": "js",
+    "modulePath": "gemini/models.js",
+    "sourceFile": "gemini/models.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "gemini",

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import {
   GEMINI_DOMAIN,
   ensureGeminiPage,
@@ -26,10 +26,24 @@ const NO_RESPONSE_PREFIX = '[NO RESPONSE]';
  * Throws ArgumentError for short aliases or invalid formats.
  */
 function unwrapBrowserBridgeEnvelope(value) {
-    if (value && typeof value === 'object' && 'data' in value && 'session' in value) {
-        return value.data;
+    if (value && typeof value === 'object' && !Array.isArray(value) && 'session' in value) {
+        if ('data' in value) return value.data;
+        throw new CommandExecutionError('Gemini model discovery returned a malformed Browser Bridge envelope');
     }
     return value;
+}
+
+function requireDiscoveredModels(value) {
+    const unwrapped = unwrapBrowserBridgeEnvelope(value);
+    if (!Array.isArray(unwrapped)) {
+        throw new CommandExecutionError('Gemini model discovery returned a malformed result');
+    }
+    for (const row of unwrapped) {
+        if (!row || typeof row.model !== 'string' || !Array.isArray(row.thinkingValues)) {
+            throw new CommandExecutionError('Gemini model discovery returned a malformed row');
+        }
+    }
+    return unwrapped;
 }
 
 function validateAskModelValue(value) {
@@ -121,23 +135,28 @@ export const askCommand = cli({
             await ensureGeminiPage(page);
 
             // Open the picker menu (click the model-picker button).
-            await page.evaluate(`
+            const pickerRaw = await page.evaluate(`
               (() => {
                 ${pickModelPickerScript()}
                 const picker = findModelPicker();
-                if (!picker) return { ok: false };
-                try { picker.click(); } catch (_) { return { ok: false }; }
+                if (!picker) return { ok: false, reason: 'Gemini model picker button was not found' };
+                try { picker.click(); } catch (_) { return { ok: false, reason: 'Failed to click Gemini model picker button' }; }
                 return { ok: true };
               })()
             `);
+            const pickerResult = unwrapBrowserBridgeEnvelope(pickerRaw);
+            if (!pickerResult || typeof pickerResult !== 'object' || !pickerResult.ok) {
+                throw new CommandExecutionError(
+                    pickerResult?.reason || 'Failed to open Gemini model picker for model discovery'
+                );
+            }
 
             // Wait for React to render the menu.
             await page.wait(1.0);
 
             // Read model entries from the open menu.
             const raw = await page.evaluate(readMenuModelsScript());
-            const unwrapped = unwrapBrowserBridgeEnvelope(raw);
-            discoveredModels = Array.isArray(unwrapped) ? unwrapped : [];
+            discoveredModels = requireDiscoveredModels(raw);
 
             // Close the menu. Thinking support is intentionally not copied from
             // the currently-visible UI into every model row: Gemini exposes
@@ -150,8 +169,8 @@ export const askCommand = cli({
         if (hasModel) {
             const availableModels = discoveredModels || [];
             if (!Array.isArray(availableModels) || availableModels.length === 0) {
-                throw new ArgumentError(
-                    'Failed to discover Gemini models. Use "opencli gemini models" to see available values.'
+                throw new CommandExecutionError(
+                    'Gemini model discovery returned no selectable models. Gemini Web may have changed its model selector UI.'
                 );
             }
             const availableIds = availableModels.map((m) => m?.model).filter(Boolean);

--- a/clis/gemini/ask.js
+++ b/clis/gemini/ask.js
@@ -1,6 +1,18 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { GEMINI_DOMAIN, readGeminiSnapshot, sendGeminiMessage, startNewGeminiChat, waitForGeminiResponse, waitForGeminiSubmission } from './utils.js';
+import {
+  GEMINI_DOMAIN,
+  ensureGeminiPage,
+  getCurrentGeminiModel,
+  readGeminiSnapshot,
+  selectGeminiModel,
+  selectGeminiThinking,
+  sendGeminiMessage,
+  startNewGeminiChat,
+  waitForGeminiResponse,
+  waitForGeminiSubmission,
+} from './utils.js';
+import { pickModelPickerScript, readMenuModelsScript } from './models.js';
 function normalizeBooleanFlag(value) {
     if (typeof value === 'boolean')
         return value;
@@ -8,6 +20,48 @@ function normalizeBooleanFlag(value) {
     return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
 }
 const NO_RESPONSE_PREFIX = '[NO RESPONSE]';
+
+/**
+ * Validate a --model value for gemini ask.
+ * Throws ArgumentError for short aliases or invalid formats.
+ */
+function unwrapBrowserBridgeEnvelope(value) {
+    if (value && typeof value === 'object' && 'data' in value && 'session' in value) {
+        return value.data;
+    }
+    return value;
+}
+
+function validateAskModelValue(value) {
+    if (!value) {
+        throw new ArgumentError(
+            '--model requires a canonical model id (e.g. "2.5-flash"). ' +
+            'Use "opencli gemini models" to list available values.'
+        );
+    }
+    // Reject short aliases like "pro", "flash", "flash-lite" that lack a version number.
+    if (!/\d+\.\d+/.test(value)) {
+        throw new ArgumentError(
+            '--model "' + value + '" is not accepted. ' +
+            'Short aliases like "pro", "flash", or "flash-lite" are not supported. ' +
+            'Use a canonical model id (e.g. "2.5-flash"). ' +
+            'Use "opencli gemini models" to list available values.'
+        );
+    }
+    // Must match canonical format: X.Y-variant
+    if (!/^\d+\.\d+-[a-z][a-z-]*$/.test(value)) {
+        throw new ArgumentError(
+            '--model "' + value + '" is not a valid canonical model id. ' +
+            'Expected format: version-variant (e.g. "2.5-flash", "3.1-pro"). ' +
+            'Use "opencli gemini models" to list available values.'
+        );
+    }
+}
+
+export const __test__ = {
+    validateAskModelValue,
+};
+
 export const askCommand = cli({
     site: 'gemini',
     name: 'ask',
@@ -21,8 +75,10 @@ export const askCommand = cli({
     defaultFormat: 'plain',
     args: [
         { name: 'prompt', required: true, positional: true, help: 'Prompt to send' },
+        { name: 'model', type: 'string', required: false, help: 'Gemini model to use (e.g. "2.5-flash"). Use "opencli gemini models" to list available values.' },
         { name: 'timeout', type: 'int', required: false, help: 'Max seconds to wait (default: 60)', default: 60 },
         { name: 'new', required: false, help: 'Start a new chat first (true/false, default: false)', default: 'false' },
+        { name: 'thinking', required: false, help: 'Thinking level: standard or extended (omitted = leave unchanged)', default: null },
     ],
     columns: ['response'],
     func: async (page, kwargs) => {
@@ -31,9 +87,157 @@ export const askCommand = cli({
         if (!Number.isInteger(timeout) || timeout < 1) {
             throw new ArgumentError('--timeout must be a positive integer (seconds)');
         }
+
+        // ── New chat (must happen before model/thinking selection) ──────
         const startFresh = normalizeBooleanFlag(kwargs.new);
         if (startFresh)
             await startNewGeminiChat(page);
+
+        // ── Early validation: model format & thinking value ────────────
+        const hasModel = kwargs.model !== undefined && kwargs.model !== null;
+        const hasThinking = kwargs.thinking != null;
+
+        let modelValue = null;
+        if (hasModel) {
+            modelValue = String(kwargs.model).trim();
+            validateAskModelValue(modelValue);
+        }
+
+        if (hasThinking) {
+            const thinkingRaw = String(kwargs.thinking ?? '').trim();
+            const thinkingValue = thinkingRaw.toLowerCase();
+            if (thinkingValue !== 'standard' && thinkingValue !== 'extended') {
+                throw new ArgumentError(
+                    `--thinking must be 'standard' or 'extended', got '${thinkingRaw}'`,
+                    'Run `opencli gemini models` to see available thinking levels.',
+                );
+            }
+        }
+
+        // ── Model and thinking discovery (shared by both model and
+        //    thinking selection) ──────────────────────────────────────
+        let discoveredModels = null;
+        if (hasModel || hasThinking) {
+            await ensureGeminiPage(page);
+
+            // Open the picker menu (click the model-picker button).
+            await page.evaluate(`
+              (() => {
+                ${pickModelPickerScript()}
+                const picker = findModelPicker();
+                if (!picker) return { ok: false };
+                try { picker.click(); } catch (_) { return { ok: false }; }
+                return { ok: true };
+              })()
+            `);
+
+            // Wait for React to render the menu.
+            await page.wait(1.0);
+
+            // Read model entries from the open menu.
+            const raw = await page.evaluate(readMenuModelsScript());
+            const unwrapped = unwrapBrowserBridgeEnvelope(raw);
+            discoveredModels = Array.isArray(unwrapped) ? unwrapped : [];
+
+            // Close the menu. Thinking support is intentionally not copied from
+            // the currently-visible UI into every model row: Gemini exposes
+            // thinking controls for the current selection, not a reliable
+            // per-model capability matrix.
+            await page.evaluate(`(() => { try { document.body.click(); } catch (_) {} })()`);
+        }
+
+        // ── Model selection ──────────────────────────────────────────────
+        if (hasModel) {
+            const availableModels = discoveredModels || [];
+            if (!Array.isArray(availableModels) || availableModels.length === 0) {
+                throw new ArgumentError(
+                    'Failed to discover Gemini models. Use "opencli gemini models" to see available values.'
+                );
+            }
+            const availableIds = availableModels.map((m) => m?.model).filter(Boolean);
+            if (!availableIds.includes(modelValue)) {
+                throw new ArgumentError(
+                    'Unknown model "' + modelValue + '". ' +
+                    'Available models: ' + availableIds.join(', ') + '. ' +
+                    'Use "opencli gemini models" to see available values.'
+                );
+            }
+            await selectGeminiModel(page, modelValue);
+        }
+
+        // ── Thinking validation and selection ──────────────────────────
+        if (hasThinking) {
+            // Reuse the pre-discovered models from the shared discovery call.
+            const discovered = discoveredModels || [];
+
+            // When --model was supplied, scope thinking to the selected model;
+            // otherwise scope to the current model from the web UI.
+            let targetModelId;
+            if (hasModel) {
+                targetModelId = modelValue;
+            } else {
+                targetModelId = await getCurrentGeminiModel(page);
+            }
+
+            // Build a map of model → thinkingValues for lookup.
+            const modelThinkingMap = new Map();
+            const allThinking = new Set();
+            for (const entry of discovered) {
+                if (entry && typeof entry.model === 'string' && Array.isArray(entry.thinkingValues)) {
+                    const tvs = entry.thinkingValues.filter((tv) => typeof tv === 'string');
+                    if (tvs.length > 0) {
+                        modelThinkingMap.set(entry.model, tvs);
+                        for (const tv of tvs) allThinking.add(tv);
+                    }
+                }
+            }
+
+            // Resolve thinkingValue from early validation.
+            const thinkingValue = String(kwargs.thinking ?? '').trim().toLowerCase();
+
+            // Validate: if we can identify the target model, scope to its
+            // thinking values; otherwise fall back to the union across all models.
+            const targetModelThinking =
+                targetModelId && modelThinkingMap.has(targetModelId)
+                    ? modelThinkingMap.get(targetModelId)
+                    : null;
+
+            if (targetModelThinking) {
+                // Scoped to the target model.
+                if (!targetModelThinking.includes(thinkingValue)) {
+                    const availableForModel = targetModelThinking.sort().join(', ');
+                    throw new ArgumentError(
+                        `--thinking '${thinkingValue}' is not available for the ${hasModel ? 'selected' : 'current'} model ('${targetModelId}')`,
+                        `Model '${targetModelId}' supports: ${availableForModel}. Run \`opencli gemini models\` for all models.`,
+                    );
+                }
+            } else if (allThinking.size > 0 && !allThinking.has(thinkingValue)) {
+                // Union fallback when the target model cannot be identified.
+                const availableList = [...allThinking].sort().join(', ');
+                throw new ArgumentError(
+                    `--thinking '${thinkingValue}' is not currently available`,
+                    `Available thinking values: ${availableList}. Run \`opencli gemini models\` for details.`,
+                );
+            }
+
+            // Select the requested thinking level before snapshot.
+            const selected = await selectGeminiThinking(page, thinkingValue);
+            if (!selected) {
+                // Build an informative hint from what we know.
+                const hintParts = [];
+                if (targetModelThinking && targetModelThinking.length > 0) {
+                    hintParts.push(`Model '${targetModelId}' supports: ${targetModelThinking.sort().join(', ')}.`);
+                } else if (allThinking.size > 0) {
+                    hintParts.push(`Available thinking values: ${[...allThinking].sort().join(', ')}.`);
+                }
+                hintParts.push('Run `opencli gemini models` for details.');
+                throw new ArgumentError(
+                    `Could not select thinking level '${thinkingValue}' in the Gemini web UI`,
+                    hintParts.join(' '),
+                );
+            }
+        }
+
         const before = await readGeminiSnapshot(page);
         await sendGeminiMessage(page, prompt);
         const submissionStartedAt = Date.now();

--- a/clis/gemini/ask.test.js
+++ b/clis/gemini/ask.test.js
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+
 const baseline = {
     turns: [{ Role: 'Assistant', Text: '旧回答' }],
     transcriptLines: ['baseline'],
@@ -21,25 +23,66 @@ const submission = {
     userAnchorTurn: { Role: 'User', Text: '请只回复：OK' },
     reason: 'user_turn',
 };
+
+const FIXTURE_MODELS = [
+    { model: '2.5-flash', thinkingValues: ['standard', 'extended'] },
+    { model: '2.5-flash-lite', thinkingValues: ['standard'] },
+    { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+    { model: '2.5-flash-thinking', thinkingValues: [] },
+];
+
 const mocks = vi.hoisted(() => ({
+    ensureGeminiPage: vi.fn(),
+    getCurrentGeminiModel: vi.fn(),
     readGeminiSnapshot: vi.fn(),
+    selectGeminiModel: vi.fn(),
+    selectGeminiThinking: vi.fn(),
     sendGeminiMessage: vi.fn(),
     startNewGeminiChat: vi.fn(),
     waitForGeminiSubmission: vi.fn(),
     waitForGeminiResponse: vi.fn(),
 }));
+
 vi.mock('./utils.js', async () => {
     const actual = await vi.importActual('./utils.js');
     return {
         ...actual,
+        ensureGeminiPage: mocks.ensureGeminiPage,
+        getCurrentGeminiModel: mocks.getCurrentGeminiModel,
         readGeminiSnapshot: mocks.readGeminiSnapshot,
+        selectGeminiModel: mocks.selectGeminiModel,
+        selectGeminiThinking: mocks.selectGeminiThinking,
         sendGeminiMessage: mocks.sendGeminiMessage,
         startNewGeminiChat: mocks.startNewGeminiChat,
         waitForGeminiSubmission: mocks.waitForGeminiSubmission,
         waitForGeminiResponse: mocks.waitForGeminiResponse,
     };
 });
-import { askCommand } from './ask.js';
+
+// Mock models.js — stub the split discovery script functions.
+const modelsMock = vi.hoisted(() => ({
+    pickModelPickerScript: vi.fn().mockReturnValue('__PICKER_SCRIPT__'),
+    readMenuModelsScript: vi.fn().mockReturnValue('__READ_MODELS_SCRIPT__'),
+    clickThinkingToggleScript: vi.fn().mockReturnValue('__TOGGLE_SCRIPT__'),
+    extractThinkingScript: vi.fn().mockReturnValue('__EXTRACT_THINKING_SCRIPT__'),
+}));
+vi.mock('./models.js', () => ({
+    pickModelPickerScript: modelsMock.pickModelPickerScript,
+    readMenuModelsScript: modelsMock.readMenuModelsScript,
+    clickThinkingToggleScript: modelsMock.clickThinkingToggleScript,
+    extractThinkingScript: modelsMock.extractThinkingScript,
+    __test__: {
+        pickModelPickerScript: modelsMock.pickModelPickerScript,
+        readMenuModelsScript: modelsMock.readMenuModelsScript,
+        clickThinkingToggleScript: modelsMock.clickThinkingToggleScript,
+        extractThinkingScript: modelsMock.extractThinkingScript,
+    },
+}));
+
+import { askCommand, __test__ } from './ask.js';
+
+const { validateAskModelValue } = __test__;
+
 function createPageMock() {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -66,11 +109,752 @@ function createPageMock() {
         nativeKeyPress: vi.fn().mockResolvedValue(undefined),
     };
 }
+
+/**
+ * Set up page.evaluate mocks for the multi-step discovery flow used by ask.
+ *
+ * The ask command opens the picker (evaluate → { ok }), waits, reads
+ * models (evaluate → models[]), then closes the menu (evaluate → anything).
+ */
+function setupDiscoveryMocks(page, models = FIXTURE_MODELS) {
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true }); // picker click
+    vi.mocked(page.evaluate).mockResolvedValueOnce(models);       // read models
+    vi.mocked(page.evaluate).mockResolvedValueOnce(undefined);    // close menu
+}
+
+function setupDiscoveryWithoutThinking(page, models = FIXTURE_MODELS) {
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+    vi.mocked(page.evaluate).mockResolvedValueOnce(models);
+    vi.mocked(page.evaluate).mockResolvedValueOnce(undefined);
+}
+
+function setupFailedDiscovery(page, reason = 'Model picker button not found') {
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: false, reason });
+}
+
+function setupDiscoveryNonArray(page) {
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ not: 'an array' });
+    vi.mocked(page.evaluate).mockResolvedValueOnce(undefined);
+}
+
+function setupDiscoveryEmpty(page) {
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+    vi.mocked(page.evaluate).mockResolvedValueOnce([]);
+    vi.mocked(page.evaluate).mockResolvedValueOnce(undefined);
+}
+
+// ── Command registration ─────────────────────────────────────────────────
+
+describe('ask command registration', () => {
+    it('is registered with site=gemini and name=ask', () => {
+        expect(askCommand.site).toBe('gemini');
+        expect(askCommand.name).toBe('ask');
+    });
+
+    it('is access=write', () => {
+        expect(askCommand.access).toBe('write');
+    });
+
+    it('declares response as its output column', () => {
+        expect(askCommand.columns).toEqual(['response']);
+    });
+
+    it('includes --model as an optional string argument', () => {
+        const modelArg = askCommand.args.find((a) => a.name === 'model');
+        expect(modelArg).toBeDefined();
+        expect(modelArg.required).toBe(false);
+        expect(modelArg.type).toBe('string');
+    });
+
+    it('includes --thinking as an optional argument', () => {
+        const thinkingArg = askCommand.args.find((a) => a.name === 'thinking');
+        expect(thinkingArg).toBeDefined();
+        expect(thinkingArg.required).toBe(false);
+    });
+
+    it('still includes prompt, timeout, and new args', () => {
+        const names = askCommand.args.map((a) => a.name);
+        expect(names).toContain('prompt');
+        expect(names).toContain('timeout');
+        expect(names).toContain('new');
+        expect(names).toContain('model');
+        expect(names).toContain('thinking');
+    });
+});
+
+// ── validateAskModelValue ────────────────────────────────────────────────
+
+describe('validateAskModelValue', () => {
+    it('accepts canonical model ids', () => {
+        expect(() => validateAskModelValue('2.5-flash')).not.toThrow();
+        expect(() => validateAskModelValue('2.5-flash-lite')).not.toThrow();
+        expect(() => validateAskModelValue('2.5-pro')).not.toThrow();
+        expect(() => validateAskModelValue('2.5-flash-thinking')).not.toThrow();
+        expect(() => validateAskModelValue('3.1-flash-lite')).not.toThrow();
+        expect(() => validateAskModelValue('3.5-flash')).not.toThrow();
+        expect(() => validateAskModelValue('3.1-pro')).not.toThrow();
+    });
+
+    it('rejects short aliases without version numbers', () => {
+        const msg = 'is not accepted';
+
+        expect(() => validateAskModelValue('pro')).toThrow(ArgumentError);
+        expect(() => validateAskModelValue('pro')).toThrow(msg);
+        expect(() => validateAskModelValue('flash')).toThrow(ArgumentError);
+        expect(() => validateAskModelValue('flash')).toThrow(msg);
+        expect(() => validateAskModelValue('flash-lite')).toThrow(ArgumentError);
+        expect(() => validateAskModelValue('flash-lite')).toThrow(msg);
+        expect(() => validateAskModelValue('lite')).toThrow(ArgumentError);
+        expect(() => validateAskModelValue('thinking')).toThrow(ArgumentError);
+    });
+
+    it('rejects empty string', () => {
+        expect(() => validateAskModelValue('')).toThrow(ArgumentError);
+    });
+
+    it('rejects values missing a variant after version', () => {
+        expect(() => validateAskModelValue('2.5')).toThrow(ArgumentError);
+    });
+
+    it('rejects inverted format (variant first)', () => {
+        expect(() => validateAskModelValue('flash-2.5')).toThrow(ArgumentError);
+    });
+
+    it('mentions opencli gemini models in error messages', () => {
+        try { validateAskModelValue('pro'); } catch (e) {
+            expect(e.message).toContain('opencli gemini models');
+        }
+        try { validateAskModelValue('2.5'); } catch (e) {
+            expect(e.message).toContain('opencli gemini models');
+        }
+    });
+});
+
+/**
+ * Helper: set up the two evaluate calls needed for thinking validation:
+ *   1. discoverModelsScript (via page.evaluate)
+ *   2. getCurrentGeminiModel (mocked separately)
+ */
+function setupDiscoveryAndModel(page, discoveredModels, currentModel) {
+    // Multi-step discovery: picker click → read models → close.
+    vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+    vi.mocked(page.evaluate).mockResolvedValueOnce(discoveredModels);
+    vi.mocked(page.evaluate).mockResolvedValueOnce(undefined); // close
+    mocks.getCurrentGeminiModel.mockResolvedValueOnce(currentModel);
+}
+
+/**
+ * Helper: set up the full happy-path mocks after thinking validation.
+ */
+function setupHappyPath() {
+    mocks.selectGeminiThinking.mockResolvedValueOnce('Selected');
+    mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+    mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+    mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+    mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+}
+
+// ── gemini ask orchestration ─────────────────────────────────────────────
+
 describe('gemini ask orchestration', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
+
+    // ── Baseline behavior (no --model) ───────────────────────────────────
+
     it('captures baseline, sends, waits for confirmed submission, then waits with the remaining timeout', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        const result = await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
+
+        expect(mocks.readGeminiSnapshot).toHaveBeenCalledWith(page);
+        expect(mocks.waitForGeminiSubmission).toHaveBeenCalledWith(page, baseline, 20);
+        expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 18);
+        expect(result).toEqual([{ response: '💬 OK' }]);
+    });
+
+    it('does not spend extra response wait time after submission has already consumed the full timeout budget', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(20000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('');
+
+        await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
+
+        expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 0);
+    });
+
+    // ── Omitted --model (no model change) ────────────────────────────────
+
+    it('does not call ensureGeminiPage or selectGeminiModel when --model is omitted', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', timeout: 10, new: 'false' });
+
+        // ensureGeminiPage may be called internally by readGeminiSnapshot/sendGeminiMessage
+        // but selectGeminiModel must NOT be called when --model is absent.
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+        // page.evaluate (for model discovery) must NOT be called.
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('does not call selectGeminiModel when --model is undefined', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', timeout: 10, new: 'false' });
+
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+    });
+
+    // ── Valid model selection ────────────────────────────────────────────
+
+    it('selects the model before readGeminiSnapshot when --model is provided', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' });
+
+        // Model discovery and selection happen first.
+        expect(mocks.ensureGeminiPage).toHaveBeenCalledWith(page);
+        expect(mocks.ensureGeminiPage).toHaveBeenCalledBefore(page.evaluate);
+        expect(page.evaluate).toHaveBeenCalledTimes(3); // picker click, read models, close
+        expect(mocks.selectGeminiModel).toHaveBeenCalledWith(page, '2.5-flash');
+
+        // Model selection happens before readGeminiSnapshot.
+        expect(mocks.selectGeminiModel).toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).toHaveBeenCalled();
+        // Verify ordering: selectGeminiModel called before readGeminiSnapshot
+        const selectCallOrder = mocks.selectGeminiModel.mock.invocationCallOrder[0];
+        const snapshotCallOrder = mocks.readGeminiSnapshot.mock.invocationCallOrder[0];
+        expect(selectCallOrder).toBeLessThan(snapshotCallOrder);
+    });
+
+    it('selects the model before sending the prompt', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' });
+
+        const selectCallOrder = mocks.selectGeminiModel.mock.invocationCallOrder[0];
+        const sendCallOrder = mocks.sendGeminiMessage.mock.invocationCallOrder[0];
+        expect(selectCallOrder).toBeLessThan(sendCallOrder);
+    });
+
+    it('selects 2.5-pro model successfully', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        const result = await askCommand.func(page, { prompt: 'hello', model: '2.5-pro', timeout: 10, new: 'false' });
+
+        expect(mocks.selectGeminiModel).toHaveBeenCalledWith(page, '2.5-pro');
+        expect(result).toEqual([{ response: '💬 OK' }]);
+    });
+
+    it('selects 2.5-flash-lite model successfully', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        const result = await askCommand.func(page, { prompt: 'hello', model: '2.5-flash-lite', timeout: 10, new: 'false' });
+
+        expect(mocks.selectGeminiModel).toHaveBeenCalledWith(page, '2.5-flash-lite');
+        expect(result).toEqual([{ response: '💬 OK' }]);
+    });
+
+    // ── Alias rejection ──────────────────────────────────────────────────
+
+    it('throws ArgumentError for alias "pro" before any model discovery', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: 'pro', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+
+        // Must not call page.evaluate (no discovery attempted).
+        expect(page.evaluate).not.toHaveBeenCalled();
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+    });
+
+    it('throws ArgumentError for alias "flash" before any model discovery', async () => {
+        const page = createPageMock();
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: 'flash', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('throws ArgumentError for alias "flash-lite" before any model discovery', async () => {
+        const page = createPageMock();
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: 'flash-lite', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('rejects aliases with error message mentioning canonical ids and opencli gemini models', async () => {
+        const page = createPageMock();
+
+        try {
+            await askCommand.func(page, { prompt: 'hello', model: 'pro', timeout: 10, new: 'false' });
+            expect.fail('Expected ArgumentError');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ArgumentError);
+            expect(e.message).toContain('not accepted');
+            expect(e.message).toContain('opencli gemini models');
+        }
+    });
+
+    // ── Invalid / unavailable model ──────────────────────────────────────
+
+    it('throws ArgumentError for a model id not in the discovered list', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: '99.9-nonexistent', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+
+        // Discovery was attempted.
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        // But model was not selected.
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+        // And no snapshot or send happened.
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
+    });
+
+    it('includes available models and suggests opencli gemini models in invalid-model error', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+
+        try {
+            await askCommand.func(page, { prompt: 'hello', model: '99.9-nonexistent', timeout: 10, new: 'false' });
+            expect.fail('Expected ArgumentError');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ArgumentError);
+            expect(e.message).toContain('99.9-nonexistent');
+            expect(e.message).toContain('Available models');
+            expect(e.message).toContain('2.5-flash');
+            expect(e.message).toContain('2.5-pro');
+            expect(e.message).toContain('opencli gemini models');
+        }
+    });
+
+    it('throws when model discovery returns non-array data', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryNonArray(page);
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    // ── Browser Bridge envelope unwrap ───────────────────────────────────
+
+    it('unwraps Browser Bridge envelope { session, data } for model discovery', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        // The envelope is returned by readMenuModelsScript.
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true }); // picker click
+        vi.mocked(page.evaluate).mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: FIXTURE_MODELS,
+        }); // read models
+        vi.mocked(page.evaluate).mockResolvedValueOnce(false); // toggle
+        vi.mocked(page.evaluate).mockResolvedValueOnce(undefined); // close
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        const result = await askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' });
+
+        expect(mocks.selectGeminiModel).toHaveBeenCalledWith(page, '2.5-flash');
+        expect(result).toEqual([{ response: '💬 OK' }]);
+    });
+
+    it('handles empty model discovery result gracefully', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryEmpty(page);
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    // ── Ordering and state ───────────────────────────────────────────────
+
+    it('does not restore previous model after completion', async () => {
+        // The ask command selects the model and does not revert it.
+        // This test verifies that selectGeminiModel is only called once
+        // (for selection) and never called again (for restoration).
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' });
+
+        // selectGeminiModel is called exactly once (for selection, not restoration).
+        expect(mocks.selectGeminiModel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not mutate other Gemini commands — only ask accepts --model', () => {
+        // Other Gemini commands (image, deep research, etc.) are in separate
+        // files and do not import model selection.  This test confirms ask
+        // is the only command that declares --model within gemini.
+        const modelArg = askCommand.args.find((a) => a.name === 'model');
+        expect(modelArg).toBeDefined();
+        // The model arg is on ask only; other commands are unchanged.
+    });
+
+    // ── Model selection + --new interaction ──────────────────────────────
+
+    it('starts new chat, then selects model when both --model and --new=true', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.startNewGeminiChat.mockResolvedValueOnce('clicked');
+        setupDiscoveryWithoutThinking(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'true' });
+
+        // New chat happens first, then model selection.
+        const newChatCallOrder = mocks.startNewGeminiChat.mock.invocationCallOrder[0];
+        const selectCallOrder = mocks.selectGeminiModel.mock.invocationCallOrder[0];
+        expect(newChatCallOrder).toBeLessThan(selectCallOrder);
+    });
+});
+
+describe('gemini ask thinking selection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // ── Valid thinking selection (current model matched) ─────────────
+    it('selects standard thinking when current model supports it', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: '请只回复：OK', timeout: 20, new: 'false', thinking: 'standard',
+        });
+
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'standard');
+        const selectCall = mocks.selectGeminiThinking.mock.invocationCallOrder[0];
+        const snapshotCall = mocks.readGeminiSnapshot.mock.invocationCallOrder[0];
+        expect(selectCall).toBeLessThan(snapshotCall);
+        expect(result).toEqual([{ response: '💬 OK' }]);
+    });
+
+    it('selects extended thinking when current model supports it', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-pro', thinkingValues: ['standard', 'extended'] }],
+            '2.5-pro',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false', thinking: 'extended',
+        });
+
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'extended');
+        expect(result[0].response).toContain('OK');
+    });
+
+    it('selects thinking with --new true: new chat before thinking before snapshot', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        mocks.startNewGeminiChat.mockResolvedValueOnce('navigate');
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'true', thinking: 'standard',
+        });
+
+        const newChatCall = mocks.startNewGeminiChat.mock.invocationCallOrder[0];
+        const thinkingCall = mocks.selectGeminiThinking.mock.invocationCallOrder[0];
+        const snapshotCall = mocks.readGeminiSnapshot.mock.invocationCallOrder[0];
+        expect(newChatCall).toBeLessThan(thinkingCall);
+        expect(thinkingCall).toBeLessThan(snapshotCall);
+    });
+
+    // ── Invalid thinking value (not standard or extended) ────────────
+    it('rejects invalid thinking value with ArgumentError', async () => {
+        const page = createPageMock();
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'invalid',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("--thinking must be 'standard' or 'extended'");
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty thinking value', async () => {
+        const page = createPageMock();
+        let err;
+        try {
+            await askCommand.func(page, { prompt: 'test', timeout: 20, thinking: '' });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("--thinking must be 'standard' or 'extended'");
+    });
+
+    // ── Current-model-scoped validation ──────────────────────────────
+    it('rejects thinking not available for the current model (cross-model mismatch)', async () => {
+        const page = createPageMock();
+        // Two models: 2.5-flash supports 'standard' only, 2.5-pro supports extended.
+        // Current model is 2.5-flash, but user requests 'extended'.
+        setupDiscoveryAndModel(page,
+            [
+                { model: '2.5-flash', thinkingValues: ['standard'] },
+                { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+            ],
+            '2.5-flash',
+        );
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("not available for the current model");
+        expect(err.message).toContain("2.5-flash");
+        expect(err.hint).toContain("standard");
+        // Must NOT mention 'extended' as available (it's not on this model).
+        expect(err.hint).not.toContain("extended");
+
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('attempts thinking selection when current model has no reliable per-model thinking data', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash-lite', thinkingValues: [] }],
+            '2.5-flash-lite',
+        );
+        mocks.selectGeminiThinking.mockResolvedValueOnce('');
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'standard',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("Could not select thinking level");
+
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'standard');
+    });
+
+    // ── Union fallback when current model unknown ────────────────────
+    it('falls back to union validation when current model is empty', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard'] }],
+            '',  // current model unknown → union fallback
+        );
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("not currently available");
+        expect(err.hint).toContain("standard");
+    });
+
+    it('falls back to union when current model not found in discovered set', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard'] }],
+            '3.0-unknown-model',  // not in discovered set
+        );
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("not currently available");
+    });
+
+    // ── Graceful degradation when discovery returns empty ────────────
+    it('proceeds when discovery returns empty', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page, [], '');
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, thinking: 'standard',
+        });
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'standard');
+        expect(result[0].response).toContain('OK');
+    });
+
+    it('does not reject empty thinkingValues as unsupported because they mean unknown support', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: [] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, thinking: 'extended',
+        });
+
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'extended');
+        expect(result[0].response).toContain('OK');
+    });
+
+    // ── Failed thinking selection ────────────────────────────────────
+    it('throws when selectGeminiThinking returns empty after successful validation', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        mocks.selectGeminiThinking.mockResolvedValueOnce('');  // failed selection
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'standard',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("Could not select thinking level");
+
+        // Must not proceed to snapshot or send.
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
+    });
+
+    it('failed selection hint includes model-specific info when current model known', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        mocks.selectGeminiThinking.mockResolvedValueOnce('');
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20, thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.hint).toContain("2.5-flash");
+        expect(err.hint).toContain("standard");
+        expect(err.hint).toContain("extended");
+        expect(err.hint).toContain("gemini models");
+    });
+
+    // ── Omitted thinking ─────────────────────────────────────────────
+    it('omitted --thinking does not call selectGeminiThinking', async () => {
         vi.spyOn(Date, 'now')
             .mockReturnValueOnce(0)
             .mockReturnValueOnce(2000);
@@ -79,22 +863,384 @@ describe('gemini ask orchestration', () => {
         mocks.sendGeminiMessage.mockResolvedValueOnce('button');
         mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
         mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
-        const result = await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
+
+        await askCommand.func(page, { prompt: 'test', timeout: 20, new: 'false' });
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+    });
+
+    it('null thinking does not call selectGeminiThinking', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
+        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
+        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
+        mocks.waitForGeminiResponse.mockResolvedValueOnce('OK');
+
+        await askCommand.func(page, { prompt: 'test', timeout: 20, thinking: null });
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+    });
+
+    // ── Case insensitivity ───────────────────────────────────────────
+    it('accepts uppercase thinking value', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, thinking: 'STANDARD',
+        });
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'standard');
+        expect(result[0].response).toContain('OK');
+    });
+
+    it('accepts mixed-case thinking value', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, thinking: 'ExTeNdEd',
+        });
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'extended');
+        expect(result[0].response).toContain('OK');
+    });
+
+    // ── Does not restore thinking after completion ───────────────────
+    it('does not call selectGeminiThinking again after send', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20, thinking: 'standard',
+        });
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledTimes(1);
+    });
+
+    // ── --model + --thinking integration ───────────────────────────
+    it('scopes thinking validation to the selected model when --model is supplied', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        // getCurrentGeminiModel should NOT be called because --model overrides it
+        mocks.getCurrentGeminiModel.mockResolvedValue('2.5-flash');
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false',
+            model: '2.5-pro', thinking: 'extended',
+        });
+
+        // Thinking validated against selected model (2.5-pro), not current (2.5-flash).
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'extended');
+        // getCurrentGeminiModel should NOT have been called when --model is supplied.
+        expect(mocks.getCurrentGeminiModel).not.toHaveBeenCalled();
+        expect(result[0].response).toContain('OK');
+    });
+
+    it('rejects thinking not available for the selected model (--model + --thinking mismatch)', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        // Multi-step discovery WITHOUT thinking extraction so per-model
+        // thinkingValues from the discovery data are preserved.
+        setupDiscoveryWithoutThinking(page, [
+            { model: '2.5-flash', thinkingValues: ['standard'] },
+            { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+        ]);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20,
+                model: '2.5-flash', thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain("not available for the selected model");
+        expect(err.message).toContain("2.5-flash");
+        expect(err.hint).toContain("standard");
+        expect(err.hint).not.toContain("extended");
+
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+    });
+
+
+    it('does not treat global/current thinking controls as selected-model support when rows have no per-model data', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page, [
+            { model: '2.5-flash', thinkingValues: [] },
+            { model: '2.5-pro', thinkingValues: [] },
+        ]);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20,
+            model: '2.5-flash', thinking: 'extended',
+        });
+
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'extended');
+        expect(result[0].response).toContain('OK');
+    });
+
+    it('unwraps Browser Bridge envelope for thinking discovery before scoped validation', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        // Multi-step discovery: picker click → envelope-wrapped read → close.
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: [
+                { model: '2.5-flash', thinkingValues: ['standard'] },
+                { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+            ],
+        });
+        vi.mocked(page.evaluate).mockResolvedValueOnce(undefined); // close
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20,
+                model: '2.5-flash', thinking: 'extended',
+            });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain('not available for the selected model');
+        expect(err.hint).toContain('standard');
+        expect(err.hint).not.toContain('extended');
+
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('uses current model for scoping when --model is omitted (unchanged behavior)', async () => {
+        const page = createPageMock();
+        setupDiscoveryAndModel(page,
+            [{ model: '2.5-flash', thinkingValues: ['standard', 'extended'] }],
+            '2.5-flash',
+        );
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false', thinking: 'standard',
+        });
+
+        expect(mocks.getCurrentGeminiModel).toHaveBeenCalled();
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledWith(page, 'standard');
+        expect(result[0].response).toContain('OK');
+    });
+
+    // ── Error message suggests gemini models ────────────────────────
+    it('error hint suggests gemini models for invalid values', async () => {
+        const page = createPageMock();
+        let err;
+        try {
+            await askCommand.func(page, { prompt: 'test', timeout: 20, thinking: 'bad-value' });
+        } catch (e) { err = e; }
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.hint).toContain('gemini models');
+    });
+
+    it('invalid thinking value caught by first check does not trigger discovery', async () => {
+        const page = createPageMock();
+        try {
+            await askCommand.func(page, { prompt: 'test', timeout: 20, thinking: 'bad' });
+        } catch (_) {}
+        // First check should catch it; neither discovery nor current-model lookup runs.
+        expect(page.evaluate).not.toHaveBeenCalled();
+        expect(mocks.getCurrentGeminiModel).not.toHaveBeenCalled();
+    });
+
+    // ── Combined --model + --thinking + --new true ordering ─────────
+
+    it('discovers models once when both --model and --thinking are supplied', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false',
+            model: '2.5-flash', thinking: 'standard',
+        });
+
+        // page.evaluate is called 3 times (picker, read, close).
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it('applies model and thinking before snapshot when both flags are supplied (no --new)', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false',
+            model: '2.5-flash', thinking: 'standard',
+        });
+
+        // Model selection before thinking selection.
+        const modelCall = mocks.selectGeminiModel.mock.invocationCallOrder[0];
+        const thinkingCall = mocks.selectGeminiThinking.mock.invocationCallOrder[0];
+        expect(modelCall).toBeLessThan(thinkingCall);
+
+        // Thinking selection before snapshot.
+        const snapshotCall = mocks.readGeminiSnapshot.mock.invocationCallOrder[0];
+        expect(thinkingCall).toBeLessThan(snapshotCall);
+    });
+
+    it('applies --new true, model, and thinking in correct order', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        mocks.startNewGeminiChat.mockResolvedValueOnce('clicked');
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20,
+            new: 'true', model: '2.5-flash', thinking: 'standard',
+        });
+
+        // Order: new chat → model selection → thinking selection → snapshot.
+        const newCall = mocks.startNewGeminiChat.mock.invocationCallOrder[0];
+        const modelCall = mocks.selectGeminiModel.mock.invocationCallOrder[0];
+        const thinkingCall = mocks.selectGeminiThinking.mock.invocationCallOrder[0];
+        const snapshotCall = mocks.readGeminiSnapshot.mock.invocationCallOrder[0];
+        expect(newCall).toBeLessThan(modelCall);
+        expect(modelCall).toBeLessThan(thinkingCall);
+        expect(thinkingCall).toBeLessThan(snapshotCall);
+    });
+
+    it('stops before snapshot and send when combined validation fails (invalid model)', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20,
+                model: '99.9-nonexistent', thinking: 'standard',
+            });
+        } catch (e) { err = e; }
+
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain('Unknown model');
+        // Must not proceed to snapshot, thinking selection, or send.
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
+    });
+
+    it('stops before snapshot and send when combined validation fails (thinking unavailable)', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryWithoutThinking(page, [
+            { model: '2.5-flash-lite', thinkingValues: ['extended'] },
+            { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+        ]);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+
+        let err;
+        try {
+            await askCommand.func(page, {
+                prompt: 'test', timeout: 20,
+                model: '2.5-flash-lite', thinking: 'standard',
+            });
+        } catch (e) { err = e; }
+
+        expect(err).toBeInstanceOf(ArgumentError);
+        expect(err.message).toContain('not available for the selected model');
+        // Must not proceed to snapshot or send.
+        expect(mocks.selectGeminiThinking).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not change response extraction when model and thinking are selected', async () => {
+        vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(2000);
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        const result = await askCommand.func(page, {
+            prompt: '请只回复：OK', timeout: 20, new: 'false',
+            model: '2.5-flash', thinking: 'standard',
+        });
+
+        // Response extraction is unchanged: same prefix, same wait logic.
         expect(mocks.readGeminiSnapshot).toHaveBeenCalledWith(page);
         expect(mocks.waitForGeminiSubmission).toHaveBeenCalledWith(page, baseline, 20);
         expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 18);
         expect(result).toEqual([{ response: '💬 OK' }]);
     });
-    it('does not spend extra response wait time after submission has already consumed the full timeout budget', async () => {
+
+    it('does not restore model or thinking after completion (combined flags)', async () => {
         vi.spyOn(Date, 'now')
             .mockReturnValueOnce(0)
-            .mockReturnValueOnce(20000);
+            .mockReturnValueOnce(2000);
         const page = createPageMock();
-        mocks.readGeminiSnapshot.mockResolvedValueOnce(baseline);
-        mocks.sendGeminiMessage.mockResolvedValueOnce('button');
-        mocks.waitForGeminiSubmission.mockResolvedValueOnce(submission);
-        mocks.waitForGeminiResponse.mockResolvedValueOnce('');
-        await askCommand.func(page, { prompt: '请只回复：OK', timeout: 20, new: 'false' });
-        expect(mocks.waitForGeminiResponse).toHaveBeenCalledWith(page, submission, '请只回复：OK', 0);
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        setupDiscoveryMocks(page);
+        mocks.selectGeminiModel.mockResolvedValueOnce(undefined);
+        setupHappyPath();
+
+        await askCommand.func(page, {
+            prompt: 'test', timeout: 20, new: 'false',
+            model: '2.5-flash', thinking: 'standard',
+        });
+
+        // Both selectGeminiModel and selectGeminiThinking are called exactly once
+        // (for selection, not for restoration).
+        expect(mocks.selectGeminiModel).toHaveBeenCalledTimes(1);
+        expect(mocks.selectGeminiThinking).toHaveBeenCalledTimes(1);
     });
 });

--- a/clis/gemini/ask.test.js
+++ b/clis/gemini/ask.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 const baseline = {
     turns: [{ Role: 'Assistant', Text: '旧回答' }],
@@ -502,7 +502,22 @@ describe('gemini ask orchestration', () => {
 
         await expect(
             askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' })
-        ).rejects.toBeInstanceOf(ArgumentError);
+        ).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails malformed Browser Bridge envelopes during model discovery', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ session: 'site:gemini' });
+
+        await expect(
+            askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' })
+        ).rejects.toBeInstanceOf(CommandExecutionError);
+
+        expect(mocks.selectGeminiModel).not.toHaveBeenCalled();
+        expect(mocks.readGeminiSnapshot).not.toHaveBeenCalled();
+        expect(mocks.sendGeminiMessage).not.toHaveBeenCalled();
     });
 
     // ── Browser Bridge envelope unwrap ───────────────────────────────────
@@ -537,7 +552,7 @@ describe('gemini ask orchestration', () => {
 
         await expect(
             askCommand.func(page, { prompt: 'hello', model: '2.5-flash', timeout: 10, new: 'false' })
-        ).rejects.toBeInstanceOf(ArgumentError);
+        ).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     // ── Ordering and state ───────────────────────────────────────────────

--- a/clis/gemini/models.js
+++ b/clis/gemini/models.js
@@ -1,0 +1,498 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { GEMINI_DOMAIN, ensureGeminiPage } from './utils.js';
+
+function isObjectRecord(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function unwrapBrowserBridgeEnvelope(value, context) {
+    if (isObjectRecord(value) && Object.prototype.hasOwnProperty.call(value, 'session')) {
+        if (Object.prototype.hasOwnProperty.call(value, 'data')) {
+            return value.data;
+        }
+        throw new CommandExecutionError(`${context} returned a malformed Browser Bridge envelope`);
+    }
+    return value;
+}
+
+// ── Shared helpers (embedded in browser scripts) ──────────────────────────
+
+function sharedHelpers() {
+    return `
+      const isVisible = (el) => {
+        if (!el) return false;
+        if (!(el instanceof HTMLElement) && !(el instanceof Element)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = el.getAttribute('aria-hidden');
+        if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0 || style.pointerEvents === 'none') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+      const VERSION_LABEL_RE = /\\d+\\.\\d+/;
+    `;
+}
+
+function findModelPickerLogic() {
+    return `
+      // Patterns for detecting model/mode selector buttons by aria-label.
+      const MODE_SELECTOR_PATTERNS = [
+        /模式选择器/i,
+        /mode[\\s-]*selector/i,
+        /model[\\s-]*selector/i,
+        /model[\\s-]*picker/i,
+        /选择模型/i,
+        /select[\\s-]+model/i,
+        /choose[\\s-]+model/i,
+        /switch[\\s-]+model/i,
+        /change[\\s-]+model/i,
+      ];
+
+      const findModelPicker = () => {
+        const buttons = Array.from(
+          document.querySelectorAll('button, [role="button"]')
+        ).filter(isVisible);
+
+        // Method 1: Detect model/mode selector via aria-label patterns.
+        for (const button of buttons) {
+          const aria = normalize(button.getAttribute('aria-label') || '');
+          for (const pattern of MODE_SELECTOR_PATTERNS) {
+            if (pattern.test(aria)) return button;
+          }
+        }
+
+        // Method 2: Detect buttons whose text contains a model-version pattern.
+        const versionCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '') || normalize(b.getAttribute('aria-label') || '');
+          return VERSION_LABEL_RE.test(text) && text.length < 80;
+        });
+        versionCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (versionCandidates.length > 0) return versionCandidates[0];
+
+        // Method 3: Detect buttons showing a known model variant as their
+        // sole text (e.g. "Pro", "Flash", "Flash-Lite").
+        const MODEL_VARIANT_RE = /^(?:gemini\\s+)?(flash|lite|pro|ultra|nano|flash-lite|flash[\\s-]*thinking)$/i;
+        const variantCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '');
+          return MODEL_VARIANT_RE.test(text) && text.length < 30;
+        });
+        variantCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (variantCandidates.length > 0) return variantCandidates[0];
+
+        // Method 4: Fallback — look for any element with model-related attributes.
+        const attrEls = Array.from(
+          document.querySelectorAll('[data-model-selector], [aria-label*="model" i], [aria-label*="模式" i]')
+        ).filter(isVisible);
+        if (attrEls.length > 0) return attrEls[0];
+
+        return null;
+      };
+    `;
+}
+
+function modelParsingLogic() {
+    return `
+      /**
+       * Best-effort extraction of a canonical model id from display text.
+       * Handles patterns like "3.1 flash-lite", "3.5 flash", "3.1 pro",
+       * "2.5-flash-thinking", "gemini 3.0 pro experimental", and entries with
+       * trailing Chinese descriptions (e.g. "3.1 Flash-Lite 极速回答").
+       */
+      const canonicalModelId = (raw) => {
+        const text = normalize(raw);
+        if (!text) return '';
+
+        // Remove leading decorative characters (e.g. checkmark icons).
+        const cleaned = text.replace(/^[^a-z0-9]+/i, '').trim();
+
+        // Known model-version patterns: "X.Y variant" or "X.Y-variant".
+        const versionRe = /^((?:gemini[\\s-]*)?(\\d+(?:\\.\\d+)?)(?:[\\s-]+(flash|pro|lite|ultra|nano|thinking|experimental))(?:[\\s-]*(flash|pro|lite|ultra|nano|thinking|experimental))?)/i;
+        const match = cleaned.match(versionRe);
+        if (match) {
+          const version = match[2];
+          let variant = (match[3] || '').toLowerCase();
+          const extra = (match[4] || '').toLowerCase();
+          if (extra) variant = variant + '-' + extra;
+          return version + '-' + variant;
+        }
+
+        // Fallback: if the text contains a version number and a known keyword.
+        const fallbackRe = /(\\d+(?:\\.\\d+)?)\\s*(flash|pro|lite|ultra|nano|thinking|experimental)/i;
+        const fallbackMatch = cleaned.match(fallbackRe);
+        if (fallbackMatch) {
+          return fallbackMatch[1] + '-' + fallbackMatch[2].toLowerCase();
+        }
+
+        // For experimental / custom models: use a cleaned version of the label.
+        if (/\\d+(?:\\.\\d+)?/.test(cleaned) && cleaned.length < 60) {
+          return cleaned.replace(/\\s+/g, '-').replace(/[^a-z0-9.-]/g, '');
+        }
+
+        return '';
+      };
+    `;
+}
+
+function thinkingExtractionLogic() {
+    return `
+      /**
+       * Extract thinking values from the full set of visible menu items.
+       * Gemini Web shows thinking levels as separate menu items
+       * (e.g. "标准 最适合回答大多数问题", "扩展 擅长解决复杂问题").
+       * Returns a deduplicated, stable-order array.
+       */
+      const extractAllThinkingValues = (menuItems) => {
+        const found = new Map();
+
+        const THINKING_PATTERNS = [
+          { value: 'standard', patterns: [/\\bstandard\\b/i, /标准/i], priority: 1 },
+          { value: 'extended', patterns: [/\\bextended\\b/i, /扩展/i], priority: 2 },
+        ];
+
+        for (const item of menuItems) {
+          const itemText = normalize(item.textContent || '');
+          const itemAria = normalize(item.getAttribute('aria-label') || '');
+          const combined = itemText + ' ' + itemAria;
+
+          // Skip model entries (contain a version like "3.1").
+          if (/\\d+\\.\\d+/.test(combined)) continue;
+          // Skip the thinking-section header itself (e.g. "思考等级").
+          if (/^思考等级|^thinking level|^thinking mode/i.test(combined.trim())) continue;
+
+          for (const { value, patterns } of THINKING_PATTERNS) {
+            for (const re of patterns) {
+              if (re.test(combined)) {
+                found.set(value, true);
+                break;
+              }
+            }
+          }
+        }
+
+        const result = [];
+        for (const { value } of THINKING_PATTERNS) {
+          if (found.has(value)) result.push(value);
+        }
+        return result;
+      };
+    `;
+}
+
+function menuEnumerationLogic() {
+    return `
+      const MENU_SELECTORS = [
+        '[role="menu"] [role="menuitem"]',
+        '[role="menu"] [role="menuitemradio"]',
+        '[role="listbox"] [role="option"]',
+        '[role="menu"] button',
+        '[role="listbox"] button',
+        '[role="menu"] li',
+        '[role="listbox"] li',
+        '[role="dialog"] [role="menuitem"]',
+        '[role="dialog"] [role="option"]',
+        '[aria-modal="true"] [role="menuitem"]',
+        '[aria-modal="true"] [role="option"]',
+        'gem-menu-item',
+        'GEM-MENU-ITEM',
+        '[role="menu"] gem-menu-item',
+        '[role="menu"] GEM-MENU-ITEM',
+        '[role="listbox"] gem-menu-item',
+        '[role="listbox"] GEM-MENU-ITEM',
+        '[role="menu"] :not(script):not(style)',
+        '[role="listbox"] :not(script):not(style)',
+      ];
+
+      const findVisibleMenuItems = () => {
+        let menuItems = [];
+        for (const sel of MENU_SELECTORS) {
+          const items = Array.from(document.querySelectorAll(sel)).filter(isVisible);
+          if (items.length >= 2) { menuItems = items; break; }
+        }
+
+        if (menuItems.length === 0) {
+          const containers = Array.from(
+            document.querySelectorAll('[role="menu"], [role="listbox"], [role="dialog"], [aria-modal="true"]')
+          ).filter(isVisible);
+          for (const container of containers) {
+            const children = Array.from(
+              container.querySelectorAll('button, [role="button"], li, [role="menuitem"], [role="option"], gem-menu-item, GEM-MENU-ITEM, :not(script):not(style)')
+            ).filter(isVisible);
+            if (children.length >= 2) { menuItems = children; break; }
+          }
+        }
+
+        return menuItems;
+      };
+    `;
+}
+
+function readMenuAndCloseLogic() {
+    return `
+      const menuItems = findVisibleMenuItems();
+
+      // ── Parse models from menu items ──────────────────────────────────
+      const results = [];
+      const seen = new Set();
+
+      for (const item of menuItems) {
+        if (!item || (!(item instanceof HTMLElement) && !(item instanceof Element))) continue;
+        const itemText = (item.textContent || '').replace(/\\s+/g, ' ').trim();
+        const modelId = canonicalModelId(itemText);
+        if (!modelId) continue;
+        if (seen.has(modelId)) continue;
+        seen.add(modelId);
+
+        results.push({ model: modelId, thinkingValues: [] });
+      }
+
+      // Guard: only thinking options, no model entries → bail out.
+      const hasModelEntries = results.some((r) => {
+        return /\\d+\\.\\d+/.test(r.model) || /flash|pro|lite/i.test(r.model);
+      });
+      if (!hasModelEntries) {
+        try { document.body.click(); } catch (_) {}
+        return [];
+      }
+
+      // Do not copy the thinking controls visible for the current Gemini UI
+      // selection onto every model row. They are not a reliable per-model
+      // capability matrix, so rows only report thinkingValues when a future UI
+      // exposes them directly on that model entry.
+
+      // ── Close the menu ────────────────────────────────────────────────
+      try { document.body.click(); } catch (_) {}
+
+      return results;
+    `;
+}
+
+// ── Exported script builders ──────────────────────────────────────────────
+
+/**
+ * Complete discovery script that finds the model picker, opens it,
+ * reads model rows, and closes the menu.
+ * Used by gemini ask for model/thinking discovery.
+ * Uses .click() to trigger React event handlers on Gemini Web.
+ */
+export function discoverModelsScript() {
+    return `
+    (() => {
+      ${sharedHelpers()}
+      ${findModelPickerLogic()}
+      ${modelParsingLogic()}
+      ${thinkingExtractionLogic()}
+      ${menuEnumerationLogic()}
+
+      const picker = findModelPicker();
+      if (!picker) return [];
+
+      // Use native .click() — Gemini Web is a React app and synthetic
+      // event dispatch may not trigger React's event handlers.
+      try { picker.click(); } catch (_) { return []; }
+
+      ${readMenuAndCloseLogic()}
+    })()
+    `;
+}
+
+/**
+ * Script that only finds and clicks the model-picker button.
+ * Does NOT read the menu — only locates and clicks the picker.
+ */
+export function pickModelPickerScript() {
+    return `${sharedHelpers()}${findModelPickerLogic()}`;
+}
+
+/**
+ * Script that reads model rows from an already-open Gemini Web
+ * model-picker menu, then closes the menu.
+ */
+export function readMenuScript() {
+    return `
+    (() => {
+      ${sharedHelpers()}
+      ${modelParsingLogic()}
+      ${thinkingExtractionLogic()}
+      ${menuEnumerationLogic()}
+      ${readMenuAndCloseLogic()}
+    })()
+    `;
+}
+
+/**
+ * Script that reads model entries from an open menu (no thinking extraction,
+ * no menu close).  Returns {models: [...], hasThinkingToggle: bool}.
+ */
+export function readMenuModelsScript() {
+    return `
+    (() => {
+      ${sharedHelpers()}
+      ${modelParsingLogic()}
+      ${menuEnumerationLogic()}
+
+      const menuItems = findVisibleMenuItems();
+
+      const results = [];
+      const seen = new Set();
+
+      for (const item of menuItems) {
+        if (!item || (!(item instanceof HTMLElement) && !(item instanceof Element))) continue;
+        const itemText = (item.textContent || '').replace(/\\s+/g, ' ').trim();
+
+        const modelId = canonicalModelId(itemText);
+        if (!modelId) continue;
+        if (seen.has(modelId)) continue;
+        seen.add(modelId);
+
+        results.push({ model: modelId, thinkingValues: [] });
+      }
+
+      const hasModelEntries = results.some((r) => {
+        return /\\d+\\.\\d+/.test(r.model) || /flash|pro|lite/i.test(r.model);
+      });
+      if (!hasModelEntries) return [];
+
+      return results;
+    })()
+    `;
+}
+
+/**
+ * Script that clicks the "思考等级" / "Thinking level" toggle in the
+ * currently-open menu to expand thinking options.
+ * Returns true if the toggle was found and clicked.
+ */
+export function clickThinkingToggleScript() {
+    return `
+    (() => {
+      const isVisible = (el) => {
+        if (!el) return false;
+        if (!(el instanceof HTMLElement) && !(el instanceof Element)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const menuItems = Array.from(
+        document.querySelectorAll('[role="menuitem"], gem-menu-item, GEM-MENU-ITEM')
+      ).filter(isVisible);
+
+      const thinkingToggle = menuItems.find((item) => {
+        const text = (item.textContent || '').trim();
+        return /思考等级|thinking level|thinking mode/i.test(text);
+      });
+
+      if (thinkingToggle) {
+        try { thinkingToggle.click(); } catch (_) { return false; }
+        return true;
+      }
+      return false;
+    })()
+    `;
+}
+
+/**
+ * Script that extracts thinking values from the currently-open menu.
+ * Looks for menu items whose text matches known thinking-level strings.
+ */
+export function extractThinkingScript() {
+    return `
+    (() => {
+      ${sharedHelpers()}
+      ${thinkingExtractionLogic()}
+      ${menuEnumerationLogic()}
+
+      const menuItems = findVisibleMenuItems();
+      return extractAllThinkingValues(menuItems);
+    })()
+    `;
+}
+
+export const __test__ = {
+    discoverModelsScript,
+    pickModelPickerScript,
+    readMenuScript,
+    readMenuModelsScript,
+    clickThinkingToggleScript,
+    extractThinkingScript,
+};
+
+// ── Command registration ──────────────────────────────────────────────────
+
+export const modelsCommand = cli({
+    site: 'gemini',
+    name: 'models',
+    access: 'read',
+    description: 'List available Gemini models from the web UI',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [],
+    columns: ['model', 'thinkingValues'],
+    func: async (page) => {
+        await ensureGeminiPage(page);
+
+        // Step 1: Open the picker menu (click the model-picker button).
+        const pickerRaw = await page.evaluate(`
+          (() => {
+            ${pickModelPickerScript()}
+            const picker = findModelPicker();
+            if (!picker) return { ok: false, reason: 'Gemini model picker button was not found' };
+            try { picker.click(); } catch (_) { return { ok: false, reason: 'Failed to click Gemini model picker button' }; }
+            return { ok: true };
+          })()
+        `);
+        const pickerResult = unwrapBrowserBridgeEnvelope(pickerRaw, 'Gemini model picker');
+        if (!pickerResult || !pickerResult.ok) {
+            throw new CommandExecutionError(
+                (pickerResult && pickerResult.reason)
+                    ? `${pickerResult.reason}. Gemini Web may have changed its model selector UI.`
+                    : 'Failed to open Gemini model picker. Gemini Web may have changed its model selector UI.'
+            );
+        }
+
+        // Step 2: Wait for React to render the menu.
+        await page.wait(1.0);
+
+        // Step 3: Read model entries from the open menu.
+        const raw = await page.evaluate(readMenuModelsScript());
+        const result = unwrapBrowserBridgeEnvelope(raw, 'Gemini models discovery');
+
+        if (!Array.isArray(result)) {
+            throw new CommandExecutionError('Gemini models discovery returned unexpected data');
+        }
+        for (const row of result) {
+            if (!row || typeof row.model !== 'string' || !Array.isArray(row.thinkingValues)) {
+                throw new CommandExecutionError('Gemini models discovery returned a malformed row');
+            }
+        }
+
+        // Step 4: Close the menu. The current Gemini UI can show thinking
+        // controls for the active model, but that is not a reliable per-model
+        // support matrix, so the command does not copy those values to every
+        // model row.
+
+        // Step 5: Close the menu.
+        await page.evaluate(`(() => { try { document.body.click(); } catch (_) {} })()`);
+
+        return result;
+    },
+});

--- a/clis/gemini/models.js
+++ b/clis/gemini/models.js
@@ -302,7 +302,7 @@ export function discoverModelsScript() {
 
       // Use native .click() — Gemini Web is a React app and synthetic
       // event dispatch may not trigger React's event handlers.
-      try { picker.click(); } catch (_) { return []; }
+      try { picker.click(); } catch (_) { throw new Error('Failed to click Gemini model picker button'); }
 
       ${readMenuAndCloseLogic()}
     })()

--- a/clis/gemini/models.test.js
+++ b/clis/gemini/models.test.js
@@ -1,0 +1,645 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+const mocks = vi.hoisted(() => ({
+    ensureGeminiPage: vi.fn(),
+}));
+
+vi.mock('./utils.js', async () => {
+    const actual = await vi.importActual('./utils.js');
+    return {
+        ...actual,
+        ensureGeminiPage: mocks.ensureGeminiPage,
+    };
+});
+
+import { modelsCommand, __test__ } from './models.js';
+
+function createPageMock() {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(),
+        getCookies: vi.fn().mockResolvedValue([]),
+        snapshot: vi.fn().mockResolvedValue(undefined),
+        click: vi.fn().mockResolvedValue(undefined),
+        typeText: vi.fn().mockResolvedValue(undefined),
+        pressKey: vi.fn().mockResolvedValue(undefined),
+        scrollTo: vi.fn().mockResolvedValue(undefined),
+        getFormState: vi.fn().mockResolvedValue({}),
+        wait: vi.fn().mockResolvedValue(undefined),
+        tabs: vi.fn().mockResolvedValue([]),
+        selectTab: vi.fn().mockResolvedValue(undefined),
+        networkRequests: vi.fn().mockResolvedValue([]),
+        consoleMessages: vi.fn().mockResolvedValue([]),
+        scroll: vi.fn().mockResolvedValue(undefined),
+        autoScroll: vi.fn().mockResolvedValue(undefined),
+        installInterceptor: vi.fn().mockResolvedValue(undefined),
+        getInterceptedRequests: vi.fn().mockResolvedValue([]),
+        waitForCapture: vi.fn().mockResolvedValue(undefined),
+        screenshot: vi.fn().mockResolvedValue(''),
+        nativeType: vi.fn().mockResolvedValue(undefined),
+        nativeKeyPress: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+const FIXTURE_MODEL_ROWS = [
+    { model: '2.5-flash', thinkingValues: ['standard', 'extended'] },
+    { model: '2.5-flash-lite', thinkingValues: ['standard'] },
+    { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+    { model: '2.5-flash-thinking', thinkingValues: [] },
+];
+
+describe('gemini models', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns model rows with model and thinkingValues columns', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });  // picker click
+        vi.mocked(page.evaluate).mockResolvedValueOnce(FIXTURE_MODEL_ROWS);  // menu read
+
+        const rows = await modelsCommand.func(page);
+
+        expect(rows).toEqual(FIXTURE_MODEL_ROWS);
+        expect(rows[0]).toHaveProperty('model');
+        expect(rows[0]).toHaveProperty('thinkingValues');
+        expect(Array.isArray(rows[0].thinkingValues)).toBe(true);
+    });
+
+    it('calls ensureGeminiPage before discovery', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce(FIXTURE_MODEL_ROWS);
+
+        await modelsCommand.func(page);
+
+        expect(mocks.ensureGeminiPage).toHaveBeenCalledWith(page);
+        expect(mocks.ensureGeminiPage).toHaveBeenCalledBefore(page.evaluate);
+    });
+
+    it('is read-only: does not start a new chat, send a message, or select a model', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce(FIXTURE_MODEL_ROWS);
+
+        await modelsCommand.func(page);
+
+        // ensureGeminiPage always gets called, but no other stateful utils.
+        expect(mocks.ensureGeminiPage).toHaveBeenCalledTimes(1);
+        // evaluate is called 3 times: picker click, model read, close menu.
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it('unwraps Browser Bridge envelope { session, data } for picker and model rows', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } });
+        vi.mocked(page.evaluate).mockResolvedValueOnce({
+            session: 'site:gemini',
+            data: FIXTURE_MODEL_ROWS,
+        });
+
+        const rows = await modelsCommand.func(page);
+
+        expect(rows).toEqual(FIXTURE_MODEL_ROWS);
+    });
+
+    it('throws CommandExecutionError when the model picker cannot be opened', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: false, reason: 'Gemini model picker button was not found' });
+
+        await expect(modelsCommand.func(page)).rejects.toThrow(/model picker/i);
+    });
+
+    it('throws CommandExecutionError when evaluate returns a non-array result', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: false });
+
+        await expect(modelsCommand.func(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws CommandExecutionError when a row is missing the model field', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce([
+            { thinkingValues: ['standard'] },
+        ]);
+
+        await expect(modelsCommand.func(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('throws CommandExecutionError when a row has a non-array thinkingValues field', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce([
+            { model: '2.5-flash', thinkingValues: 'standard' },
+        ]);
+
+        await expect(modelsCommand.func(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('accepts rows with empty thinkingValues array', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce([
+            { model: '2.5-flash', thinkingValues: [] },
+            { model: '2.5-pro', thinkingValues: [] },
+        ]);
+
+        const rows = await modelsCommand.func(page);
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].thinkingValues).toEqual([]);
+        expect(rows[1].thinkingValues).toEqual([]);
+    });
+
+    it('keeps model values as strings and thinkingValues as string arrays', async () => {
+        const page = createPageMock();
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        vi.mocked(page.evaluate).mockResolvedValueOnce({ ok: true });
+        vi.mocked(page.evaluate).mockResolvedValueOnce([
+            { model: '2.5-flash-lite', thinkingValues: ['standard'] },
+            { model: '2.5-pro', thinkingValues: ['standard', 'extended'] },
+        ]);
+
+        const rows = await modelsCommand.func(page);
+
+        for (const row of rows) {
+            expect(typeof row.model).toBe('string');
+            expect(Array.isArray(row.thinkingValues)).toBe(true);
+            for (const tv of row.thinkingValues) {
+                expect(typeof tv).toBe('string');
+            }
+        }
+    });
+});
+
+describe('gemini models command registration', () => {
+    it('is registered with site=gemini and name=models', () => {
+        expect(modelsCommand.site).toBe('gemini');
+        expect(modelsCommand.name).toBe('models');
+    });
+
+    it('is access=read (not write)', () => {
+        expect(modelsCommand.access).toBe('read');
+    });
+
+    it('declares model and thinkingValues as its output columns', () => {
+        expect(modelsCommand.columns).toEqual(['model', 'thinkingValues']);
+    });
+
+    it('has no CLI arguments', () => {
+        expect(modelsCommand.args).toEqual([]);
+    });
+
+    it('is a browser command', () => {
+        expect(modelsCommand.browser).toBe(true);
+    });
+
+    it('targets gemini.google.com', () => {
+        expect(modelsCommand.domain).toBe('gemini.google.com');
+    });
+});
+
+// ── DOM fixture tests (jsdom) ──────────────────────────────────────────────
+// These tests run the actual discoverModelsScript() against pre-built DOM
+// fixtures that simulate the Gemini web UI model picker and menu.
+
+/**
+ * Create a JSDOM instance wired up for the discovery script.
+ *
+ * - All elements get a realistic getBoundingClientRect so isVisible() passes.
+ * - getComputedStyle is patched to honour inline style changes (e.g. display
+ *   toggling when the picker menu opens).
+ * - Click handlers can be attached to elements before the script runs.
+ */
+function createGeminiDom(htmlFixture) {
+    const dom = new JSDOM(`<!doctype html><body>${htmlFixture}</body>`, {
+        pretendToBeVisual: true,
+        runScripts: 'outside-only',
+    });
+    const { window } = dom;
+    const { document } = window;
+
+    // Make every element appear to have non-zero bounding rect so isVisible
+    // does not reject elements merely because jsdom returns all-zero rects.
+    Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value() {
+            return { width: 100, height: 24, top: 0, left: 0, right: 100, bottom: 24 };
+        },
+    });
+
+    return { window, document };
+}
+
+/**
+ * Normalize element text to a single-line, whitespace-compacted label
+ * suitable for use as a spy key.
+ */
+function normalizeLabel(el) {
+    const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    const aria = (el.getAttribute('aria-label') || '').replace(/\s+/g, ' ').trim();
+    return (text || aria || '(anonymous)').slice(0, 80);
+}
+
+/**
+ * Run the discovery script in a jsdom window and return the result.
+ */
+function evalDiscoverScript(window) {
+    const scriptText = __test__.discoverModelsScript();
+    return window.eval(scriptText);
+}
+
+/**
+ * Build a click-spy instrumented window. Returns a `spy` object where each
+ * key is a normalized label of a clickable element and the value is the
+ * number of times that element received a click event.
+ */
+function instrumentClickSpy(window) {
+    const { document } = window;
+    const spy = {};
+
+    function record(label) {
+        spy[label] = (spy[label] || 0) + 1;
+    }
+
+    // Track clicks on all interactive elements.
+    document.querySelectorAll('button, [role="button"], [role="menuitem"], [role="option"], [role="menuitemradio"]').forEach((el) => {
+        const label = normalizeLabel(el);
+        el.addEventListener('click', () => record(label));
+    });
+
+    // Track body clicks (menu dismiss).
+    let bodyClickCount = 0;
+    document.body.addEventListener('click', () => {
+        bodyClickCount++;
+    });
+    // Patch body.click so we can read the count after script returns.
+    const originalBodyClick = document.body.click.bind(document.body);
+    document.body.click = function () {
+        bodyClickCount++;
+        return originalBodyClick();
+    };
+    // Attach the count to spy via a getter.
+    Object.defineProperty(spy, '(body)', {
+        get() { return bodyClickCount; },
+        enumerable: true,
+        configurable: true,
+    });
+
+    return spy;
+}
+
+describe('discoverModelsScript — DOM fixture extraction', () => {
+    it('extracts model rows without inferring global thinking controls as per-model support', () => {
+        const { window, document } = createGeminiDom(`
+            <header>
+              <button id="model-picker">2.5 Flash</button>
+              <button>New chat</button>
+            </header>
+            <div id="model-menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+              <div role="menuitem">2.5 Flash Lite</div>
+              <div role="menuitem">2.5 Pro</div>
+              <div role="menuitem">2.5 Flash Thinking</div>
+              <!-- Thinking levels as separate menu items (Gemini Web pattern) -->
+              <div role="menuitem">Standard</div>
+              <div role="menuitem">Extended</div>
+            </div>
+          `);
+
+        // Click handler opens the menu (simulating React render on click).
+        document.getElementById('model-picker').addEventListener('click', () => {
+            document.getElementById('model-menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(4);
+
+        // Thinking menu items are global/current-selection controls, not a
+        // reliable per-model capability matrix, so they are not copied to rows.
+        const models = new Map(result.map((r) => [r.model, r.thinkingValues]));
+
+        expect(models.get('2.5-flash')).toEqual([]);
+        expect(models.get('2.5-flash-lite')).toEqual([]);
+        expect(models.get('2.5-pro')).toEqual([]);
+        expect(models.has('2.5-flash-thinking')).toBe(true);
+        expect(models.get('2.5-flash-thinking')).toEqual([]);
+    });
+
+    it('extracts models from menu items with role=option inside role=listbox', () => {
+        const { window, document } = createGeminiDom(`
+            <header>
+              <button id="model-picker">2.5 Pro</button>
+            </header>
+            <div id="menu" role="listbox" style="display: none;">
+              <div role="option">2.5 Flash</div>
+              <div role="option">2.5 Pro</div>
+              <div role="option">2.5 Flash Lite</div>
+            </div>
+          `);
+
+        document.getElementById('model-picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(3);
+        const modelIds = result.map((r) => r.model).sort();
+        expect(modelIds).toEqual(['2.5-flash', '2.5-flash-lite', '2.5-pro']);
+    });
+
+    it('returns canonical model ids matching acceptance criteria examples (3.1-flash-lite, 3.5-flash, 3.1-pro)', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">3.1 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">3.1 Flash Lite</div>
+              <div role="menuitem">3.5 Flash</div>
+              <div role="menuitem">3.1 Pro</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+        const modelIds = result.map((r) => r.model).sort();
+        expect(modelIds).toEqual(['3.1-flash-lite', '3.1-pro', '3.5-flash']);
+    });
+
+    it('does not infer separate thinking-level menu items as per-model support', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+              <div role="menuitem">2.5 Pro</div>
+              <!-- Thinking levels as separate items (real Gemini Web pattern) -->
+              <div role="menuitem">Standard</div>
+              <div role="menuitem">Extended</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+
+        expect(result).toHaveLength(2);
+        const models = new Map(result.map((r) => [r.model, r.thinkingValues]));
+        expect(models.get('2.5-flash')).toEqual([]);
+        expect(models.get('2.5-pro')).toEqual([]);
+    });
+
+    it('returns empty array when model picker is absent', () => {
+        const { window, document } = createGeminiDom(`
+            <header>
+              <button>Settings</button>
+              <button>Help</button>
+            </header>
+            <div role="menu">
+              <div role="menuitem">Theme</div>
+            </div>
+          `);
+
+        const result = evalDiscoverScript(window);
+
+        expect(result).toEqual([]);
+    });
+
+    it('returns empty array when menu items contain only thinking options (no model entries)', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">Standard</div>
+              <div role="menuitem">Extended</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+
+        expect(result).toEqual([]);
+    });
+
+    it('deduplicates model entries with the same canonical id', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+              <div role="menuitem">2.5 Flash</div>
+              <div role="menuitem">2.5 Pro</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const result = evalDiscoverScript(window);
+        expect(result).toHaveLength(2);
+        const modelIds = result.map((r) => r.model).sort();
+        expect(modelIds).toEqual(['2.5-flash', '2.5-pro']);
+    });
+});
+
+describe('discoverModelsScript — read-only verification (DOM fixture)', () => {
+    it('only clicks the model picker and document.body, never model items', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="model-picker">2.5 Flash</button>
+            <button id="new-chat-btn">New chat</button>
+            <div id="model-menu" role="menu" style="display: none;">
+              <div role="menuitem" id="model-flash">2.5 Flash</div>
+              <div role="menuitem" id="model-pro">2.5 Pro</div>
+              <!-- Thinking items as separate menu items -->
+              <div role="menuitem" id="think-standard">Standard</div>
+              <div role="menuitem" id="think-extended">Extended</div>
+            </div>
+            <div id="composer">
+              <div contenteditable="true">Enter a prompt</div>
+              <button id="send-btn" aria-label="Send">Send</button>
+            </div>
+          `);
+
+        // Show menu on click.
+        document.getElementById('model-picker').addEventListener('click', () => {
+            document.getElementById('model-menu').style.display = 'block';
+        });
+
+        const spy = instrumentClickSpy(window);
+
+        const result = evalDiscoverScript(window);
+
+        // The script must have found models (not an empty result).
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+
+        // The picker button is clicked to open the menu.  That's expected.
+        expect(spy['2.5 Flash']).toBeGreaterThanOrEqual(1);
+
+        // The script clicks document.body to close the menu.  That's allowed.
+        expect(spy['(body)']).toBeGreaterThanOrEqual(1);
+
+        // BUT it must NOT click any model menu item, new-chat button, or send button.
+        expect(spy['2.5 Flash'] || 0).toBeGreaterThanOrEqual(1); // picker only
+        expect(spy['2.5 Pro'] || 0).toBe(0);
+        expect(spy['New chat'] || 0).toBe(0);
+        expect(spy['Send'] || 0).toBe(0);
+        // Thinking items as separate menuitems — should NOT be clicked.
+        expect(spy['Standard'] || 0).toBe(0);
+        expect(spy['Extended'] || 0).toBe(0);
+    });
+
+    it('does not click thinking controls (separate menu items without toggle)', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+              <div role="menuitem">2.5 Pro</div>
+              <!-- Thinking levels as separate menu items (no toggle present) -->
+              <div role="menuitem" id="think-standard">Standard</div>
+              <div role="menuitem" id="think-extended">Extended</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const spy = instrumentClickSpy(window);
+
+        const result = evalDiscoverScript(window);
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+
+        // Model picker click is allowed.
+        expect(spy['2.5 Flash']).toBeGreaterThanOrEqual(1);
+        // Body click (menu dismiss) is allowed.
+        expect(spy['(body)']).toBeGreaterThanOrEqual(1);
+
+        // Thinking items must NOT receive clicks (no 思考等级 toggle).
+        expect(spy['Standard'] || 0).toBe(0);
+        expect(spy['Extended'] || 0).toBe(0);
+    });
+
+    it('does not click a new-chat button', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <button id="new-chat" aria-label="New chat">New chat</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const spy = instrumentClickSpy(window);
+
+        const result = evalDiscoverScript(window);
+        expect(Array.isArray(result)).toBe(true);
+
+        expect(spy['New chat'] || 0).toBe(0);
+        expect(spy['2.5 Flash']).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not click a send/submit button', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">2.5 Flash</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">2.5 Flash</div>
+            </div>
+            <div>
+              <div contenteditable="true"></div>
+              <button id="send" aria-label="Send">Send</button>
+              <button id="submit">Submit</button>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const spy = instrumentClickSpy(window);
+
+        const result = evalDiscoverScript(window);
+        expect(Array.isArray(result)).toBe(true);
+
+        expect(spy['Send'] || 0).toBe(0);
+        expect(spy['Submit'] || 0).toBe(0);
+    });
+
+    it('only clicks the picker and body — no other elements receive clicks', () => {
+        const { window, document } = createGeminiDom(`
+            <button id="picker">3.1 Flash</button>
+            <button>New chat</button>
+            <button>Settings</button>
+            <div id="menu" role="menu" style="display: none;">
+              <div role="menuitem">3.1 Flash Lite</div>
+              <div role="menuitem">3.5 Flash</div>
+              <div role="menuitem">3.1 Pro</div>
+              <!-- Thinking items as separate menu items (no toggle) -->
+              <div role="menuitem">Standard</div>
+              <div role="menuitem">Extended</div>
+            </div>
+            <div>
+              <button id="send" aria-label="Send message">Send</button>
+            </div>
+          `);
+
+        document.getElementById('picker').addEventListener('click', () => {
+            document.getElementById('menu').style.display = 'block';
+        });
+
+        const spy = instrumentClickSpy(window);
+
+        const result = evalDiscoverScript(window);
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+
+        // The only elements that may receive clicks:
+        //   - The model picker ("3.1 Flash") — to open the menu.
+        //   - document.body — to close the menu.
+        for (const [label, count] of Object.entries(spy)) {
+            if (label === '3.1 Flash' || label === '(body)') {
+                expect(count).toBeGreaterThanOrEqual(1);
+            } else {
+                expect(count).toBe(0);
+            }
+        }
+
+        // Explicitly verify the dangerous controls.
+        expect(spy['New chat'] || 0).toBe(0);
+        expect(spy['Settings'] || 0).toBe(0);
+        // Menu items should not receive clicks.
+        expect(spy['3.1 Flash Lite'] || 0).toBe(0);
+        expect(spy['3.5 Flash'] || 0).toBe(0);
+        expect(spy['3.1 Pro'] || 0).toBe(0);
+        // Thinking controls should not receive clicks.
+        expect(spy['Standard'] || 0).toBe(0);
+        expect(spy['Extended'] || 0).toBe(0);
+        // Send button should not receive clicks.
+        expect(spy['Send message'] || 0).toBe(0);
+    });
+});

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -1842,6 +1842,468 @@ export async function exportGeminiDeepResearchReport(page, timeoutSeconds = 120)
         : await getCurrentGeminiUrl(page);
     return pickGeminiDeepResearchExportUrl(urls, currentUrl);
 }
+// ── Thinking-level selection ─────────────────────────────────────────
+
+/**
+ * Browser evaluate script that opens the Gemini model-picker menu.
+ * Returns { ok: true } on success, { ok: false } on failure.
+ */
+function openModelPickerForThinkingScript() {
+    return `
+    (() => {
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = el.getAttribute('aria-hidden');
+        if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0 || style.pointerEvents === 'none') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+      const VERSION_LABEL_RE = /\\d+\\.\\d+/;
+
+      const MODE_SELECTOR_PATTERNS = [
+        /模式选择器/i,
+        /mode[\\s-]*selector/i,
+        /model[\\s-]*selector/i,
+        /model[\\s-]*picker/i,
+        /选择模型/i,
+        /select[\\s-]+model/i,
+        /choose[\\s-]+model/i,
+        /switch[\\s-]+model/i,
+        /change[\\s-]+model/i,
+      ];
+
+      const MODEL_VARIANT_RE = /^(?:gemini\\s+)?(flash|lite|pro|ultra|nano|flash-lite|flash[\\s-]*thinking)$/i;
+
+      const findModelPicker = () => {
+        const buttons = Array.from(
+          document.querySelectorAll('button, [role="button"]')
+        ).filter(isVisible);
+
+        // Method 1: Detect model/mode selector via aria-label patterns.
+        for (const button of buttons) {
+          const aria = normalize(button.getAttribute('aria-label') || '');
+          for (const pattern of MODE_SELECTOR_PATTERNS) {
+            if (pattern.test(aria)) return button;
+          }
+        }
+
+        // Method 2: Detect buttons whose text contains a model-version pattern.
+        const versionCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '') || normalize(b.getAttribute('aria-label') || '');
+          return VERSION_LABEL_RE.test(text) && text.length < 80;
+        });
+        versionCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (versionCandidates.length > 0) return versionCandidates[0];
+
+        // Method 3: Detect buttons showing a known model variant as their
+        // sole text (e.g. "Pro", "Flash", "Flash-Lite").
+        const variantCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '');
+          return MODEL_VARIANT_RE.test(text) && text.length < 30;
+        });
+        variantCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (variantCandidates.length > 0) return variantCandidates[0];
+
+        // Method 4: Fallback — look for any element with model-related attributes.
+        const attrEls = Array.from(
+          document.querySelectorAll('[data-model-selector], [aria-label*="model" i], [aria-label*="模式" i]')
+        ).filter(isVisible);
+        if (attrEls.length > 0) return attrEls[0];
+
+        return null;
+      };
+
+      const picker = findModelPicker();
+      if (!picker) return { ok: false, reason: 'Model picker not found' };
+
+      try {
+        picker.click();
+        return { ok: true };
+      } catch (_) {
+        return { ok: false, reason: 'Failed to click model picker' };
+      }
+    })()
+    `;
+}
+
+/**
+ * Browser evaluate script that clicks the "思考等级" / "Thinking level"
+ * toggle inside an already-open model-picker menu to expand thinking options.
+ * Returns true if the toggle was found and clicked.
+ */
+function clickThinkingToggleInMenuScript() {
+    return `
+    (() => {
+      const isVisible = (el) => {
+        if (!el) return false;
+        if (!(el instanceof HTMLElement) && !(el instanceof Element)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const MENU_SELECTORS = [
+        '[role="menu"] [role="menuitem"]',
+        '[role="menu"] [role="menuitemradio"]',
+        '[role="listbox"] [role="option"]',
+        '[role="menu"] button',
+        '[role="listbox"] button',
+        '[role="menu"] li',
+        '[role="listbox"] li',
+        '[role="dialog"] [role="menuitem"]',
+        '[role="dialog"] [role="option"]',
+        '[aria-modal="true"] [role="menuitem"]',
+        '[aria-modal="true"] [role="option"]',
+        'gem-menu-item',
+        'GEM-MENU-ITEM',
+      ];
+
+      let menuItems = [];
+      for (const sel of MENU_SELECTORS) {
+        const items = Array.from(document.querySelectorAll(sel)).filter(isVisible);
+        if (items.length >= 2) { menuItems = items; break; }
+      }
+
+      if (menuItems.length === 0) {
+        const containers = Array.from(
+          document.querySelectorAll('[role="menu"], [role="listbox"], [role="dialog"], [aria-modal="true"]')
+        ).filter(isVisible);
+        for (const container of containers) {
+          const children = Array.from(
+            container.querySelectorAll('button, [role="button"], li, [role="menuitem"], [role="option"], gem-menu-item, GEM-MENU-ITEM, :not(script):not(style)')
+          ).filter(isVisible);
+          if (children.length >= 2) { menuItems = children; break; }
+        }
+      }
+
+      const thinkingToggle = menuItems.find((item) => {
+        const text = (item.textContent || '').replace(/\\s+/g, ' ').trim();
+        return /思考等级|thinking level|thinking mode/i.test(text);
+      });
+
+      if (thinkingToggle) {
+        try { thinkingToggle.click(); } catch (_) { return false; }
+        return true;
+      }
+      return false;
+    })()
+    `;
+}
+
+/**
+ * Browser evaluate script that selects a specific thinking level from an
+ * already-open model-picker menu (after the thinking section has been
+ * expanded).  Closes the menu after selection (or on failure).
+ *
+ * @param {string} thinkingValue - 'standard' or 'extended'
+ * @returns a function string for page.evaluate() that returns the matched
+ *          label text, or empty string on failure
+ */
+function selectThinkingInMenuScript(thinkingValue) {
+    const normalizedValue = String(thinkingValue || '').trim().toLowerCase();
+    if (!normalizedValue) return '(() => "")';
+    const labelMap = JSON.stringify({
+        standard: ['standard', '标准', '標準'],
+        extended: ['extended', '扩展', '擴展', '拡張'],
+    });
+    return `
+    (() => {
+      const LABEL_MAP = ${labelMap};
+      const candidateLabels = LABEL_MAP['${normalizedValue}'] || ['${normalizedValue}'];
+
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = el.getAttribute('aria-hidden');
+        if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0 || style.pointerEvents === 'none') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+
+      const textOf = (node) => [
+        node?.textContent || '',
+        node instanceof HTMLElement ? (node.innerText || '') : '',
+        node?.getAttribute?.('aria-label') || '',
+        node?.getAttribute?.('title') || '',
+        node?.getAttribute?.('data-tooltip') || '',
+      ].join(' ');
+
+      const matchesThinking = (node) => {
+        const combined = normalize(textOf(node));
+        if (!combined) return false;
+        return candidateLabels.some((label) => combined.includes(label));
+      };
+
+      // Search inside visible menu containers first.
+      const containers = Array.from(
+        document.querySelectorAll('[role="menu"], [role="listbox"], [role="dialog"], [aria-modal="true"]')
+      ).filter(isVisible);
+
+      const SELECTORS = [
+        'button', '[role="button"]', '[role="menuitem"]', '[role="menuitemradio"]',
+        '[role="option"]', '[role="radio"]', '[role="switch"]', 'li',
+      ];
+
+      let candidates = [];
+      for (const container of containers) {
+        for (const sel of SELECTORS) {
+          const nodes = Array.from(container.querySelectorAll(sel))
+            .filter((node) => isVisible(node) && matchesThinking(node));
+          candidates.push(...nodes);
+        }
+      }
+
+      // Fallback: search the entire page.
+      if (candidates.length === 0) {
+        for (const sel of SELECTORS) {
+          const nodes = Array.from(document.querySelectorAll(sel))
+            .filter((node) => isVisible(node) && matchesThinking(node));
+          candidates.push(...nodes);
+        }
+      }
+
+      if (candidates.length === 0) {
+        try { document.body.click(); } catch (_) {}
+        return '';
+      }
+
+      // Prefer exact match over substring.
+      candidates.sort((a, b) => {
+        const aText = normalize(textOf(a));
+        const bText = normalize(textOf(b));
+        const aExact = candidateLabels.some((l) => aText === l);
+        const bExact = candidateLabels.some((l) => bText === l);
+        if (aExact && !bExact) return -1;
+        if (!aExact && bExact) return 1;
+        return 0;
+      });
+
+      const target = candidates[0];
+      let matchedLabel = '';
+      try {
+        target.click();
+        matchedLabel = (target.textContent || '').trim();
+      } catch (_) {
+        try { document.body.click(); } catch (_) {}
+        return '';
+      }
+
+      // Close the menu after successful selection.
+      try { document.body.click(); } catch (_) {}
+
+      return matchedLabel;
+    })()
+    `;
+}
+
+/**
+ * Select a Gemini thinking level in the web UI.
+ *
+ * Multi-step approach matching modelsCommand.func:
+ *  1. Open the model-picker menu.
+ *  2. Wait for React to render the menu.
+ *  3. Click the "思考等级"/"Thinking level" toggle to expand thinking options.
+ *  4. Wait for the expanded items to render.
+ *  5. Select the requested thinking level.
+ *  6. Close the menu.
+ *
+ * @param {object} page - Puppeteer page object
+ * @param {string} thinkingValue - 'standard' or 'extended'
+ * @returns {Promise<string>} matched label text, or empty string on failure
+ */
+export async function selectGeminiThinking(page, thinkingValue) {
+    await ensureGeminiPage(page);
+
+    // Step 1: Open the picker menu.
+    const pickerRaw = await page.evaluate(openModelPickerForThinkingScript()).catch(() => null);
+    const pickerResult = unwrapGeminiEvaluateResult(pickerRaw, 'Gemini thinking model picker');
+    if (!pickerResult || !pickerResult.ok) return '';
+
+    // Step 2: Wait for React to render the menu.
+    await page.wait(0.8);
+
+    // Step 3: Click the thinking toggle to expand thinking options.
+    const toggleRaw = await page.evaluate(clickThinkingToggleInMenuScript()).catch(() => false);
+    const toggleClicked = unwrapGeminiEvaluateResult(toggleRaw, 'Gemini thinking toggle');
+
+    if (toggleClicked) {
+        // Step 4: Wait for the expanded thinking items to render.
+        await page.wait(0.5);
+    }
+
+    // Step 5: Select the requested thinking level (also closes the menu).
+    const matchedRaw = await page.evaluate(selectThinkingInMenuScript(thinkingValue)).catch(() => '');
+    const matched = unwrapGeminiEvaluateResult(matchedRaw, 'Gemini thinking selection');
+
+    if (typeof matched === 'string' && matched) {
+        await page.wait(0.3);
+        return matched;
+    }
+
+    return '';
+}
+
+// ── Current model detection ─────────────────────────────────────────
+
+/**
+ * Browser evaluate script that reads the currently selected model from the
+ * Gemini model-picker button and returns its canonical model ID.
+ *
+ * Uses the same canonicalModelId logic as discoverModelsScript so that
+ * the returned ID can be matched against discovered model entries.
+ *
+ * @returns a function string for page.evaluate()
+ */
+function getCurrentGeminiModelScript() {
+    return `
+    (() => {
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = el.getAttribute('aria-hidden');
+        if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0 || style.pointerEvents === 'none') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+
+      const VERSION_LABEL_RE = /\\d+\\.\\d+/;
+
+      const MODE_SELECTOR_PATTERNS = [
+        /模式选择器/i,
+        /mode[\\s-]*selector/i,
+        /model[\\s-]*selector/i,
+        /model[\\s-]*picker/i,
+        /选择模型/i,
+        /select[\\s-]+model/i,
+        /choose[\\s-]+model/i,
+        /switch[\\s-]+model/i,
+        /change[\\s-]+model/i,
+      ];
+
+      const MODEL_VARIANT_RE = /^(?:gemini\\s+)?(flash|lite|pro|ultra|nano|flash-lite|flash[\\s-]*thinking)$/i;
+
+      const findModelPicker = () => {
+        const buttons = Array.from(
+          document.querySelectorAll('button, [role="button"]')
+        ).filter(isVisible);
+
+        // Method 1: Detect model/mode selector via aria-label patterns.
+        for (const button of buttons) {
+          const aria = normalize(button.getAttribute('aria-label') || '');
+          for (const pattern of MODE_SELECTOR_PATTERNS) {
+            if (pattern.test(aria)) return button;
+          }
+        }
+
+        // Method 2: Detect buttons whose text contains a model-version pattern.
+        const versionCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '') || normalize(b.getAttribute('aria-label') || '');
+          return VERSION_LABEL_RE.test(text) && text.length < 80;
+        });
+        versionCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (versionCandidates.length > 0) return versionCandidates[0];
+
+        // Method 3: Detect buttons showing a known model variant as their
+        // sole text (e.g. "Pro", "Flash", "Flash-Lite").
+        const variantCandidates = buttons.filter((b) => {
+          const text = normalize(b.textContent || '');
+          return MODEL_VARIANT_RE.test(text) && text.length < 30;
+        });
+        variantCandidates.sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return aRect.top - bRect.top || aRect.left - bRect.left;
+        });
+        if (variantCandidates.length > 0) return variantCandidates[0];
+
+        // Method 4: Fallback — look for any element with model-related attributes.
+        const attrEls = Array.from(
+          document.querySelectorAll('[data-model-selector], [aria-label*="model" i], [aria-label*="模式" i]')
+        ).filter(isVisible);
+        if (attrEls.length > 0) return attrEls[0];
+
+        return null;
+      };
+
+      const canonicalModelId = (raw) => {
+        const text = normalize(raw);
+        if (!text) return '';
+        const cleaned = text.replace(/^[^a-z0-9]+/i, '').trim();
+        const versionRe = /^((?:gemini[\\s-]*)?(\\d+(?:\\.\\d+)?)(?:[\\s-]+(flash|pro|lite|ultra|nano|thinking|experimental))(?:[\\s-]*(flash|pro|lite|ultra|nano|thinking|experimental))?)/i;
+        const match = cleaned.match(versionRe);
+        if (match) {
+          const version = match[2];
+          let variant = (match[3] || '').toLowerCase();
+          const extra = (match[4] || '').toLowerCase();
+          if (extra) variant = variant + '-' + extra;
+          return version + '-' + variant;
+        }
+        const fallbackRe = /(\\d+(?:\\.\\d+)?)\\s*(flash|pro|lite|ultra|nano|thinking|experimental)/i;
+        const fallbackMatch = cleaned.match(fallbackRe);
+        if (fallbackMatch) {
+          return fallbackMatch[1] + '-' + fallbackMatch[2].toLowerCase();
+        }
+        if (/\\d+(?:\\.\\d+)?/.test(cleaned) && cleaned.length < 60) {
+          return cleaned.replace(/\\s+/g, '-').replace(/[^a-z0-9.-]/g, '');
+        }
+        return '';
+      };
+
+      const picker = findModelPicker();
+      if (!picker) return '';
+
+      const combined = normalize(picker.textContent || '') + ' ' + normalize(picker.getAttribute('aria-label') || '');
+      return canonicalModelId(combined);
+    })()
+    `;
+}
+
+/**
+ * Get the canonical ID of the currently selected Gemini model from the
+ * model-picker button in the web UI.
+ *
+ * @param {object} page - Puppeteer page object
+ * @returns {Promise<string>} canonical model ID, or empty string on failure
+ */
+export async function getCurrentGeminiModel(page) {
+    await ensureGeminiPage(page);
+    const modelId = await page.evaluate(getCurrentGeminiModelScript()).catch(() => '');
+    return typeof modelId === 'string' ? modelId : '';
+}
+
 export const __test__ = {
     GEMINI_COMPOSER_SELECTORS,
     GEMINI_COMPOSER_MARKER_ATTR,
@@ -1855,6 +2317,11 @@ export const __test__ = {
     expandGeminiRecentScript,
     submitComposerScript,
     insertComposerTextFallbackScript,
+    openModelPickerForThinkingScript,
+    clickThinkingToggleInMenuScript,
+    selectThinkingInMenuScript,
+    selectGeminiModelScript,
+    getCurrentGeminiModelScript,
 };
 export async function getGeminiVisibleImageUrls(page) {
     await ensureGeminiPage(page);
@@ -2053,4 +2520,160 @@ export async function waitForGeminiResponse(page, baseline, promptText, timeoutS
         }
     }
     return '';
+}
+
+/**
+ * Evaluate script that selects a specific Gemini model from the web UI
+ * model picker by canonical model id (e.g. "2.5-flash").
+ *
+ * Returns { ok: true } on success, or { ok: false, reason: "..." }
+ * when the picker or model item could not be found / clicked.
+ */
+/**
+ * Browser evaluate script that finds and clicks a model entry in an
+ * already-open Gemini model-picker menu.  Does NOT open the picker.
+ */
+function selectModelInMenuScript(modelId) {
+    return `
+    (() => {
+      const targetModelId = ${JSON.stringify(modelId)};
+      if (!targetModelId) return { ok: false, reason: 'No model id provided' };
+
+      const isVisible = (el) => {
+        if (!(el instanceof HTMLElement) && !(el instanceof Element)) return false;
+        if (el.hidden || el.closest('[hidden]')) return false;
+        const ariaHidden = el.getAttribute('aria-hidden');
+        if (ariaHidden && ariaHidden.toLowerCase() === 'true') return false;
+        if (el.closest('[aria-hidden="true"]')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (Number(style.opacity) === 0 || style.pointerEvents === 'none') return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+
+      const canonicalModelId = (raw) => {
+        const text = normalize(raw);
+        if (!text) return '';
+        const cleaned = text.replace(/^[^a-z0-9]+/i, '').trim();
+        const versionRe = /^((?:gemini[\\s-]*)?(\\d+(?:\\.\\d+)?)(?:[\\s-]+(flash|pro|lite|ultra|nano|thinking|experimental))(?:[\\s-]*(flash|pro|lite|ultra|nano|thinking|experimental))?)/i;
+        const match = cleaned.match(versionRe);
+        if (match) {
+          const version = match[2];
+          let variant = (match[3] || '').toLowerCase();
+          const extra = (match[4] || '').toLowerCase();
+          if (extra) variant = variant + '-' + extra;
+          return version + '-' + variant;
+        }
+        const fallbackRe = /(\\d+(?:\\.\\d+)?)\\s*(flash|pro|lite|ultra|nano|thinking|experimental)/i;
+        const fallbackMatch = cleaned.match(fallbackRe);
+        if (fallbackMatch) {
+          return fallbackMatch[1] + '-' + fallbackMatch[2].toLowerCase();
+        }
+        if (/\\d+(?:\\.\\d+)?/.test(cleaned) && cleaned.length < 60) {
+          return cleaned.replace(/\\s+/g, '-').replace(/[^a-z0-9.-]/g, '');
+        }
+        return '';
+      };
+
+      const MENU_SELECTORS = [
+        '[role="menu"] [role="menuitem"]',
+        '[role="menu"] [role="menuitemradio"]',
+        '[role="listbox"] [role="option"]',
+        '[role="menu"] button',
+        '[role="listbox"] button',
+        '[role="menu"] li',
+        '[role="listbox"] li',
+        '[role="dialog"] [role="menuitem"]',
+        '[role="dialog"] [role="option"]',
+        '[aria-modal="true"] [role="menuitem"]',
+        '[aria-modal="true"] [role="option"]',
+        'gem-menu-item',
+        'GEM-MENU-ITEM',
+      ];
+
+      let menuItems = [];
+      for (const sel of MENU_SELECTORS) {
+        const items = Array.from(document.querySelectorAll(sel)).filter(isVisible);
+        if (items.length >= 2) { menuItems = items; break; }
+      }
+
+      if (menuItems.length === 0) {
+        const containers = Array.from(
+          document.querySelectorAll('[role="menu"], [role="listbox"], [role="dialog"], [aria-modal="true"]')
+        ).filter(isVisible);
+        for (const container of containers) {
+          const children = Array.from(
+            container.querySelectorAll('button, [role="button"], li, [role="menuitem"], [role="option"], gem-menu-item, GEM-MENU-ITEM, :not(script):not(style)')
+          ).filter(isVisible);
+          if (children.length >= 2) { menuItems = children; break; }
+        }
+      }
+
+      let matched = null;
+      for (const item of menuItems) {
+        const id = canonicalModelId(item.textContent || '');
+        if (id === targetModelId) {
+          matched = item;
+          break;
+        }
+      }
+
+      if (!matched) {
+        try { document.body.click(); } catch (_) {}
+        return { ok: false, reason: 'Model "' + targetModelId + '" not found in picker menu' };
+      }
+
+      try {
+        matched.click();
+      } catch (_) {
+        try { document.body.click(); } catch (_) {}
+        return { ok: false, reason: 'Failed to click model menu item' };
+      }
+
+      return { ok: true };
+    })()
+    `;
+}
+
+/**
+ * Legacy wrapper kept for test compatibility — delegates to
+ * selectModelInMenuScript.  New callers should prefer the split
+ * openModelPickerForThinkingScript + selectModelInMenuScript
+ * pattern with an explicit page.wait between them.
+ */
+export function selectGeminiModelScript(modelId) {
+    return selectModelInMenuScript(modelId);
+}
+
+/**
+ * Select a Gemini model by canonical id (e.g. "2.5-flash") in the
+ * web UI model picker.  Opens the picker, waits for React, then clicks
+ * the matching entry.  Throws CommandExecutionError on failure.
+ */
+export async function selectGeminiModel(page, modelId) {
+    await ensureGeminiPage(page);
+
+    // Open the picker menu.
+    const pickerRaw = await page.evaluate(openModelPickerForThinkingScript());
+    const pickerResult = unwrapGeminiEvaluateResult(pickerRaw, 'Gemini model picker');
+    if (!pickerResult || !pickerResult.ok) {
+        throw new CommandExecutionError(
+            pickerResult?.reason || 'Failed to open model picker for model selection'
+        );
+    }
+
+    // Wait for React to render the menu.
+    await page.wait(0.8);
+
+    // Find and click the matching menu item.
+    const raw = await page.evaluate(selectModelInMenuScript(modelId));
+    const result = unwrapGeminiEvaluateResult(raw, 'Gemini model selection');
+    if (!result || !result.ok) {
+        throw new CommandExecutionError(
+            result?.reason || 'Failed to select Gemini model "' + modelId + '"'
+        );
+    }
 }

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -2676,4 +2676,14 @@ export async function selectGeminiModel(page, modelId) {
             result?.reason || 'Failed to select Gemini model "' + modelId + '"'
         );
     }
+
+    await page.wait(0.5);
+    const selectedModelId = await getCurrentGeminiModel(page);
+    if (selectedModelId !== modelId) {
+        throw new CommandExecutionError(
+            selectedModelId
+                ? `Gemini model selection read-back returned "${selectedModelId}", expected "${modelId}"`
+                : `Gemini model selection did not expose selected model "${modelId}" after click`
+        );
+    }
 }

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -595,10 +595,24 @@ describe('Gemini model/thinking selection Browser Bridge envelopes', () => {
         vi.mocked(page.evaluate)
             .mockResolvedValueOnce('https://gemini.google.com/app')
             .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
-            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } });
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce('2.5-flash');
 
         await expect(selectGeminiModel(page, '2.5-flash')).resolves.toBeUndefined();
 
-        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        expect(page.evaluate).toHaveBeenCalledTimes(5);
+    });
+
+    it('typed-fails when model selection read-back does not match the requested model', async () => {
+        const page = createPageMock();
+        vi.mocked(page.evaluate)
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce('2.5-pro');
+
+        await expect(selectGeminiModel(page, '2.5-flash')).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });

--- a/clis/gemini/utils.test.js
+++ b/clis/gemini/utils.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, sendGeminiMessage, } from './utils.js';
+import { __test__, collectGeminiTranscriptAdditions, getGeminiConversationList, getGeminiPageState, getGeminiVisibleTurns, pickGeminiDeepResearchExportUrl, readGeminiSnapshot, sanitizeGeminiResponseText, selectGeminiModel, selectGeminiThinking, sendGeminiMessage, } from './utils.js';
 function createPageMock() {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -388,5 +388,217 @@ describe('pickGeminiDeepResearchExportUrl', () => {
             'performance::https://www.google-analytics.com/g/collect?v=2',
         ], 'https://gemini.google.com/app/abc');
         expect(picked).toEqual({ url: '', source: 'none' });
+    });
+});
+
+// ── Model-picker detection DOM fixture tests ─────────────────────────────
+// These tests verify that openModelPickerForThinkingScript,
+// selectGeminiModelScript, and getCurrentGeminiModelScript share the same
+// 4-method picker detection strategy as models.js (discoverModelsScript).
+
+function createPickerDom(htmlFixture) {
+    const dom = new JSDOM(`<!doctype html><body>${htmlFixture}</body>`, {
+        pretendToBeVisual: true,
+        runScripts: 'outside-only',
+    });
+    const { window } = dom;
+    Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value() {
+            return { width: 100, height: 24, top: 0, left: 0, right: 100, bottom: 24 };
+        },
+    });
+    return { window, document: window.document };
+}
+
+function evalScript(window, scriptFn) {
+    const scriptText = scriptFn();
+    return window.eval(scriptText);
+}
+
+describe('openModelPickerForThinkingScript — picker detection', () => {
+    it('Method 1: detects picker by aria-label "mode-selector"', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="mode selector">Choose</button>
+            <button>New chat</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 1: detects picker by aria-label "模式选择器"', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="模式选择器">选择</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 1: detects picker by aria-label "model-picker"', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="model picker">Pick</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 1: detects picker by aria-label "选择模型"', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="选择模型">选择</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 2: detects picker by version-number text', () => {
+        const { window } = createPickerDom(`
+            <button>2.5 Flash</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 3: detects picker by variant-only text "Flash"', () => {
+        const { window } = createPickerDom(`
+            <button>Flash</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 3: detects picker by variant-only text "Pro"', () => {
+        const { window } = createPickerDom(`
+            <button>Pro</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 3: detects picker by variant-only text "Lite"', () => {
+        const { window } = createPickerDom(`
+            <button>Lite</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 3: detects picker by variant-only text "Flash-Lite"', () => {
+        const { window } = createPickerDom(`
+            <button>Flash-Lite</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('Method 4: detects picker by data-model-selector attribute', () => {
+        const { window } = createPickerDom(`
+            <button data-model-selector="true">Choose</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('returns { ok: false } when no picker is found', () => {
+        const { window } = createPickerDom(`
+            <button>New chat</button>
+            <button>Sign in</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: false, reason: 'Model picker not found' });
+    });
+
+    it('Method 1 wins over Method 2 for ambiguous buttons', () => {
+        // A button with both a model-selector aria-label and a version-like
+        // text should still be found (Method 1 returns early).
+        const { window } = createPickerDom(`
+            <button aria-label="mode selector">3.0 Config</button>
+        `);
+        const result = evalScript(window, __test__.openModelPickerForThinkingScript);
+        expect(result).toEqual({ ok: true });
+    });
+});
+
+describe('selectGeminiModelScript — picker detection parity', () => {
+    it('Method 1: detects picker by aria-label "mode-selector" and selects model', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="mode selector">Choose</button>
+            <div role="menu" style="display:none;">
+              <button role="menuitem">2.5 Flash</button>
+            </div>
+        `);
+        // Show the menu so the script can find menu items (just test picker detection).
+        // The script will fail to find the model in the menu (shown), but we check
+        // the picker was found by the aria-label.
+        const result = evalScript(window, () => __test__.selectGeminiModelScript('2.5-flash'));
+        // The menu is visible but doesn't contain the right items — we just care
+        // that the picker was found (not the old "Model picker button not found" error).
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('not found in picker menu');
+    });
+
+    it('Method 3: detects picker by variant-only text "Flash" and attempts selection', () => {
+        const { window } = createPickerDom(`
+            <button>Flash</button>
+            <div role="menu" style="display:none;">
+              <button role="menuitem">2.5 Flash</button>
+            </div>
+        `);
+        const result = evalScript(window, () => __test__.selectGeminiModelScript('2.5-flash'));
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('not found in picker menu');
+    });
+});
+
+describe('getCurrentGeminiModelScript — picker detection parity', () => {
+    it('Method 1: detects picker by aria-label "模式选择器"', () => {
+        const { window } = createPickerDom(`
+            <button aria-label="模式选择器">2.5 Flash</button>
+        `);
+        const result = window.eval(__test__.getCurrentGeminiModelScript());
+        expect(result).toBe('2.5-flash');
+    });
+
+    it('Method 3: detects picker by variant-only text "Flash"', () => {
+        const { window } = createPickerDom(`
+            <button>Flash</button>
+        `);
+        const result = window.eval(__test__.getCurrentGeminiModelScript());
+        expect(result).toBe('');
+    });
+
+    it('Method 2: detects picker by version-number text and extracts model id', () => {
+        const { window } = createPickerDom(`
+            <button>2.5 Pro</button>
+        `);
+        const result = window.eval(__test__.getCurrentGeminiModelScript());
+        expect(result).toBe('2.5-pro');
+    });
+});
+
+describe('Gemini model/thinking selection Browser Bridge envelopes', () => {
+    it('unwraps envelopes while selecting a thinking level', async () => {
+        const page = createPageMock();
+        vi.mocked(page.evaluate)
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
+            .mockResolvedValueOnce({ session: 'site:gemini', data: true })
+            .mockResolvedValueOnce({ session: 'site:gemini', data: 'Extended' });
+
+        const result = await selectGeminiThinking(page, 'extended');
+
+        expect(result).toBe('Extended');
+        expect(page.evaluate).toHaveBeenCalledTimes(4);
+    });
+
+    it('unwraps envelopes while selecting a model', async () => {
+        const page = createPageMock();
+        vi.mocked(page.evaluate)
+            .mockResolvedValueOnce('https://gemini.google.com/app')
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } })
+            .mockResolvedValueOnce({ session: 'site:gemini', data: { ok: true } });
+
+        await expect(selectGeminiModel(page, '2.5-flash')).resolves.toBeUndefined();
+
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
     });
 });

--- a/docs/adapters/browser/gemini.md
+++ b/docs/adapters/browser/gemini.md
@@ -7,8 +7,9 @@
 | Command | Description |
 |---------|-------------|
 | `opencli gemini new` | Start a new Gemini web chat |
-| `opencli gemini ask <prompt>` | Send a prompt and return only the assistant reply |
+| `opencli gemini ask <prompt> [--model <value>] [--thinking <level>]` | Send a prompt and return only the assistant reply |
 | `opencli gemini image <prompt>` | Generate images in Gemini and optionally save them locally |
+| `opencli gemini models` | List available Gemini models |
 | `opencli gemini deep-research <prompt>` | Start a Gemini Deep Research run and confirm it |
 | `opencli gemini deep-research-result <query>` | Export Deep Research report URL from a Gemini conversation |
 | `opencli gemini status` | Check Gemini web page availability and login state |
@@ -25,8 +26,23 @@ opencli gemini new
 # Ask Gemini and return minimal plain-text output
 opencli gemini ask "Reply with exactly: HELLO"
 
+# Ask with a specific model selected
+opencli gemini ask "Explain quantum computing in one sentence" --model 2.5-flash
+
 # Ask in a new chat and wait longer
 opencli gemini ask "Summarize this design in 3 bullets" --new true --timeout 90
+
+# Ask with extended thinking
+opencli gemini ask "Explain quantum computing" --thinking extended
+
+# Ask with standard thinking in a fresh chat
+opencli gemini ask "Hello" --new true --thinking standard
+
+# Ask with a specific model and thinking level combined
+opencli gemini ask "Explain quantum computing in one sentence" --model 2.5-pro --thinking extended
+
+# Ask in a new chat with a specific model and thinking level
+opencli gemini ask "Summarize this design in 3 bullets" --new true --model 2.5-flash --thinking standard
 
 # Generate an icon image with short flags
 opencli gemini image "Generate a tiny cyan moon icon" --rt 1:1 --st icon
@@ -36,6 +52,12 @@ opencli gemini image "A watercolor sunset over a lake" --sd true
 
 # Save generated images to a custom directory
 opencli gemini image "A flat illustration of a robot" --op ~/tmp/gemini-images
+
+# List available models
+opencli gemini models
+
+# List models as JSON for scripting
+opencli gemini models -f json
 ```
 
 ## Options
@@ -45,8 +67,10 @@ opencli gemini image "A flat illustration of a robot" --op ~/tmp/gemini-images
 | Option | Description |
 |--------|-------------|
 | `prompt` | Prompt to send (required positional argument) |
+| `--model` | Gemini model to use (e.g. `2.5-flash`, `2.5-pro`). Use `opencli gemini models` to list available values. |
 | `--timeout` | Max seconds to wait for a reply (default: `60`) |
 | `--new` | Start a new chat before sending (default: `false`) |
+| `--thinking` | Thinking level: `standard` or `extended` (omitted = leave unchanged) |
 
 ### `image`
 
@@ -58,8 +82,24 @@ opencli gemini image "A flat illustration of a robot" --op ~/tmp/gemini-images
 | `--op` | Output directory for downloaded images (default: `~/tmp/gemini-images`) |
 | `--sd` | Skip download and only print the Gemini page link |
 
+### `models`
+
+| Column | Description |
+|--------|-------------|
+| `model` | Canonical model ID (e.g. `2.5-flash`, `2.5-pro`, `2.5-flash-lite`) |
+| `thinkingValues` | Per-model thinking levels only when Gemini exposes them directly on the model entry; otherwise `[]`. The current Gemini UI usually exposes thinking controls for the active model, so this command does not infer support for every model. |
+
+- `models` discovers available models from the visible Gemini web UI model picker.
+- The command is read-only: it does not select a model, change a thinking level, start a new chat, or submit a prompt.
+- Model IDs match the canonical format used by later `gemini ask` model selection.
+- Throws a command error when the model picker cannot be opened, which helps surface Gemini Web UI changes. Returns an empty list only when the picker opens but no model entries are available.
+
 ## Behavior
 
+- When `--new true` is combined with `--model` and/or `--thinking`, the new chat is created first, then the model and thinking level are selected, then the snapshot is read, and finally the prompt is submitted.
+- `ask --model <value>` selects the requested model before reading the page state and sending the prompt. The selected model remains visible in the Gemini web UI after the command completes. Short aliases like `pro` or `flash` are rejected—use canonical model IDs from `opencli gemini models`.
+- When `--model` is omitted, `ask` does not change the current model.
+- All other Gemini commands (`image`, `deep-research`, etc.) are unaffected and do not accept `--model`.
 - `ask` uses plain minimal output and returns only the assistant response text prefixed with `💬`.
 - `image` also uses plain output and prints `status / file / link` instead of a table.
 - `image` always starts from a fresh Gemini chat before sending the prompt.


### PR DESCRIPTION
## Motivation

This improves the existing Gemini Web adapter by adding model discovery and optional model/thinking selection for `gemini ask`.

## Summary

- add `opencli gemini models` to discover canonical Gemini Web model IDs
- add `--model` and `--thinking` options to `opencli gemini ask`
- handle Browser Bridge envelopes in Gemini model/thinking selection and document the model-listing semantics

## Validation

- `npm run typecheck`
- `npx vitest run --project adapter clis/gemini/ask.test.js clis/gemini/models.test.js clis/gemini/utils.test.js`
- `npm run build && node dist/src/main.js validate`
- `npm test`
