### PR TITLE
feat(twitter): add `post-thread` for multi-tweet threads

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -36516,6 +36516,48 @@
   },
   {
     "site": "twitter",
+    "name": "post-thread",
+    "description": "Post a multi-tweet thread: the first tweet, then each subsequent tweet as a reply to the previous one.",
+    "access": "write",
+    "domain": "x.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "text",
+        "type": "string",
+        "required": false,
+        "positional": true,
+        "help": "Thread text; separate tweets with a line of \"---\" or blank lines"
+      },
+      {
+        "name": "file",
+        "type": "str",
+        "required": false,
+        "help": "Path to a text file with the thread (tweets separated by \"---\" or blank lines)"
+      },
+      {
+        "name": "delay",
+        "type": "int",
+        "default": 3000,
+        "required": false,
+        "help": "Delay in ms between posts (default 3000)"
+      }
+    ],
+    "columns": [
+      "status",
+      "index",
+      "id",
+      "url",
+      "text"
+    ],
+    "type": "js",
+    "modulePath": "twitter/post-thread.js",
+    "sourceFile": "twitter/post-thread.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "twitter",
     "name": "profile",
     "description": "Fetch a Twitter user profile — bio, stats, etc. (defaults to the logged-in user when no username is given)",
     "access": "read",

--- a/clis/twitter/post-thread.js
+++ b/clis/twitter/post-thread.js
@@ -1,0 +1,115 @@
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { cli, getRegistry, Strategy } from '@jackwener/opencli/registry';
+import { readFileSync, statSync } from 'node:fs';
+
+const DEFAULT_DELAY_MS = 3000;
+const MAX_DELAY_MS = 60000;
+
+/**
+ * Split raw text into thread segments. A line containing only `---` (optionally
+ * surrounded by whitespace) is the segment delimiter; if none is present, fall
+ * back to splitting on blank lines. Empty segments are dropped.
+ */
+export function parseThreadSegments(raw) {
+    const text = String(raw || '').replace(/\r\n/g, '\n');
+    const hasRule = /^\s*---\s*$/m.test(text);
+    const parts = hasRule ? text.split(/^\s*---\s*$/m) : text.split(/\n\s*\n/);
+    const segments = parts.map((s) => s.trim()).filter(Boolean);
+    if (!segments.length) {
+        throw new ArgumentError('No thread segments found. Separate tweets with a line containing only "---" (or blank lines).');
+    }
+    return segments;
+}
+
+function resolveSegments(kwargs) {
+    if (kwargs.file) {
+        const file = String(kwargs.file);
+        let st;
+        try {
+            st = statSync(file);
+        } catch {
+            throw new ArgumentError(`File not found: ${file}`);
+        }
+        if (!st.isFile()) {
+            throw new ArgumentError(`Not a readable file: ${file}`);
+        }
+        return parseThreadSegments(readFileSync(file, 'utf-8'));
+    }
+    if (typeof kwargs.text === 'string' && kwargs.text.trim()) {
+        return parseThreadSegments(kwargs.text);
+    }
+    throw new ArgumentError('Provide thread text via <text> or --file.');
+}
+
+function idFromUrl(url) {
+    const m = String(url || '').match(/\/status\/(\d+)/);
+    return m ? m[1] : '';
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+cli({
+    site: 'twitter',
+    name: 'post-thread',
+    access: 'write',
+    description: 'Post a multi-tweet thread: the first tweet, then each subsequent tweet as a reply to the previous one.',
+    domain: 'x.com',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'text', type: 'string', positional: true, help: 'Thread text; separate tweets with a line of "---" or blank lines' },
+        { name: 'file', help: 'Path to a text file with the thread (tweets separated by "---" or blank lines)' },
+        { name: 'delay', type: 'int', default: DEFAULT_DELAY_MS, help: `Delay in ms between posts (default ${DEFAULT_DELAY_MS})` },
+    ],
+    columns: ['status', 'index', 'id', 'url', 'text'],
+    func: async (page, kwargs) => {
+        if (!page)
+            throw new CommandExecutionError('Browser session required for twitter post-thread');
+
+        const segments = resolveSegments(kwargs);
+        const delay = Math.min(Math.max(Number(kwargs.delay ?? DEFAULT_DELAY_MS) || 0, 0), MAX_DELAY_MS);
+
+        // Reuse the already-tested single-tweet `post` and `reply` commands so
+        // this command owns only the orchestration (chaining + pacing), not the
+        // fragile Draft.js composer handling.
+        const registry = getRegistry();
+        const post = registry.get('twitter/post');
+        const reply = registry.get('twitter/reply');
+        if (!post || !reply) {
+            throw new CommandExecutionError('twitter post/reply commands are unavailable in the registry');
+        }
+
+        const rows = [];
+        let prevUrl = '';
+        for (let i = 0; i < segments.length; i++) {
+            const text = segments[i];
+            if (i > 0 && delay) await sleep(delay);
+
+            let result;
+            if (i === 0) {
+                [result] = await post.func(page, { text });
+            } else {
+                [result] = await reply.func(page, { url: prevUrl, text });
+            }
+
+            const ok = result?.status === 'success';
+            const url = result?.url ?? '';
+            rows.push({
+                status: result?.status ?? 'failed',
+                index: i + 1,
+                id: idFromUrl(url),
+                url,
+                text,
+            });
+
+            // Stop the chain on the first failure — later replies have no parent.
+            if (!ok || !url) {
+                rows.push({ status: 'aborted', index: i + 1, id: '', url: '',
+                    text: `Thread stopped at tweet ${i + 1}: ${result?.message ?? 'no URL returned'}` });
+                break;
+            }
+            prevUrl = url;
+        }
+        return rows;
+    },
+});

--- a/clis/twitter/post-thread.test.js
+++ b/clis/twitter/post-thread.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './post.js';
+import './reply.js';
+import './post-thread.js';
+import { parseThreadSegments } from './post-thread.js';
+
+describe('parseThreadSegments', () => {
+    it('splits on lines containing only ---', () => {
+        expect(parseThreadSegments('a\n---\nb\n---\nc')).toEqual(['a', 'b', 'c']);
+    });
+    it('preserves internal blank lines within a segment when --- is used', () => {
+        expect(parseThreadSegments('line1\n\nline2\n---\nnext')).toEqual(['line1\n\nline2', 'next']);
+    });
+    it('falls back to blank-line splitting when no --- present', () => {
+        expect(parseThreadSegments('a\n\nb\n\nc')).toEqual(['a', 'b', 'c']);
+    });
+    it('drops empty segments and trims', () => {
+        expect(parseThreadSegments('  a  \n---\n\n---\n b ')).toEqual(['a', 'b']);
+    });
+    it('throws when there is no content', () => {
+        expect(() => parseThreadSegments('   \n---\n   ')).toThrow();
+    });
+});
+
+describe('twitter post-thread', () => {
+    it('registers as a UI browser write command', () => {
+        const cmd = getRegistry().get('twitter/post-thread');
+        expect(cmd).toBeDefined();
+        expect(cmd.browser).toBe(true);
+        expect(cmd.access).toBe('write');
+    });
+
+    it('posts the first tweet, then chains the rest as replies', async () => {
+        const post = getRegistry().get('twitter/post');
+        const reply = getRegistry().get('twitter/reply');
+        const postSpy = vi.spyOn(post, 'func').mockResolvedValue([
+            { status: 'success', url: 'https://x.com/u/status/1' },
+        ]);
+        const replySpy = vi.spyOn(reply, 'func')
+            .mockResolvedValueOnce([{ status: 'success', url: 'https://x.com/u/status/2' }])
+            .mockResolvedValueOnce([{ status: 'success', url: 'https://x.com/u/status/3' }]);
+
+        const cmd = getRegistry().get('twitter/post-thread');
+        const rows = await cmd.func({}, { text: 'one\n---\ntwo\n---\nthree', delay: 0 });
+
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        expect(replySpy).toHaveBeenCalledTimes(2);
+        // second reply chains onto the first reply's URL
+        expect(replySpy.mock.calls[1][1]).toMatchObject({ url: 'https://x.com/u/status/2', text: 'three' });
+        expect(rows.map((r) => r.url)).toEqual([
+            'https://x.com/u/status/1',
+            'https://x.com/u/status/2',
+            'https://x.com/u/status/3',
+        ]);
+        expect(rows.map((r) => r.id)).toEqual(['1', '2', '3']);
+        postSpy.mockRestore();
+        replySpy.mockRestore();
+    });
+
+    it('aborts the chain when a tweet fails', async () => {
+        const post = getRegistry().get('twitter/post');
+        const reply = getRegistry().get('twitter/reply');
+        const postSpy = vi.spyOn(post, 'func').mockResolvedValue([
+            { status: 'success', url: 'https://x.com/u/status/1' },
+        ]);
+        const replySpy = vi.spyOn(reply, 'func').mockResolvedValue([
+            { status: 'failed', message: 'rate limited' },
+        ]);
+
+        const cmd = getRegistry().get('twitter/post-thread');
+        const rows = await cmd.func({}, { text: 'one\n---\ntwo\n---\nthree', delay: 0 });
+
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        expect(replySpy).toHaveBeenCalledTimes(1); // stops after the first failed reply
+        expect(rows.some((r) => r.status === 'aborted')).toBe(true);
+        postSpy.mockRestore();
+        replySpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## What

Adds `twitter post-thread` — a first-class command to post a **multi-tweet thread**.

Closes the gap described in #2063: `twitter post` is advertised as "Post a new tweet/**thread**" but only ever posts a single tweet, and the `twitter thread` name is already the *read* command.

## How

`post-thread` takes the thread text (positional `<text>` or `--file`), splits it into segments (a line containing only `---`, or blank lines), and chains them:

- tweet **1** → `twitter post`
- tweet **2..N** → `twitter reply` onto the previous tweet's URL

It reuses the already-tested `post` and `reply` commands **via the registry**, so this command owns only the orchestration — chaining, pacing (`--delay`), and **abort-on-failure** (stops cleanly if a tweet fails, since later replies would have no parent). No duplication of the fragile Draft.js composer logic.

```bash
opencli twitter post-thread --file thread.txt   # tweets separated by "---" lines
```

## Design note

Implements **option 1** from #2063 (new command, registry reuse, zero changes to existing composer code — lowest risk). Happy to reshape toward extending `post` directly, or a native modal "Add post → Post all" thread, if you'd prefer — tradeoffs are in the issue.

## Testing

- `clis/twitter/post-thread.test.js` — 8 tests: `parseThreadSegments` (delimiter, blank-line fallback, trim/empty, throws), registration, chaining order (reply N chains onto reply N-1's URL), abort-on-failure. All passing.
- `npx tsc --noEmit` clean; `cli-manifest.json` regenerated via `npm run build-manifest`.
- Verified in practice: we posted a real 8-tweet thread by chaining `post`→`reply` (the exact flow this command wraps).
