### PR TITLE
feat(zhihu): add `zhihu publish` for column articles (专栏文章)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -43975,6 +43975,55 @@
   },
   {
     "site": "zhihu",
+    "name": "publish",
+    "description": "Publish a Zhihu column article (专栏文章). Without --execute, saves a private draft only.",
+    "access": "write",
+    "domain": "zhuanlan.zhihu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "title",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Article title"
+      },
+      {
+        "name": "text",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Article body as HTML"
+      },
+      {
+        "name": "file",
+        "type": "str",
+        "required": false,
+        "help": "Path to an HTML file for the article body"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "required": false,
+        "help": "Actually publish. Omit to save a private draft only."
+      }
+    ],
+    "columns": [
+      "status",
+      "outcome",
+      "message",
+      "article_id",
+      "url",
+      "author_identity"
+    ],
+    "type": "js",
+    "modulePath": "zhihu/publish.js",
+    "sourceFile": "zhihu/publish.js",
+    "navigateBefore": "https://zhuanlan.zhihu.com"
+  },
+  {
+    "site": "zhihu",
     "name": "question",
     "description": "知乎问题详情和回答",
     "access": "read",

--- a/clis/zhihu/publish.js
+++ b/clis/zhihu/publish.js
@@ -1,0 +1,79 @@
+import { CliError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { resolveCurrentUserIdentity, resolvePayload } from './write-shared.js';
+cli({
+    site: 'zhihu',
+    name: 'publish',
+    access: 'write',
+    description: 'Publish a Zhihu column article (专栏文章). Without --execute, saves a private draft only.',
+    domain: 'zhuanlan.zhihu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'title', positional: true, required: true, help: 'Article title' },
+        { name: 'text', positional: true, help: 'Article body as HTML' },
+        { name: 'file', help: 'Path to an HTML file for the article body' },
+        { name: 'execute', type: 'boolean', help: 'Actually publish. Omit to save a private draft only.' },
+    ],
+    columns: ['status', 'outcome', 'message', 'article_id', 'url', 'author_identity'],
+    func: async (page, kwargs) => {
+        if (!page)
+            throw new CommandExecutionError('Browser session required for zhihu publish');
+        const title = String(kwargs.title ?? '').trim();
+        if (!title)
+            throw new CliError('INVALID_INPUT', 'title is required');
+        const content = await resolvePayload(kwargs);
+        const execute = Boolean(kwargs.execute);
+        // Same-origin context so the cookie-authenticated fetch calls succeed.
+        await page.goto('https://zhuanlan.zhihu.com/');
+        await page.wait(2);
+        const authorIdentity = await resolveCurrentUserIdentity(page);
+        const apiResult = await page.evaluate(`(async () => {
+            var title = ${JSON.stringify(title)};
+            var content = ${JSON.stringify(content)};
+            var execute = ${JSON.stringify(execute)};
+            var base = 'https://zhuanlan.zhihu.com/api/articles';
+            var headers = { 'Content-Type': 'application/json' };
+
+            // 1. create a draft
+            var c = await fetch(base + '/drafts', { method: 'POST', credentials: 'include', headers: headers,
+                body: JSON.stringify({ title: title, delta_time: 0, can_reward: false }) });
+            if (!c.ok) return { ok: false, step: 'draft', status: c.status, message: (await c.text()).slice(0, 300) };
+            var draft = await c.json();
+            if (!draft || !draft.id) return { ok: false, step: 'draft', status: c.status, message: 'Draft API response did not include a draft id' };
+            var id = String(draft.id);
+
+            // 2. save title + HTML content
+            var s = await fetch(base + '/' + id + '/draft', { method: 'PATCH', credentials: 'include', headers: headers,
+                body: JSON.stringify({ title: title, content: content, delta_time: 30, table_of_contents: false }) });
+            if (!s.ok) return { ok: false, step: 'save', status: s.status, id: id, message: (await s.text()).slice(0, 300) };
+
+            if (!execute) {
+                return { ok: true, id: id, published: false, url: 'https://zhuanlan.zhihu.com/p/' + id + '/edit' };
+            }
+
+            // 3. publish
+            var p = await fetch(base + '/' + id + '/publish', { method: 'PUT', credentials: 'include', headers: headers,
+                body: JSON.stringify({}) });
+            var ptext = await p.text();
+            if (!p.ok) return { ok: false, step: 'publish', status: p.status, id: id, message: ptext.slice(0, 300) };
+            var url = 'https://zhuanlan.zhihu.com/p/' + id;
+            try { var d = JSON.parse(ptext); if (d && d.url) url = d.url; } catch (e) {}
+            return { ok: true, id: id, published: true, url: url };
+        })()`);
+        if (!apiResult?.ok) {
+            throw new CliError('COMMAND_EXEC', `zhihu publish failed at step "${apiResult?.step ?? 'unknown'}": ${apiResult?.message ?? 'unknown error'}`);
+        }
+        const message = apiResult.published
+            ? `Article published: ${title}`
+            : 'Draft saved (private). Review the edit URL, then re-run with --execute to publish.';
+        return [{
+            status: 'success',
+            outcome: apiResult.published ? 'published' : 'draft_saved',
+            message,
+            article_id: apiResult.id,
+            url: apiResult.url,
+            author_identity: authorIdentity,
+        }];
+    },
+});

--- a/clis/zhihu/publish.test.js
+++ b/clis/zhihu/publish.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './publish.js';
+function makePage(apiResult) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn()
+            .mockResolvedValueOnce({ slug: 'alice' })
+            .mockResolvedValueOnce(apiResult),
+    };
+}
+describe('zhihu publish', () => {
+    it('registers as a cookie browser command', () => {
+        const cmd = getRegistry().get('zhihu/publish');
+        expect(cmd).toBeDefined();
+        expect(cmd.strategy).toBe('cookie');
+        expect(cmd.browser).toBe(true);
+        expect(cmd.access).toBe('write');
+    });
+    it('saves a private draft when --execute is omitted', async () => {
+        const cmd = getRegistry().get('zhihu/publish');
+        const page = makePage({ ok: true, id: '99', published: false, url: 'https://zhuanlan.zhihu.com/p/99/edit' });
+        const rows = await cmd.func(page, { title: 'T', text: '<p>hi</p>' });
+        expect(rows).toEqual([
+            expect.objectContaining({
+                status: 'success',
+                outcome: 'draft_saved',
+                article_id: '99',
+                url: 'https://zhuanlan.zhihu.com/p/99/edit',
+                author_identity: 'alice',
+            }),
+        ]);
+    });
+    it('publishes the article when --execute is set', async () => {
+        const cmd = getRegistry().get('zhihu/publish');
+        const page = makePage({ ok: true, id: '99', published: true, url: 'https://zhuanlan.zhihu.com/p/99' });
+        const rows = await cmd.func(page, { title: 'T', text: '<p>hi</p>', execute: true });
+        expect(rows).toEqual([
+            expect.objectContaining({ outcome: 'published', article_id: '99', url: 'https://zhuanlan.zhihu.com/p/99' }),
+        ]);
+    });
+    it('throws COMMAND_EXEC on API error', async () => {
+        const cmd = getRegistry().get('zhihu/publish');
+        const page = makePage({ ok: false, step: 'publish', status: 400, id: '99', message: 'forbidden' });
+        await expect(cmd.func(page, { title: 'T', text: '<p>hi</p>', execute: true }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+    it('requires a title', async () => {
+        const cmd = getRegistry().get('zhihu/publish');
+        const page = makePage({ ok: true, id: '1', published: false, url: 'x' });
+        await expect(cmd.func(page, { title: '   ', text: '<p>hi</p>' }))
+            .rejects.toMatchObject({ code: 'INVALID_INPUT' });
+    });
+});


### PR DESCRIPTION
## What

Adds `zhihu publish` — a write adapter that publishes a **Zhihu column article (专栏文章)**. Zhihu had read/write adapters for answers and comments, but no way to publish a standalone article; this fills that gap.

## How

Follows the same same-origin, cookie-authenticated `fetch` pattern as the existing `zhihu answer` adapter — it drives the logged-in editor's own endpoints, no fragile UI automation:

```
POST   /api/articles/drafts         create a draft        -> { id }
PATCH  /api/articles/{id}/draft      save title + HTML body
PUT    /api/articles/{id}/publish    publish (only with --execute)
```

## Safety

Consistent with the repo's write-gating convention, but a bit friendlier for a long-form article:

- **without `--execute`** → stops after saving a **private draft** and returns the edit URL so the author can review rendering first;
- **with `--execute`** → also publishes.

Body content comes from `<text>` or `--file <html>` (reuses `resolvePayload` from `write-shared.js`).

## Usage

```bash
# save a private draft for review
opencli zhihu publish "My title" --file article.html

# publish
opencli zhihu publish "My title" --file article.html --execute
```

## Testing

- `clis/zhihu/publish.test.js` — 5 unit tests (registration, draft-only, publish, API-error, title-required), all passing.
- `npx tsc --noEmit` clean; `cli-manifest.json` regenerated via `npm run build-manifest`.
- **Verified end-to-end against real Zhihu**: created/saved drafts and published a live article, then confirmed rendering in the editor (headings, blockquote, code blocks, inline code, lists, links). One practical note: Zhihu's draft API silently drops raw `<table>` elements, so callers should render tabular data as a `<pre>` code block or list — worth a docs mention, happy to add.

Would love feedback, and glad to adjust anything to match your conventions. 🙏
