### PR TITLE
fix(browser): assign clickable refs to interactive controls in table cells (#2056)

### DIFF
--- a/src/browser/dom-snapshot.test.ts
+++ b/src/browser/dom-snapshot.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
 
 describe('generateSnapshotJs', () => {
@@ -358,5 +359,97 @@ describe('Search Element Detection', () => {
     expect(js).toContain('compoundInfos');
     // And emit a sidecar section after the tree so agents can find the JSON
     expect(js).toContain("'compounds ('");
+  });
+});
+
+describe('table cell interactive refs (#2056)', () => {
+  it('exposes a shared assignRef helper used by the main walk', () => {
+    const js = generateSnapshotJs();
+    expect(js).toContain('function assignRef(el)');
+    // The normal interactive path routes through the shared helper, so table
+    // cells and the main tree assign refs (and fingerprints) identically.
+    expect(js).toContain('const idx = assignRef(el)');
+  });
+
+  it('assigns clickable refs to form controls inside table cells', () => {
+    const js = generateSnapshotJs();
+    // serializeTable scans each cell for interactive controls that were
+    // previously dropped (button / input / select / textarea) ...
+    expect(js).toContain("cell.querySelectorAll('button, input, select, textarea')");
+    // ... skips disabled / non-interactive ones via the shared predicate ...
+    expect(js).toContain('isInteractive(control)');
+    // ... and gives each a real ref plus a [N] marker in the markdown cell.
+    expect(js).toContain('assignRef(control)');
+    expect(js).toContain('refMarks');
+  });
+
+  it('defers table-cell ref assignment until after the render gate', () => {
+    const js = generateSnapshotJs();
+    // Regression: assignRef mutates shared ref state. If serializeTable claimed
+    // refs while building the grid and then bailed (grid.length < 2 / throw),
+    // the caller falls through to the generic walk and re-assigns — orphaning
+    // the first ref and desyncing refIdentity from the emitted [N] tokens.
+    // The cell loop must only COLLECT controls; assignRef must run after the gate.
+    const gate = js.indexOf('grid.length < 2');
+    const tableAssign = js.indexOf('assignRef(control)');
+    expect(gate).toBeGreaterThan(-1);
+    expect(tableAssign).toBeGreaterThan(gate);
+  });
+});
+
+describe('table cell interactive refs — behavior (#2056)', () => {
+  // Evaluate the generated snapshot against a real (jsdom) DOM. jsdom returns
+  // zero-size rects, which the engine prunes, so give every element a visible
+  // in-viewport box and turn off the paint-order probe (elementFromPoint is
+  // unreliable under jsdom).
+  function runSnapshot(bodyHtml: string, opts: Record<string, unknown> = {}) {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>${bodyHtml}</body></html>`, {
+      url: 'https://example.com/',
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const { window } = dom;
+    const box = { x: 0, y: 0, top: 0, left: 0, right: 120, bottom: 24, width: 120, height: 24 };
+    window.Element.prototype.getBoundingClientRect = function (): DOMRect { return box as unknown as DOMRect; };
+    Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+    const output = window.eval(generateSnapshotJs({ paintOrderCheck: false, ...opts }));
+    return { output, document: window.document };
+  }
+
+  it('gives a table-cell <button> a real ref and a [N] marker in the table', () => {
+    const { output, document } = runSnapshot(`
+      <table>
+        <tr><th>Name</th><th>Action</th></tr>
+        <tr><td>Alice</td><td><button>Details</button></td></tr>
+      </table>`);
+    const ref = document.querySelector('button')!.getAttribute('data-opencli-ref');
+    expect(ref).toBeTruthy();
+    expect(output).toContain('|table|');
+    expect(output).toContain('[' + ref + ']');
+  });
+
+  it('keeps table-cell controls in INTERACTIVE_ONLY snapshots (no ancestor pruning)', () => {
+    const { output, document } = runSnapshot(`
+      <div><section>
+        <table>
+          <tr><th>Name</th><th>Action</th></tr>
+          <tr><td>Alice</td><td><button>Follow up</button></td></tr>
+        </table>
+      </section></div>`, { interactiveOnly: true });
+    const ref = document.querySelector('button')!.getAttribute('data-opencli-ref');
+    expect(ref).toBeTruthy();
+    // the table survives even though its only interactivity lives inside cells
+    expect(output).toContain('|table|');
+    expect(output).toContain('[' + ref + ']');
+  });
+
+  it('does not assign a ref to a disabled control in a cell', () => {
+    const { document } = runSnapshot(`
+      <table>
+        <tr><th>Name</th><th>Action</th></tr>
+        <tr><td>Alice</td><td><select disabled><option>x</option></select></td></tr>
+      </table>`);
+    expect(document.querySelector('select')!.hasAttribute('data-opencli-ref')).toBe(false);
   });
 });

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -409,7 +409,10 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
         // Detect labels that wrap form controls up to two levels deep (label > span > input)
         if (hasFormControlDescendant(el, 2)) return true;
       }
-      if (el.disabled && (tag === 'button' || tag === 'input')) return false;
+      // Disabled native form controls are not actionable — exclude button /
+      // input / select / textarea alike (previously only button/input, so
+      // disabled selects & textareas leaked refs, notably in table cells).
+      if (el.disabled && (tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea')) return false;
       return true;
     }
     // Span wrappers for UI components - check if they contain form controls
@@ -623,7 +626,22 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
               } catch { text = '[' + text + '](' + href + ')'; }
             }
           }
-          cells.push(text || '');
+          // Interactive form controls inside a cell were previously dropped —
+          // no ref, so click <N> / --role / --text could not locate them (#2056).
+          // Collect the outermost enabled controls now, but DEFER assignRef: it
+          // mutates shared ref state, and the gates below can still bail out into
+          // the generic walk, which would then re-assign and orphan these refs.
+          const controls = [];
+          const claimed = [];
+          for (const control of cell.querySelectorAll('button, input, select, textarea')) {
+            // isInteractive only rejects disabled button/input; guard here so a
+            // disabled <select> / <textarea> in a cell is not given a clickable ref.
+            if (!isInteractive(control) || control.disabled) continue;
+            if (claimed.some(c => c.contains(control))) continue;
+            claimed.push(control);
+            controls.push(control);
+          }
+          cells.push({ text, controls });
         }
         if (cells.length > 0) {
           grid.push(cells);
@@ -631,25 +649,40 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
         }
       }
       if (grid.length < 2 || maxCols === 0) return false; // need at least header + 1 row
+      // The table is now committed to markdown rendering, so it is safe to claim
+      // refs. Walk the grid in document order (top-to-bottom, left-to-right) so
+      // the [N] indices stay monotonic with the surrounding tree, then fold the
+      // markers into each cell before column widths are measured.
+      let claimed = 0;
+      for (const row of grid) {
+        for (const cell of row) {
+          if (!cell.controls.length) continue;
+          const refMarks = cell.controls.map(control => '[' + assignRef(control) + ']');
+          cell.text = refMarks.join('') + (cell.text ? ' ' + cell.text : '');
+          claimed += cell.controls.length;
+        }
+      }
       // Pad rows to maxCols
-      for (const row of grid) { while (row.length < maxCols) row.push(''); }
+      for (const row of grid) { while (row.length < maxCols) row.push({ text: '', controls: [] }); }
       // Compute column widths
       const widths = [];
       for (let c = 0; c < maxCols; c++) {
         let w = 3;
-        for (const row of grid) { if (row[c].length > w) w = Math.min(row[c].length, 40); }
+        for (const row of grid) { if (row[c].text.length > w) w = Math.min(row[c].text.length, 40); }
         widths.push(w);
       }
       const indent = '  '.repeat(depth);
       const tableLines = [];
       // Header
-      tableLines.push(indent + '| ' + grid[0].map((c, i) => c.padEnd(widths[i])).join(' | ') + ' |');
+      tableLines.push(indent + '| ' + grid[0].map((c, i) => c.text.padEnd(widths[i])).join(' | ') + ' |');
       tableLines.push(indent + '| ' + widths.map(w => '-'.repeat(w)).join(' | ') + ' |');
       // Body
       for (let r = 1; r < grid.length; r++) {
-        tableLines.push(indent + '| ' + grid[r].map((c, i) => c.padEnd(widths[i])).join(' | ') + ' |');
+        tableLines.push(indent + '| ' + grid[r].map((c, i) => c.text.padEnd(widths[i])).join(' | ') + ' |');
       }
-      return tableLines;
+      // Report interactivity so INTERACTIVE_ONLY ancestors don't prune these
+      // lines and orphan the refs we just claimed (#2056).
+      return { lines: tableLines, interactive: claimed > 0 };
     } catch { return false; }
   }
 
@@ -663,6 +696,26 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   const compoundInfos = {};
   let iframeCount = 0;
   let crossOriginIndex = 0;
+
+  // Assign the next interactive ref to an element: annotate data-opencli-ref,
+  // record its fingerprint (stale-ref detection) and any compound contract,
+  // and return the index. Shared by the main walk and serializeTable so that
+  // interactive controls inside <table> cells get real, clickable refs.
+  function assignRef(el) {
+    interactiveIndex++;
+    if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
+    refIdentity['' + interactiveIndex] = {
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute('role') || '',
+      text: (el.textContent || '').trim().slice(0, 30),
+      ariaLabel: el.getAttribute('aria-label') || '',
+      id: el.id || '',
+      testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
+    };
+    const compound = compoundInfoOf(el);
+    if (compound) compoundInfos['' + interactiveIndex] = compound;
+    return interactiveIndex;
+  }
 
   function walk(el, depth, parentPropagatingRect) {
     if (depth > MAX_DEPTH) return false;
@@ -689,12 +742,15 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
 
     // Table: try markdown serialization before generic walk
     if (tag === 'table' && MARKDOWN_TABLES) {
-      const tableLines = serializeTable(el, depth);
-      if (tableLines) {
+      const table = serializeTable(el, depth);
+      if (table) {
         const indent = '  '.repeat(depth);
         lines.push(indent + '|table|');
-        for (const tl of tableLines) lines.push(tl);
-        return false; // tables usually non-interactive
+        for (const tl of table.lines) lines.push(tl);
+        // Return the table's interactivity WITHOUT re-descending into it: when
+        // cells claimed refs, ancestors must treat the subtree as interactive so
+        // INTERACTIVE_ONLY does not prune these lines and orphan those refs.
+        return table.interactive;
       }
       // Fall through to generic walk if markdown failed
     }
@@ -811,22 +867,8 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
 
     // Interactive index + data-ref + fingerprint
     if (interactive) {
-      interactiveIndex++;
-      if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
-      line += isScrollable ? '|scroll[' + interactiveIndex + ']|' : '[' + interactiveIndex + ']';
-      // Store fingerprint for stale-ref detection
-      refIdentity['' + interactiveIndex] = {
-        tag: tag,
-        role: el.getAttribute('role') || '',
-        text: (el.textContent || '').trim().slice(0, 30),
-        ariaLabel: el.getAttribute('aria-label') || '',
-        id: el.id || '',
-        testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
-      };
-      // Compound contract for date/select/file — captured per-ref so the
-      // sidecar maps one-to-one with the [N] tokens in the tree.
-      const compound = compoundInfoOf(el);
-      if (compound) compoundInfos['' + interactiveIndex] = compound;
+      const idx = assignRef(el);
+      line += isScrollable ? '|scroll[' + idx + ']|' : '[' + idx + ']';
     }
 
     // Tag + attributes


### PR DESCRIPTION
## What
`browser state` drops interactive controls (`<button>` / `<input>` / `<select>` / `<textarea>`) rendered **inside `<table>` cells**: they get no `[N]` ref, so `click <N>`, `click --text`, and `click --role button` can't locate them. Only `<a href>` links survived. This makes CRM / admin data-grids (action buttons per row) undriveable with first-class commands. Closes #2056.

## Root cause
In `src/browser/dom-snapshot.ts`: `serializeTable` only wrapped a single `a[href]` cell as a markdown link, and the walk `<table>` branch does `return false` (no descent) — so cell controls never got a `data-opencli-ref`.

## Fix
- Extract a shared `assignRef(el)` helper (data-opencli-ref + `refIdentity` fingerprint + `compoundInfoOf`), and route the main interactive path through it so table cells and the main tree assign refs identically.
- In `serializeTable`, once the table commits to markdown rendering, assign a ref to each **outermost enabled** cell control and prefix its `[N]` marker to the cell text.
- **Deferred** past the `grid.length < 2` / `maxCols` eligibility gate: the cell loop only *collects* controls, and `assignRef` runs after the gate — so a table that bails into the generic walk isn't double-assigned.
- **Disabled** `select`/`textarea` are skipped (`isInteractive` only rejects disabled button/input).
- The table branch now returns the table's interactivity (`claimed > 0`) instead of always `false`, so `INTERACTIVE_ONLY` ancestors don't prune the table and orphan the refs.

## Test
`src/browser/dom-snapshot.test.ts`: string assertions for the wiring + a jsdom `runSnapshot` that evaluates the generated script against a real DOM — asserting (a) a table-cell button gets a real `data-opencli-ref` + `[N]` marker, (b) INTERACTIVE_ONLY keeps a table wrapped in non-interactive ancestors, (c) a disabled `<select>` gets no ref.

## Verification
- `tsc --noEmit` clean
- `vitest run src/browser/dom-snapshot.test.ts` → 39 passed
- `check:typed-error-lint` / `check:silent-column-drop` → no new violations