### PR TITLE
feat(cls): add public 财联社 adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -7464,6 +7464,75 @@
     "siteSession": "persistent"
   },
   {
+    "site": "cls",
+    "name": "article",
+    "description": "读取财联社文章详情正文，支持文章 ID 或 detail URL",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "财联社文章 ID 或 https://www.cls.cn/detail/<id> URL"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "content",
+      "brief",
+      "subjects",
+      "author",
+      "level",
+      "readingCount",
+      "pubTime",
+      "audioUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cls/article.js",
+    "sourceFile": "cls/article.js"
+  },
+  {
+    "site": "cls",
+    "name": "telegraph",
+    "description": "财联社电报快讯列表，默认返回最新 20 条",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回数量 (max 100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "content",
+      "subjects",
+      "stocks",
+      "level",
+      "readingCount",
+      "commentCount",
+      "shareCount",
+      "pubTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cls/telegraph.js",
+    "sourceFile": "cls/telegraph.js"
+  },
+  {
     "site": "cnki",
     "name": "search",
     "description": "中国知网论文搜索（海外版）",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -7499,6 +7499,129 @@
   },
   {
     "site": "cls",
+    "name": "calendar",
+    "description": "财联社首页投资日历事件，默认返回前 20 条",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回数量 (max 100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "date",
+      "week",
+      "time",
+      "title",
+      "country",
+      "star"
+    ],
+    "type": "js",
+    "modulePath": "cls/calendar.js",
+    "sourceFile": "cls/calendar.js"
+  },
+  {
+    "site": "cls",
+    "name": "hot",
+    "description": "财联社首页热门文章，默认返回前 10 条",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "返回数量 (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "brief",
+      "author",
+      "readingCount",
+      "pubTime",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cls/hot.js",
+    "sourceFile": "cls/hot.js"
+  },
+  {
+    "site": "cls",
+    "name": "plates",
+    "description": "财联社首页热门板块和主力资金，默认返回前 10 条",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "返回数量 (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "code",
+      "name",
+      "changePct",
+      "mainFundDiff",
+      "upStocks",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cls/plates.js",
+    "sourceFile": "cls/plates.js"
+  },
+  {
+    "site": "cls",
+    "name": "subjects",
+    "description": "财联社首页热门话题，默认返回前 10 条",
+    "access": "read",
+    "domain": "www.cls.cn",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "返回数量 (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "name",
+      "description",
+      "attentionCount",
+      "newestArticleId",
+      "newestArticleTitle",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "cls/subjects.js",
+    "sourceFile": "cls/subjects.js"
+  },
+  {
+    "site": "cls",
     "name": "telegraph",
     "description": "财联社电报快讯列表，默认返回最新 20 条",
     "access": "read",

--- a/clis/cls/article.js
+++ b/clis/cls/article.js
@@ -1,0 +1,41 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+  CLS_BASE,
+  CLS_DOMAIN,
+  extractArticleDetailFromNextData,
+  fetchHtml,
+  mapArticleDetailRow,
+  parseArticleId,
+} from './utils.js';
+
+cli({
+  site: 'cls',
+  name: 'article',
+  access: 'read',
+  description: '读取财联社文章详情正文，支持文章 ID 或 detail URL',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'id', positional: true, required: true, help: '财联社文章 ID 或 https://www.cls.cn/detail/<id> URL' },
+  ],
+  columns: [
+    'id',
+    'title',
+    'content',
+    'brief',
+    'subjects',
+    'author',
+    'level',
+    'readingCount',
+    'pubTime',
+    'audioUrl',
+    'url',
+  ],
+  func: async (args) => {
+    const id = parseArticleId(args.id);
+    const html = await fetchHtml(`${CLS_BASE}/detail/${id}`, 'cls article');
+    const detail = extractArticleDetailFromNextData(html);
+    return [mapArticleDetailRow(detail)];
+  },
+});

--- a/clis/cls/calendar.js
+++ b/clis/cls/calendar.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CLS_DOMAIN, fetchHomePageProps, mapCalendarRows, normalizeLimit } from './utils.js';
+
+cli({
+  site: 'cls',
+  name: 'calendar',
+  access: 'read',
+  description: '财联社首页投资日历事件，默认返回前 20 条',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: '返回数量 (max 100)' },
+  ],
+  columns: ['rank', 'id', 'date', 'week', 'time', 'title', 'country', 'star'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 20, 100);
+    const pageProps = await fetchHomePageProps('cls calendar');
+    return mapCalendarRows(pageProps.investKalendarData, limit);
+  },
+});

--- a/clis/cls/commands.test.js
+++ b/clis/cls/commands.test.js
@@ -3,6 +3,11 @@ import { getRegistry, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import {
   extractArticleDetailFromNextData,
+  fetchHtml,
+  mapCalendarRows,
+  mapHotArticleRows,
+  mapHotPlateRows,
+  mapHotSubjectRows,
   mapArticleDetailRow,
   mapTelegraphRows,
   normalizeLimit,
@@ -10,6 +15,10 @@ import {
 } from './utils.js';
 import './telegraph.js';
 import './article.js';
+import './hot.js';
+import './subjects.js';
+import './plates.js';
+import './calendar.js';
 
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -33,6 +42,10 @@ describe('cls command registration', () => {
   it('registers public read commands with stable row columns', () => {
     const telegraph = getRegistry().get('cls/telegraph');
     const article = getRegistry().get('cls/article');
+    const hot = getRegistry().get('cls/hot');
+    const subjects = getRegistry().get('cls/subjects');
+    const plates = getRegistry().get('cls/plates');
+    const calendar = getRegistry().get('cls/calendar');
 
     expect(telegraph).toMatchObject({
       site: 'cls',
@@ -78,6 +91,81 @@ describe('cls command registration', () => {
       'audioUrl',
       'url',
     ]);
+
+    expect(hot).toMatchObject({
+      site: 'cls',
+      name: 'hot',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(hot.columns).toEqual([
+      'rank',
+      'id',
+      'title',
+      'brief',
+      'author',
+      'readingCount',
+      'pubTime',
+      'url',
+    ]);
+
+    expect(subjects).toMatchObject({
+      site: 'cls',
+      name: 'subjects',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(subjects.columns).toEqual([
+      'rank',
+      'id',
+      'name',
+      'description',
+      'attentionCount',
+      'newestArticleId',
+      'newestArticleTitle',
+      'url',
+    ]);
+
+    expect(plates).toMatchObject({
+      site: 'cls',
+      name: 'plates',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(plates.columns).toEqual([
+      'rank',
+      'code',
+      'name',
+      'changePct',
+      'mainFundDiff',
+      'upStocks',
+      'url',
+    ]);
+
+    expect(calendar).toMatchObject({
+      site: 'cls',
+      name: 'calendar',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(calendar.columns).toEqual([
+      'rank',
+      'id',
+      'date',
+      'week',
+      'time',
+      'title',
+      'country',
+      'star',
+    ]);
   });
 });
 
@@ -88,6 +176,17 @@ describe('cls utils', () => {
     expect(() => normalizeLimit(0, 20, 100)).toThrow(ArgumentError);
     expect(() => normalizeLimit(1.5, 20, 100)).toThrow(ArgumentError);
     expect(() => normalizeLimit(101, 20, 100)).toThrow(ArgumentError);
+  });
+
+  it('uses a browser-like user agent for CLS HTML fetches', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(htmlResponse('<html></html>'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchHtml('https://www.cls.cn/', 'cls test');
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers['User-Agent']).toContain('Chrome/');
+    expect(headers['User-Agent']).not.toContain('opencli');
   });
 
   it('parses a CLS article id from a bare id or detail URL', () => {
@@ -227,6 +326,89 @@ describe('cls utils', () => {
       content: '',
     })).toThrow(CommandExecutionError);
   });
+
+  it('maps homepage hot articles from SSR state', () => {
+    expect(mapHotArticleRows([{
+      id: 2411240,
+      title: '【早报】普京：考虑全面禁止柴油出口',
+      brief: '①人工智能标准发布',
+      author: '财联社',
+      ctime: 1782687600,
+      readNum: 598124,
+    }], 1)).toEqual([{
+      rank: 1,
+      id: '2411240',
+      title: '【早报】普京：考虑全面禁止柴油出口',
+      brief: '①人工智能标准发布',
+      author: '财联社',
+      readingCount: 598124,
+      pubTime: '2026-06-28T23:00:00.000Z',
+      url: 'https://www.cls.cn/detail/2411240',
+    }]);
+  });
+
+  it('maps homepage popular subjects from SSR state', () => {
+    expect(mapHotSubjectRows([{
+      id: 1556,
+      name: '环球市场情报',
+      description: '网罗天下要闻',
+      attention_num: 161350,
+      newest_article_id: 2411657,
+      newest_article_title: '西班牙6月CPI同比增长3.2%',
+    }], 1)).toEqual([{
+      rank: 1,
+      id: '1556',
+      name: '环球市场情报',
+      description: '网罗天下要闻',
+      attentionCount: 161350,
+      newestArticleId: '2411657',
+      newestArticleTitle: '西班牙6月CPI同比增长3.2%',
+      url: 'https://www.cls.cn/subject/1556',
+    }]);
+  });
+
+  it('maps homepage hot plates with percentage output', () => {
+    expect(mapHotPlateRows([{
+      secu_code: 'cls82054',
+      secu_name: '生物制品',
+      change: 0.0736,
+      main_fund_diff: 848165739,
+      up_stock: [
+        { secu_code: 'sz300204', secu_name: '舒泰神', change: 0.2 },
+        { secu_code: 'sh688765', secu_name: '禾元生物-U', change: 0.2 },
+      ],
+    }], 1)).toEqual([{
+      rank: 1,
+      code: 'cls82054',
+      name: '生物制品',
+      changePct: 7.36,
+      mainFundDiff: 848165739,
+      upStocks: '舒泰神(sz300204), 禾元生物-U(sh688765)',
+      url: 'https://www.cls.cn/plate?code=cls82054',
+    }]);
+  });
+
+  it('flattens homepage investment calendar days', () => {
+    expect(mapCalendarRows([{
+      calendar_day: '2026-06-29',
+      week: '星期一',
+      items: [{
+        id: 809033,
+        calendar_time: '2026-06-29 00:00:00',
+        title: '芝商所推出微型指数期权',
+        event: { country: '美国', star: 5 },
+      }],
+    }], 1)).toEqual([{
+      rank: 1,
+      id: '809033',
+      date: '2026-06-29',
+      week: '星期一',
+      time: '2026-06-29 00:00:00',
+      title: '芝商所推出微型指数期权',
+      country: '美国',
+      star: 5,
+    }]);
+  });
 });
 
 describe('cls telegraph command', () => {
@@ -309,5 +491,76 @@ describe('cls article command', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(htmlResponse('<html></html>')));
 
     await expect(command().func({ id: '2411505' })).rejects.toBeInstanceOf(EmptyResultError);
+  });
+});
+
+describe('cls homepage SSR commands', () => {
+  const homeState = {
+    props: {
+      pageProps: {
+        hotArticleData: [{
+          id: 2411240,
+          title: '热门文章',
+          brief: '摘要',
+          author: '财联社',
+          ctime: 1782687600,
+          readNum: 100,
+        }],
+        hotSubject: [{
+          id: 1556,
+          name: '环球市场情报',
+          description: '网罗天下要闻',
+          attention_num: 161350,
+          newest_article_id: 2411657,
+          newest_article_title: '最新文章',
+        }],
+        hotPlate: [{
+          secu_code: 'cls82054',
+          secu_name: '生物制品',
+          change: 0.0736,
+          main_fund_diff: 848165739,
+          up_stock: [],
+        }],
+        investKalendarData: [{
+          calendar_day: '2026-06-29',
+          week: '星期一',
+          items: [{ id: 809033, calendar_time: '2026-06-29 00:00:00', title: '事件', event: { country: '美国', star: 5 } }],
+        }],
+      },
+    },
+  };
+
+  function stubHomePage() {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(htmlResponse(
+      `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(homeState)}</script>`,
+    )));
+  }
+
+  it('hot command fetches homepage SSR data', async () => {
+    stubHomePage();
+    await expect(getRegistry().get('cls/hot').func({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ id: '2411240', title: '热门文章' }),
+    ]);
+  });
+
+  it('subjects command fetches homepage SSR data', async () => {
+    stubHomePage();
+    await expect(getRegistry().get('cls/subjects').func({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ id: '1556', name: '环球市场情报' }),
+    ]);
+  });
+
+  it('plates command fetches homepage SSR data', async () => {
+    stubHomePage();
+    await expect(getRegistry().get('cls/plates').func({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ code: 'cls82054', name: '生物制品' }),
+    ]);
+  });
+
+  it('calendar command fetches homepage SSR data', async () => {
+    stubHomePage();
+    await expect(getRegistry().get('cls/calendar').func({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ id: '809033', title: '事件' }),
+    ]);
   });
 });

--- a/clis/cls/commands.test.js
+++ b/clis/cls/commands.test.js
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { getRegistry, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  extractArticleDetailFromNextData,
+  mapArticleDetailRow,
+  mapTelegraphRows,
+  normalizeLimit,
+  parseArticleId,
+} from './utils.js';
+import './telegraph.js';
+import './article.js';
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function htmlResponse(body, status = 200) {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('cls command registration', () => {
+  it('registers public read commands with stable row columns', () => {
+    const telegraph = getRegistry().get('cls/telegraph');
+    const article = getRegistry().get('cls/article');
+
+    expect(telegraph).toMatchObject({
+      site: 'cls',
+      name: 'telegraph',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(telegraph.columns).toEqual([
+      'rank',
+      'id',
+      'title',
+      'content',
+      'subjects',
+      'stocks',
+      'level',
+      'readingCount',
+      'commentCount',
+      'shareCount',
+      'pubTime',
+      'url',
+    ]);
+
+    expect(article).toMatchObject({
+      site: 'cls',
+      name: 'article',
+      access: 'read',
+      domain: 'www.cls.cn',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    expect(article.columns).toEqual([
+      'id',
+      'title',
+      'content',
+      'brief',
+      'subjects',
+      'author',
+      'level',
+      'readingCount',
+      'pubTime',
+      'audioUrl',
+      'url',
+    ]);
+  });
+});
+
+describe('cls utils', () => {
+  it('validates limit without silent clamping', () => {
+    expect(normalizeLimit(undefined, 20, 100)).toBe(20);
+    expect(normalizeLimit('3', 20, 100)).toBe(3);
+    expect(() => normalizeLimit(0, 20, 100)).toThrow(ArgumentError);
+    expect(() => normalizeLimit(1.5, 20, 100)).toThrow(ArgumentError);
+    expect(() => normalizeLimit(101, 20, 100)).toThrow(ArgumentError);
+  });
+
+  it('parses a CLS article id from a bare id or detail URL', () => {
+    expect(parseArticleId('2411505')).toBe('2411505');
+    expect(parseArticleId('https://www.cls.cn/detail/2411505')).toBe('2411505');
+    expect(parseArticleId(' https://www.cls.cn/detail/2411505?foo=bar ')).toBe('2411505');
+    expect(() => parseArticleId('https://www.cls.cn/telegraph')).toThrow(ArgumentError);
+  });
+
+  it('maps telegraph API rows into the declared CLI shape', () => {
+    const rows = mapTelegraphRows([
+      {
+        id: 2411513,
+        title: '全国5条中小河流发生超警以上洪水',
+        brief: '财联社6月29日电，水利部消息。',
+        content: '<p>财联社6月29日电，水利部消息。</p>',
+        ctime: 1782691200,
+        author: '财联社',
+        level: 'B',
+        reading_num: 1200,
+        comment_num: 3,
+        share_num: 4,
+        subjects: [{ subject_name: '水利' }, { name: '洪水' }],
+        stock_list: [{ stock_code: '601669', stock_name: '中国电建' }],
+      },
+    ], 1);
+
+    expect(rows).toEqual([{
+      rank: 1,
+      id: '2411513',
+      title: '全国5条中小河流发生超警以上洪水',
+      content: '财联社6月29日电，水利部消息。',
+      subjects: '水利, 洪水',
+      stocks: '中国电建(601669)',
+      level: 'B',
+      readingCount: 1200,
+      commentCount: 3,
+      shareCount: 4,
+      pubTime: '2026-06-29T00:00:00.000Z',
+      url: 'https://www.cls.cn/detail/2411513',
+    }]);
+  });
+
+  it('uses readable telegraph content as title fallback when API title is empty', () => {
+    const rows = mapTelegraphRows([
+      {
+        id: 2411632,
+        title: '',
+        brief: '财联社6月29日电，外资周一净卖出价值7.7万亿韩元的韩国综合股价指数（KOSPI）股票，创历史最大单日净卖出规模。',
+        content: '财联社6月29日电，外资今日净卖出价值7.7万亿韩元的韩国KOSPI股票，创历史最大单日净卖出规模。',
+        ctime: 1782714931,
+        reading_num: 47070,
+        comment_num: 0,
+        share_num: 20,
+        subjects: [{ subject_name: '环球市场情报' }],
+        stock_list: [],
+      },
+    ], 1);
+
+    expect(rows[0]).toMatchObject({
+      id: '2411632',
+      title: '财联社6月29日电，外资今日净卖出价值7.7万亿韩元的韩国KOSPI股票，创历史最大单日净卖出规模。',
+      content: '财联社6月29日电，外资今日净卖出价值7.7万亿韩元的韩国KOSPI股票，创历史最大单日净卖出规模。',
+    });
+  });
+
+  it('extracts and maps article detail from Next.js page state', () => {
+    const state = {
+      props: {
+        pageProps: {
+          articleDetail: {
+            id: 2411505,
+            title: '印尼塞梅鲁火山喷发 灰柱高度约700米',
+            brief: '火山喷发快讯',
+            content: '<p>财联社6月29日电，印尼火山喷发。</p>',
+            ctime: 1782691200,
+            readingNum: 88,
+            author: '财联社',
+            subject: [{ subject_name: '火山' }],
+            level: 'C',
+            miniMaxAudioUrl: 'https://audio.example/2411505.mp3',
+          },
+        },
+      },
+    };
+    const html = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(state)}</script>`;
+
+    const detail = extractArticleDetailFromNextData(html);
+    expect(mapArticleDetailRow(detail)).toEqual({
+      id: '2411505',
+      title: '印尼塞梅鲁火山喷发 灰柱高度约700米',
+      content: '财联社6月29日电，印尼火山喷发。',
+      brief: '火山喷发快讯',
+      subjects: '火山',
+      author: '财联社',
+      level: 'C',
+      readingCount: 88,
+      pubTime: '2026-06-29T00:00:00.000Z',
+      audioUrl: 'https://audio.example/2411505.mp3',
+      url: 'https://www.cls.cn/detail/2411505',
+    });
+  });
+
+  it('parses Next.js JSON without decoding entities before JSON.parse', () => {
+    const state = {
+      props: {
+        pageProps: {
+          articleDetail: {
+            id: 2411505,
+            title: 'A &quot;quoted&quot; title',
+            content: '正文',
+          },
+        },
+      },
+    };
+    const html = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(state)}</script>`;
+
+    expect(extractArticleDetailFromNextData(html).title).toBe('A &quot;quoted&quot; title');
+  });
+
+  it('maps empty author objects to null instead of object sentinels', () => {
+    expect(mapArticleDetailRow({
+      id: 2411505,
+      title: '印尼塞梅鲁火山喷发 灰柱高度约700米',
+      content: '正文',
+      author: {},
+      subject: [],
+    })).toMatchObject({
+      author: null,
+    });
+  });
+
+  it('typed-fails article details without readable content', () => {
+    expect(() => mapArticleDetailRow({
+      id: 2411505,
+      title: '印尼塞梅鲁火山喷发 灰柱高度约700米',
+      content: '',
+    })).toThrow(CommandExecutionError);
+  });
+});
+
+describe('cls telegraph command', () => {
+  const command = () => getRegistry().get('cls/telegraph');
+
+  it('fetches the public telegraph cache endpoint and maps rows', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      errno: 0,
+      data: {
+        roll_data: [{
+          id: 2411513,
+          title: '港股午评',
+          content: '港股午间收盘。',
+          ctime: 1782691200,
+          reading_num: 10,
+          comment_num: 1,
+          share_num: 2,
+          subjects: [],
+          stock_list: [],
+        }],
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(command().func({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({
+        rank: 1,
+        id: '2411513',
+        title: '港股午评',
+        url: 'https://www.cls.cn/detail/2411513',
+      }),
+    ]);
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://www.cls.cn/api/cache?name=telegraph');
+  });
+
+  it('typed-fails invalid payloads and empty rows', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ errno: 0, data: { roll_data: [] } }))
+      .mockResolvedValueOnce(jsonResponse({ errno: 0, data: { roll_data: [{ title: 'missing id' }] } })));
+
+    await expect(command().func({ limit: 1 })).rejects.toBeInstanceOf(EmptyResultError);
+    await expect(command().func({ limit: 1 })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+});
+
+describe('cls article command', () => {
+  const command = () => getRegistry().get('cls/article');
+
+  it('fetches a public detail page and extracts articleDetail from __NEXT_DATA__', async () => {
+    const state = {
+      props: {
+        pageProps: {
+          articleDetail: {
+            id: 2411505,
+            title: '文章标题',
+            brief: '',
+            content: '文章正文',
+            ctime: 1782691200,
+            readingNum: 7,
+            subject: [],
+          },
+        },
+      },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(htmlResponse(
+      `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify(state)}</script>`,
+    )));
+
+    await expect(command().func({ id: 'https://www.cls.cn/detail/2411505' })).resolves.toEqual([
+      expect.objectContaining({
+        id: '2411505',
+        title: '文章标题',
+        content: '文章正文',
+        url: 'https://www.cls.cn/detail/2411505',
+      }),
+    ]);
+  });
+
+  it('typed-fails missing article state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(htmlResponse('<html></html>')));
+
+    await expect(command().func({ id: '2411505' })).rejects.toBeInstanceOf(EmptyResultError);
+  });
+});

--- a/clis/cls/hot.js
+++ b/clis/cls/hot.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CLS_DOMAIN, fetchHomePageProps, mapHotArticleRows, normalizeLimit } from './utils.js';
+
+cli({
+  site: 'cls',
+  name: 'hot',
+  access: 'read',
+  description: '财联社首页热门文章，默认返回前 10 条',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 10, help: '返回数量 (max 30)' },
+  ],
+  columns: ['rank', 'id', 'title', 'brief', 'author', 'readingCount', 'pubTime', 'url'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 10, 30);
+    const pageProps = await fetchHomePageProps('cls hot');
+    return mapHotArticleRows(pageProps.hotArticleData, limit);
+  },
+});

--- a/clis/cls/plates.js
+++ b/clis/cls/plates.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CLS_DOMAIN, fetchHomePageProps, mapHotPlateRows, normalizeLimit } from './utils.js';
+
+cli({
+  site: 'cls',
+  name: 'plates',
+  access: 'read',
+  description: '财联社首页热门板块和主力资金，默认返回前 10 条',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 10, help: '返回数量 (max 30)' },
+  ],
+  columns: ['rank', 'code', 'name', 'changePct', 'mainFundDiff', 'upStocks', 'url'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 10, 30);
+    const pageProps = await fetchHomePageProps('cls plates');
+    return mapHotPlateRows(pageProps.hotPlate, limit);
+  },
+});

--- a/clis/cls/subjects.js
+++ b/clis/cls/subjects.js
@@ -1,0 +1,21 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CLS_DOMAIN, fetchHomePageProps, mapHotSubjectRows, normalizeLimit } from './utils.js';
+
+cli({
+  site: 'cls',
+  name: 'subjects',
+  access: 'read',
+  description: '财联社首页热门话题，默认返回前 10 条',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 10, help: '返回数量 (max 30)' },
+  ],
+  columns: ['rank', 'id', 'name', 'description', 'attentionCount', 'newestArticleId', 'newestArticleTitle', 'url'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 10, 30);
+    const pageProps = await fetchHomePageProps('cls subjects');
+    return mapHotSubjectRows(pageProps.hotSubject, limit);
+  },
+});

--- a/clis/cls/telegraph.js
+++ b/clis/cls/telegraph.js
@@ -1,0 +1,40 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CLS_DOMAIN, fetchJson, mapTelegraphRows, normalizeLimit } from './utils.js';
+
+const TELEGRAPH_URL = 'https://www.cls.cn/api/cache?name=telegraph';
+
+cli({
+  site: 'cls',
+  name: 'telegraph',
+  access: 'read',
+  description: '财联社电报快讯列表，默认返回最新 20 条',
+  domain: CLS_DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'limit', type: 'int', default: 20, help: '返回数量 (max 100)' },
+  ],
+  columns: [
+    'rank',
+    'id',
+    'title',
+    'content',
+    'subjects',
+    'stocks',
+    'level',
+    'readingCount',
+    'commentCount',
+    'shareCount',
+    'pubTime',
+    'url',
+  ],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 20, 100);
+    const data = await fetchJson(TELEGRAPH_URL, 'cls telegraph');
+    if (data?.errno !== 0) {
+      throw new CommandExecutionError(`cls telegraph API returned errno=${data?.errno ?? 'unknown'}${data?.msg ? `: ${data.msg}` : ''}`);
+    }
+    return mapTelegraphRows(data?.data?.roll_data, limit);
+  },
+});

--- a/clis/cls/utils.js
+++ b/clis/cls/utils.js
@@ -4,7 +4,7 @@ export const CLS_BASE = 'https://www.cls.cn';
 export const CLS_DOMAIN = 'www.cls.cn';
 
 const REQUEST_HEADERS = {
-  'User-Agent': 'Mozilla/5.0 (compatible; opencli/1.0; +https://github.com/jackwener/opencli)',
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
   'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
 };
 
@@ -79,6 +79,28 @@ export async function fetchHtml(url, commandLabel) {
   }
 }
 
+export function extractNextData(html, commandLabel) {
+  const match = String(html ?? '').match(/<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
+  if (!match) {
+    throw new EmptyResultError(commandLabel, 'The page did not contain __NEXT_DATA__.');
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch (error) {
+    throw new CommandExecutionError(`${commandLabel} returned malformed __NEXT_DATA__: ${error?.message || error}`);
+  }
+}
+
+export async function fetchHomePageProps(commandLabel) {
+  const html = await fetchHtml(`${CLS_BASE}/`, commandLabel);
+  const data = extractNextData(html, commandLabel);
+  const pageProps = data?.props?.pageProps;
+  if (!pageProps || typeof pageProps !== 'object') {
+    throw new EmptyResultError(commandLabel, 'The homepage did not expose pageProps.');
+  }
+  return pageProps;
+}
+
 export function htmlToText(value) {
   return decodeEntities(String(value ?? '')
     .replace(/<br\s*\/?>/gi, '\n')
@@ -110,6 +132,25 @@ function toCount(value) {
   if (value === null || value === undefined || value === '') return null;
   const count = Number(value);
   return Number.isFinite(count) ? count : null;
+}
+
+function toStringId(value, commandLabel, label = 'id') {
+  const id = String(value ?? '').trim();
+  if (!/^\d+$/.test(id)) {
+    throw new CommandExecutionError(`${commandLabel} returned malformed payload: ${label} must be numeric`);
+  }
+  return id;
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function ratioToPct(value) {
+  const number = toNumberOrNull(value);
+  return number === null ? null : Number((number * 100).toFixed(4));
 }
 
 function joinSubjects(value) {
@@ -201,17 +242,7 @@ export function mapTelegraphRows(items, limit) {
 }
 
 export function extractArticleDetailFromNextData(html) {
-  const match = String(html ?? '').match(/<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
-  if (!match) {
-    throw new EmptyResultError('cls article', 'The detail page did not contain __NEXT_DATA__.');
-  }
-
-  let data;
-  try {
-    data = JSON.parse(match[1]);
-  } catch (error) {
-    throw new CommandExecutionError(`cls article returned malformed __NEXT_DATA__: ${error?.message || error}`);
-  }
+  const data = extractNextData(html, 'cls article');
 
   const candidates = [
     data?.props?.pageProps?.articleDetail,
@@ -248,4 +279,135 @@ export function mapArticleDetailRow(detail) {
     audioUrl: getAudioUrl(detail) ? String(getAudioUrl(detail)) : null,
     url: `${CLS_BASE}/detail/${id}`,
   };
+}
+
+export function mapHotArticleRows(items, limit) {
+  if (!Array.isArray(items)) {
+    throw new CommandExecutionError('cls hot returned malformed payload: hotArticleData must be an array');
+  }
+  if (items.length === 0) {
+    throw new EmptyResultError('cls hot', 'The homepage returned no hot articles.');
+  }
+
+  return items.slice(0, limit).map((item, index) => {
+    const id = toStringId(item?.id, 'cls hot');
+    const title = htmlToText(item?.title);
+    if (!title) {
+      throw new CommandExecutionError(`cls hot returned malformed payload for ${id}: title is missing`);
+    }
+    return {
+      rank: index + 1,
+      id,
+      title,
+      brief: htmlToText(item?.brief),
+      author: normalizeAuthor(item?.author),
+      readingCount: toCount(item?.readNum ?? item?.reading_num),
+      pubTime: unixSecondsToIso(item?.ctime),
+      url: `${CLS_BASE}/detail/${id}`,
+    };
+  });
+}
+
+export function mapHotSubjectRows(items, limit) {
+  if (!Array.isArray(items)) {
+    throw new CommandExecutionError('cls subjects returned malformed payload: hotSubject must be an array');
+  }
+  if (items.length === 0) {
+    throw new EmptyResultError('cls subjects', 'The homepage returned no popular subjects.');
+  }
+
+  return items.slice(0, limit).map((item, index) => {
+    const id = toStringId(item?.id, 'cls subjects');
+    const name = htmlToText(item?.name);
+    if (!name) {
+      throw new CommandExecutionError(`cls subjects returned malformed payload for ${id}: name is missing`);
+    }
+    const newestArticleId = item?.newest_article_id ? toStringId(item.newest_article_id, 'cls subjects', 'newest_article_id') : null;
+    return {
+      rank: index + 1,
+      id,
+      name,
+      description: htmlToText(item?.description),
+      attentionCount: toCount(item?.attention_num),
+      newestArticleId,
+      newestArticleTitle: htmlToText(item?.newest_article_title),
+      url: `${CLS_BASE}/subject/${id}`,
+    };
+  });
+}
+
+function joinUpStocks(value) {
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((item) => {
+      const name = htmlToText(item?.secu_name ?? item?.name);
+      const code = String(item?.secu_code ?? item?.code ?? '').trim();
+      if (name && code) return `${name}(${code})`;
+      return name || code;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+export function mapHotPlateRows(items, limit) {
+  if (!Array.isArray(items)) {
+    throw new CommandExecutionError('cls plates returned malformed payload: hotPlate must be an array');
+  }
+  if (items.length === 0) {
+    throw new EmptyResultError('cls plates', 'The homepage returned no hot plates.');
+  }
+
+  return items.slice(0, limit).map((item, index) => {
+    const code = String(item?.secu_code ?? '').trim();
+    if (!code) {
+      throw new CommandExecutionError('cls plates returned malformed payload: plate code is missing');
+    }
+    const name = htmlToText(item?.secu_name);
+    if (!name) {
+      throw new CommandExecutionError(`cls plates returned malformed payload for ${code}: name is missing`);
+    }
+    return {
+      rank: index + 1,
+      code,
+      name,
+      changePct: ratioToPct(item?.change),
+      mainFundDiff: toNumberOrNull(item?.main_fund_diff),
+      upStocks: joinUpStocks(item?.up_stock),
+      url: `${CLS_BASE}/plate?code=${encodeURIComponent(code)}`,
+    };
+  });
+}
+
+export function mapCalendarRows(days, limit) {
+  if (!Array.isArray(days)) {
+    throw new CommandExecutionError('cls calendar returned malformed payload: investKalendarData must be an array');
+  }
+  const flattened = [];
+  for (const day of days) {
+    const items = Array.isArray(day?.items) ? day.items : [];
+    for (const item of items) {
+      flattened.push({ day, item });
+    }
+  }
+  if (flattened.length === 0) {
+    throw new EmptyResultError('cls calendar', 'The homepage returned no calendar events.');
+  }
+
+  return flattened.slice(0, limit).map(({ day, item }, index) => {
+    const id = toStringId(item?.id, 'cls calendar');
+    const title = htmlToText(item?.title ?? item?.event?.title ?? item?.economic?.name);
+    if (!title) {
+      throw new CommandExecutionError(`cls calendar returned malformed payload for ${id}: title is missing`);
+    }
+    return {
+      rank: index + 1,
+      id,
+      date: String(day?.calendar_day ?? '').trim(),
+      week: String(day?.week ?? '').trim(),
+      time: String(item?.calendar_time ?? '').trim(),
+      title,
+      country: htmlToText(item?.event?.country ?? item?.economic?.country ?? item?.holiday?.country),
+      star: toCount(item?.event?.star ?? item?.economic?.star),
+    };
+  });
 }

--- a/clis/cls/utils.js
+++ b/clis/cls/utils.js
@@ -1,0 +1,251 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const CLS_BASE = 'https://www.cls.cn';
+export const CLS_DOMAIN = 'www.cls.cn';
+
+const REQUEST_HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (compatible; opencli/1.0; +https://github.com/jackwener/opencli)',
+  'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+};
+
+export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+  const raw = value ?? defaultValue;
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new ArgumentError(`${label} must be a positive integer`);
+  }
+  if (limit > maxValue) {
+    throw new ArgumentError(`${label} must be <= ${maxValue}`);
+  }
+  return limit;
+}
+
+export function parseArticleId(input) {
+  const raw = String(input ?? '').trim();
+  if (!raw) throw new ArgumentError('cls article id must not be empty');
+
+  const detailMatch = raw.match(/(?:^|\/)detail\/(\d+)(?:[/?#]|$)/);
+  const id = detailMatch?.[1] ?? (/^\d+$/.test(raw) ? raw : '');
+  if (!id) {
+    throw new ArgumentError('cls article id must be a numeric id or https://www.cls.cn/detail/<id> URL');
+  }
+  return id;
+}
+
+export async function fetchJson(url, commandLabel) {
+  let resp;
+  try {
+    resp = await fetch(url, {
+      headers: {
+        ...REQUEST_HEADERS,
+        Accept: 'application/json,text/plain,*/*',
+        Referer: `${CLS_BASE}/`,
+      },
+    });
+  } catch (error) {
+    throw new CommandExecutionError(`${commandLabel} request failed: ${error?.message || error}`);
+  }
+  if (!resp.ok) {
+    throw new CommandExecutionError(`${commandLabel} request failed: HTTP ${resp.status}`);
+  }
+  try {
+    return await resp.json();
+  } catch (error) {
+    throw new CommandExecutionError(`${commandLabel} returned malformed JSON: ${error?.message || error}`);
+  }
+}
+
+export async function fetchHtml(url, commandLabel) {
+  let resp;
+  try {
+    resp = await fetch(url, {
+      headers: {
+        ...REQUEST_HEADERS,
+        Accept: 'text/html,application/xhtml+xml',
+        Referer: `${CLS_BASE}/`,
+      },
+      redirect: 'follow',
+    });
+  } catch (error) {
+    throw new CommandExecutionError(`${commandLabel} request failed: ${error?.message || error}`);
+  }
+  if (!resp.ok) {
+    throw new CommandExecutionError(`${commandLabel} request failed: HTTP ${resp.status}`);
+  }
+  try {
+    return await resp.text();
+  } catch (error) {
+    throw new CommandExecutionError(`${commandLabel} returned unreadable HTML: ${error?.message || error}`);
+  }
+}
+
+export function htmlToText(value) {
+  return decodeEntities(String(value ?? '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|section|article)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim());
+}
+
+function decodeEntities(value) {
+  return value
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+export function unixSecondsToIso(value) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return new Date(seconds * 1000).toISOString();
+}
+
+function toCount(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const count = Number(value);
+  return Number.isFinite(count) ? count : null;
+}
+
+function joinSubjects(value) {
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      return item?.subject_name ?? item?.name ?? item?.title ?? '';
+    })
+    .map((item) => String(item).trim())
+    .filter(Boolean)
+    .join(', ');
+}
+
+function joinStocks(value) {
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      const name = String(item?.stock_name ?? item?.name ?? '').trim();
+      const code = String(item?.stock_code ?? item?.code ?? '').trim();
+      if (name && code) return `${name}(${code})`;
+      return name || code;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+function requireArticleId(row, commandLabel) {
+  const id = String(row?.id ?? row?.article_id ?? '').trim();
+  if (!/^\d+$/.test(id)) {
+    throw new CommandExecutionError(`${commandLabel} returned malformed payload: row is missing a numeric id`);
+  }
+  return id;
+}
+
+function getArticleSubjects(detail) {
+  return detail?.subject ?? detail?.subjects ?? detail?.subjectList ?? [];
+}
+
+function getReadingCount(detail) {
+  return detail?.readingNum ?? detail?.reading_num ?? detail?.reading_count ?? null;
+}
+
+function getAudioUrl(detail) {
+  return detail?.miniMaxAudioUrl ?? detail?.mini_max_audio_url ?? detail?.audio_url ?? null;
+}
+
+function normalizeAuthor(value) {
+  if (typeof value === 'string') {
+    const author = value.trim();
+    return author || null;
+  }
+  if (!value || typeof value !== 'object') return null;
+  const author = value.name ?? value.nickname ?? value.author_name ?? value.username;
+  return typeof author === 'string' && author.trim() ? author.trim() : null;
+}
+
+export function mapTelegraphRows(items, limit) {
+  if (!Array.isArray(items)) {
+    throw new CommandExecutionError('cls telegraph returned malformed payload: roll_data must be an array');
+  }
+  if (items.length === 0) {
+    throw new EmptyResultError('cls telegraph', 'The public telegraph cache returned no rows.');
+  }
+
+  return items.slice(0, limit).map((item, index) => {
+    const id = requireArticleId(item, 'cls telegraph');
+    const content = htmlToText(item?.content || item?.brief || item?.title);
+    const title = htmlToText(item?.title || content || item?.brief);
+    if (!title) {
+      throw new CommandExecutionError(`cls telegraph returned malformed payload for ${id}: title/content is missing`);
+    }
+    return {
+      rank: index + 1,
+      id,
+      title,
+      content,
+      subjects: joinSubjects(item?.subjects),
+      stocks: joinStocks(item?.stock_list),
+      level: item?.level ? String(item.level) : null,
+      readingCount: toCount(item?.reading_num),
+      commentCount: toCount(item?.comment_num),
+      shareCount: toCount(item?.share_num),
+      pubTime: unixSecondsToIso(item?.ctime),
+      url: `${CLS_BASE}/detail/${id}`,
+    };
+  });
+}
+
+export function extractArticleDetailFromNextData(html) {
+  const match = String(html ?? '').match(/<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
+  if (!match) {
+    throw new EmptyResultError('cls article', 'The detail page did not contain __NEXT_DATA__.');
+  }
+
+  let data;
+  try {
+    data = JSON.parse(match[1]);
+  } catch (error) {
+    throw new CommandExecutionError(`cls article returned malformed __NEXT_DATA__: ${error?.message || error}`);
+  }
+
+  const candidates = [
+    data?.props?.pageProps?.articleDetail,
+    data?.props?.pageProps?.initialState?.articleDetail,
+    data?.props?.pageProps?.detail,
+  ];
+  const detail = candidates.find((item) => item && typeof item === 'object');
+  if (!detail) {
+    throw new EmptyResultError('cls article', 'The public detail page did not expose articleDetail.');
+  }
+  return detail;
+}
+
+export function mapArticleDetailRow(detail) {
+  const id = requireArticleId(detail, 'cls article');
+  const title = String(detail?.title ?? '').trim();
+  if (!title) {
+    throw new CommandExecutionError(`cls article returned malformed payload for ${id}: title is missing`);
+  }
+  const content = htmlToText(detail?.content ?? '');
+  if (!content) {
+    throw new CommandExecutionError(`cls article returned malformed payload for ${id}: content is missing`);
+  }
+  return {
+    id,
+    title,
+    content,
+    brief: htmlToText(detail?.brief ?? ''),
+    subjects: joinSubjects(getArticleSubjects(detail)),
+    author: normalizeAuthor(detail?.author),
+    level: detail?.level ? String(detail.level) : null,
+    readingCount: toCount(getReadingCount(detail)),
+    pubTime: unixSecondsToIso(detail?.ctime),
+    audioUrl: getAudioUrl(detail) ? String(getAudioUrl(detail)) : null,
+    url: `${CLS_BASE}/detail/${id}`,
+  };
+}

--- a/docs/adapters/browser/cls.md
+++ b/docs/adapters/browser/cls.md
@@ -7,6 +7,10 @@
 | Command | Description |
 |---------|-------------|
 | `opencli cls telegraph` | 财联社电报快讯列表 |
+| `opencli cls hot` | 财联社首页热门文章 |
+| `opencli cls subjects` | 财联社首页热门话题 |
+| `opencli cls plates` | 财联社首页热门板块和主力资金 |
+| `opencli cls calendar` | 财联社首页投资日历事件 |
 | `opencli cls article <id-or-url>` | 财联社文章详情正文 |
 
 ## Usage Examples
@@ -14,6 +18,18 @@
 ```bash
 # Latest telegraph items
 opencli cls telegraph --limit 10
+
+# Homepage hot articles
+opencli cls hot --limit 10
+
+# Popular subjects
+opencli cls subjects --limit 10
+
+# Hot plates / market sectors
+opencli cls plates --limit 10
+
+# Investment calendar
+opencli cls calendar --limit 20
 
 # Read an article by ID
 opencli cls article 2411505
@@ -28,5 +44,6 @@ opencli cls telegraph --limit 3 -f json
 ## Notes
 
 - `telegraph` uses the public `api/cache?name=telegraph` JSON cache and does not require a browser session.
+- `hot`, `subjects`, `plates`, and `calendar` read public data from the homepage Next.js state.
 - `article` fetches the public detail page and reads the article payload from the page's Next.js state.
 - `depth` is not included yet because the visible web page uses signed internal endpoints for that list.

--- a/docs/adapters/browser/cls.md
+++ b/docs/adapters/browser/cls.md
@@ -1,0 +1,32 @@
+# CLS (财联社)
+
+**Mode**: 🌐 Public · **Domain**: `www.cls.cn`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli cls telegraph` | 财联社电报快讯列表 |
+| `opencli cls article <id-or-url>` | 财联社文章详情正文 |
+
+## Usage Examples
+
+```bash
+# Latest telegraph items
+opencli cls telegraph --limit 10
+
+# Read an article by ID
+opencli cls article 2411505
+
+# Read an article by URL
+opencli cls article https://www.cls.cn/detail/2411505
+
+# JSON output
+opencli cls telegraph --limit 3 -f json
+```
+
+## Notes
+
+- `telegraph` uses the public `api/cache?name=telegraph` JSON cache and does not require a browser session.
+- `article` fetches the public detail page and reads the article payload from the page's Next.js state.
+- `depth` is not included yet because the visible web page uses signed internal endpoints for that list.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -99,6 +99,7 @@ Run `opencli list` for the live registry.
 | Site                                           | Commands                                                                                                                                       | Mode         |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | **[hackernews](./browser/hackernews.md)**         | `top` `new` `best` `ask` `show` `jobs` `search` `user`                                                                                         | 🌐 Public    |
+| **[cls](./browser/cls.md)**                       | `telegraph` `article`                                                                                                                          | 🌐 Public    |
 | **[bbc](./browser/bbc.md)**                       | `news`                                                                                                                                         | 🌐 Public    |
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[juejin](./browser/juejin.md)**                 | `recommend` `hot`                                                                                                                              | 🌐 Public    |

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -99,7 +99,7 @@ Run `opencli list` for the live registry.
 | Site                                           | Commands                                                                                                                                       | Mode         |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | **[hackernews](./browser/hackernews.md)**         | `top` `new` `best` `ask` `show` `jobs` `search` `user`                                                                                         | 🌐 Public    |
-| **[cls](./browser/cls.md)**                       | `telegraph` `article`                                                                                                                          | 🌐 Public    |
+| **[cls](./browser/cls.md)**                       | `telegraph` `hot` `subjects` `plates` `calendar` `article`                                                                                     | 🌐 Public    |
 | **[bbc](./browser/bbc.md)**                       | `news`                                                                                                                                         | 🌐 Public    |
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[juejin](./browser/juejin.md)**                 | `recommend` `hot`                                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
## Summary
- Add a public `cls` adapter for 财联社 with six read commands: `telegraph`, `hot`, `subjects`, `plates`, `calendar`, and `article`.
- Map telegraph rows from the public cache API, article details from public detail page state, and homepage sections from public Next.js SSR state.
- Add adapter tests, docs, and manifest entries.

## Strategy
- `cls telegraph`: `PUBLIC_API`, using `https://www.cls.cn/api/cache?name=telegraph` with no login or browser session.
- `cls hot` / `subjects` / `plates` / `calendar`: `DOM_STATE`, fetching the public homepage and reading `__NEXT_DATA__.props.pageProps`.
- `cls article`: `DOM_STATE`, fetching public detail pages and reading `__NEXT_DATA__.props.pageProps.articleDetail`.
- `depth` and channel-specific subject/finance/vip/fm APIs are intentionally excluded for now: direct replay of the visible web endpoints returned signature errors or loading placeholders.

## Test Plan
- [x] `npx vitest run --project adapter clis/cls/commands.test.js` — 22 passed
- [x] `npm run build-manifest` — manifest compiled 1263 entries
- [x] `node scripts/check-silent-column-drop.mjs` — no new violations
- [x] `node scripts/check-typed-error-lint.mjs` — no new violations
- [x] `node scripts/check-listing-id-pairing.mjs` — advisory only
- [x] `node dist/src/main.js cls telegraph --limit 2 -f json` — returned live rows, including empty-title API rows via content fallback
- [x] `node dist/src/main.js cls hot --limit 2 -f json` — returned live homepage hot articles
- [x] `node dist/src/main.js cls subjects --limit 2 -f json` — returned live popular subjects
- [x] `node dist/src/main.js cls plates --limit 2 -f json` — returned live hot plates
- [x] `node dist/src/main.js cls calendar --limit 2 -f json` — returned live calendar events
- [x] `node dist/src/main.js cls article 2411505 -f json` — returned live article content

## Full Test Note
- `npm test` was run on Windows and failed in unrelated existing areas: symlink permission errors in `src/plugin.test.ts` and path-separator expectations in existing instagram/twitter/xiaoyuzhou/suno tests. The new `cls` adapter tests and repo adapter audit gates pass.
