### PR TITLE
Add raw ChatGPT and Gemini export commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -6248,6 +6248,109 @@
   },
   {
     "site": "chatgpt",
+    "name": "backend-detail",
+    "description": "Fetch raw ChatGPT conversation detail from the backend API",
+    "access": "read",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation ID or full /c/<id> URL"
+      }
+    ],
+    "columns": [
+      "Id",
+      "Status",
+      "Body"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/backend-detail.js",
+    "sourceFile": "chatgpt/backend-detail.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
+    "name": "backend-detail-batch",
+    "description": "Fetch multiple raw ChatGPT conversation details from the backend API",
+    "access": "read",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "ids",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Comma or whitespace separated conversation IDs or /c/<id> URLs"
+      },
+      {
+        "name": "delay-ms",
+        "type": "int",
+        "default": 1000,
+        "required": false,
+        "help": "Delay between backend detail requests inside the batch"
+      }
+    ],
+    "columns": [
+      "Id",
+      "Status",
+      "Body",
+      "Error"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/backend-detail-batch.js",
+    "sourceFile": "chatgpt/backend-detail-batch.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
+    "name": "backend-history",
+    "description": "List ChatGPT conversations from the backend API instead of the visible sidebar",
+    "access": "read",
+    "domain": "chatgpt.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 200,
+        "required": false,
+        "help": "Max backend conversations to return"
+      },
+      {
+        "name": "page-size",
+        "type": "int",
+        "default": 100,
+        "required": false,
+        "help": "Backend page size per request"
+      }
+    ],
+    "columns": [
+      "Index",
+      "Id",
+      "Title",
+      "Url",
+      "CreateTime",
+      "UpdateTime",
+      "Raw"
+    ],
+    "type": "js",
+    "modulePath": "chatgpt/backend-history.js",
+    "sourceFile": "chatgpt/backend-history.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "chatgpt",
     "name": "deep-research-result",
     "description": "Read a completed ChatGPT Deep Research report from the conversation payload",
     "access": "read",
@@ -14046,6 +14149,37 @@
     "type": "js",
     "modulePath": "gemini/new.js",
     "sourceFile": "gemini/new.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "gemini",
+    "name": "raw-detail",
+    "description": "Fetch a Gemini conversation DOM raw detail with text turns and image URLs",
+    "access": "read",
+    "domain": "gemini.google.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Conversation id, /app/<id> path, or Gemini conversation URL"
+      }
+    ],
+    "columns": [
+      "Id",
+      "Url",
+      "Title",
+      "Turns",
+      "Images",
+      "Raw"
+    ],
+    "type": "js",
+    "modulePath": "gemini/raw-detail.js",
+    "sourceFile": "gemini/raw-detail.js",
     "navigateBefore": false,
     "siteSession": "persistent"
   },

--- a/clis/chatgpt/backend-detail-batch.js
+++ b/clis/chatgpt/backend-detail-batch.js
@@ -1,0 +1,66 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    CHATGPT_DOMAIN,
+    ensureChatGPTLogin,
+    ensureOnChatGPT,
+    fetchChatGPTBackendJsonBatch,
+    parseChatGPTConversationId,
+    requireNonNegativeInt,
+} from './utils.js';
+
+function parseIdList(value) {
+    const ids = String(value || '')
+        .split(/[,\s]+/)
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map((part) => parseChatGPTConversationId(part));
+    if (!ids.length) {
+        throw new ArgumentError(
+            'chatgpt backend-detail-batch requires at least one conversation id',
+            'Example: opencli chatgpt backend-detail-batch id1,id2,id3',
+        );
+    }
+    return Array.from(new Set(ids));
+}
+
+export const backendDetailBatchCommand = cli({
+    site: 'chatgpt',
+    name: 'backend-detail-batch',
+    access: 'read',
+    description: 'Fetch multiple raw ChatGPT conversation details from the backend API',
+    domain: CHATGPT_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'ids', positional: true, required: true, help: 'Comma or whitespace separated conversation IDs or /c/<id> URLs' },
+        { name: 'delay-ms', type: 'int', default: 1000, help: 'Delay between backend detail requests inside the batch' },
+    ],
+    columns: ['Id', 'Status', 'Body', 'Error'],
+    func: async (page, kwargs) => {
+        const ids = parseIdList(kwargs.ids);
+        const delayMs = requireNonNegativeInt(
+            Number(kwargs['delay-ms'] ?? 1000),
+            'chatgpt backend-detail-batch --delay-ms',
+            'Example: opencli chatgpt backend-detail-batch id1,id2 --delay-ms 1000',
+        );
+        await ensureOnChatGPT(page);
+        await ensureChatGPTLogin(page, 'ChatGPT backend-detail-batch requires a logged-in ChatGPT session.');
+        const results = await fetchChatGPTBackendJsonBatch(
+            page,
+            ids.map((id) => `/backend-api/conversation/${id}`),
+            { label: 'chatgpt backend-detail-batch', delayMs },
+        );
+        return ids.map((id, index) => {
+            const result = results[index] || {};
+            return {
+                Id: id,
+                Status: result.status || '',
+                Body: result.ok ? result.body : null,
+                Error: result.ok ? '' : (result.body?.detail || `HTTP ${result.status || 0}`),
+            };
+        });
+    },
+});

--- a/clis/chatgpt/backend-detail.js
+++ b/clis/chatgpt/backend-detail.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    CHATGPT_DOMAIN,
+    ensureChatGPTLogin,
+    ensureOnChatGPT,
+    fetchChatGPTBackendJson,
+    parseChatGPTConversationId,
+} from './utils.js';
+
+export const backendDetailCommand = cli({
+    site: 'chatgpt',
+    name: 'backend-detail',
+    access: 'read',
+    description: 'Fetch raw ChatGPT conversation detail from the backend API',
+    domain: CHATGPT_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Conversation ID or full /c/<id> URL' },
+    ],
+    columns: ['Id', 'Status', 'Body'],
+    func: async (page, kwargs) => {
+        const id = parseChatGPTConversationId(kwargs.id);
+        await ensureOnChatGPT(page);
+        await ensureChatGPTLogin(page, 'ChatGPT backend-detail requires a logged-in ChatGPT session.');
+        const result = await fetchChatGPTBackendJson(page, `/backend-api/conversation/${id}`, 'chatgpt backend-detail');
+        return [{
+            Id: id,
+            Status: result.status,
+            Body: result.body,
+        }];
+    },
+});

--- a/clis/chatgpt/backend-history.js
+++ b/clis/chatgpt/backend-history.js
@@ -1,0 +1,65 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    CHATGPT_DOMAIN,
+    CHATGPT_URL,
+    ensureChatGPTLogin,
+    ensureOnChatGPT,
+    fetchChatGPTBackendConversationItems,
+    requirePositiveInt,
+} from './utils.js';
+
+export const backendHistoryCommand = cli({
+    site: 'chatgpt',
+    name: 'backend-history',
+    access: 'read',
+    description: 'List ChatGPT conversations from the backend API instead of the visible sidebar',
+    domain: CHATGPT_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 200, help: 'Max backend conversations to return' },
+        { name: 'page-size', type: 'int', default: 100, help: 'Backend page size per request' },
+    ],
+    columns: ['Index', 'Id', 'Title', 'Url', 'CreateTime', 'UpdateTime', 'Raw'],
+    func: async (page, kwargs) => {
+        const limit = requirePositiveInt(
+            Number(kwargs.limit ?? 200),
+            'chatgpt backend-history --limit',
+            'Example: opencli chatgpt backend-history --limit 500',
+        );
+        const pageSize = requirePositiveInt(
+            Number(kwargs['page-size'] ?? 100),
+            'chatgpt backend-history --page-size',
+            'Example: opencli chatgpt backend-history --page-size 100',
+        );
+        if (pageSize > 100) {
+            throw new ArgumentError('page-size', 'must be ≤ 100 for the ChatGPT backend conversations API');
+        }
+
+        await ensureOnChatGPT(page);
+        await ensureChatGPTLogin(page, 'ChatGPT backend-history requires a logged-in ChatGPT session.');
+
+        const items = await fetchChatGPTBackendConversationItems(page, {
+            limit,
+            pageSize,
+            label: 'chatgpt backend-history',
+        });
+        const rows = items.map((item, index) => ({
+            Index: index + 1,
+            Id: String(item.id || item.conversation_id || '').trim(),
+            Title: String(item.title || '(untitled)').trim() || '(untitled)',
+            Url: `${CHATGPT_URL}/c/${String(item.id || item.conversation_id || '').trim()}`,
+            CreateTime: item.create_time || '',
+            UpdateTime: item.update_time || '',
+            Raw: item,
+        }));
+
+        if (!rows.length) {
+            throw new EmptyResultError('chatgpt backend-history', 'No ChatGPT backend conversations were returned.');
+        }
+        return rows;
+    },
+});

--- a/clis/chatgpt/commands.test.js
+++ b/clis/chatgpt/commands.test.js
@@ -9,6 +9,9 @@ import './send.js';
 import './read.js';
 import './history.js';
 import './detail.js';
+import './backend-history.js';
+import './backend-detail.js';
+import './backend-detail-batch.js';
 import './deep-research-result.js';
 import './new.js';
 import './status.js';
@@ -52,6 +55,9 @@ describe('chatgpt browser command registration', () => {
             read: 'read',
             history: 'read',
             detail: 'read',
+            'backend-history': 'read',
+            'backend-detail': 'read',
+            'backend-detail-batch': 'read',
             'deep-research-result': 'read',
             new: 'read',
             status: 'read',
@@ -120,6 +126,124 @@ describe('chatgpt browser command registration', () => {
             expect.objectContaining({ name: 'stable', type: 'int', default: 6 }),
         ]));
         expect(detail.columns).toEqual(['Index', 'Role', 'Text', 'Generating', 'StableSeconds']);
+    });
+
+    it('registers backend raw commands', () => {
+        const history = getRegistry().get('chatgpt/backend-history');
+        const detail = getRegistry().get('chatgpt/backend-detail');
+        const batch = getRegistry().get('chatgpt/backend-detail-batch');
+        expect(history.args).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'limit', type: 'int', default: 200 }),
+            expect.objectContaining({ name: 'page-size', type: 'int', default: 100 }),
+        ]));
+        expect(history.columns).toEqual(['Index', 'Id', 'Title', 'Url', 'CreateTime', 'UpdateTime', 'Raw']);
+        expect(detail.args).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'id', positional: true, required: true }),
+        ]));
+        expect(detail.columns).toEqual(['Id', 'Status', 'Body']);
+        expect(batch.args).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'ids', positional: true, required: true }),
+            expect.objectContaining({ name: 'delay-ms', type: 'int', default: 1000 }),
+        ]));
+        expect(batch.columns).toEqual(['Id', 'Status', 'Body', 'Error']);
+    });
+
+    it('reads ChatGPT backend conversation history with bearer auth', async () => {
+        const command = getRegistry().get('chatgpt/backend-history');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                if (s === 'window.location.href') return Promise.resolve('https://chatgpt.com/');
+                if (s.includes('composerSelectors') && s.includes('hasComposer')) {
+                    return Promise.resolve({ url: 'https://chatgpt.com/', title: 'ChatGPT', hasComposer: true, isLoggedIn: true, hasLoginGate: false });
+                }
+                if (s.includes('/api/auth/session')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        url: '/backend-api/conversations?offset=0&limit=2&order=updated',
+                        contentType: 'application/json',
+                        size: 200,
+                        body: {
+                            items: [
+                                { id: 'conv-1', title: 'First', create_time: '2026-01-01T00:00:00Z', update_time: '2026-01-02T00:00:00Z' },
+                                { id: 'conv-2', title: 'Second', create_time: '2026-01-03T00:00:00Z', update_time: '2026-01-04T00:00:00Z' },
+                            ],
+                            total: 2,
+                        },
+                    });
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        await expect(command.func(page, { limit: 2, 'page-size': 2 })).resolves.toEqual([
+            expect.objectContaining({ Index: 1, Id: 'conv-1', Title: 'First', Url: 'https://chatgpt.com/c/conv-1' }),
+            expect.objectContaining({ Index: 2, Id: 'conv-2', Title: 'Second', Raw: expect.objectContaining({ id: 'conv-2' }) }),
+        ]);
+    });
+
+    it('reads ChatGPT backend conversation detail with bearer auth', async () => {
+        const command = getRegistry().get('chatgpt/backend-detail');
+        const body = { conversation_id: 'conv-1', mapping: { root: { id: 'root' } } };
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                if (s === 'window.location.href') return Promise.resolve('https://chatgpt.com/');
+                if (s.includes('composerSelectors') && s.includes('hasComposer')) {
+                    return Promise.resolve({ url: 'https://chatgpt.com/', title: 'ChatGPT', hasComposer: true, isLoggedIn: true, hasLoginGate: false });
+                }
+                if (s.includes('/api/auth/session')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        url: '/backend-api/conversation/conv-1',
+                        contentType: 'application/json',
+                        size: 100,
+                        body,
+                    });
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        await expect(command.func(page, { id: 'conv-1' })).resolves.toEqual([
+            { Id: 'conv-1', Status: 200, Body: body },
+        ]);
+    });
+
+    it('reads ChatGPT backend conversation detail raw bodies in a batch', async () => {
+        const command = getRegistry().get('chatgpt/backend-detail-batch');
+        const body1 = { conversation_id: 'conv-1', mapping: { root: { id: 'root' } } };
+        const body2 = { conversation_id: 'conv-2', mapping: { root: { id: 'root' } } };
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                const s = String(script);
+                if (s === 'window.location.href') return Promise.resolve('https://chatgpt.com/');
+                if (s.includes('composerSelectors') && s.includes('hasComposer')) {
+                    return Promise.resolve({ url: 'https://chatgpt.com/', title: 'ChatGPT', hasComposer: true, isLoggedIn: true, hasLoginGate: false });
+                }
+                if (s.includes('/api/auth/session') && s.includes('/backend-api/conversation/conv-1') && s.includes('/backend-api/conversation/conv-2')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        results: [
+                            { ok: true, status: 200, url: '/backend-api/conversation/conv-1', body: body1 },
+                            { ok: true, status: 200, url: '/backend-api/conversation/conv-2', body: body2 },
+                        ],
+                    });
+                }
+                return Promise.resolve(undefined);
+            }),
+        };
+
+        await expect(command.func(page, { ids: 'conv-1,conv-2', 'delay-ms': 0 })).resolves.toEqual([
+            { Id: 'conv-1', Status: 200, Body: body1, Error: '' },
+            { Id: 'conv-2', Status: 200, Body: body2, Error: '' },
+        ]);
     });
 
     it('registers deep research result command with wait options', () => {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -359,6 +359,132 @@ export async function ensureChatGPTLogin(page, message = 'ChatGPT requires a log
     return state;
 }
 
+export async function fetchChatGPTBackendJson(page, path, label = 'chatgpt backend fetch') {
+    const normalizedPath = String(path || '').startsWith('/') ? String(path) : `/${String(path || '')}`;
+    const result = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(async () => {
+        const sessionResponse = await fetch('/api/auth/session', { credentials: 'include' });
+        if (!sessionResponse.ok) {
+            return { ok: false, status: sessionResponse.status, url: '/api/auth/session', body: { detail: 'session fetch failed' } };
+        }
+        const session = await sessionResponse.json();
+        if (!session.accessToken) {
+            return { ok: false, status: 401, url: '/api/auth/session', body: { detail: 'missing access token' } };
+        }
+        const response = await fetch(${JSON.stringify(normalizedPath)}, {
+            credentials: 'include',
+            headers: { Authorization: 'Bearer ' + session.accessToken },
+        });
+        const text = await response.text();
+        let body;
+        try {
+            body = JSON.parse(text);
+        } catch {
+            body = { raw_text: text };
+        }
+        return {
+            ok: response.ok,
+            status: response.status,
+            url: ${JSON.stringify(normalizedPath)},
+            contentType: response.headers.get('content-type') || '',
+            size: text.length,
+            body,
+        };
+    })()`)), label);
+    if (!result.ok) {
+        if (result.status === 401 || result.status === 403) {
+            throw new AuthRequiredError(CHATGPT_DOMAIN, `${label} requires a logged-in ChatGPT session with backend API access.`);
+        }
+        throw new CommandExecutionError(`${label} failed with HTTP ${result.status}`);
+    }
+    return result;
+}
+
+export async function fetchChatGPTBackendJsonBatch(page, paths, { label = 'chatgpt backend batch fetch', delayMs = 0 } = {}) {
+    const normalizedPaths = paths.map((path) => String(path || '').startsWith('/') ? String(path) : `/${String(path || '')}`);
+    const result = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(async () => {
+        const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        const sessionResponse = await fetch('/api/auth/session', { credentials: 'include' });
+        if (!sessionResponse.ok) {
+            return { ok: false, status: sessionResponse.status, url: '/api/auth/session', body: { detail: 'session fetch failed' }, results: [] };
+        }
+        const session = await sessionResponse.json();
+        if (!session.accessToken) {
+            return { ok: false, status: 401, url: '/api/auth/session', body: { detail: 'missing access token' }, results: [] };
+        }
+        const paths = ${JSON.stringify(normalizedPaths)};
+        const delayMs = ${JSON.stringify(Math.max(0, Number(delayMs) || 0))};
+        const results = [];
+        for (const path of paths) {
+            try {
+                const response = await fetch(path, {
+                    credentials: 'include',
+                    headers: { Authorization: 'Bearer ' + session.accessToken },
+                });
+                const text = await response.text();
+                let body;
+                try {
+                    body = JSON.parse(text);
+                } catch {
+                    body = { raw_text: text };
+                }
+                results.push({
+                    ok: response.ok,
+                    status: response.status,
+                    url: path,
+                    contentType: response.headers.get('content-type') || '',
+                    size: text.length,
+                    body,
+                });
+            } catch (error) {
+                results.push({
+                    ok: false,
+                    status: 0,
+                    url: path,
+                    body: { detail: String(error) },
+                });
+            }
+            if (delayMs > 0) await sleep(delayMs);
+        }
+        return { ok: true, status: 200, results };
+    })()`)), label);
+    if (!result.ok) {
+        if (result.status === 401 || result.status === 403) {
+            throw new AuthRequiredError(CHATGPT_DOMAIN, `${label} requires a logged-in ChatGPT session with backend API access.`);
+        }
+        throw new CommandExecutionError(`${label} failed with HTTP ${result.status}`);
+    }
+    if (!Array.isArray(result.results)) {
+        throw new CommandExecutionError(`${label} returned malformed batch payload`);
+    }
+    return result.results;
+}
+
+export async function fetchChatGPTBackendConversationItems(page, { limit, pageSize, label = 'chatgpt backend-history' }) {
+    const rows = [];
+    let offset = 0;
+    let total = Infinity;
+    while (rows.length < limit && offset < total) {
+        const batchLimit = Math.min(pageSize, limit - rows.length);
+        const result = await fetchChatGPTBackendJson(
+            page,
+            `/backend-api/conversations?offset=${offset}&limit=${batchLimit}&order=updated`,
+            label,
+        );
+        const body = result.body || {};
+        const items = Array.isArray(body.items) ? body.items : [];
+        total = Number.isFinite(Number(body.total)) ? Number(body.total) : offset + items.length;
+        for (const item of items) {
+            const id = String(item.id || item.conversation_id || '').trim();
+            if (!id) continue;
+            rows.push(item);
+            if (rows.length >= limit) break;
+        }
+        if (!items.length) break;
+        offset += items.length;
+    }
+    return rows;
+}
+
 export async function ensureChatGPTComposer(page, message = 'ChatGPT composer is not available on the current page.') {
     const state = await ensureChatGPTLogin(page, message);
     if (!state.hasComposer) {

--- a/clis/gemini/commands.test.js
+++ b/clis/gemini/commands.test.js
@@ -25,6 +25,7 @@ import { statusCommand } from './status.js';
 import { historyCommand, extractGeminiId } from './history.js';
 import { detailCommand } from './detail.js';
 import { readCommand } from './read.js';
+import { rawDetailCommand } from './raw-detail.js';
 
 function makePage() {
     return {
@@ -187,6 +188,40 @@ describe('gemini detail', () => {
         mocks.ensureGeminiPage.mockResolvedValue(undefined);
         mocks.getGeminiVisibleTurns.mockResolvedValue([]);
         await expect(detailCommand.func(makePage(), { id: 'abc' })).rejects.toBeInstanceOf(EmptyResultError);
+    });
+});
+
+describe('gemini raw-detail', () => {
+    it('returns raw DOM detail rows for a conversation id', async () => {
+        mocks.ensureGeminiPage.mockResolvedValue(undefined);
+        const page = makePage();
+        page.evaluate.mockResolvedValue({
+            url: 'https://gemini.google.com/app/b8368a89d4242e5f',
+            title: 'Gemini',
+            turns: [{ role: 'User', text: 'hello', images: [] }],
+            images: [],
+        });
+
+        const rows = await rawDetailCommand.func(page, { id: 'b8368a89d4242e5f' });
+
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://gemini.google.com/app/b8368a89d4242e5f',
+            expect.objectContaining({ waitUntil: 'load' }),
+        );
+        expect(rows).toEqual([
+            {
+                Id: 'b8368a89d4242e5f',
+                Url: 'https://gemini.google.com/app/b8368a89d4242e5f',
+                Title: 'Gemini',
+                Turns: [{ role: 'User', text: 'hello', images: [] }],
+                Images: [],
+                Raw: expect.objectContaining({ title: 'Gemini' }),
+            },
+        ]);
+    });
+
+    it('throws ArgumentError when raw-detail id is missing', async () => {
+        await expect(rawDetailCommand.func(makePage(), { id: '' })).rejects.toBeInstanceOf(ArgumentError);
     });
 });
 

--- a/clis/gemini/history.js
+++ b/clis/gemini/history.js
@@ -41,11 +41,11 @@ export const historyCommand = cli({
     columns: ['Index', 'Id', 'Title', 'Url'],
     func: async (page, kwargs) => {
         const rawLimit = Number(kwargs?.limit ?? 20);
-        if (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > 200) {
-            throw new ArgumentError('limit', 'must be a positive integer ≤ 200');
+        if (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > 2000) {
+            throw new ArgumentError('limit', 'must be a positive integer ≤ 2000');
         }
         await ensureGeminiPage(page);
-        const conversations = await getGeminiConversationList(page);
+        const conversations = await getGeminiConversationList(page, rawLimit);
         if (!conversations.length) {
             throw new EmptyResultError(
                 'gemini history',

--- a/clis/gemini/raw-detail.js
+++ b/clis/gemini/raw-detail.js
@@ -1,0 +1,134 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    GEMINI_APP_URL,
+    GEMINI_DOMAIN,
+    clickGeminiConversationById,
+    ensureGeminiPage,
+} from './utils.js';
+
+function parseGeminiId(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return '';
+    try {
+        const url = new URL(raw, GEMINI_APP_URL);
+        const match = url.pathname.match(/^\/app\/([A-Za-z0-9_-]+)/);
+        if (match) return match[1];
+    } catch {}
+    const trimmed = raw.replace(/^.*\/app\//, '').replace(/\/.*$/, '');
+    return /^[A-Za-z0-9_-]+$/.test(trimmed) ? trimmed : '';
+}
+
+function extractGeminiRawDetailScript() {
+    return `
+    (() => {
+      const clean = (value) => String(value || '')
+        .replace(/\\u00a0/g, ' ')
+        .replace(/\\s+/g, ' ')
+        .trim();
+      const rectOf = (el) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        };
+      };
+      const imageOf = (img) => ({
+        src: img.currentSrc || img.src || '',
+        alt: img.alt || '',
+        naturalWidth: img.naturalWidth || 0,
+        naturalHeight: img.naturalHeight || 0,
+        rect: rectOf(img),
+        testId: img.getAttribute('data-testid') || img.getAttribute('data-test-id') || '',
+        className: String(img.className || ''),
+      });
+      const buttonsOf = (root) => Array.from(root.querySelectorAll('button, [role="button"]'))
+        .map((button) => ({
+          label: clean((button.getAttribute('aria-label') || '') + ' ' + (button.textContent || '')),
+          testId: button.getAttribute('data-testid') || button.getAttribute('data-test-id') || '',
+          rect: rectOf(button),
+        }))
+        .filter((button) => button.label || button.testId);
+      const userText = (root) => {
+        const query = root.querySelector('user-query, user-query-content, [class*="query-text"]');
+        const text = clean(query?.innerText || query?.textContent || '');
+        return text.replace(/^你说\\s*/, '').trim();
+      };
+      const assistantText = (root) => {
+        const response = root.querySelector('model-response, response-container, [class*="response-content"], [class*="model-response"]');
+        const text = clean(response?.innerText || response?.textContent || '');
+        return text.replace(/^Gemini 说\\s*/, '').trim();
+      };
+      const containers = Array.from(document.querySelectorAll('.conversation-container, user-query, model-response'));
+      const containerRoots = [];
+      for (const node of containers) {
+        const root = node.closest('.conversation-container') || node;
+        if (!containerRoots.includes(root)) containerRoots.push(root);
+      }
+      const turns = [];
+      for (const root of containerRoots) {
+        const query = userText(root);
+        const answer = assistantText(root);
+        const images = Array.from(root.querySelectorAll('img')).map(imageOf).filter((image) => image.src);
+        const buttons = buttonsOf(root);
+        if (query) {
+          turns.push({ role: 'User', text: query, images: images.filter((image) => /uploaded|preview|所上传/i.test(image.alt + ' ' + image.testId + ' ' + image.className)), raw: { rect: rectOf(root), buttons } });
+        }
+        if (answer || images.length || buttons.some((button) => /下载|download|复制图片|copy image|分享图片|share image/i.test(button.label))) {
+          turns.push({ role: 'Assistant', text: answer, images, raw: { rect: rectOf(root), buttons } });
+        }
+      }
+      const turnImages = turns.flatMap((turn) => turn.images || []);
+      return {
+        url: location.href,
+        title: document.title || '',
+        turns,
+        images: turnImages,
+        buttons: buttonsOf(document.body),
+      };
+    })()
+  `;
+}
+
+export const rawDetailCommand = cli({
+    site: 'gemini',
+    name: 'raw-detail',
+    access: 'read',
+    description: 'Fetch a Gemini conversation DOM raw detail with text turns and image URLs',
+    domain: GEMINI_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Conversation id, /app/<id> path, or Gemini conversation URL' },
+    ],
+    columns: ['Id', 'Url', 'Title', 'Turns', 'Images', 'Raw'],
+    func: async (page, kwargs) => {
+        const id = parseGeminiId(kwargs?.id);
+        if (!id) {
+            throw new ArgumentError('id', 'must be a Gemini conversation id, /app/<id> path, or URL');
+        }
+        await ensureGeminiPage(page);
+        await page.goto(`${GEMINI_APP_URL}/${id}`, { waitUntil: 'load', settleMs: 2500 });
+        await page.wait(2);
+        let raw = await page.evaluate(extractGeminiRawDetailScript());
+        if (!raw?.turns?.length || raw.turns.every((turn) => !turn.text && !turn.images?.length)) {
+            await clickGeminiConversationById(page, id);
+            raw = await page.evaluate(extractGeminiRawDetailScript());
+        }
+        if (!raw?.turns?.length) {
+            throw new EmptyResultError('gemini raw-detail', `No Gemini turns were found for ${id}.`);
+        }
+        return [{
+            Id: id,
+            Url: raw.url || `${GEMINI_APP_URL}/${id}`,
+            Title: raw.title || '',
+            Turns: raw.turns,
+            Images: raw.images || [],
+            Raw: raw,
+        }];
+    },
+});

--- a/clis/gemini/utils.js
+++ b/clis/gemini/utils.js
@@ -1027,6 +1027,69 @@ function expandGeminiRecentScript() {
     })()
   `;
 }
+function scrollGeminiConversationListScript() {
+    return `
+    (async () => {
+      const selector = 'a[href*="/app"]';
+      const candidates = [
+        ...Array.from(document.querySelectorAll('bard-sidenav infinite-scroller, side-navigation-content infinite-scroller, infinite-scroller')),
+        ...Array.from(document.querySelectorAll('nav, aside, [role="navigation"], nav *, aside *, [role="navigation"] *')),
+      ];
+      const scrollables = candidates
+        .filter((node) => node instanceof HTMLElement && node.querySelector?.(selector))
+        .filter((node) => {
+          const style = window.getComputedStyle(node);
+          return /(auto|scroll)/i.test(style.overflowY || '') || node.scrollHeight > node.clientHeight + 10;
+        })
+        .sort((left, right) => (right.scrollHeight - right.clientHeight) - (left.scrollHeight - left.clientHeight));
+      const root = scrollables[0];
+      if (!(root instanceof HTMLElement)) return { changed: false, reason: 'no-scroll-root' };
+      const before = root.scrollTop;
+      const max = Math.max(0, root.scrollHeight - root.clientHeight);
+      root.scrollTop = max;
+      root.dispatchEvent(new Event('scroll', { bubbles: true }));
+      const delta = Math.max(1200, root.clientHeight * 4);
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      root.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: delta }));
+      window.scrollBy(0, delta);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      window.scrollBy(0, delta);
+      return {
+        changed: root.scrollTop > before + 2,
+        before,
+        after: root.scrollTop,
+        max,
+        scrollHeight: root.scrollHeight,
+        clientHeight: root.clientHeight,
+        windowY: window.scrollY || window.pageYOffset || 0,
+      };
+    })()
+  `;
+}
+function resetGeminiConversationListScrollScript() {
+    return `
+    (() => {
+      const selector = 'a[href*="/app"]';
+      const candidates = [
+        ...Array.from(document.querySelectorAll('bard-sidenav infinite-scroller, side-navigation-content infinite-scroller, infinite-scroller')),
+        ...Array.from(document.querySelectorAll('nav, aside, [role="navigation"], nav *, aside *, [role="navigation"] *')),
+      ];
+      const scrollables = candidates
+        .filter((node) => node instanceof HTMLElement && node.querySelector?.(selector))
+        .filter((node) => {
+          const style = window.getComputedStyle(node);
+          return /(auto|scroll)/i.test(style.overflowY || '') || node.scrollHeight > node.clientHeight + 10;
+        })
+        .sort((left, right) => (right.scrollHeight - right.clientHeight) - (left.scrollHeight - left.clientHeight));
+      const root = scrollables[0];
+      if (!(root instanceof HTMLElement)) return { changed: false, reason: 'no-scroll-root' };
+      const before = root.scrollTop;
+      root.scrollTop = 0;
+      root.dispatchEvent(new Event('scroll', { bubbles: true }));
+      return { changed: before > 2, before, after: root.scrollTop };
+    })()
+  `;
+}
 function clickGeminiConversationByTitleScript(query) {
     const normalizedQuery = normalizeGeminiTitle(query);
     return `
@@ -1065,6 +1128,24 @@ function clickGeminiConversationByTitleScript(query) {
       }
       return false;
     })(${JSON.stringify(normalizedQuery)})
+  `;
+}
+function clickGeminiConversationByIdScript(id) {
+    return `
+    ((targetId) => {
+      const anchors = Array.from(document.querySelectorAll('a[href]'));
+      for (const anchor of anchors) {
+        if (!(anchor instanceof HTMLAnchorElement)) continue;
+        let url;
+        try { url = new URL(anchor.href); } catch { continue; }
+        if (url.hostname !== '${GEMINI_DOMAIN}' && !url.hostname.endsWith('.${GEMINI_DOMAIN}')) continue;
+        if (url.pathname !== '/app/' + targetId) continue;
+        anchor.scrollIntoView({ block: 'center' });
+        anchor.click();
+        return { clicked: true, title: (anchor.textContent || '').replace(/\\s+/g, ' ').trim(), url: anchor.href };
+      }
+      return { clicked: false };
+    })(${JSON.stringify(id)})
   `;
 }
 function currentUrlScript() {
@@ -1135,14 +1216,11 @@ export async function startNewGeminiChat(page) {
     await page.wait(1);
     return action;
 }
-export async function getGeminiConversationList(page) {
+export async function getGeminiConversationList(page, maxRows = 200) {
     await ensureGeminiPage(page);
-    let rows = [];
-    // Gemini collapses the sidebar "最近"/Recents section by default, hiding
-    // the conversation anchors. Retry extraction after expanding it.
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-        const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
-        rows = raw.flatMap((item) => {
+    const byKey = new Map();
+    const appendRows = (raw) => {
+        const rows = raw.flatMap((item) => {
             if (!isObjectRecord(item) || typeof item.title !== 'string' || typeof item.url !== 'string') {
                 throw new CommandExecutionError('Gemini conversation list returned a malformed row');
             }
@@ -1150,17 +1228,63 @@ export async function getGeminiConversationList(page) {
                 return [];
             return { Title: item.title, Url: item.url };
         });
-        if (rows.length > 0)
+        for (const row of rows) {
+            const key = `${row.Url}::${row.Title}`;
+            if (!byKey.has(key)) byKey.set(key, row);
+        }
+    };
+    await page.evaluate(expandGeminiRecentScript()).catch(() => false);
+    await page.wait(0.5);
+    await page.evaluate(resetGeminiConversationListScrollScript()).catch(() => null);
+    await page.wait(0.5);
+    // Gemini collapses the sidebar "最近"/Recents section by default, hiding
+    // the conversation anchors. Retry extraction after expanding it.
+    let idleRounds = 0;
+    let lastSize = -1;
+    let lastScrollHeight = -1;
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+        const raw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
+        appendRows(raw);
+        if (byKey.size >= maxRows)
             break;
-        const changedRaw = unwrapGeminiEvaluateResult(await page.evaluate(expandGeminiRecentScript()), 'Gemini sidebar expand');
-        const changed = changedRaw === true;
-        // Give the React sidebar a moment to render the expanded anchors,
-        // longer on the first expansion (sidebar slide-in is async).
-        await page.wait(attempt === 0 ? 1.2 : 0.6);
-        if (!changed && attempt > 0)
+        let scrollHeight = lastScrollHeight;
+        let changed = byKey.size > lastSize;
+        if (byKey.size === 0) {
+            const changedRaw = unwrapGeminiEvaluateResult(await page.evaluate(expandGeminiRecentScript()), 'Gemini sidebar expand');
+            changed = changedRaw === true;
+            // Give the React sidebar a moment to render the expanded anchors,
+            // longer on the first expansion (sidebar slide-in is async).
+            await page.wait(attempt === 0 ? 1.2 : 0.6);
+        }
+        else {
+            const scrollRaw = unwrapGeminiEvaluateResult(await page.evaluate(scrollGeminiConversationListScript()), 'Gemini sidebar scroll');
+            scrollHeight = Number(scrollRaw?.scrollHeight ?? scrollRaw?.max ?? lastScrollHeight);
+            changed = changed || !!scrollRaw?.changed || scrollHeight > lastScrollHeight;
+            await page.wait(changed ? 0.8 : 1.2);
+        }
+        if (changed) {
+            idleRounds = 0;
+        }
+        else {
+            idleRounds += 1;
+        }
+        lastSize = byKey.size;
+        lastScrollHeight = scrollHeight;
+        if (idleRounds >= 20) {
+            await page.evaluate(scrollGeminiConversationListScript()).catch(() => null);
+            await page.wait(3);
+            const finalRaw = requireGeminiArrayResult(await page.evaluate(getGeminiConversationListScript()), 'Gemini conversation list');
+            const beforeFinal = byKey.size;
+            appendRows(finalRaw);
+            if (byKey.size > beforeFinal) {
+                idleRounds = 0;
+                lastSize = byKey.size;
+                continue;
+            }
             break;
+        }
     }
-    return rows;
+    return Array.from(byKey.values()).slice(0, maxRows);
 }
 export async function clickGeminiConversationByTitle(page, query) {
     await ensureGeminiPage(page);
@@ -1171,6 +1295,27 @@ export async function clickGeminiConversationByTitle(page, query) {
     if (clicked)
         await page.wait(1);
     return !!clicked;
+}
+export async function clickGeminiConversationById(page, id) {
+    await ensureGeminiPage(page);
+    const targetId = String(id || '').trim();
+    if (!targetId)
+        return null;
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+        const clicked = requireGeminiObjectResult(await page.evaluate(clickGeminiConversationByIdScript(targetId)), 'Gemini conversation click by id');
+        if (clicked.clicked) {
+            await page.wait(2.5);
+            return clicked;
+        }
+        if (attempt === 0) {
+            await page.evaluate(expandGeminiRecentScript()).catch(() => false);
+        }
+        else {
+            await page.evaluate(scrollGeminiConversationListScript()).catch(() => null);
+        }
+        await page.wait(0.5);
+    }
+    return null;
 }
 export async function getGeminiVisibleTurns(page) {
     const turns = await getGeminiStructuredTurns(page);


### PR DESCRIPTION
## Summary
- add `opencli chatgpt backend-history`, `backend-detail`, and `backend-detail-batch` for logged-in backend raw JSON export
- make `opencli gemini history --limit` scroll the sidebar infinite list instead of stopping at the initially visible rows
- add `opencli gemini raw-detail <id>` to capture DOM text turns plus image metadata for backup workflows

## Verification
- `npm run build-manifest`
- `./dist/src/main.js validate chatgpt/backend-history`
- `./dist/src/main.js validate chatgpt/backend-detail`
- `./dist/src/main.js validate chatgpt/backend-detail-batch`
- `./dist/src/main.js validate gemini/history`
- `./dist/src/main.js validate gemini/raw-detail`
- `git diff --check`
- live smoke: `chatgpt backend-history --limit 10000` returned 1208 conversations in the logged-in account
- live smoke: `gemini history --limit 1000` returned a stable 719 conversations after the infinite-scroll fix
- live smoke: `gemini raw-detail 9db801bc3b2e6fb6` returned 8 turns and 4 in-turn images

Local note: `npm test -- clis/gemini/commands.test.js` and narrower `npx vitest run --project unit clis/gemini/commands.test.js --reporter=verbose` exit 138 in this local environment before emitting test output. I validated with build/validate/live smoke above.

Commit: https://github.com/lmmsoft/OpenCLI/commit/26b8dc1361bf9411ee71c755cfc7d5cbfae27cd8
