### PR TITLE
fix: escape pipes in markdown output and fix contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ cli({
   description: 'Trending posts on MySite',
   domain: 'www.mysite.com',
   strategy: Strategy.PUBLIC,
+  access: 'read',
   browser: false,
   args: [
     { name: 'query', positional: true, required: true, help: 'Search keyword' },
@@ -84,14 +85,12 @@ cli({
     const { query, limit = 10 } = kwargs;
     await page.goto('https://www.mysite.com');
 
-    const data = await page.evaluate(`
-      (async () => {
-        const res = await fetch('/api/search?q=${encodeURIComponent(query)}', {
-          credentials: 'include'
-        });
-        return (await res.json()).results;
-      })()
-    `);
+    const data = await page.evaluate(async (q: string) => {
+      const res = await fetch('/api/search?q=' + encodeURIComponent(q), {
+        credentials: 'include'
+      });
+      return (await res.json()).results;
+    }, query);
 
     return data.slice(0, Number(limit)).map((item: any) => ({
       title: item.title,

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -398,7 +398,7 @@ class CDPPage extends BasePage {
     }
     if (level === 'all') return [...this._consoleMessages];
     // 'error' level includes both console.error() and uncaught exceptions
-    if (level === 'error') return this._consoleMessages.filter(m => m.type === 'error' || m.type === 'warning');
+    if (level === 'error') return this._consoleMessages.filter(m => m.type === 'error');
     return this._consoleMessages.filter(m => m.type === level);
   }
 

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -59,4 +59,11 @@ describe('output TTY detection', () => {
     expect(out).toBe('# Title\n\nBody');
     expect(out).not.toContain('| markdown |');
   });
+
+  it('escapes pipe characters in markdown table cells', () => {
+    render([{ name: 'a|b', score: 10 }], { fmt: 'md', columns: ['name', 'score'] });
+    const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+
+    expect(out).toContain('| a\\|b | 10 |');
+  });
 });

--- a/src/output.ts
+++ b/src/output.ts
@@ -53,7 +53,7 @@ function renderTable(data: unknown, opts: RenderOptions): void {
 
   const header = columns.map(c => capitalize(c));
   const table = new Table({
-    head: header.map(h => h),
+    head: [...header],
     style: { head: [], border: [] },
     wordWrap: true,
     wrapOnWordBoundary: true,
@@ -124,7 +124,7 @@ function renderMarkdown(data: unknown, opts: RenderOptions): void {
   console.log('| ' + columns.join(' | ') + ' |');
   console.log('| ' + columns.map(() => '---').join(' | ') + ' |');
   for (const row of rows) {
-    console.log('| ' + columns.map(c => String((row as Record<string, unknown>)[c] ?? '')).join(' | ') + ' |');
+    console.log('| ' + columns.map(c => String((row as Record<string, unknown>)[c] ?? '').replace(/\|/g, '\\|')).join(' | ') + ' |');
   }
 }
 


### PR DESCRIPTION
If any cell value in markdown table output contains a `|` character, the whole table breaks. Added escaping so pipes render correctly.

While reading through CONTRIBUTING.md I noticed a few issues:
- the `page.evaluate` example uses a template literal that's vulnerable to injection — switched to passing the query as a function argument instead
- the pipeline adapter example was missing the required `access` field, so anyone copy-pasting the guide would hit a crash at registration
- also removed a `.map(h => h)` no-op and fixed the `consoleMessages('error')` filter that was including warnings