### PR TITLE
fix(weibo): resolve uid before the full auth probe to avoid HTTP 400 (#2047)

### DIFF
--- a/clis/weibo/auth.js
+++ b/clis/weibo/auth.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
-import { getSelfUid } from './utils.js';
+import { getSelfUid, unwrapEvaluateResult } from './utils.js';
 
 async function hasWeiboSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://weibo.com' });
@@ -40,11 +40,18 @@ async function verifyWeiboIdentity(page) {
   await page.wait(3);
   // getSelfUid throws AuthRequiredError when no logged-in uid can be resolved.
   const uid = await getSelfUid(page);
-  const result = await page.evaluate(buildWeiboIdentityProbe(uid));
+  if (typeof uid !== 'string' || !uid.trim()) {
+    throw new CommandExecutionError('Weibo uid resolver returned a malformed uid');
+  }
+  const result = unwrapEvaluateResult(await page.evaluate(buildWeiboIdentityProbe(uid)));
   if (result?.kind === 'auth') throw new AuthRequiredError('weibo.com', result.detail);
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /ajax/profile/info`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`Weibo whoami failed: ${result.detail}`);
+  if (!result || Array.isArray(result) || typeof result !== 'object') {
+    throw new CommandExecutionError('Weibo whoami returned malformed probe payload');
+  }
   if (!result?.ok) throw new CommandExecutionError(`Unexpected Weibo probe: ${JSON.stringify(result)}`);
+  if (!result.user_id) throw new CommandExecutionError('Weibo whoami returned no user id');
   return { user_id: result.user_id, screen_name: result.screen_name, profile_url: result.profile_url };
 }
 

--- a/clis/weibo/auth.js
+++ b/clis/weibo/auth.js
@@ -1,5 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+import { getSelfUid } from './utils.js';
 
 async function hasWeiboSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://weibo.com' });
@@ -7,15 +8,14 @@ async function hasWeiboSessionCookie(page) {
   return names.has('SUB') && names.has('SUBP');
 }
 
-async function verifyWeiboIdentity(page) {
-  if (!await hasWeiboSessionCookie(page)) {
-    throw new AuthRequiredError('weibo.com', 'Weibo SUB / SUBP cookies missing');
-  }
-  await page.goto('https://weibo.com/');
-  await page.wait(3);
-  const result = await page.evaluate(`(async () => {
+// Weibo's /ajax/profile/info requires the current uid — the bare endpoint
+// returns HTTP 400 in the current web app. Mirror `weibo me`: resolve the uid
+// first, then probe /ajax/profile/info?uid=<uid>.
+function buildWeiboIdentityProbe(uid) {
+  const infoUrl = '/ajax/profile/info?uid=' + encodeURIComponent(uid);
+  return `(async () => {
     try {
-      const res = await fetch('/ajax/profile/info', { credentials: 'include', headers: { 'Accept': 'application/json' } });
+      const res = await fetch(${JSON.stringify(infoUrl)}, { credentials: 'include', headers: { 'Accept': 'application/json' } });
       if (res.status === 401 || res.status === 403) {
         return { kind: 'auth', detail: 'Weibo /ajax/profile/info HTTP ' + res.status };
       }
@@ -29,7 +29,18 @@ async function verifyWeiboIdentity(page) {
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
-  })()`);
+  })()`;
+}
+
+async function verifyWeiboIdentity(page) {
+  if (!await hasWeiboSessionCookie(page)) {
+    throw new AuthRequiredError('weibo.com', 'Weibo SUB / SUBP cookies missing');
+  }
+  await page.goto('https://weibo.com/');
+  await page.wait(3);
+  // getSelfUid throws AuthRequiredError when no logged-in uid can be resolved.
+  const uid = await getSelfUid(page);
+  const result = await page.evaluate(buildWeiboIdentityProbe(uid));
   if (result?.kind === 'auth') throw new AuthRequiredError('weibo.com', result.detail);
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /ajax/profile/info`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`Weibo whoami failed: ${result.detail}`);
@@ -51,3 +62,5 @@ registerSiteAuthCommands({
     return verifyWeiboIdentity(page);
   },
 });
+
+export const __test__ = { buildWeiboIdentityProbe, verifyWeiboIdentity };

--- a/clis/weibo/auth.test.js
+++ b/clis/weibo/auth.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { __test__ } from './auth.js';
+
+function makePage({ cookies = [{ name: 'SUB' }, { name: 'SUBP' }], evalResults = [] } = {}) {
+    let i = 0;
+    return {
+        getCookies: vi.fn().mockResolvedValue(cookies),
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(() => Promise.resolve(evalResults[i++])),
+    };
+}
+
+describe('weibo auth identity probe', () => {
+    it('probes /ajax/profile/info with the resolved uid (not the bare 400-prone endpoint)', () => {
+        const script = __test__.buildWeiboIdentityProbe('12345');
+        expect(script).toContain('/ajax/profile/info?uid=12345');
+        // the uid-less form is what returns HTTP 400 — it must be gone
+        expect(script).not.toContain("fetch('/ajax/profile/info'");
+    });
+
+    it('url-encodes the uid', () => {
+        expect(__test__.buildWeiboIdentityProbe('a b')).toContain('/ajax/profile/info?uid=a%20b');
+    });
+
+    it('resolves the logged-in identity via uid before probing', async () => {
+        const page = makePage({
+            evalResults: [
+                '12345', // getSelfUid → current uid
+                { ok: true, user_id: '12345', screen_name: 'Alice', profile_url: '/u/12345' }, // probe
+            ],
+        });
+        const result = await __test__.verifyWeiboIdentity(page);
+        expect(result).toEqual({ user_id: '12345', screen_name: 'Alice', profile_url: '/u/12345' });
+        // the second evaluate is the identity probe, carrying the resolved uid
+        expect(page.evaluate.mock.calls[1][0]).toContain('/ajax/profile/info?uid=12345');
+    });
+
+    it('throws AuthRequiredError when SUB/SUBP cookies are missing, before navigating', async () => {
+        const page = makePage({ cookies: [{ name: 'SUB' }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthRequiredError when the logged-in uid cannot be resolved', async () => {
+        const page = makePage({ evalResults: [null, null] }); // getSelfUid store + config both empty
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps a non-ok probe response to CommandExecutionError', async () => {
+        const page = makePage({ evalResults: ['12345', { kind: 'http', httpStatus: 400 }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps an auth-kind probe response to AuthRequiredError', async () => {
+        const page = makePage({ evalResults: ['12345', { kind: 'auth', detail: 'anonymous' }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps an exception-kind probe response to CommandExecutionError', async () => {
+        const page = makePage({ evalResults: ['12345', { kind: 'exception', detail: 'boom' }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/weibo/auth.test.js
+++ b/clis/weibo/auth.test.js
@@ -37,6 +37,32 @@ describe('weibo auth identity probe', () => {
         expect(page.evaluate.mock.calls[1][0]).toContain('/ajax/profile/info?uid=12345');
     });
 
+    it('unwraps Browser Bridge envelopes from uid and profile probes', async () => {
+        const page = makePage({
+            evalResults: [
+                { session: 's1', data: '12345' },
+                { session: 's1', data: { ok: true, user_id: '12345', screen_name: 'Alice', profile_url: '/u/12345' } },
+            ],
+        });
+        await expect(__test__.verifyWeiboIdentity(page)).resolves.toEqual({
+            user_id: '12345',
+            screen_name: 'Alice',
+            profile_url: '/u/12345',
+        });
+        expect(page.evaluate.mock.calls[1][0]).toContain('/ajax/profile/info?uid=12345');
+    });
+
+    it('typed-fails malformed uid payloads instead of probing /ajax/profile/info with garbage', async () => {
+        const page = makePage({ evalResults: [{ uid: '12345' }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('typed-fails malformed probe payloads', async () => {
+        const page = makePage({ evalResults: ['12345', null] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
     it('throws AuthRequiredError when SUB/SUBP cookies are missing, before navigating', async () => {
         const page = makePage({ cookies: [{ name: 'SUB' }] });
         await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
@@ -60,6 +86,11 @@ describe('weibo auth identity probe', () => {
 
     it('maps an exception-kind probe response to CommandExecutionError', async () => {
         const page = makePage({ evalResults: ['12345', { kind: 'exception', detail: 'boom' }] });
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('typed-fails success-shaped probes missing user_id', async () => {
+        const page = makePage({ evalResults: ['12345', { ok: true, screen_name: 'Alice', profile_url: '/u/12345' }] });
         await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });


### PR DESCRIPTION
## What
`opencli auth status --site weibo --full` fails with `HTTP 400 from /ajax/profile/info` even on a logged-in Browser Bridge session, while `weibo me` and quick auth work. Closes #2047.

## Root cause
`verifyWeiboIdentity` probed the bare `/ajax/profile/info` **without a uid**, which the current Weibo web app rejects with HTTP 400. `weibo me` already works because it resolves the current uid first and requests `/ajax/profile/info?uid=<uid>`.

## Fix
Mirror the `weibo me` path:
- Resolve the logged-in uid via the existing `getSelfUid(page)` (Vue store → `get_config` fallback; it throws `AuthRequiredError` when no uid resolves, so a genuinely logged-out session still fails cleanly).
- Probe `/ajax/profile/info?uid=<uid>` (uid `encodeURIComponent`'d, baked into the evaluated script via `JSON.stringify`).
- Extract the probe into `buildWeiboIdentityProbe(uid)`; typed-error handling (auth / http / exception / ok) is unchanged. `quickCheck` (cookie-only) and `poll` are untouched.

## Test
New `clis/weibo/auth.test.js` (8 tests): probe carries `uid=` and url-encodes it; full `verifyWeiboIdentity` flow via a mocked page; missing SUB/SUBP → `AuthRequiredError` before navigation; unresolvable uid → `AuthRequiredError`; non-ok / auth / exception probe results map to the right typed errors.

## Verification
- `vitest run clis/weibo/auth.test.js` → 8 passed; all Weibo adapter tests pass (7 files, 47 tests).
- `check:typed-error-lint` / `check:silent-column-drop` → no new violations.