### PR TITLE
fix(browser): end-to-end command deadlines, safe transport retries, CDP timeouts

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -11,6 +11,24 @@ let frameTargetCleanupRegistered = false;
 const CDP_RESPONSE_BODY_CAPTURE_LIMIT = 8 * 1024 * 1024;
 const CDP_REQUEST_BODY_CAPTURE_LIMIT = 1 * 1024 * 1024;
 const networkCaptures = /* @__PURE__ */ new Map();
+const CDP_COMMAND_TIMEOUT_MS = 6e4;
+const CDP_PROBE_TIMEOUT_MS = 2e3;
+async function sendDebuggerCommand(target, method, params, timeoutMs = CDP_COMMAND_TIMEOUT_MS) {
+  let timer;
+  const commandPromise = params === void 0 ? chrome.debugger.sendCommand(target, method) : chrome.debugger.sendCommand(target, method, params);
+  try {
+    return await Promise.race([
+      commandPromise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(
+          `CDP command ${method} timed out after ${Math.round(timeoutMs / 1e3)}s — the page may be blocked by a native dialog (alert/confirm/print)`
+        )), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer !== void 0) clearTimeout(timer);
+  }
+}
 function isDebuggableUrl$1(url) {
   if (!url) return true;
   return url.startsWith("http://") || url.startsWith("https://") || url === "about:blank" || url.startsWith("data:");
@@ -29,10 +47,10 @@ async function ensureAttached(tabId, aggressiveRetry = false) {
   }
   if (attached.has(tabId)) {
     try {
-      await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+      await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
         expression: "1",
         returnByValue: true
-      });
+      }, CDP_PROBE_TIMEOUT_MS);
       return;
     } catch {
       attached.delete(tabId);
@@ -83,27 +101,27 @@ async function ensureAttached(tabId, aggressiveRetry = false) {
   }
   attached.add(tabId);
   try {
-    await chrome.debugger.sendCommand({ tabId }, "Runtime.enable");
+    await sendDebuggerCommand({ tabId }, "Runtime.enable");
   } catch {
   }
   if (preservedNetworkCapture) {
     try {
-      await chrome.debugger.sendCommand({ tabId }, "Network.enable");
+      await sendDebuggerCommand({ tabId }, "Network.enable");
       networkCaptures.set(tabId, preservedNetworkCapture);
     } catch {
     }
   }
 }
-async function evaluate(tabId, expression, aggressiveRetry = false) {
+async function evaluate(tabId, expression, aggressiveRetry = false, timeoutMs = CDP_COMMAND_TIMEOUT_MS) {
   const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
   for (let attempt = 1; attempt <= MAX_EVAL_RETRIES; attempt++) {
     try {
       await ensureAttached(tabId, aggressiveRetry);
-      const result = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+      const result = await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
         expression,
         returnByValue: true,
         awaitPromise: true
-      });
+      }, timeoutMs);
       if (result.exceptionDetails) {
         const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
         throw new Error(errMsg);
@@ -134,7 +152,7 @@ async function screenshot(tabId, options = {}) {
   const needsOverride = fullPage || overrideWidth !== void 0 || overrideHeight !== void 0;
   if (needsOverride) {
     if (overrideWidth !== void 0 && fullPage) {
-      await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
+      await sendDebuggerCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
         mobile: false,
         width: overrideWidth,
         height: 0,
@@ -144,14 +162,14 @@ async function screenshot(tabId, options = {}) {
     let finalWidth = overrideWidth ?? 0;
     let finalHeight = overrideHeight ?? 0;
     if (fullPage) {
-      const metrics = await chrome.debugger.sendCommand({ tabId }, "Page.getLayoutMetrics");
+      const metrics = await sendDebuggerCommand({ tabId }, "Page.getLayoutMetrics");
       const size = metrics.cssContentSize || metrics.contentSize;
       if (size) {
         if (finalWidth === 0) finalWidth = Math.ceil(size.width);
         finalHeight = Math.ceil(size.height);
       }
     }
-    await chrome.debugger.sendCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
+    await sendDebuggerCommand({ tabId }, "Emulation.setDeviceMetricsOverride", {
       mobile: false,
       width: finalWidth,
       height: finalHeight,
@@ -163,28 +181,28 @@ async function screenshot(tabId, options = {}) {
     if (format === "jpeg" && options.quality !== void 0) {
       params.quality = Math.max(0, Math.min(100, options.quality));
     }
-    const result = await chrome.debugger.sendCommand({ tabId }, "Page.captureScreenshot", params);
+    const result = await sendDebuggerCommand({ tabId }, "Page.captureScreenshot", params);
     return result.data;
   } finally {
     if (needsOverride) {
-      await chrome.debugger.sendCommand({ tabId }, "Emulation.clearDeviceMetricsOverride").catch(() => {
+      await sendDebuggerCommand({ tabId }, "Emulation.clearDeviceMetricsOverride").catch(() => {
       });
     }
   }
 }
 async function setFileInputFiles(tabId, files, selector) {
   await ensureAttached(tabId);
-  await chrome.debugger.sendCommand({ tabId }, "DOM.enable");
-  const doc = await chrome.debugger.sendCommand({ tabId }, "DOM.getDocument");
+  await sendDebuggerCommand({ tabId }, "DOM.enable");
+  const doc = await sendDebuggerCommand({ tabId }, "DOM.getDocument");
   const query = selector || 'input[type="file"]';
-  const result = await chrome.debugger.sendCommand({ tabId }, "DOM.querySelector", {
+  const result = await sendDebuggerCommand({ tabId }, "DOM.querySelector", {
     nodeId: doc.root.nodeId,
     selector: query
   });
   if (!result.nodeId) {
     throw new Error(`No element found matching selector: ${query}`);
   }
-  await chrome.debugger.sendCommand({ tabId }, "DOM.setFileInputFiles", {
+  await sendDebuggerCommand({ tabId }, "DOM.setFileInputFiles", {
     files,
     nodeId: result.nodeId
   });
@@ -310,9 +328,9 @@ async function ensureFrameTarget(tabId, frameId, aggressiveRetry = false, target
   const key = frameTargetKey(tabId, frameId);
   const existing = frameTargets.get(key);
   if (existing) return existing;
-  await chrome.debugger.sendCommand({ tabId }, "Target.setDiscoverTargets", { discover: true }).catch(() => {
+  await sendDebuggerCommand({ tabId }, "Target.setDiscoverTargets", { discover: true }).catch(() => {
   });
-  await chrome.debugger.sendCommand({ tabId }, "Target.setAutoAttach", {
+  await sendDebuggerCommand({ tabId }, "Target.setAutoAttach", {
     autoAttach: true,
     waitForDebuggerOnStart: false,
     flatten: true,
@@ -331,7 +349,7 @@ async function ensureFrameTarget(tabId, frameId, aggressiveRetry = false, target
   return targetId;
 }
 async function resolveFrameTargetId(tabId, frameId, targetUrl) {
-  const result = await chrome.debugger.sendCommand({ tabId }, "Target.getTargets").catch(() => null);
+  const result = await sendDebuggerCommand({ tabId }, "Target.getTargets").catch(() => null);
   const targets = result?.targetInfos ?? [];
   const frameTarget = targets.find((candidate) => {
     const candidateId = candidate.targetId || candidate.id;
@@ -342,14 +360,14 @@ async function resolveFrameTargetId(tabId, frameId, targetUrl) {
   const candidates = targets.filter((target) => target.type === "iframe").map((target) => `${target.targetId || target.id || "?"} ${target.url || ""}`).join("; ");
   throw new Error(`No iframe target found for frame ${frameId}${targetUrl ? ` (${targetUrl})` : ""}. Candidates: ${candidates || "none"}`);
 }
-async function sendCommandInFrameTarget(tabId, frameId, method, params = {}, aggressiveRetry = false, _timeoutMs = 3e4, targetUrl) {
+async function sendCommandInFrameTarget(tabId, frameId, method, params = {}, aggressiveRetry = false, timeoutMs = CDP_COMMAND_TIMEOUT_MS, targetUrl) {
   const targetId = await ensureFrameTarget(tabId, frameId, aggressiveRetry, targetUrl);
   const target = { targetId };
-  return chrome.debugger.sendCommand(target, method, params);
+  return sendDebuggerCommand(target, method, params, timeoutMs);
 }
 async function insertText(tabId, text) {
   await ensureAttached(tabId);
-  await chrome.debugger.sendCommand({ tabId }, "Input.insertText", { text });
+  await sendDebuggerCommand({ tabId }, "Input.insertText", { text });
 }
 function registerFrameTracking() {
   registerFrameTargetCleanup();
@@ -387,22 +405,22 @@ function registerFrameTracking() {
 }
 async function getFrameTree(tabId) {
   await ensureAttached(tabId);
-  return chrome.debugger.sendCommand({ tabId }, "Page.getFrameTree");
+  return sendDebuggerCommand({ tabId }, "Page.getFrameTree");
 }
-async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = false) {
+async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = false, timeoutMs = CDP_COMMAND_TIMEOUT_MS) {
   await ensureAttached(tabId, aggressiveRetry);
-  await chrome.debugger.sendCommand({ tabId }, "Runtime.enable").catch(() => {
+  await sendDebuggerCommand({ tabId }, "Runtime.enable").catch(() => {
   });
   const contexts = tabFrameContexts.get(tabId);
   const contextId = contexts?.get(frameId);
   if (contextId !== void 0) {
     try {
-      const result2 = await chrome.debugger.sendCommand({ tabId }, "Runtime.evaluate", {
+      const result2 = await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
         expression,
         contextId,
         returnByValue: true,
         awaitPromise: true
-      });
+      }, timeoutMs);
       if (result2.exceptionDetails) {
         const errMsg = result2.exceptionDetails.exception?.description || result2.exceptionDetails.text || "Eval error";
         throw new Error(errMsg);
@@ -421,7 +439,7 @@ async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = fal
     expression,
     returnByValue: true,
     awaitPromise: true
-  }, aggressiveRetry);
+  }, aggressiveRetry, timeoutMs);
   if (result.exceptionDetails) {
     const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
     throw new Error(errMsg);
@@ -466,7 +484,7 @@ function getOrCreateNetworkCaptureEntry(tabId, requestId, fallback) {
 }
 async function startNetworkCapture(tabId, pattern) {
   await ensureAttached(tabId);
-  await chrome.debugger.sendCommand({ tabId }, "Network.enable");
+  await sendDebuggerCommand({ tabId }, "Network.enable");
   networkCaptures.set(tabId, {
     patterns: normalizeCapturePatterns(pattern),
     entries: [],
@@ -552,7 +570,7 @@ function registerListeners() {
           entry.requestBodyTruncated = truncated;
         }
         try {
-          const postData = await chrome.debugger.sendCommand({ tabId }, "Network.getRequestPostData", { requestId });
+          const postData = await sendDebuggerCommand({ tabId }, "Network.getRequestPostData", { requestId });
           if (postData?.postData) {
             const raw = postData.postData;
             const fullSize = raw.length;
@@ -586,7 +604,7 @@ function registerListeners() {
       const entry = state.entries[stateEntryIndex];
       if (!entry) return;
       try {
-        const body = await chrome.debugger.sendCommand({ tabId }, "Network.getResponseBody", { requestId });
+        const body = await sendDebuggerCommand({ tabId }, "Network.getResponseBody", { requestId });
         if (typeof body?.body === "string") {
           const fullSize = body.body.length;
           const truncated = fullSize > CDP_RESPONSE_BODY_CAPTURE_LIMIT;
@@ -1758,6 +1776,12 @@ async function listAutomationWebTabs(leaseKey) {
   const tabs = await listAutomationTabs(leaseKey);
   return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
+function commandCdpTimeoutMs(cmd) {
+  if (typeof cmd.timeout === "number" && cmd.timeout > 0) {
+    return Math.max(1e4, cmd.timeout * 1e3 - 5e3);
+  }
+  return void 0;
+}
 async function handleExec(cmd, leaseKey) {
   if (!cmd.code) return { id: cmd.id, ok: false, error: "Missing code" };
   const cmdTabId = await resolveCommandTabId(cmd);
@@ -1770,10 +1794,10 @@ async function handleExec(cmd, leaseKey) {
       if (cmd.frameIndex < 0 || cmd.frameIndex >= frames.length) {
         return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${frames.length} cross-origin frames available)` };
       }
-      const data2 = await evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive);
+      const data2 = await evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive, commandCdpTimeoutMs(cmd));
       return pageScopedResult(cmd.id, tabId, data2);
     }
-    const data = await evaluateAsync(tabId, cmd.code, aggressive);
+    const data = await evaluateAsync(tabId, cmd.code, aggressive, commandCdpTimeoutMs(cmd));
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -2039,10 +2063,11 @@ async function handleCdp(cmd, leaseKey) {
     const params = cmd.cdpParams ?? {};
     const routeFrameId = typeof params.frameId === "string" && params.sessionId === "target" ? params.frameId : void 0;
     const routeTargetUrl = typeof params.targetUrl === "string" ? params.targetUrl : void 0;
-    const data = routeFrameId ? await sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive, 3e4, routeTargetUrl) : await chrome.debugger.sendCommand(
+    const data = routeFrameId ? await sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive, commandCdpTimeoutMs(cmd) ?? 3e4, routeTargetUrl) : await sendDebuggerCommand(
       { tabId },
       cmd.cdpMethod,
-      stripOpenCliFrameRoutingParams(params, false)
+      stripOpenCliFrameRoutingParams(params, false),
+      commandCdpTimeoutMs(cmd)
     );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -436,7 +436,7 @@ async function evaluateInFrame(tabId, expression, frameId, aggressiveRetry = fal
       contexts?.delete(frameId);
     }
   }
-  await sendCommandInFrameTarget(tabId, frameId, "Runtime.enable", {}, aggressiveRetry).catch(() => void 0);
+  await sendCommandInFrameTarget(tabId, frameId, "Runtime.enable", {}, aggressiveRetry, timeoutMs).catch(() => void 0);
   const result = await sendCommandInFrameTarget(tabId, frameId, "Runtime.evaluate", {
     expression,
     returnByValue: true,

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -16,6 +16,8 @@ const CDP_PROBE_TIMEOUT_MS = 2e3;
 async function sendDebuggerCommand(target, method, params, timeoutMs = CDP_COMMAND_TIMEOUT_MS) {
   let timer;
   const commandPromise = params === void 0 ? chrome.debugger.sendCommand(target, method) : chrome.debugger.sendCommand(target, method, params);
+  commandPromise.catch(() => {
+  });
   try {
     return await Promise.race([
       commandPromise,

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -552,7 +552,8 @@ describe('background tab isolation', () => {
       { index: 1, frameId: 'cross-origin-sibling', url: 'https://y.example/iframe', name: 'sibling-y' },
     ]);
     expect(execResult.ok).toBe(true);
-    expect(evaluateInFrame).toHaveBeenCalledWith(1, 'document.title', 'cross-origin-nested', false);
+    // Fifth arg is the CDP deadline derived from cmd.timeout (undefined here — no timeout on the command).
+    expect(evaluateInFrame).toHaveBeenCalledWith(1, 'document.title', 'cross-origin-nested', false, undefined);
   });
 
   it('creates new tabs inside the automation container', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -556,6 +556,53 @@ describe('background tab isolation', () => {
     expect(evaluateInFrame).toHaveBeenCalledWith(1, 'document.title', 'cross-origin-nested', false, undefined);
   });
 
+  it('derives the CDP deadline from cmd.timeout for exec (timeout*1000 - 5s, floor 10s)', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const evaluateAsync = vi.fn(async () => 'main-result');
+    vi.doMock('./cdp', () => ({
+      registerListeners: vi.fn(),
+      registerFrameTracking: vi.fn(),
+      hasActiveNetworkCapture: vi.fn(() => false),
+      detach: vi.fn(async () => {}),
+      evaluateAsync,
+      evaluateInFrame: vi.fn(),
+      getFrameTree: vi.fn(),
+      screenshot: vi.fn(),
+      setFileInputFiles: vi.fn(),
+      insertText: vi.fn(),
+      startNetworkCapture: vi.fn(),
+      readNetworkCapture: vi.fn(async () => []),
+      ensureAttached: vi.fn(),
+    }));
+
+    const mod = await import('./background');
+    mod.__test__.setAutomationWindowId(adapterKey('twitter'), 1);
+
+    // 120s transport timeout → 115s CDP deadline
+    await mod.__test__.handleCommand({
+      id: 'exec-with-timeout',
+      action: 'exec',
+      code: '1',
+      session: 'twitter',
+      surface: 'adapter',
+      timeout: 120,
+    });
+    expect(evaluateAsync).toHaveBeenLastCalledWith(1, '1', false, 115_000);
+
+    // Tiny transport timeout → clamped to the 10s floor
+    await mod.__test__.handleCommand({
+      id: 'exec-with-tiny-timeout',
+      action: 'exec',
+      code: '1',
+      session: 'twitter',
+      surface: 'adapter',
+      timeout: 8,
+    });
+    expect(evaluateAsync).toHaveBeenLastCalledWith(1, '1', false, 10_000);
+  });
+
   it('creates new tabs inside the automation container', async () => {
     const { chrome, create } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1490,6 +1490,20 @@ async function listAutomationWebTabs(leaseKey: string): Promise<chrome.tabs.Tab[
   return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
 
+/**
+ * Derive the per-command CDP deadline from the daemon-side timeout (seconds)
+ * the CLI transport put on the command. Undercut it by 5s so this (more
+ * specific) error reaches the CLI before the daemon's generic timer fires.
+ * Returns undefined when the command carries no timeout — callers fall back
+ * to the executor's default deadline.
+ */
+function commandCdpTimeoutMs(cmd: Command): number | undefined {
+  if (typeof cmd.timeout === 'number' && cmd.timeout > 0) {
+    return Math.max(10_000, cmd.timeout * 1000 - 5_000);
+  }
+  return undefined;
+}
+
 async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
   if (!cmd.code) return { id: cmd.id, ok: false, error: 'Missing code' };
   const cmdTabId = await resolveCommandTabId(cmd);
@@ -1502,10 +1516,10 @@ async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
       if (cmd.frameIndex < 0 || cmd.frameIndex >= frames.length) {
         return { id: cmd.id, ok: false, error: `Frame index ${cmd.frameIndex} out of range (${frames.length} cross-origin frames available)` };
       }
-      const data = await executor.evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive);
+      const data = await executor.evaluateInFrame(tabId, cmd.code, frames[cmd.frameIndex].frameId, aggressive, commandCdpTimeoutMs(cmd));
       return pageScopedResult(cmd.id, tabId, data);
     }
-    const data = await executor.evaluateAsync(tabId, cmd.code, aggressive);
+    const data = await executor.evaluateAsync(tabId, cmd.code, aggressive, commandCdpTimeoutMs(cmd));
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
     return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -1809,11 +1823,12 @@ async function handleCdp(cmd: Command, leaseKey: string): Promise<Result> {
       : undefined;
     const routeTargetUrl = typeof params.targetUrl === 'string' ? params.targetUrl : undefined;
     const data = routeFrameId
-      ? await executor.sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive, 30_000, routeTargetUrl)
-      : await chrome.debugger.sendCommand(
+      ? await executor.sendCommandInFrameTarget(tabId, routeFrameId, cmd.cdpMethod, stripOpenCliFrameRoutingParams(params, true), aggressive, commandCdpTimeoutMs(cmd) ?? 30_000, routeTargetUrl)
+      : await executor.sendDebuggerCommand(
         { tabId },
         cmd.cdpMethod,
         stripOpenCliFrameRoutingParams(params, false),
+        commandCdpTimeoutMs(cmd),
       );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -608,3 +608,49 @@ describe('cdp evaluateInFrame stale context fallback', () => {
     expect(debuggerApi.attach).toHaveBeenCalledWith({ targetId: 'stale-frame' }, '1.3');
   });
 });
+
+describe('cdp command deadline', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function createHangingChromeMock() {
+    const { chrome, debuggerApi } = createChromeMock();
+    // A page-blocking native dialog (alert/confirm) makes Runtime.evaluate
+    // never resolve; every other command still works.
+    debuggerApi.sendCommand = vi.fn((_target: unknown, method: string) => {
+      if (method === 'Runtime.evaluate') return new Promise<never>(() => {});
+      return Promise.resolve({});
+    }) as typeof debuggerApi.sendCommand;
+    return { chrome, debuggerApi };
+  }
+
+  it('evaluate rejects instead of hanging forever when Runtime.evaluate never resolves', async () => {
+    vi.useFakeTimers();
+    const { chrome } = createHangingChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const pending = mod.evaluate(1, 'alert("blocked")');
+    const assertion = expect(pending).rejects.toThrow(/timed out after 60s/);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+  });
+
+  it('evaluate honors a caller-supplied deadline from the command timeout', async () => {
+    vi.useFakeTimers();
+    const { chrome } = createHangingChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./cdp');
+    const pending = mod.evaluate(1, 'alert("blocked")', false, 10_000);
+    const assertion = expect(pending).rejects.toThrow(/timed out after 10s/);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+  });
+});

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -85,6 +85,10 @@ export async function sendDebuggerCommand<T = unknown>(
   const commandPromise = (params === undefined
     ? chrome.debugger.sendCommand(target, method)
     : chrome.debugger.sendCommand(target, method, params)) as Promise<T>;
+  // If the timeout wins the race, the command promise may still reject much
+  // later (e.g. debugger detach on tab close) — swallow that on a side branch
+  // so it never surfaces as an unhandled rejection in the service worker.
+  commandPromise.catch(() => {});
   try {
     return await Promise.race([
       commandPromise,

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -58,6 +58,47 @@ export type DownloadWaitResult = {
 };
 
 const networkCaptures = new Map<number, NetworkCaptureState>();
+
+/**
+ * Default deadline for a single chrome.debugger command. chrome.debugger has
+ * no timeout of its own: a page-blocking native dialog (alert/confirm/print/
+ * beforeunload) makes Runtime.evaluate hang forever, wedging every later
+ * command on the tab. Long enough for legitimate in-page waits (default 30s
+ * plus headroom), short enough to fail before the daemon's 120s timer.
+ */
+const CDP_COMMAND_TIMEOUT_MS = 60_000;
+/** Health-check probe deadline — a blocked probe should fail fast. */
+const CDP_PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * chrome.debugger.sendCommand with a deadline. The underlying command cannot
+ * be cancelled — this only unblocks the caller so the CLI gets an error
+ * instead of an infinite hang.
+ */
+export async function sendDebuggerCommand<T = unknown>(
+  target: chrome.debugger.Debuggee,
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs: number = CDP_COMMAND_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const commandPromise = (params === undefined
+    ? chrome.debugger.sendCommand(target, method)
+    : chrome.debugger.sendCommand(target, method, params)) as Promise<T>;
+  try {
+    return await Promise.race([
+      commandPromise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(
+          `CDP command ${method} timed out after ${Math.round(timeoutMs / 1000)}s — the page may be blocked by a native dialog (alert/confirm/print)`,
+        )), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 /** Check if a URL can be attached via CDP — only allow http(s) and blank pages. */
 function isDebuggableUrl(url?: string): boolean {
   if (!url) return true;  // empty/undefined = tab still loading, allow it
@@ -83,9 +124,9 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
   if (attached.has(tabId)) {
     // Verify the debugger is still actually attached by sending a harmless command
     try {
-      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+      await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
         expression: '1', returnByValue: true,
-      });
+      }, CDP_PROBE_TIMEOUT_MS);
       return; // Still attached and working
     } catch {
       // Stale cache entry — need to re-attach
@@ -158,7 +199,7 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
   attached.add(tabId);
 
   try {
-    await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable');
+    await sendDebuggerCommand({ tabId }, 'Runtime.enable');
   } catch {
     // Some pages may not need explicit enable
   }
@@ -170,7 +211,7 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
   // while those awaits yield to the event loop.
   if (preservedNetworkCapture) {
     try {
-      await chrome.debugger.sendCommand({ tabId }, 'Network.enable');
+      await sendDebuggerCommand({ tabId }, 'Network.enable');
       networkCaptures.set(tabId, preservedNetworkCapture);
     } catch {
       // Leave capture cleared rather than arm a half-attached Network domain;
@@ -179,7 +220,12 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
   }
 }
 
-export async function evaluate(tabId: number, expression: string, aggressiveRetry: boolean = false): Promise<unknown> {
+export async function evaluate(
+  tabId: number,
+  expression: string,
+  aggressiveRetry: boolean = false,
+  timeoutMs: number = CDP_COMMAND_TIMEOUT_MS,
+): Promise<unknown> {
   // Retry the entire evaluate (attach + command).
   // Normal: 2 retries. Browser: 3 retries (tolerates extension interference).
   const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
@@ -187,11 +233,11 @@ export async function evaluate(tabId: number, expression: string, aggressiveRetr
     try {
       await ensureAttached(tabId, aggressiveRetry);
 
-      const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+      const result = await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
         expression,
         returnByValue: true,
         awaitPromise: true,
-      }) as {
+      }, timeoutMs) as {
         result?: { type: string; value?: unknown; description?: string; subtype?: string };
         exceptionDetails?: { exception?: { description?: string }; text?: string };
       };
@@ -245,7 +291,7 @@ export async function screenshot(
   if (needsOverride) {
     // When width is set, apply it first so layout reflows before we read content size.
     if (overrideWidth !== undefined && fullPage) {
-      await chrome.debugger.sendCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
+      await sendDebuggerCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
         mobile: false,
         width: overrideWidth,
         height: 0,
@@ -255,7 +301,7 @@ export async function screenshot(
     let finalWidth = overrideWidth ?? 0;
     let finalHeight = overrideHeight ?? 0;
     if (fullPage) {
-      const metrics = await chrome.debugger.sendCommand({ tabId }, 'Page.getLayoutMetrics') as {
+      const metrics = await sendDebuggerCommand({ tabId }, 'Page.getLayoutMetrics') as {
         contentSize?: { width: number; height: number };
         cssContentSize?: { width: number; height: number };
       };
@@ -265,7 +311,7 @@ export async function screenshot(
         finalHeight = Math.ceil(size.height);
       }
     }
-    await chrome.debugger.sendCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
+    await sendDebuggerCommand({ tabId }, 'Emulation.setDeviceMetricsOverride', {
       mobile: false,
       width: finalWidth,
       height: finalHeight,
@@ -279,14 +325,14 @@ export async function screenshot(
       params.quality = Math.max(0, Math.min(100, options.quality));
     }
 
-    const result = await chrome.debugger.sendCommand({ tabId }, 'Page.captureScreenshot', params) as {
+    const result = await sendDebuggerCommand({ tabId }, 'Page.captureScreenshot', params) as {
       data: string; // base64-encoded
     };
 
     return result.data;
   } finally {
     if (needsOverride) {
-      await chrome.debugger.sendCommand({ tabId }, 'Emulation.clearDeviceMetricsOverride').catch(() => {});
+      await sendDebuggerCommand({ tabId }, 'Emulation.clearDeviceMetricsOverride').catch(() => {});
     }
   }
 }
@@ -308,16 +354,16 @@ export async function setFileInputFiles(
   await ensureAttached(tabId);
 
   // Enable DOM domain (required for DOM.querySelector and DOM.setFileInputFiles)
-  await chrome.debugger.sendCommand({ tabId }, 'DOM.enable');
+  await sendDebuggerCommand({ tabId }, 'DOM.enable');
 
   // Get the document root
-  const doc = await chrome.debugger.sendCommand({ tabId }, 'DOM.getDocument') as {
+  const doc = await sendDebuggerCommand({ tabId }, 'DOM.getDocument') as {
     root: { nodeId: number };
   };
 
   // Find the file input element
   const query = selector || 'input[type="file"]';
-  const result = await chrome.debugger.sendCommand({ tabId }, 'DOM.querySelector', {
+  const result = await sendDebuggerCommand({ tabId }, 'DOM.querySelector', {
     nodeId: doc.root.nodeId,
     selector: query,
   }) as { nodeId: number };
@@ -327,7 +373,7 @@ export async function setFileInputFiles(
   }
 
   // Set files directly via CDP — Chrome reads from local filesystem
-  await chrome.debugger.sendCommand({ tabId }, 'DOM.setFileInputFiles', {
+  await sendDebuggerCommand({ tabId }, 'DOM.setFileInputFiles', {
     files,
     nodeId: result.nodeId,
   });
@@ -471,8 +517,8 @@ async function ensureFrameTarget(
   const existing = frameTargets.get(key);
   if (existing) return existing;
 
-  await chrome.debugger.sendCommand({ tabId }, 'Target.setDiscoverTargets', { discover: true }).catch(() => {});
-  await chrome.debugger.sendCommand({ tabId }, 'Target.setAutoAttach', {
+  await sendDebuggerCommand({ tabId }, 'Target.setDiscoverTargets', { discover: true }).catch(() => {});
+  await sendDebuggerCommand({ tabId }, 'Target.setAutoAttach', {
     autoAttach: true,
     waitForDebuggerOnStart: false,
     flatten: true,
@@ -491,7 +537,7 @@ async function ensureFrameTarget(
 }
 
 async function resolveFrameTargetId(tabId: number, frameId: string, targetUrl?: string): Promise<string> {
-  const result = await chrome.debugger.sendCommand({ tabId }, 'Target.getTargets').catch(() => null) as
+  const result = await sendDebuggerCommand({ tabId }, 'Target.getTargets').catch(() => null) as
     | { targetInfos?: Array<{ targetId?: string; id?: string; type?: string; url?: string }> }
     | null;
   const targets = result?.targetInfos ?? [];
@@ -518,12 +564,12 @@ export async function sendCommandInFrameTarget(
   method: string,
   params: Record<string, unknown> = {},
   aggressiveRetry: boolean = false,
-  _timeoutMs: number = 30_000,
+  timeoutMs: number = CDP_COMMAND_TIMEOUT_MS,
   targetUrl?: string,
 ): Promise<unknown> {
   const targetId = await ensureFrameTarget(tabId, frameId, aggressiveRetry, targetUrl);
   const target = { targetId } as chrome.debugger.Debuggee;
-  return chrome.debugger.sendCommand(target, method, params);
+  return sendDebuggerCommand(target, method, params, timeoutMs);
 }
 
 export async function insertText(
@@ -531,7 +577,7 @@ export async function insertText(
   text: string,
 ): Promise<void> {
   await ensureAttached(tabId);
-  await chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text });
+  await sendDebuggerCommand({ tabId }, 'Input.insertText', { text });
 }
 
 export function registerFrameTracking(): void {
@@ -572,7 +618,7 @@ export function registerFrameTracking(): void {
 
 export async function getFrameTree(tabId: number): Promise<any> {
   await ensureAttached(tabId);
-  return chrome.debugger.sendCommand({ tabId }, 'Page.getFrameTree');
+  return sendDebuggerCommand({ tabId }, 'Page.getFrameTree');
 }
 
 export async function evaluateInFrame(
@@ -580,22 +626,23 @@ export async function evaluateInFrame(
   expression: string,
   frameId: string,
   aggressiveRetry: boolean = false,
+  timeoutMs: number = CDP_COMMAND_TIMEOUT_MS,
 ): Promise<unknown> {
   await ensureAttached(tabId, aggressiveRetry);
 
-  await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable').catch(() => {});
+  await sendDebuggerCommand({ tabId }, 'Runtime.enable').catch(() => {});
 
   const contexts = tabFrameContexts.get(tabId);
   const contextId = contexts?.get(frameId);
 
   if (contextId !== undefined) {
     try {
-      const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+      const result = await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
         expression,
         contextId,
         returnByValue: true,
         awaitPromise: true,
-      }) as {
+      }, timeoutMs) as {
         result?: { type: string; value?: unknown; description?: string; subtype?: string };
         exceptionDetails?: { exception?: { description?: string }; text?: string };
       };
@@ -627,7 +674,7 @@ export async function evaluateInFrame(
     expression,
     returnByValue: true,
     awaitPromise: true,
-  }, aggressiveRetry) as {
+  }, aggressiveRetry, timeoutMs) as {
     result?: { type: string; value?: unknown; description?: string; subtype?: string };
     exceptionDetails?: { exception?: { description?: string }; text?: string };
   };
@@ -694,7 +741,7 @@ export async function startNetworkCapture(
   pattern?: string,
 ): Promise<void> {
   await ensureAttached(tabId);
-  await chrome.debugger.sendCommand({ tabId }, 'Network.enable');
+  await sendDebuggerCommand({ tabId }, 'Network.enable');
   networkCaptures.set(tabId, {
     patterns: normalizeCapturePatterns(pattern),
     entries: [],
@@ -794,7 +841,7 @@ export function registerListeners(): void {
           entry.requestBodyTruncated = truncated;
         }
         try {
-          const postData = await chrome.debugger.sendCommand({ tabId }, 'Network.getRequestPostData', { requestId }) as { postData?: string };
+          const postData = await sendDebuggerCommand({ tabId }, 'Network.getRequestPostData', { requestId }) as { postData?: string };
           if (postData?.postData) {
             const raw = postData.postData;
             const fullSize = raw.length;
@@ -841,7 +888,7 @@ export function registerListeners(): void {
       const entry = state.entries[stateEntryIndex];
       if (!entry) return;
       try {
-        const body = await chrome.debugger.sendCommand({ tabId }, 'Network.getResponseBody', { requestId }) as {
+        const body = await sendDebuggerCommand({ tabId }, 'Network.getResponseBody', { requestId }) as {
           body?: string;
           base64Encoded?: boolean;
         };

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -673,7 +673,7 @@ export async function evaluateInFrame(
   }
 
   // No cached context, or the cached one went stale: resolve via the frame target.
-  await sendCommandInFrameTarget(tabId, frameId, 'Runtime.enable', {}, aggressiveRetry).catch(() => undefined);
+  await sendCommandInFrameTarget(tabId, frameId, 'Runtime.enable', {}, aggressiveRetry, timeoutMs).catch(() => undefined);
   const result = await sendCommandInFrameTarget(tabId, frameId, 'Runtime.evaluate', {
     expression,
     returnByValue: true,

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -77,6 +77,12 @@ export interface Command {
   frameIndex?: number;
   /** Browser profile/context selected by the CLI. Used by the daemon for routing. */
   contextId?: string;
+  /**
+   * Daemon-side command timeout in seconds, set by the CLI transport. The
+   * extension derives its CDP deadline from this so it fails just before the
+   * daemon timer and its (more specific) error wins.
+   */
+  timeout?: number;
 }
 
 export interface Result {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -6,6 +6,7 @@ import {
   getDaemonHealth,
   requestDaemonShutdown,
   sendCommand,
+  setDaemonCommandTimeoutSeconds,
 } from './daemon-client.js';
 import * as daemonLifecycle from './daemon-lifecycle.js';
 
@@ -309,7 +310,7 @@ describe('daemon-client', () => {
     expect(ids[0]).not.toBe(ids[1]);
   });
 
-  it('sendCommand runs full bridge ensure on a local TypeError before resending', async () => {
+  it('sendCommand runs full bridge ensure on a pre-connect TypeError (ECONNREFUSED) before resending', async () => {
     const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady').mockResolvedValue({
       health: {
         state: 'ready',
@@ -325,9 +326,11 @@ describe('daemon-client', () => {
       },
       spawnedProcess: null,
     });
+    const refused = new TypeError('fetch failed');
+    (refused as { cause?: unknown }).cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:19825'), { code: 'ECONNREFUSED' });
     const fetchMock = vi.mocked(fetch);
     fetchMock
-      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockRejectedValueOnce(refused)
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -338,6 +341,34 @@ describe('daemon-client', () => {
 
     expect(ensureSpy).toHaveBeenCalledWith(expect.objectContaining({ verbose: false }));
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('sendCommand does NOT resend on a post-connect TypeError (ECONNRESET) — surfaces command_result_unknown', async () => {
+    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
+    const reset = new TypeError('fetch failed');
+    (reset as { cause?: unknown }).cause = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    vi.mocked(fetch).mockRejectedValueOnce(reset);
+
+    await expect(sendCommand('navigate', { url: 'https://example.com' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: 'command_result_unknown',
+    } satisfies Partial<BrowserCommandError>);
+
+    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendCommand does NOT resend on a bare TypeError with no pre-connect cause', async () => {
+    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    await expect(sendCommand('exec', { code: 'window.__mutate = true' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: 'command_result_unknown',
+    } satisfies Partial<BrowserCommandError>);
+
+    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('sendCommand does NOT wait when the bridge reports profile_required', async () => {
@@ -361,6 +392,54 @@ describe('daemon-client', () => {
 
     expect(ensureSpy).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendCommand plumbs the default command timeout into body.timeout', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 1 }),
+    } as Response);
+
+    await expect(sendCommand('exec', { code: '1' })).resolves.toBe(1);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body)) as { timeout?: number };
+    expect(body.timeout).toBe(120);
+  });
+
+  it('sendCommand extends body.timeout past an extension-side timeoutMs (wait-download)', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: { downloaded: true } }),
+    } as Response);
+
+    await sendCommand('wait-download', { timeoutMs: 240_000 });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body)) as { timeout?: number };
+    // 240s extension wait + 15s margin
+    expect(body.timeout).toBe(255);
+  });
+
+  it('setDaemonCommandTimeoutSeconds raises the transport deadline for the user --timeout', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 1 }),
+    } as Response);
+
+    setDaemonCommandTimeoutSeconds(300);
+    try {
+      await sendCommand('exec', { code: '1' });
+    } finally {
+      setDaemonCommandTimeoutSeconds(null);
+    }
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body)) as { timeout?: number };
+    expect(body.timeout).toBe(300);
   });
 
   it('sendCommand surfaces an AbortError as command_result_unknown without ensure or resend', async () => {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -442,6 +442,36 @@ describe('daemon-client', () => {
     expect(body.timeout).toBe(300);
   });
 
+  it('client HTTP abort fires only after the daemon timer margin (timeout*1000 + 10s)', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.mocked(fetch);
+      let aborted = false;
+      fetchMock.mockImplementationOnce((_url, init) => new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true;
+          reject(Object.assign(new Error('This operation was aborted'), { name: 'AbortError' }));
+        });
+      }));
+
+      const pending = sendCommand('exec', { code: '1' });
+      const assertion = expect(pending).rejects.toMatchObject({
+        name: 'BrowserCommandError',
+        code: 'command_result_unknown',
+      } satisfies Partial<BrowserCommandError>);
+
+      // Just before the margin the daemon still owns the deadline — no abort.
+      await vi.advanceTimersByTimeAsync(120_000 + 9_999);
+      expect(aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(aborted).toBe(true);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('sendCommand surfaces an AbortError as command_result_unknown without ensure or resend', async () => {
     const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
     const abortErr = new Error('The operation was aborted');

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -6,6 +6,7 @@
 
 import { sleep } from '../utils.js';
 import { BrowserConnectError } from '../errors.js';
+import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT } from '../daemon-utils.js';
 import { classifyBrowserError } from './errors.js';
 import { resolveProfileContextId } from './profile.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './config.js';
@@ -25,6 +26,69 @@ let _idCounter = 0;
 
 function generateId(): string {
   return `cmd_${process.pid}_${Date.now()}_${++_idCounter}`;
+}
+
+/**
+ * Transport-level deadlines share one source of truth: `body.timeout` (seconds).
+ * The daemon arms its per-command timer from it, the extension derives its CDP
+ * deadline from the same value, and the client HTTP abort fires only after the
+ * daemon's structured timeout response should have arrived — so failures
+ * surface innermost-first (extension < daemon < client) with a real error
+ * instead of an opaque client-side AbortError.
+ */
+const DEFAULT_COMMAND_TIMEOUT_SECONDS = 120;
+/** Headroom past an extension-side operation's own timer (e.g. wait-download). */
+const EXTENSION_OP_TIMEOUT_MARGIN_MS = 15_000;
+/** Client aborts only this long after the daemon timer should have fired. */
+const HTTP_TIMEOUT_MARGIN_MS = 10_000;
+
+let _userCommandTimeoutSeconds: number | null = null;
+
+/**
+ * Propagate the user's `--timeout` down to the transport layer. Without this
+ * the daemon/HTTP deadlines stay at their defaults and a long-running command
+ * gets aborted mid-flight even though the user explicitly allowed more time.
+ */
+export function setDaemonCommandTimeoutSeconds(seconds: number | null): void {
+  _userCommandTimeoutSeconds = typeof seconds === 'number' && seconds > 0 ? Math.ceil(seconds) : null;
+}
+
+function effectiveCommandTimeoutSeconds(params: Omit<DaemonCommand, 'id' | 'action'>): number {
+  const base = _userCommandTimeoutSeconds ?? DEFAULT_COMMAND_TIMEOUT_SECONDS;
+  if (typeof params.timeoutMs === 'number' && params.timeoutMs > 0) {
+    return Math.max(base, Math.ceil((params.timeoutMs + EXTENSION_OP_TIMEOUT_MARGIN_MS) / 1000));
+  }
+  return base;
+}
+
+/**
+ * undici surfaces network failures as `TypeError: fetch failed` with the real
+ * error in `.cause` (possibly an AggregateError). Only failures that happen
+ * before the request could reach the daemon are safe to auto-retry — a reset
+ * or hang-up after connect means the daemon may have already dispatched the
+ * command to the browser.
+ */
+const PRE_CONNECT_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+]);
+
+function isPreConnectFetchError(err: unknown): boolean {
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+  while (queue.length) {
+    const current = queue.pop();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    const { code, cause, errors } = current as { code?: unknown; cause?: unknown; errors?: unknown };
+    if (typeof code === 'string' && PRE_CONNECT_ERROR_CODES.has(code)) return true;
+    if (cause) queue.push(cause);
+    if (Array.isArray(errors)) queue.push(...errors);
+  }
+  return false;
 }
 
 export interface DaemonCommand {
@@ -69,6 +133,12 @@ export interface DaemonCommand {
   frameIndex?: number;
   /** Browser profile/context to route the command to. */
   contextId?: string;
+  /**
+   * Daemon-side command timeout in seconds. Set by the transport layer from
+   * the effective command deadline; the extension derives its CDP deadline
+   * from the same value.
+   */
+  timeout?: number;
 }
 
 export interface DaemonResult {
@@ -104,8 +174,12 @@ export {
  * Retry policy is explicit:
  * - pre-dispatch bridge/profile errors: run the full daemon/extension ensure
  *   path, then resend with a fresh transport id;
- * - local TypeError before dispatch: same full ensure path, because the daemon
- *   may be stopped/stale and needs spawn/replacement, not just polling;
+ * - fetch TypeError whose cause is a pre-connect failure (ECONNREFUSED etc.):
+ *   same full ensure path, because the daemon may be stopped/stale and needs
+ *   spawn/replacement — the request never reached it, so resending is safe;
+ * - fetch TypeError after connect (ECONNRESET / socket hang-up): NOT retried —
+ *   the daemon may have already dispatched the command to the browser, so this
+ *   surfaces as `command_result_unknown` instead of risking a double write;
  * - `command_result_unknown` and AbortError: never retry automatically.
  */
 async function sendCommandRaw(
@@ -125,13 +199,21 @@ async function sendCommandRaw(
       : undefined;
     const contextId = params.contextId ?? resolveProfileContextId();
     const windowMode = params.windowMode ?? envWindowMode;
-    const command: DaemonCommand = { id, action, ...params, ...(contextId && { contextId }), ...(windowMode && { windowMode }) };
+    const timeoutSeconds = effectiveCommandTimeoutSeconds(params);
+    const command: DaemonCommand = {
+      id,
+      action,
+      ...params,
+      timeout: timeoutSeconds,
+      ...(contextId && { contextId }),
+      ...(windowMode && { windowMode }),
+    };
     try {
       const res = await requestDaemon('/command', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(command),
-        timeout: 30000,
+        timeout: timeoutSeconds * 1000 + HTTP_TIMEOUT_MARGIN_MS,
       });
 
       const result = (await res.json()) as DaemonResult;
@@ -179,14 +261,26 @@ async function sendCommandRaw(
         );
       }
 
-      if (!dispatchRecoveryUsed && err instanceof TypeError) {
-        dispatchRecoveryUsed = true;
-        await ensureBrowserBridgeReady({
-          timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
-          contextId,
-          verbose: false,
-        });
-        continue;
+      if (err instanceof TypeError) {
+        if (!isPreConnectFetchError(err)) {
+          // Connection dropped after the request may have reached the daemon
+          // (ECONNRESET / socket hang-up) — the command may already be running
+          // in the browser, so resending would risk a double write.
+          throw new BrowserCommandError(
+            'Connection to the daemon was lost mid-command; it may have already been applied.',
+            COMMAND_RESULT_UNKNOWN_CODE,
+            COMMAND_RESULT_UNKNOWN_HINT,
+          );
+        }
+        if (!dispatchRecoveryUsed) {
+          dispatchRecoveryUsed = true;
+          await ensureBrowserBridgeReady({
+            timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
+            contextId,
+            verbose: false,
+          });
+          continue;
+        }
       }
 
       if (err instanceof Error) {

--- a/src/daemon-utils.ts
+++ b/src/daemon-utils.ts
@@ -35,6 +35,16 @@ export function buildExtensionDisconnectFailure(input: {
   return buildCommandDispatchFailure(input.contextId);
 }
 
+export function buildCommandTimeoutFailure(action: string, timeoutMs: number): DaemonFailureContract {
+  return {
+    message: `Browser ${action} command timed out after ${Math.round(timeoutMs / 1000)}s; it may still complete in the browser.`,
+    errorCode: COMMAND_RESULT_UNKNOWN_CODE,
+    errorHint: COMMAND_RESULT_UNKNOWN_HINT,
+    status: 408,
+    countAsCommandResultUnknown: true,
+  };
+}
+
 export function buildCommandDispatchFailure(contextId: string): DaemonFailureContract {
   return {
     message: `Browser profile "${contextId}" disconnected before command dispatch`,

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -4,6 +4,7 @@ import {
   COMMAND_RESULT_UNKNOWN_CODE,
   COMMAND_RESULT_UNKNOWN_HINT,
   buildCommandDispatchFailure,
+  buildCommandTimeoutFailure,
   buildExtensionDisconnectFailure,
   commandResultUnknownMessage,
   getResponseCorsHeaders,
@@ -71,6 +72,16 @@ describe('daemon command dispatch', () => {
       errorCode: 'profile_disconnected',
       status: 503,
       countAsCommandResultUnknown: false,
+    });
+  });
+
+  it('classifies daemon-side command timeouts as command_result_unknown with a 408', () => {
+    expect(buildCommandTimeoutFailure('navigate', 120_000)).toEqual({
+      message: 'Browser navigate command timed out after 120s; it may still complete in the browser.',
+      errorCode: 'command_result_unknown',
+      errorHint: COMMAND_RESULT_UNKNOWN_HINT,
+      status: 408,
+      countAsCommandResultUnknown: true,
     });
   });
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -30,6 +30,7 @@ import { DEFAULT_CONTEXT_ID } from './browser/profile.js';
 import { recordExtensionVersion } from './update-check.js';
 import {
   buildCommandDispatchFailure,
+  buildCommandTimeoutFailure,
   buildExtensionDisconnectFailure,
   getResponseCorsHeaders,
 } from './daemon-utils.js';
@@ -326,8 +327,14 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       }
       const result = await new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
+          const entry = pending.get(body.id);
           pending.delete(body.id);
-          reject(new Error(`Command timeout (${timeoutMs / 1000}s)`));
+          const failure = buildCommandTimeoutFailure(entry?.action ?? 'unknown', timeoutMs);
+          if (failure.countAsCommandResultUnknown && entry?.dispatched) {
+            commandResultUnknownCount++;
+            log.warn(`[daemon] Command timed out after dispatch (id=${body.id}, action=${entry.action}, timeout=${timeoutMs}ms)`);
+          }
+          reject(new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status));
         }, timeoutMs);
         const entry = {
           contextId: route.connection!.contextId,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -7,9 +7,13 @@ const { mockGetDaemonHealth, mockConnect, mockClose, mockFindShadowedUserAdapter
   mockFindShadowedUserAdapters: vi.fn(),
 }));
 
-vi.mock('./browser/daemon-transport.js', () => ({
-  getDaemonHealth: mockGetDaemonHealth,
-}));
+vi.mock('./browser/daemon-transport.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./browser/daemon-transport.js')>();
+  return {
+    ...actual,
+    getDaemonHealth: mockGetDaemonHealth,
+  };
+});
 
 vi.mock('./browser/index.js', () => ({
   BrowserBridge: class {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -6,6 +6,7 @@
 
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
+import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { getDaemonHealth } from './browser/daemon-transport.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
@@ -79,10 +80,14 @@ export type DoctorReport = {
  */
 export async function checkConnectivity(opts?: { timeout?: number }): Promise<ConnectivityResult> {
   const start = Date.now();
+  const timeoutSeconds = opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS;
+  // This is a health probe: shrink the transport's per-command deadline so a
+  // hung daemon/extension fails the check in seconds, not the default 120s.
+  setDaemonCommandTimeoutSeconds(timeoutSeconds);
   try {
     const bridge = new BrowserBridge();
     const page = await bridge.connect({
-      timeout: opts?.timeout ?? DOCTOR_LIVE_TIMEOUT_SECONDS,
+      timeout: timeoutSeconds,
       session: DOCTOR_SESSION,
       surface: 'browser',
     });
@@ -96,6 +101,8 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
     return { ok: true, durationMs: Date.now() - start };
   } catch (err) {
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
+  } finally {
+    setDaemonCommandTimeoutSeconds(null);
   }
 }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -30,6 +30,7 @@ import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceRece
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { resolveProfileContextId } from './browser/profile.js';
+import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -216,6 +217,11 @@ export async function executeCommand(
   }
 
   const userTimeoutSec = readUserTimeoutSeconds(cmd, kwargs);
+  // Propagate --timeout to the daemon transport so its per-command deadline
+  // (and the derived extension/HTTP deadlines) honor the user's value instead
+  // of the default. Set unconditionally so a previous command's value never
+  // leaks into this one.
+  setDaemonCommandTimeoutSeconds(userTimeoutSec);
   const traceMode = normalizeTraceMode(opts.trace);
 
   const hookCtx: HookContext = {


### PR DESCRIPTION
## Summary

Three P0 connectivity/stability fixes from a deep audit of the CLI → daemon → extension bridge. They share one root cause: the timeout and retry contracts between the three layers were disconnected.

### 1. One command deadline plumbed through all three layers

- `daemon-client` hardcoded a **30s** HTTP timeout while the daemon default was **120s**, and no caller ever set `body.timeout` — the daemon timer and its 408 branch were dead code. Every command slower than 30s (slow navigate, long eval, big screenshot, `wait --for download`) died with an opaque client-side `AbortError` while still running in the browser. Likely the root cause of #1777.
- Now the transport computes an effective timeout and sends it as `body.timeout` (seconds):
  - default 120s;
  - `--timeout N` reaches the transport via `setDaemonCommandTimeoutSeconds()` (wired in `execution.ts`);
  - extension-side waits (`timeoutMs`, e.g. wait-download) get a 15s margin on top.
- Layered so failures surface innermost-first with a real error: **extension CDP deadline < daemon timer < client HTTP abort** (+10s margin).
- The daemon per-command timer now rejects with the structured `command_result_unknown` contract (408) via `buildCommandTimeoutFailure()` instead of a bare `Error` the client cannot classify.

### 2. No more replaying possibly-dispatched commands on fetch `TypeError`

Any `TypeError: fetch failed` used to trigger ensure + resend **with a fresh id**, bypassing the daemon's duplicate-id guard. undici raises the same `TypeError` for `ECONNREFUSED` (request never sent — safe to retry) and `ECONNRESET`/socket hang-up (daemon may have already dispatched the command — a daemon crash mid-`click` could double-submit a form). The retry now checks `err.cause` and only pre-connect failures (`ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`, …) go through the ensure+resend path; post-connect drops surface as `command_result_unknown`, consistent with the existing write-safety contract.

### 3. Real deadlines for `chrome.debugger` commands

The extension's CDP calls had no timeout at all — `sendCommandInFrameTarget` declared `_timeoutMs` and never used it. A page-blocking native dialog (`alert`/`confirm`/`beforeunload`) hung `Runtime.evaluate` forever, and since `ensureAttached`'s health probe is also a `Runtime.evaluate`, **every subsequent command on the tab wedged**. Now:

- all `chrome.debugger.sendCommand` calls go through `sendDebuggerCommand()` which races a timer (default 60s, health probe 2s);
- `exec` / `cdp` commands derive their deadline from the transport's `body.timeout`, undercut by 5s so the more specific extension error beats the daemon's generic timer;
- the timeout error message points at the likely cause (native dialog).

## Testing

- `npm test` — full suite green (544 files, 5901 tests).
- `tsc --noEmit` clean in both packages (extension has pre-existing unrelated test-file strictness errors, unchanged).
- `vite build` for the extension bundle succeeds; `extension/dist/background.js` rebuilt and committed per repo convention.
- New regression tests:
  - `daemon-client`: default/`timeoutMs`/user-timeout plumbing into `body.timeout`; ECONNREFUSED retried, ECONNRESET and bare `TypeError` → `command_result_unknown` without resend.
  - `daemon`: `buildCommandTimeoutFailure` contract (408 + `command_result_unknown`).
  - `extension/cdp`: hung `Runtime.evaluate` now rejects at the default and caller-supplied deadlines instead of hanging forever.

Fixes the "connected but `This operation was aborted`" failure mode reported in #1777.