### PR TITLE
feat(adapter): add Mercury reimbursement helpers

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -23088,6 +23088,200 @@
     "navigateBefore": "https://medium.com"
   },
   {
+    "site": "mercury",
+    "name": "check-login",
+    "description": "Open Mercury reimbursements and report whether the active browser profile is logged in",
+    "access": "read",
+    "example": "opencli --profile <profile> mercury check-login -f json",
+    "domain": "app.mercury.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "status",
+      "loggedIn",
+      "url",
+      "hasSubmitExpense",
+      "hasReimbursements",
+      "title"
+    ],
+    "type": "js",
+    "modulePath": "mercury/check-login.js",
+    "sourceFile": "mercury/check-login.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "mercury",
+    "name": "reimbursement-draft",
+    "description": "Create a Mercury reimbursement draft from a local receipt, correct OCR fields, and stop at Review",
+    "access": "write",
+    "example": "opencli --profile <profile> mercury reimbursement-draft --receipt /tmp/receipt.png --amount 140.00 --currency CNY --date 2026-06-26 --merchant \"Example Merchant\" --category \"Marketing & Advertising\" --notes \"Example business purpose.\" -f json",
+    "domain": "app.mercury.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "receipt",
+        "type": "str",
+        "required": true,
+        "help": "Local receipt/proof file path"
+      },
+      {
+        "name": "amount",
+        "type": "str",
+        "required": true,
+        "help": "Original-currency amount, e.g. 140.00"
+      },
+      {
+        "name": "currency",
+        "type": "str",
+        "default": "CNY",
+        "required": false,
+        "help": "Original currency code"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Expense date as YYYY-MM-DD"
+      },
+      {
+        "name": "merchant",
+        "type": "str",
+        "required": true,
+        "help": "Merchant shown on the reimbursement"
+      },
+      {
+        "name": "category",
+        "type": "str",
+        "default": "Marketing & Advertising",
+        "required": false,
+        "help": "Mercury expense category"
+      },
+      {
+        "name": "notes",
+        "type": "str",
+        "required": true,
+        "help": "Business purpose / reimbursement notes"
+      },
+      {
+        "name": "ocr-wait-seconds",
+        "type": "str",
+        "default": "8",
+        "required": false,
+        "help": "Seconds to wait after receipt upload before correcting OCR-overwritten fields"
+      },
+      {
+        "name": "close-after-review",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Close the Review dialog after verification; final Submit is still never clicked"
+      }
+    ],
+    "columns": [
+      "status",
+      "url",
+      "receipt",
+      "uploaded",
+      "fieldsTouched",
+      "reviewReady",
+      "submitBlocked",
+      "warnings"
+    ],
+    "type": "js",
+    "modulePath": "mercury/reimbursement-draft.js",
+    "sourceFile": "mercury/reimbursement-draft.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "mercury",
+    "name": "reimbursement-plan",
+    "description": "Validate Mercury reimbursement inputs and print the draft plan without opening a browser",
+    "access": "read",
+    "example": "opencli mercury reimbursement-plan --receipt /tmp/receipt.png --amount 140.00 --currency CNY --date 2026-06-26 --merchant \"Example Merchant\" --category \"Marketing & Advertising\" --notes \"Example business purpose.\" -f json",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "receipt",
+        "type": "str",
+        "required": true,
+        "help": "Local receipt/proof file path"
+      },
+      {
+        "name": "amount",
+        "type": "str",
+        "required": true,
+        "help": "Original-currency amount, e.g. 140.00"
+      },
+      {
+        "name": "currency",
+        "type": "str",
+        "default": "CNY",
+        "required": false,
+        "help": "Original currency code"
+      },
+      {
+        "name": "date",
+        "type": "str",
+        "required": true,
+        "help": "Expense date as YYYY-MM-DD"
+      },
+      {
+        "name": "merchant",
+        "type": "str",
+        "required": true,
+        "help": "Merchant shown on the reimbursement"
+      },
+      {
+        "name": "category",
+        "type": "str",
+        "default": "Marketing & Advertising",
+        "required": false,
+        "help": "Mercury expense category"
+      },
+      {
+        "name": "notes",
+        "type": "str",
+        "required": true,
+        "help": "Business purpose / reimbursement notes"
+      },
+      {
+        "name": "ocr-wait-seconds",
+        "type": "str",
+        "default": "8",
+        "required": false,
+        "help": "Seconds the draft command waits after receipt upload before correcting OCR fields"
+      },
+      {
+        "name": "close-after-review",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "For draft command: close the Review dialog after verification"
+      }
+    ],
+    "columns": [
+      "status",
+      "receipt",
+      "amount",
+      "currency",
+      "date",
+      "merchant",
+      "category",
+      "notes",
+      "safety"
+    ],
+    "type": "js",
+    "modulePath": "mercury/reimbursement-plan.js",
+    "sourceFile": "mercury/reimbursement-plan.js"
+  },
+  {
     "site": "mubu",
     "name": "doc",
     "description": "读取幕布文档内容（默认输出 Markdown，可用 --output text 输出纯文本）",

--- a/clis/mercury/check-login.js
+++ b/clis/mercury/check-login.js
@@ -1,0 +1,29 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { inspectMercury } from './utils.js';
+
+cli({
+    site: 'mercury',
+    name: 'check-login',
+    description: 'Open Mercury reimbursements and report whether the active browser profile is logged in',
+    access: 'read',
+    example: 'opencli --profile <profile> mercury check-login -f json',
+    domain: 'app.mercury.com',
+    strategy: Strategy.UI,
+    browser: true,
+    siteSession: 'persistent',
+    defaultWindowMode: 'foreground',
+    navigateBefore: false,
+    args: [],
+    columns: ['status', 'loggedIn', 'url', 'hasSubmitExpense', 'hasReimbursements', 'title'],
+    func: async (page) => {
+        const state = await inspectMercury(page);
+        return [{
+            status: state.loggedIn ? 'ready' : 'needs_login',
+            loggedIn: state.loggedIn,
+            url: state.url,
+            hasSubmitExpense: state.hasSubmitExpense,
+            hasReimbursements: state.hasReimbursements,
+            title: state.title,
+        }];
+    },
+});

--- a/clis/mercury/mercury.test.js
+++ b/clis/mercury/mercury.test.js
@@ -1,0 +1,261 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { normalizeReimbursementInput } from './utils.js';
+import './check-login.js';
+import './reimbursement-draft.js';
+import './reimbursement-plan.js';
+
+let tmpDir;
+let receiptPath;
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-mercury-test-'));
+    receiptPath = path.join(tmpDir, 'receipt.png');
+    fs.writeFileSync(receiptPath, 'receipt');
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function validArgs(overrides = {}) {
+    return {
+        receipt: receiptPath,
+        amount: '140.00',
+        currency: 'CNY',
+        date: '2026-06-26',
+        merchant: 'Example Merchant',
+        category: 'Marketing & Advertising',
+        notes: 'Example business purpose.',
+        ...overrides,
+    };
+}
+
+function createPageMock(evaluateResults, overrides = {}) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn()
+            .mockImplementation(() => {
+                if (!evaluateResults.length) throw new Error('unexpected evaluate call');
+                return evaluateResults.shift();
+            }),
+        uploadFiles: vi.fn().mockResolvedValue({
+            uploaded: true,
+            files: 1,
+            file_names: ['receipt.png'],
+            target: '[data-testid="expense-attachment-upload"]',
+            matches_n: 1,
+            match_level: 'exact',
+        }),
+        setFileInput: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function loggedInState(overrides = {}) {
+    return {
+        url: 'https://app.mercury.com/expenses/my-expenses',
+        loggedIn: true,
+        hasSubmitExpense: true,
+        hasReimbursements: true,
+        title: 'Mercury',
+        ...overrides,
+    };
+}
+
+function createSurface(overrides = {}) {
+    return {
+        url: 'https://app.mercury.com/expenses/my-expenses',
+        title: 'Mercury',
+        hasFinalSubmit: false,
+        hasForm: false,
+        bodyPreview: 'My Expenses Submit expense',
+        ...overrides,
+    };
+}
+
+function clickResult(clicked = true) {
+    return { clicked, text: clicked ? 'clicked' : '' };
+}
+
+function fillResult(touched = {}) {
+    return {
+        touched: {
+            amount: true,
+            currency: true,
+            date: true,
+            merchant: true,
+            category: true,
+            notes: true,
+            ...touched,
+        },
+    };
+}
+
+function reviewState(overrides = {}) {
+    return {
+        url: 'https://app.mercury.com/expenses/review',
+        title: 'Mercury',
+        hasReview: true,
+        hasSubmitExpenseButton: true,
+        bodyPreview: 'Review Submit expense',
+        ...overrides,
+    };
+}
+
+describe('mercury reimbursement input validation', () => {
+    it('normalizes valid input and keeps receipt absolute internally', () => {
+        const input = normalizeReimbursementInput(validArgs());
+        expect(input).toMatchObject({
+            receipt: receiptPath,
+            amount: '140.00',
+            currency: 'CNY',
+            date: '2026-06-26',
+            merchant: 'Example Merchant',
+            category: 'Marketing & Advertising',
+            notes: 'Example business purpose.',
+            ocrWaitSeconds: 8,
+            closeAfterReview: false,
+        });
+    });
+
+    it('rejects malformed local-only arguments before browser work', () => {
+        expect(() => normalizeReimbursementInput(validArgs({ amount: '0' }))).toThrow(ArgumentError);
+        expect(() => normalizeReimbursementInput(validArgs({ amount: '1.999' }))).toThrow(ArgumentError);
+        expect(() => normalizeReimbursementInput(validArgs({ currency: 'US' }))).toThrow(ArgumentError);
+        expect(() => normalizeReimbursementInput(validArgs({ date: '2026-02-30' }))).toThrow(ArgumentError);
+        expect(() => normalizeReimbursementInput(validArgs({ 'ocr-wait-seconds': 'abc' }))).toThrow(ArgumentError);
+        expect(() => normalizeReimbursementInput(validArgs({ receipt: path.join(tmpDir, 'missing.png') }))).toThrow(ArgumentError);
+    });
+});
+
+describe('mercury reimbursement-plan', () => {
+    it('validates locally and returns a deterministic basename-only plan', async () => {
+        const command = getRegistry().get('mercury/reimbursement-plan');
+        const rows = await command.func(validArgs());
+        expect(rows).toEqual([expect.objectContaining({
+            status: 'ready',
+            receipt: 'receipt.png',
+            amount: '140.00',
+            currency: 'CNY',
+            safety: expect.stringContaining('never clicks final Submit expense'),
+        })]);
+    });
+});
+
+describe('mercury reimbursement-draft', () => {
+    const command = getRegistry().get('mercury/reimbursement-draft');
+
+    it('throws AuthRequiredError instead of returning a fake draft when logged out', async () => {
+        const page = createPageMock([loggedInState({ loggedIn: false, url: 'https://app.mercury.com/login' })]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.uploadFiles).not.toHaveBeenCalled();
+    });
+
+    it('typed-fails malformed login state payloads', async () => {
+        const page = createPageMock([{ url: 'https://app.mercury.com/expenses/my-expenses', title: 'Mercury' }]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.uploadFiles).not.toHaveBeenCalled();
+    });
+
+    it('refuses to click when an existing review/submit surface is already open', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface({ hasFinalSubmit: true, hasForm: true, bodyPreview: 'Review Submit expense amount merchant' }),
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.uploadFiles).not.toHaveBeenCalled();
+    });
+
+    it('typed-fails malformed create expense surface payloads', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            { url: 'https://app.mercury.com/expenses/my-expenses', title: 'Mercury', hasForm: false },
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.uploadFiles).not.toHaveBeenCalled();
+    });
+
+    it('typed-fails upload confirmation drift', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+        ], {
+            uploadFiles: vi.fn().mockResolvedValue({ uploaded: false, files: 0 }),
+        });
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails upload confirmation for the wrong file name', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+        ], {
+            uploadFiles: vi.fn().mockResolvedValue({ uploaded: true, files: 1, file_names: ['other.png'] }),
+        });
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails missed required field selectors before Review', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+            fillResult({ merchant: false }),
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toThrow(/merchant/);
+    });
+
+    it('typed-fails if Mercury does not reach Review with final submit visible', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+            fillResult(),
+            clickResult(true),
+            reviewState({ hasReview: false, hasSubmitExpenseButton: false }),
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails malformed review payloads', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+            fillResult(),
+            clickResult(true),
+            { url: 'https://app.mercury.com/expenses/review', title: 'Mercury', hasReview: true },
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('returns review-ready summary without clicking final Submit expense', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+            fillResult(),
+            clickResult(true),
+            reviewState(),
+        ]);
+        const rows = await command.func(page, validArgs());
+        expect(rows).toEqual([expect.objectContaining({
+            status: 'review_ready',
+            receipt: 'receipt.png',
+            uploaded: true,
+            reviewReady: true,
+            submitBlocked: true,
+            warnings: 'final Submit expense was intentionally not clicked',
+        })]);
+        expect(page.uploadFiles).toHaveBeenCalledWith('[data-testid="expense-attachment-upload"]', [receiptPath]);
+        expect(page.evaluate).toHaveBeenCalledTimes(6);
+    });
+});

--- a/clis/mercury/mercury.test.js
+++ b/clis/mercury/mercury.test.js
@@ -80,7 +80,7 @@ function createSurface(overrides = {}) {
 }
 
 function clickResult(clicked = true) {
-    return { clicked, text: clicked ? 'clicked' : '' };
+    return { clicked, blocked: false, text: clicked ? 'clicked' : '' };
 }
 
 function fillResult(touched = {}) {
@@ -172,6 +172,16 @@ describe('mercury reimbursement-draft', () => {
         expect(page.uploadFiles).not.toHaveBeenCalled();
     });
 
+    it('typed-fails if the create click probe sees a submit/review surface', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            { clicked: false, blocked: true, text: 'Submit expense' },
+        ]);
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.uploadFiles).not.toHaveBeenCalled();
+    });
+
     it('typed-fails malformed create expense surface payloads', async () => {
         const page = createPageMock([
             loggedInState(),
@@ -199,6 +209,23 @@ describe('mercury reimbursement-draft', () => {
             clickResult(true),
         ], {
             uploadFiles: vi.fn().mockResolvedValue({ uploaded: true, files: 1, file_names: ['other.png'] }),
+        });
+        await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails upload confirmation for the wrong input target', async () => {
+        const page = createPageMock([
+            loggedInState(),
+            createSurface(),
+            clickResult(true),
+        ], {
+            uploadFiles: vi.fn().mockResolvedValue({
+                uploaded: true,
+                files: 1,
+                file_names: ['receipt.png'],
+                target: '[data-testid="wrong"]',
+                matches_n: 1,
+            }),
         });
         await expect(command.func(page, validArgs())).rejects.toBeInstanceOf(CommandExecutionError);
     });

--- a/clis/mercury/reimbursement-draft.js
+++ b/clis/mercury/reimbursement-draft.js
@@ -1,11 +1,15 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     MERCURY_EXPENSES_URL,
     RECEIPT_INPUT_SELECTOR,
+    assertCreateExpenseSurface,
+    assertLoggedIn,
     clickText,
     fillReimbursementFields,
     inspectMercury,
     normalizeReimbursementInput,
+    receiptBasename,
     reviewSnapshot,
 } from './utils.js';
 
@@ -36,90 +40,68 @@ cli({
     func: async (page, kwargs) => {
         const input = normalizeReimbursementInput(kwargs);
         const before = await inspectMercury(page);
-        if (!before.loggedIn) {
-            return [{
-                status: 'needs_login',
-                url: before.url,
-                receipt: input.receipt,
-                uploaded: false,
-                fieldsTouched: '',
-                reviewReady: false,
-                submitBlocked: true,
-                warnings: 'Mercury redirected to login. Log in with the selected browser profile, then rerun.',
-            }];
-        }
+        assertLoggedIn(before);
 
-        if (!before.hasSubmitExpense) {
-            await page.goto(MERCURY_EXPENSES_URL, { waitUntil: 'load', settleMs: 1500 });
-            await page.wait({ time: 1 });
+        await page.goto(MERCURY_EXPENSES_URL, { waitUntil: 'load', settleMs: 1500 });
+        await page.wait({ time: 1 });
+        const createSurface = await assertCreateExpenseSurface(page);
+        if (createSurface.hasFinalSubmit && /review/i.test(createSurface.bodyPreview || '')) {
+            throw new CommandExecutionError('Mercury appears to have an existing expense review open; refusing to click a possible final Submit expense button');
         }
 
         const opened = await clickText(page, ['Submit expense', 'New expense']);
         if (!opened.clicked) {
-            return [{
-                status: 'blocked',
-                url: before.url,
-                receipt: input.receipt,
-                uploaded: false,
-                fieldsTouched: '',
-                reviewReady: false,
-                submitBlocked: true,
-                warnings: 'Could not find the Mercury Submit expense button/link.',
-            }];
+            throw new CommandExecutionError('Could not find the Mercury Submit expense or New expense button');
         }
 
         await page.wait({ time: 2 });
 
-        let uploaded = false;
-        const uploadWarnings = [];
-        try {
-            if (page.setFileInput) {
-                await page.setFileInput([input.receipt], RECEIPT_INPUT_SELECTOR);
-            }
-            else if (page.uploadFiles) {
-                await page.uploadFiles(RECEIPT_INPUT_SELECTOR, [input.receipt]);
-            }
-            else {
-                throw new Error('OpenCLI page object does not expose file upload support');
-            }
-            uploaded = true;
+        if (!page.uploadFiles) {
+            throw new CommandExecutionError('Mercury reimbursement-draft requires Browser Bridge uploadFiles support to verify the intended receipt input');
         }
-        catch (error) {
-            uploadWarnings.push(`upload failed: ${error instanceof Error ? error.message : String(error)}`);
+        const upload = await page.uploadFiles(RECEIPT_INPUT_SELECTOR, [input.receipt]);
+        if (!upload || upload.uploaded !== true || upload.files !== 1) {
+            throw new CommandExecutionError('Mercury receipt upload did not confirm exactly one uploaded file');
+        }
+        const uploadedNames = Array.isArray(upload.file_names) ? upload.file_names : [];
+        if (!uploadedNames.includes(receiptBasename(input.receipt))) {
+            throw new CommandExecutionError('Mercury receipt upload did not confirm the expected receipt file');
         }
 
         if (input.ocrWaitSeconds > 0) await page.wait({ time: input.ocrWaitSeconds });
 
         const fields = await fillReimbursementFields(page, input);
         await page.wait({ time: 1 });
+        const expectedFields = ['amount', 'currency', 'date', 'merchant', 'category', 'notes'];
+        const missing = expectedFields.filter((key) => !fields.touched[key]);
+        if (missing.length > 0) {
+            throw new CommandExecutionError(`Mercury reimbursement form fields were not all filled: ${missing.join(', ')}`);
+        }
 
         const reviewClick = await clickText(page, ['Review']);
+        if (!reviewClick.clicked) {
+            throw new CommandExecutionError('Mercury Review button was not clicked; inspect the page for validation errors');
+        }
         await page.wait({ time: 2 });
         const review = await reviewSnapshot(page);
+        if (!review.hasReview || !review.hasSubmitExpenseButton) {
+            throw new CommandExecutionError('Mercury did not reach the Review step with the final Submit expense button visible');
+        }
 
         if (input.closeAfterReview) {
             await clickText(page, ['Close']);
             await page.wait({ time: 1 });
         }
 
-        const expectedFields = ['amount', 'currency', 'date', 'merchant', 'category', 'notes'];
-        const missing = expectedFields.filter((key) => !fields.touched[key]);
-        const warnings = [
-            ...uploadWarnings,
-            reviewClick.clicked ? '' : 'Review button was not clicked; inspect the page for validation errors.',
-            missing.length > 0 ? `field selectors missed: ${missing.join(', ')}` : '',
-            'final Submit expense was intentionally not clicked',
-        ].filter(Boolean).join('; ');
-
         return [{
-            status: review.hasSubmitExpenseButton ? 'review_ready' : 'draft_open',
+            status: 'review_ready',
             url: review.url,
-            receipt: input.receipt,
-            uploaded,
+            receipt: receiptBasename(input.receipt),
+            uploaded: true,
             fieldsTouched: JSON.stringify(fields.touched),
-            reviewReady: review.hasSubmitExpenseButton,
+            reviewReady: true,
             submitBlocked: true,
-            warnings,
+            warnings: 'final Submit expense was intentionally not clicked',
         }];
     },
 });

--- a/clis/mercury/reimbursement-draft.js
+++ b/clis/mercury/reimbursement-draft.js
@@ -4,8 +4,8 @@ import {
     MERCURY_EXPENSES_URL,
     RECEIPT_INPUT_SELECTOR,
     assertCreateExpenseSurface,
+    clickCreateExpenseButton,
     assertLoggedIn,
-    clickText,
     fillReimbursementFields,
     inspectMercury,
     normalizeReimbursementInput,
@@ -49,7 +49,7 @@ cli({
             throw new CommandExecutionError('Mercury appears to have an existing expense review open; refusing to click a possible final Submit expense button');
         }
 
-        const opened = await clickText(page, ['Submit expense', 'New expense']);
+        const opened = await clickCreateExpenseButton(page);
         if (!opened.clicked) {
             throw new CommandExecutionError('Could not find the Mercury Submit expense or New expense button');
         }
@@ -62,6 +62,9 @@ cli({
         const upload = await page.uploadFiles(RECEIPT_INPUT_SELECTOR, [input.receipt]);
         if (!upload || upload.uploaded !== true || upload.files !== 1) {
             throw new CommandExecutionError('Mercury receipt upload did not confirm exactly one uploaded file');
+        }
+        if (upload.target !== RECEIPT_INPUT_SELECTOR || upload.matches_n !== 1) {
+            throw new CommandExecutionError('Mercury receipt upload did not confirm the intended receipt input');
         }
         const uploadedNames = Array.isArray(upload.file_names) ? upload.file_names : [];
         if (!uploadedNames.includes(receiptBasename(input.receipt))) {
@@ -78,7 +81,21 @@ cli({
             throw new CommandExecutionError(`Mercury reimbursement form fields were not all filled: ${missing.join(', ')}`);
         }
 
-        const reviewClick = await clickText(page, ['Review']);
+        const reviewClick = await page.evaluate(`(() => {
+            const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+            const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'))
+              .filter((node) => {
+                const style = window.getComputedStyle(node);
+                return style.visibility !== 'hidden' && style.display !== 'none' && node.offsetParent !== null;
+              });
+            const el = candidates.find((node) => norm(node.innerText || node.textContent || '') === 'review');
+            if (!el) return { clicked: false };
+            el.click();
+            return { clicked: true, text: el.innerText || el.textContent || '' };
+        })()`);
+        if (!reviewClick || typeof reviewClick !== 'object' || typeof reviewClick.clicked !== 'boolean') {
+            throw new CommandExecutionError('Mercury returned malformed Review click result');
+        }
         if (!reviewClick.clicked) {
             throw new CommandExecutionError('Mercury Review button was not clicked; inspect the page for validation errors');
         }
@@ -89,7 +106,13 @@ cli({
         }
 
         if (input.closeAfterReview) {
-            await clickText(page, ['Close']);
+            await page.evaluate(`(() => {
+                const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+                const el = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'))
+                  .find((node) => norm(node.innerText || node.textContent || '') === 'close');
+                el?.click();
+                return { clicked: Boolean(el) };
+            })()`);
             await page.wait({ time: 1 });
         }
 

--- a/clis/mercury/reimbursement-draft.js
+++ b/clis/mercury/reimbursement-draft.js
@@ -1,0 +1,125 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    MERCURY_EXPENSES_URL,
+    RECEIPT_INPUT_SELECTOR,
+    clickText,
+    fillReimbursementFields,
+    inspectMercury,
+    normalizeReimbursementInput,
+    reviewSnapshot,
+} from './utils.js';
+
+cli({
+    site: 'mercury',
+    name: 'reimbursement-draft',
+    description: 'Create a Mercury reimbursement draft from a local receipt, correct OCR fields, and stop at Review',
+    access: 'write',
+    example: 'opencli --profile <profile> mercury reimbursement-draft --receipt /tmp/receipt.png --amount 140.00 --currency CNY --date 2026-06-26 --merchant "Example Merchant" --category "Marketing & Advertising" --notes "Example business purpose." -f json',
+    domain: 'app.mercury.com',
+    strategy: Strategy.UI,
+    browser: true,
+    siteSession: 'persistent',
+    defaultWindowMode: 'foreground',
+    navigateBefore: false,
+    args: [
+        { name: 'receipt', required: true, help: 'Local receipt/proof file path' },
+        { name: 'amount', required: true, help: 'Original-currency amount, e.g. 140.00' },
+        { name: 'currency', default: 'CNY', help: 'Original currency code' },
+        { name: 'date', required: true, help: 'Expense date as YYYY-MM-DD' },
+        { name: 'merchant', required: true, help: 'Merchant shown on the reimbursement' },
+        { name: 'category', default: 'Marketing & Advertising', help: 'Mercury expense category' },
+        { name: 'notes', required: true, help: 'Business purpose / reimbursement notes' },
+        { name: 'ocr-wait-seconds', default: '8', help: 'Seconds to wait after receipt upload before correcting OCR-overwritten fields' },
+        { name: 'close-after-review', type: 'boolean', default: false, help: 'Close the Review dialog after verification; final Submit is still never clicked' },
+    ],
+    columns: ['status', 'url', 'receipt', 'uploaded', 'fieldsTouched', 'reviewReady', 'submitBlocked', 'warnings'],
+    func: async (page, kwargs) => {
+        const input = normalizeReimbursementInput(kwargs);
+        const before = await inspectMercury(page);
+        if (!before.loggedIn) {
+            return [{
+                status: 'needs_login',
+                url: before.url,
+                receipt: input.receipt,
+                uploaded: false,
+                fieldsTouched: '',
+                reviewReady: false,
+                submitBlocked: true,
+                warnings: 'Mercury redirected to login. Log in with the selected browser profile, then rerun.',
+            }];
+        }
+
+        if (!before.hasSubmitExpense) {
+            await page.goto(MERCURY_EXPENSES_URL, { waitUntil: 'load', settleMs: 1500 });
+            await page.wait({ time: 1 });
+        }
+
+        const opened = await clickText(page, ['Submit expense', 'New expense']);
+        if (!opened.clicked) {
+            return [{
+                status: 'blocked',
+                url: before.url,
+                receipt: input.receipt,
+                uploaded: false,
+                fieldsTouched: '',
+                reviewReady: false,
+                submitBlocked: true,
+                warnings: 'Could not find the Mercury Submit expense button/link.',
+            }];
+        }
+
+        await page.wait({ time: 2 });
+
+        let uploaded = false;
+        const uploadWarnings = [];
+        try {
+            if (page.setFileInput) {
+                await page.setFileInput([input.receipt], RECEIPT_INPUT_SELECTOR);
+            }
+            else if (page.uploadFiles) {
+                await page.uploadFiles(RECEIPT_INPUT_SELECTOR, [input.receipt]);
+            }
+            else {
+                throw new Error('OpenCLI page object does not expose file upload support');
+            }
+            uploaded = true;
+        }
+        catch (error) {
+            uploadWarnings.push(`upload failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+
+        if (input.ocrWaitSeconds > 0) await page.wait({ time: input.ocrWaitSeconds });
+
+        const fields = await fillReimbursementFields(page, input);
+        await page.wait({ time: 1 });
+
+        const reviewClick = await clickText(page, ['Review']);
+        await page.wait({ time: 2 });
+        const review = await reviewSnapshot(page);
+
+        if (input.closeAfterReview) {
+            await clickText(page, ['Close']);
+            await page.wait({ time: 1 });
+        }
+
+        const expectedFields = ['amount', 'currency', 'date', 'merchant', 'category', 'notes'];
+        const missing = expectedFields.filter((key) => !fields.touched[key]);
+        const warnings = [
+            ...uploadWarnings,
+            reviewClick.clicked ? '' : 'Review button was not clicked; inspect the page for validation errors.',
+            missing.length > 0 ? `field selectors missed: ${missing.join(', ')}` : '',
+            'final Submit expense was intentionally not clicked',
+        ].filter(Boolean).join('; ');
+
+        return [{
+            status: review.hasSubmitExpenseButton ? 'review_ready' : 'draft_open',
+            url: review.url,
+            receipt: input.receipt,
+            uploaded,
+            fieldsTouched: JSON.stringify(fields.touched),
+            reviewReady: review.hasSubmitExpenseButton,
+            submitBlocked: true,
+            warnings,
+        }];
+    },
+});

--- a/clis/mercury/reimbursement-plan.js
+++ b/clis/mercury/reimbursement-plan.js
@@ -1,0 +1,38 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { normalizeReimbursementInput } from './utils.js';
+
+cli({
+    site: 'mercury',
+    name: 'reimbursement-plan',
+    description: 'Validate Mercury reimbursement inputs and print the draft plan without opening a browser',
+    access: 'read',
+    example: 'opencli mercury reimbursement-plan --receipt /tmp/receipt.png --amount 140.00 --currency CNY --date 2026-06-26 --merchant "Example Merchant" --category "Marketing & Advertising" --notes "Example business purpose." -f json',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'receipt', required: true, help: 'Local receipt/proof file path' },
+        { name: 'amount', required: true, help: 'Original-currency amount, e.g. 140.00' },
+        { name: 'currency', default: 'CNY', help: 'Original currency code' },
+        { name: 'date', required: true, help: 'Expense date as YYYY-MM-DD' },
+        { name: 'merchant', required: true, help: 'Merchant shown on the reimbursement' },
+        { name: 'category', default: 'Marketing & Advertising', help: 'Mercury expense category' },
+        { name: 'notes', required: true, help: 'Business purpose / reimbursement notes' },
+        { name: 'ocr-wait-seconds', default: '8', help: 'Seconds the draft command waits after receipt upload before correcting OCR fields' },
+        { name: 'close-after-review', type: 'boolean', default: false, help: 'For draft command: close the Review dialog after verification' },
+    ],
+    columns: ['status', 'receipt', 'amount', 'currency', 'date', 'merchant', 'category', 'notes', 'safety'],
+    func: async (kwargs) => {
+        const input = normalizeReimbursementInput(kwargs);
+        return [{
+            status: 'ready',
+            receipt: input.receipt,
+            amount: input.amount,
+            currency: input.currency,
+            date: input.date,
+            merchant: input.merchant,
+            category: input.category,
+            notes: input.notes,
+            safety: 'reimbursement-draft stops at Mercury Review and never clicks final Submit expense',
+        }];
+    },
+});

--- a/clis/mercury/reimbursement-plan.js
+++ b/clis/mercury/reimbursement-plan.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { normalizeReimbursementInput } from './utils.js';
+import { normalizeReimbursementInput, receiptBasename } from './utils.js';
 
 cli({
     site: 'mercury',
@@ -25,7 +25,7 @@ cli({
         const input = normalizeReimbursementInput(kwargs);
         return [{
             status: 'ready',
-            receipt: input.receipt,
+            receipt: receiptBasename(input.receipt),
             amount: input.amount,
             currency: input.currency,
             date: input.date,

--- a/clis/mercury/utils.js
+++ b/clis/mercury/utils.js
@@ -166,6 +166,39 @@ export async function clickText(page, labels) {
     return payload;
 }
 
+export async function clickCreateExpenseButton(page) {
+    const result = await page.evaluate(`(() => {
+        const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+        const wanted = new Set(['submit expense', 'new expense']);
+        const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'))
+          .filter((node) => {
+            const style = window.getComputedStyle(node);
+            return style.visibility !== 'hidden' && style.display !== 'none' && node.offsetParent !== null;
+          })
+          .filter((node) => wanted.has(norm(node.innerText || node.textContent || '')));
+        const dangerous = candidates.find((node) => {
+          const container = node.closest('[role="dialog"], dialog, form, [aria-modal="true"]');
+          const context = String(container?.innerText || container?.textContent || '').replace(/\\s+/g, ' ').trim();
+          return Boolean(container) || /Review|receipt|amount|merchant|category|notes|expense date/i.test(context);
+        });
+        if (dangerous) {
+          return { clicked: false, blocked: true, text: dangerous.innerText || dangerous.textContent || '' };
+        }
+        const el = candidates[0];
+        if (!el) return { clicked: false, blocked: false };
+        el.click();
+        return { clicked: true, blocked: false, text: el.innerText || el.textContent || '' };
+    })()`);
+    const payload = assertObject(result, 'create expense click result');
+    if (typeof payload.clicked !== 'boolean' || typeof payload.blocked !== 'boolean') {
+        throw new CommandExecutionError('Mercury returned malformed create expense click result');
+    }
+    if (payload.blocked) {
+        throw new CommandExecutionError('Mercury is already showing a submit/review surface; refusing to click a possible final Submit expense button');
+    }
+    return payload;
+}
+
 export async function assertCreateExpenseSurface(page) {
     const state = await page.evaluate(`(() => {
         const text = document.body?.innerText || '';

--- a/clis/mercury/utils.js
+++ b/clis/mercury/utils.js
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const MERCURY_EXPENSES_URL = 'https://app.mercury.com/expenses/my-expenses';
+export const RECEIPT_INPUT_SELECTOR = '[data-testid="expense-attachment-upload"]';
+
+export function requireString(kwargs, name) {
+    const value = kwargs[name];
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw new CommandExecutionError(`Missing required argument: ${name}`);
+    }
+    return value.trim();
+}
+
+export function optionalString(kwargs, name, fallback) {
+    const value = kwargs[name];
+    if (typeof value !== 'string' || value.trim() === '') return fallback;
+    return value.trim();
+}
+
+export function optionalBoolean(kwargs, name, fallback = false) {
+    const value = kwargs[name];
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+        return ['1', 'true', 'yes', 'y', 'on'].includes(value.toLowerCase());
+    }
+    return fallback;
+}
+
+export function normalizeReimbursementInput(kwargs) {
+    const receipt = path.resolve(requireString(kwargs, 'receipt'));
+    const stat = fs.statSync(receipt, { throwIfNoEntry: false });
+    if (!stat || !stat.isFile()) {
+        throw new CommandExecutionError(`Receipt file does not exist: ${receipt}`);
+    }
+
+    const amount = requireString(kwargs, 'amount').replace(/,/g, '');
+    if (!/^\d+(\.\d{1,2})?$/.test(amount)) {
+        throw new CommandExecutionError(`Amount must be a positive number with up to two decimals: ${amount}`);
+    }
+
+    const date = requireString(kwargs, 'date');
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        throw new CommandExecutionError(`Date must be YYYY-MM-DD: ${date}`);
+    }
+
+    const ocrWaitSecondsRaw = optionalString(kwargs, 'ocr-wait-seconds', '8');
+    const ocrWaitSeconds = Math.max(0, Number(ocrWaitSecondsRaw) || 0);
+
+    return {
+        receipt,
+        amount,
+        currency: optionalString(kwargs, 'currency', 'CNY').toUpperCase(),
+        date,
+        merchant: requireString(kwargs, 'merchant'),
+        category: optionalString(kwargs, 'category', 'Marketing & Advertising'),
+        notes: requireString(kwargs, 'notes'),
+        ocrWaitSeconds,
+        closeAfterReview: optionalBoolean(kwargs, 'close-after-review', false),
+    };
+}
+
+export async function inspectMercury(page) {
+    await page.goto(MERCURY_EXPENSES_URL, { waitUntil: 'load', settleMs: 1500 });
+    await page.wait({ time: 1 });
+
+    return page.evaluate(`(() => {
+        const text = document.body?.innerText || '';
+        const url = location.href;
+        return {
+            url,
+            loggedIn: !/\\/login\\b/.test(url) && !/sign in|log in|password|passkey/i.test(text),
+            hasSubmitExpense: /Submit expense/i.test(text),
+            hasReimbursements: /Reimbursements|My Expenses|Submitted Expenses/i.test(text),
+            title: document.title
+        };
+    })()`);
+}
+
+export async function clickText(page, labels) {
+    return page.evaluate(`(() => {
+        const labels = ${JSON.stringify(labels)};
+        const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+        const wanted = labels.map(norm);
+        const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'));
+        const el = candidates.find((node) => wanted.includes(norm(node.innerText || node.textContent || '')));
+        if (!el) return { clicked: false, labels };
+        el.click();
+        return { clicked: true, text: el.innerText || el.textContent || '' };
+    })()`);
+}
+
+export async function fillReimbursementFields(page, input) {
+    return page.evaluate(`(() => {
+        const payload = ${JSON.stringify(input)};
+        const setNativeValue = (el, value) => {
+            const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+            const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+            setter?.call(el, value);
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            el.dispatchEvent(new Event('blur', { bubbles: true }));
+        };
+        const visible = (nodes) => nodes.find((node) => {
+            const style = window.getComputedStyle(node);
+            return style.visibility !== 'hidden' && style.display !== 'none' && node.offsetParent !== null;
+        });
+        const allInputs = Array.from(document.querySelectorAll('input, textarea'));
+        const bySelector = (selector) => visible(Array.from(document.querySelectorAll(selector)));
+        const byTextNear = (label) => {
+            const nodes = Array.from(document.querySelectorAll('label, div, span, p'));
+            for (const node of nodes) {
+                if (!label.test(node.innerText || node.textContent || '')) continue;
+                const box = node.closest('label, fieldset, div');
+                const field = box?.querySelector('input, textarea');
+                if (field) return field;
+            }
+            return undefined;
+        };
+        const amount = bySelector('input[id^="amount"], input[name*="amount" i]') || byTextNear(/amount/i);
+        const merchant = bySelector('input[id^="merchant"], input[name*="merchant" i]') || byTextNear(/merchant/i);
+        const notes = visible(Array.from(document.querySelectorAll('textarea'))) || byTextNear(/notes|memo|purpose/i);
+        const date =
+            bySelector('input[type="date"], input[id*="date" i], input[name*="date" i]') ||
+            byTextNear(/date|expense date/i) ||
+            allInputs.find((field) => /yyyy|mm|dd|\\d{4}-\\d{2}-\\d{2}/i.test(field.getAttribute('placeholder') || ''));
+        const currency =
+            bySelector('input[id*="currency" i], input[name*="currency" i]') ||
+            byTextNear(/currency/i) ||
+            allInputs.find((field) => /currency/i.test(field.getAttribute('aria-label') || ''));
+        const category =
+            bySelector('input[id*="category" i], input[name*="category" i]') ||
+            byTextNear(/category/i) ||
+            allInputs.find((field) =>
+                /category|select/i.test(\`\${field.getAttribute('placeholder') || ''} \${field.getAttribute('aria-label') || ''}\`)
+            );
+
+        const touched = {};
+        if (amount) { setNativeValue(amount, payload.amount); touched.amount = true; }
+        if (currency) { setNativeValue(currency, payload.currency); touched.currency = true; }
+        if (date) { setNativeValue(date, payload.date); touched.date = true; }
+        if (merchant) { setNativeValue(merchant, payload.merchant); touched.merchant = true; }
+        if (notes) { setNativeValue(notes, payload.notes); touched.notes = true; }
+        if (category) {
+            category.focus();
+            setNativeValue(category, payload.category);
+            category.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            category.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+            touched.category = true;
+        }
+        return { touched };
+    })()`);
+}
+
+export async function reviewSnapshot(page) {
+    return page.evaluate(`(() => {
+        const text = document.body?.innerText || '';
+        return {
+            url: location.href,
+            hasReview: /Review|Submit expense/i.test(text),
+            hasSubmitExpenseButton: /Submit expense/i.test(text),
+            bodyPreview: text.replace(/\\s+/g, ' ').trim().slice(0, 1200)
+        };
+    })()`);
+}

--- a/clis/mercury/utils.js
+++ b/clis/mercury/utils.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 export const MERCURY_EXPENSES_URL = 'https://app.mercury.com/expenses/my-expenses';
 export const RECEIPT_INPUT_SELECTOR = '[data-testid="expense-attachment-upload"]';
@@ -8,7 +8,7 @@ export const RECEIPT_INPUT_SELECTOR = '[data-testid="expense-attachment-upload"]
 export function requireString(kwargs, name) {
     const value = kwargs[name];
     if (typeof value !== 'string' || value.trim() === '') {
-        throw new CommandExecutionError(`Missing required argument: ${name}`);
+        throw new ArgumentError(`Missing required argument: ${name}`);
     }
     return value.trim();
 }
@@ -23,49 +23,116 @@ export function optionalBoolean(kwargs, name, fallback = false) {
     const value = kwargs[name];
     if (typeof value === 'boolean') return value;
     if (typeof value === 'string') {
-        return ['1', 'true', 'yes', 'y', 'on'].includes(value.toLowerCase());
+        const normalized = value.trim().toLowerCase();
+        if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+        if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+        throw new ArgumentError(`Boolean argument ${name} must be true or false`);
     }
     return fallback;
 }
 
-export function normalizeReimbursementInput(kwargs) {
+function parseReceiptPath(kwargs) {
     const receipt = path.resolve(requireString(kwargs, 'receipt'));
-    const stat = fs.statSync(receipt, { throwIfNoEntry: false });
+    let stat;
+    try {
+        stat = fs.statSync(receipt, { throwIfNoEntry: false });
+    }
+    catch (error) {
+        throw new ArgumentError(`Receipt file cannot be read: ${receipt}`, error instanceof Error ? error.message : undefined);
+    }
     if (!stat || !stat.isFile()) {
-        throw new CommandExecutionError(`Receipt file does not exist: ${receipt}`);
+        throw new ArgumentError(`Receipt file does not exist: ${receipt}`);
     }
+    return receipt;
+}
 
+function parseAmount(kwargs) {
     const amount = requireString(kwargs, 'amount').replace(/,/g, '');
-    if (!/^\d+(\.\d{1,2})?$/.test(amount)) {
-        throw new CommandExecutionError(`Amount must be a positive number with up to two decimals: ${amount}`);
+    if (!/^\d+(\.\d{1,2})?$/.test(amount) || Number(amount) <= 0) {
+        throw new ArgumentError(`Amount must be a positive number with up to two decimals: ${amount}`);
     }
+    return amount;
+}
 
+function parseCurrency(kwargs) {
+    const currency = optionalString(kwargs, 'currency', 'CNY').toUpperCase();
+    if (!/^[A-Z]{3}$/.test(currency)) {
+        throw new ArgumentError(`Currency must be a three-letter ISO currency code: ${currency}`);
+    }
+    return currency;
+}
+
+function parseDate(kwargs) {
     const date = requireString(kwargs, 'date');
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-        throw new CommandExecutionError(`Date must be YYYY-MM-DD: ${date}`);
+    const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) {
+        throw new ArgumentError(`Date must be YYYY-MM-DD: ${date}`);
     }
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (parsed.getUTCFullYear() !== year || parsed.getUTCMonth() !== month - 1 || parsed.getUTCDate() !== day) {
+        throw new ArgumentError(`Date must be a real calendar date: ${date}`);
+    }
+    return date;
+}
 
-    const ocrWaitSecondsRaw = optionalString(kwargs, 'ocr-wait-seconds', '8');
-    const ocrWaitSeconds = Math.max(0, Number(ocrWaitSecondsRaw) || 0);
+function parseOcrWaitSeconds(kwargs) {
+    const raw = optionalString(kwargs, 'ocr-wait-seconds', '8');
+    if (!/^\d+$/.test(raw)) {
+        throw new ArgumentError(`ocr-wait-seconds must be a non-negative integer: ${raw}`);
+    }
+    return Number(raw);
+}
 
+export function normalizeReimbursementInput(kwargs) {
     return {
-        receipt,
-        amount,
-        currency: optionalString(kwargs, 'currency', 'CNY').toUpperCase(),
-        date,
+        receipt: parseReceiptPath(kwargs),
+        amount: parseAmount(kwargs),
+        currency: parseCurrency(kwargs),
+        date: parseDate(kwargs),
         merchant: requireString(kwargs, 'merchant'),
         category: optionalString(kwargs, 'category', 'Marketing & Advertising'),
         notes: requireString(kwargs, 'notes'),
-        ocrWaitSeconds,
+        ocrWaitSeconds: parseOcrWaitSeconds(kwargs),
         closeAfterReview: optionalBoolean(kwargs, 'close-after-review', false),
     };
+}
+
+export function receiptBasename(receipt) {
+    return path.basename(receipt);
+}
+
+export function assertObject(value, label) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new CommandExecutionError(`Mercury returned malformed ${label}`);
+    }
+    return value;
+}
+
+export function assertMercuryState(value, label = 'page state') {
+    const state = assertObject(value, label);
+    if (typeof state.url !== 'string' || typeof state.title !== 'string') {
+        throw new CommandExecutionError(`Mercury returned malformed ${label}`);
+    }
+    return state;
+}
+
+function assertBooleanFields(state, label, fields) {
+    for (const field of fields) {
+        if (typeof state[field] !== 'boolean') {
+            throw new CommandExecutionError(`Mercury returned malformed ${label}: ${field} must be boolean`);
+        }
+    }
+    return state;
 }
 
 export async function inspectMercury(page) {
     await page.goto(MERCURY_EXPENSES_URL, { waitUntil: 'load', settleMs: 1500 });
     await page.wait({ time: 1 });
 
-    return page.evaluate(`(() => {
+    const state = await page.evaluate(`(() => {
         const text = document.body?.innerText || '';
         const url = location.href;
         return {
@@ -76,23 +143,49 @@ export async function inspectMercury(page) {
             title: document.title
         };
     })()`);
+    return assertBooleanFields(assertMercuryState(state, 'login state'), 'login state', ['loggedIn', 'hasSubmitExpense', 'hasReimbursements']);
 }
 
 export async function clickText(page, labels) {
-    return page.evaluate(`(() => {
+    const result = await page.evaluate(`(() => {
         const labels = ${JSON.stringify(labels)};
         const norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
         const wanted = labels.map(norm);
-        const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'));
+        const candidates = Array.from(document.querySelectorAll('button, a, [role="button"], [role="link"]'))
+          .filter((node) => {
+            const style = window.getComputedStyle(node);
+            return style.visibility !== 'hidden' && style.display !== 'none' && node.offsetParent !== null;
+          });
         const el = candidates.find((node) => wanted.includes(norm(node.innerText || node.textContent || '')));
         if (!el) return { clicked: false, labels };
         el.click();
         return { clicked: true, text: el.innerText || el.textContent || '' };
     })()`);
+    const payload = assertObject(result, 'click result');
+    if (typeof payload.clicked !== 'boolean') throw new CommandExecutionError('Mercury returned malformed click result');
+    return payload;
+}
+
+export async function assertCreateExpenseSurface(page) {
+    const state = await page.evaluate(`(() => {
+        const text = document.body?.innerText || '';
+        return {
+            url: location.href,
+            title: document.title,
+            hasFinalSubmit: /Submit expense/i.test(text) && /Review|receipt|amount|merchant|category|notes/i.test(text),
+            hasForm: /receipt|amount|merchant|category|notes|expense date/i.test(text),
+            bodyPreview: text.replace(/\\s+/g, ' ').trim().slice(0, 600)
+        };
+    })()`);
+    const payload = assertBooleanFields(assertMercuryState(state, 'expense form state'), 'expense form state', ['hasFinalSubmit', 'hasForm']);
+    if (payload.hasFinalSubmit && !payload.hasForm) {
+        throw new CommandExecutionError('Mercury is showing a submit button without a recognizable expense form; refusing to click');
+    }
+    return payload;
 }
 
 export async function fillReimbursementFields(page, input) {
-    return page.evaluate(`(() => {
+    const result = await page.evaluate(`(() => {
         const payload = ${JSON.stringify(input)};
         const setNativeValue = (el, value) => {
             const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
@@ -151,16 +244,29 @@ export async function fillReimbursementFields(page, input) {
         }
         return { touched };
     })()`);
+    const payload = assertObject(result, 'field fill result');
+    if (!payload.touched || typeof payload.touched !== 'object' || Array.isArray(payload.touched)) {
+        throw new CommandExecutionError('Mercury returned malformed field fill result');
+    }
+    return payload;
 }
 
 export async function reviewSnapshot(page) {
-    return page.evaluate(`(() => {
+    const snapshot = await page.evaluate(`(() => {
         const text = document.body?.innerText || '';
         return {
             url: location.href,
-            hasReview: /Review|Submit expense/i.test(text),
+            title: document.title,
+            hasReview: /Review/i.test(text),
             hasSubmitExpenseButton: /Submit expense/i.test(text),
             bodyPreview: text.replace(/\\s+/g, ' ').trim().slice(0, 1200)
         };
     })()`);
+    return assertBooleanFields(assertMercuryState(snapshot, 'review state'), 'review state', ['hasReview', 'hasSubmitExpenseButton']);
+}
+
+export function assertLoggedIn(state) {
+    if (!state.loggedIn) {
+        throw new AuthRequiredError('app.mercury.com', 'Mercury reimbursements require a logged-in browser session');
+    }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,6 +104,7 @@ export default defineConfig({
                 { text: 'Instagram', link: '/adapters/browser/instagram' },
                 { text: 'JD.com', link: '/adapters/browser/jd' },
                 { text: 'Medium', link: '/adapters/browser/medium' },
+                { text: 'Mercury', link: '/adapters/browser/mercury' },
                 { text: 'Mubu', link: '/adapters/browser/mubu' },
                 { text: 'TikTok', link: '/adapters/browser/tiktok' },
                 { text: 'Web (Generic)', link: '/adapters/browser/web' },

--- a/docs/adapters/browser/mercury.md
+++ b/docs/adapters/browser/mercury.md
@@ -76,8 +76,10 @@ For `reimbursement-plan`:
 
 - `status: "ready"` means the local receipt exists and amount/date formats are
   valid.
-- Missing receipt files, non-positive amount strings, or non-`YYYY-MM-DD` dates
-  fail before Mercury is opened.
+- Missing receipt files, non-positive amount strings, malformed currency codes,
+  invalid calendar dates, or invalid wait/boolean flags fail before Mercury is
+  opened.
+- Output uses the receipt basename, not the absolute local path.
 
 For `reimbursement-draft`:
 
@@ -88,9 +90,9 @@ For `reimbursement-draft`:
 - Mercury shows the Review step with the expected receipt, amount, currency,
   date, merchant, category, and notes.
 
-If `reviewReady` is false, keep the browser open and inspect the page for
-Mercury validation errors. The command returns which field selectors were
-missed, if any.
+If upload confirmation, required field correction, or the Review postcondition
+fails, the command throws a typed error instead of returning a partial success
+row. Keep the browser open and inspect Mercury for validation errors.
 
 ## Testing
 
@@ -156,9 +158,10 @@ Pass condition: Mercury stops at Review and the returned row has
 
 - `needs_login`: open Mercury in the same Chrome/OpenCLI profile, finish login,
   then rerun `check-login`.
-- `uploaded: false`: verify the file exists locally and that Mercury still uses
-  the receipt input selector above.
-- `reviewReady: false`: inspect Mercury for validation errors; the command may
-  have uploaded the receipt and filled fields but failed to reach Review.
+- Upload failure: verify the file exists locally and that Mercury still uses the
+  receipt input selector above. The command requires Browser Bridge
+  `uploadFiles` support so it can verify the intended file input.
+- Review failure: inspect Mercury for validation errors; the command may have
+  uploaded the receipt and filled fields but failed to reach Review.
 - Category did not commit: custom Mercury dropdowns can be sensitive to UI
   changes. Retry with the exact category label visible in Mercury.

--- a/docs/adapters/browser/mercury.md
+++ b/docs/adapters/browser/mercury.md
@@ -1,0 +1,164 @@
+# Mercury
+
+**Mode**: 🔐 Browser · **Domain**: `app.mercury.com`
+
+Mercury reimbursements are authenticated browser UI flows. There is no public
+API and no stable JSON endpoint for creating an expense, so the adapter drives
+the visible Mercury reimbursements page through OpenCLI Browser Bridge. It
+creates a **draft**, uploads a local receipt file, waits for Mercury OCR, then
+re-applies the agent-provided fields because OCR can overwrite amount, currency,
+date, or merchant.
+
+The write command is deliberately conservative: it stops at Mercury's Review
+step and never clicks the final `Submit expense` button. A human or responsible
+agent must inspect the Review page before any final submission.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli mercury reimbursement-plan` | Validate a reimbursement payload locally without opening Mercury |
+| `opencli mercury check-login` | Open Mercury reimbursements and report whether the selected browser profile is logged in |
+| `opencli mercury reimbursement-draft` | Create a reimbursement draft, attach the receipt, correct OCR-overwritten fields, and stop at Review |
+
+`reimbursement-plan` and `reimbursement-draft` take the same business payload:
+
+| Flag | Meaning |
+|------|---------|
+| `--receipt` | Absolute or relative path to a local receipt/proof file |
+| `--amount` | Original-currency positive amount, e.g. `140.00` |
+| `--currency` | Original currency code, default `CNY` |
+| `--date` | Expense date as `YYYY-MM-DD` |
+| `--merchant` | Merchant name to show in Mercury |
+| `--category` | Mercury expense category, default `Marketing & Advertising` |
+| `--notes` | Business purpose / reimbursement notes |
+| `--ocr-wait-seconds` | Seconds to wait after receipt upload before reapplying fields, default `8` |
+| `--close-after-review` | Close Review after verification; still never submits |
+
+## Agent Workflow
+
+```bash
+# 1. Confirm the selected browser profile is logged into Mercury
+opencli --profile <profile> mercury check-login -f json
+
+# 2. Validate the payload locally first
+opencli mercury reimbursement-plan \
+  --receipt /absolute/path/to/receipt.png \
+  --amount 140.00 \
+  --currency CNY \
+  --date 2026-06-26 \
+  --merchant "Example Merchant" \
+  --category "Marketing & Advertising" \
+  --notes "Example business purpose." \
+  -f json
+
+# 3. Create the draft and stop at Review
+opencli --profile <profile> mercury reimbursement-draft \
+  --receipt /absolute/path/to/receipt.png \
+  --amount 140.00 \
+  --currency CNY \
+  --date 2026-06-26 \
+  --merchant "Example Merchant" \
+  --category "Marketing & Advertising" \
+  --notes "Example business purpose." \
+  -f json
+```
+
+## Expected Results
+
+For `check-login`:
+
+- `status: "ready"` means the profile reached Mercury reimbursements.
+- `status: "needs_login"` means Mercury redirected to login; sign into Mercury
+  in that Chrome/OpenCLI profile and rerun.
+
+For `reimbursement-plan`:
+
+- `status: "ready"` means the local receipt exists and amount/date formats are
+  valid.
+- Missing receipt files, non-positive amount strings, or non-`YYYY-MM-DD` dates
+  fail before Mercury is opened.
+
+For `reimbursement-draft`:
+
+- `uploaded: true`
+- `reviewReady: true`
+- `submitBlocked: true`
+- `warnings` includes `final Submit expense was intentionally not clicked`
+- Mercury shows the Review step with the expected receipt, amount, currency,
+  date, merchant, category, and notes.
+
+If `reviewReady` is false, keep the browser open and inspect the page for
+Mercury validation errors. The command returns which field selectors were
+missed, if any.
+
+## Testing
+
+Run repository-level checks:
+
+```bash
+npm run dev -- validate mercury
+npm run typecheck
+npm run docs:build
+```
+
+Run a local input smoke test:
+
+```bash
+npm run dev -- mercury reimbursement-plan \
+  --receipt /tmp/example-receipt.png \
+  --amount 1.00 \
+  --currency USD \
+  --date 2026-06-30 \
+  --merchant "OpenCLI Test Merchant" \
+  --category "Office Supplies & Equipment" \
+  --notes "OpenCLI adapter smoke test; do not submit." \
+  -f json
+```
+
+Run a real UI smoke test only in a test Mercury workspace/profile or with a
+harmless test receipt:
+
+```bash
+npm run dev -- --profile <profile> mercury reimbursement-draft \
+  --receipt /absolute/path/to/test-receipt.png \
+  --amount 1.00 \
+  --currency USD \
+  --date 2026-06-30 \
+  --merchant "OpenCLI Test Merchant" \
+  --category "Office Supplies & Equipment" \
+  --notes "OpenCLI adapter smoke test; do not submit." \
+  -f json
+```
+
+Pass condition: Mercury stops at Review and the returned row has
+`submitBlocked: true`. Do not click final Submit during smoke tests.
+
+## Notes
+
+- **Login is required.** This adapter uses the selected OpenCLI browser profile;
+  it does not store Mercury credentials or run an OAuth/login flow.
+- **Receipt upload** targets Mercury's attachment input:
+  `[data-testid="expense-attachment-upload"]`. If Mercury changes that selector,
+  upload can fail while the rest of the form remains visible.
+- **OCR happens before correction.** Mercury OCR can misread currency (for
+  example `CNY` as `JPY`) or overwrite merchant/amount. The command uploads the
+  receipt first, waits, then re-fills fields from the CLI arguments.
+- **Review is not submission.** `reimbursement-draft` never presses the final
+  `Submit expense` button. It prepares a draft for inspection.
+- **Use original currency.** Enter the currency shown on the source receipt
+  when Mercury supports it, then verify Mercury's converted reimbursement amount
+  on the Review page.
+- **Output is intentionally compact.** The returned row is a control-plane
+  status summary; Mercury remains the source of truth for final visual review.
+
+## Troubleshooting
+
+- `needs_login`: open Mercury in the same Chrome/OpenCLI profile, finish login,
+  then rerun `check-login`.
+- `uploaded: false`: verify the file exists locally and that Mercury still uses
+  the receipt input selector above.
+- `reviewReady: false`: inspect Mercury for validation errors; the command may
+  have uploaded the receipt and filled fields but failed to reach Review.
+- Category did not commit: custom Mercury dropdowns can be sensitive to UI
+  changes. Retry with the exact category label visible in Mercury.


### PR DESCRIPTION
## Summary
- add a bundled `mercury` adapter with reimbursement input planning, login checks, and draft creation
- follow the official adapter path from Extending OpenCLI for upstream PRs; the separate local plugin prototype remains outside this PR
- upload local receipt files through Mercury's expense attachment input, wait for OCR, then correct common reimbursement fields
- stop at the Review step and intentionally never click the final `Submit expense` button
- add agent-facing Mercury docs with workflow, expected outputs, testing, safety notes, and troubleshooting

## Verification
- `npm run dev -- validate mercury`
- `npm run dev -- mercury reimbursement-plan --receipt /tmp/example-receipt.png --amount 140.00 --currency CNY --date 2026-06-26 --merchant "Example Merchant" --category "Marketing & Advertising" --notes "Example business purpose." -f json`
- `npm run typecheck`
- `npm run docs:build`