### PR TITLE
fix(xiaohongshu,rednote): surface search risk-control blocks instead of returning []

### DIFF
--- a/clis/rednote/rednote.test.js
+++ b/clis/rednote/rednote.test.js
@@ -171,6 +171,18 @@ describe('rednote search browser-bridge envelopes', () => {
         expect(page.evaluate).toHaveBeenCalledTimes(1);
     });
 
+    it('rejects with risk-control error instead of silently returning [] when blocked', async () => {
+        const page = createSearchPageMock([
+            { session: 'site:rednote', data: 'security_block' },
+        ]);
+
+        await expect(search.func(page, { query: 'tesla', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('risk control'),
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
     it('unwraps search extraction envelopes and preserves rednote row shape', async () => {
         const url = 'https://www.rednote.com/search_result/68e90be80000000004022e66?xsec_token=test-token';
         const page = createSearchPageMock([

--- a/clis/rednote/search.js
+++ b/clis/rednote/search.js
@@ -53,6 +53,11 @@ const WAIT_FOR_CONTENT_JS = `
     };
     const detect = () => {
       if (document.querySelector('section.note-item')) return 'content';
+      // Risk-control block detected via URL redirect only — NOT page text.
+      // The search page echoes the query back, so matching '安全限制' in body
+      // text would false-positive when a user literally searches that term.
+      if (/error_code=(300017|300031)/.test(location.href)
+        || (location.href || '').includes('website-login/error')) return 'security_block';
       if (/登录后查看搜索结果|请登录/.test(document.body?.innerText || '')) return 'login_wall';
       if (hasLoginModal()) return 'login_wall';
       return null;
@@ -86,6 +91,9 @@ cli({
         const keyword = encodeURIComponent(kwargs.query);
         await page.goto(`https://www.rednote.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
         const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
+        if (waitResult === 'security_block') {
+            throw new CommandExecutionError('Rednote search was blocked by risk control (captcha).', 'The session is likely rate-limited or flagged. Pause scraping and retry later from the same logged-in session.');
+        }
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.rednote.com', 'Rednote search results are blocked behind a login wall');
         }

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -6,7 +6,7 @@
  * Ref: https://github.com/jackwener/opencli/issues/10
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
@@ -24,6 +24,11 @@ const WAIT_FOR_CONTENT_JS = `
     );
     const detect = () => {
       if (findNoteCard()) return 'content';
+      // Risk-control block detected via URL redirect only — NOT page text.
+      // The search page echoes the query back, so matching '安全限制' in body
+      // text would false-positive when a user literally searches that term.
+      if (/error_code=(300017|300031)/.test(location.href)
+        || (location.href || '').includes('website-login/error')) return 'security_block';
       if (/登录后查看搜索结果/.test(document.body?.innerText || '')) return 'login_wall';
       return null;
     };
@@ -288,6 +293,9 @@ export const command = cli({
         // Uses MutationObserver to resolve as soon as content appears,
         // instead of a fixed delay + blind retry.
         const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
+        if (waitResult === 'security_block') {
+            throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by risk control (captcha).', 'The session is likely rate-limited or flagged. Pause scraping and retry later from the same logged-in session.');
+        }
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
         }

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -69,6 +69,18 @@ describe('xiaohongshu search', () => {
         });
         expect(page.evaluate).toHaveBeenCalledTimes(1);
     });
+    it('rejects with risk-control error instead of silently returning [] when blocked', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            { session: 'site:xiaohongshu', data: 'security_block' },
+        ]);
+
+        await expect(cmd.func(page, { query: '特斯拉', limit: 5 })).rejects.toMatchObject({
+            code: 'SECURITY_BLOCK',
+            message: expect.stringContaining('risk control'),
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
     it('returns ranked results with search_result url and author_url preserved', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');


### PR DESCRIPTION
## Description

`xiaohongshu/search` and `rednote/search` silently return `[]` when the session hits risk control (captcha / 安全限制), making a block indistinguishable from a genuine no-results query. The `note` / `comments` / `download` adapters already detect this via `securityBlock` and throw, but `search` only checked for the login wall — so a risk-control page falls through to the extractor and yields an empty array with exit code 0.

This adds risk-control detection to both search frontends' `WAIT_FOR_CONTENT_JS`:

- Detects the risk-control **URL redirect** (`error_code=300017/300031`, `website-login/error`) rather than page text. The search page echoes the query back into the DOM, so matching `安全限制` in body text would false-positive when a user literally searches that term — URL-only detection avoids this. (This is the one structural difference from `note.js`, where the detail page does not reflect user input.)
- Throws `CliError('SECURITY_BLOCK', ...)` for xiaohongshu (matching its `note`/`comments`/`download`) and `CommandExecutionError` for rednote (matching its `note`/`comments`/`download`).
- `detect()` order is `content → security_block → login_wall`: results take priority, and risk-control is checked before the login wall since a block page may also contain login text.

Related issue: #1136 (rednote ↔ xiaohongshu 1:1 parity)

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR (`npm run build`, `npx tsc --noEmit`, `npm test` — 45 passed)
- [x] I updated tests (added a risk-control regression test to each search adapter)
- [ ] I included output or screenshots when useful

## Screenshots / Output

Before: `opencli rednote search "<query>"` under risk control → `[]` (exit 0), indistinguishable from no results.
After: throws `SECURITY_BLOCK` (xiaohongshu) / `COMMAND_EXEC` (rednote) so callers can tell "blocked" from "empty".
