### PR TITLE
refactor(transport): exactly-once command transport — journal, waiters, absolute deadlines

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -115,34 +115,25 @@ async function ensureAttached(tabId, aggressiveRetry = false) {
   }
 }
 async function evaluate(tabId, expression, aggressiveRetry = false, timeoutMs = CDP_COMMAND_TIMEOUT_MS) {
-  const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
-  for (let attempt = 1; attempt <= MAX_EVAL_RETRIES; attempt++) {
-    try {
-      await ensureAttached(tabId, aggressiveRetry);
-      const result = await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
-        expression,
-        returnByValue: true,
-        awaitPromise: true
-      }, timeoutMs);
-      if (result.exceptionDetails) {
-        const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
-        throw new Error(errMsg);
-      }
-      return result.result?.value;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      const isNavigateError = msg.includes("Inspected target navigated") || msg.includes("Target closed");
-      const isAttachError = isNavigateError || msg.includes("attach failed") || msg.includes("Debugger is not attached") || msg.includes("chrome-extension://");
-      if (isAttachError && attempt < MAX_EVAL_RETRIES) {
-        attached.delete(tabId);
-        const retryMs = isNavigateError ? 200 : 500;
-        await new Promise((resolve) => setTimeout(resolve, retryMs));
-        continue;
-      }
-      throw e;
+  try {
+    await ensureAttached(tabId, aggressiveRetry);
+    const result = await sendDebuggerCommand({ tabId }, "Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true
+    }, timeoutMs);
+    if (result.exceptionDetails) {
+      const errMsg = result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Eval error";
+      throw new Error(errMsg);
     }
+    return result.result?.value;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("Detached") || msg.includes("Debugger is not attached") || msg.includes("Target closed")) {
+      attached.delete(tabId);
+    }
+    throw e;
   }
-  throw new Error("evaluate: max retries exhausted");
 }
 const evaluateAsync = evaluate;
 async function screenshot(tabId, options = {}) {
@@ -656,8 +647,97 @@ async function refreshMappings() {
   }
 }
 
+const JOURNAL_KEY = "opencli_command_journal_v1";
+const JOURNAL_MAX_ENTRIES = 64;
+const JOURNAL_RESULT_MAX_BYTES = 64 * 1024;
+let cache = null;
+let writeQueue = Promise.resolve();
+const inFlight = /* @__PURE__ */ new Map();
+async function load() {
+  if (cache) return cache;
+  try {
+    const stored = await chrome.storage.session.get(JOURNAL_KEY);
+    cache = stored?.[JOURNAL_KEY] ?? {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+function persist() {
+  const snapshot = cache;
+  if (!snapshot) return;
+  writeQueue = writeQueue.then(async () => {
+    try {
+      await chrome.storage.session.set({ [JOURNAL_KEY]: snapshot });
+    } catch {
+    }
+  });
+}
+function trim(journal) {
+  const ids = Object.keys(journal);
+  if (ids.length <= JOURNAL_MAX_ENTRIES) return;
+  ids.sort((a, b) => journal[a].ts - journal[b].ts);
+  for (const id of ids.slice(0, ids.length - JOURNAL_MAX_ENTRIES)) delete journal[id];
+}
+function resultByteLength(result) {
+  try {
+    return JSON.stringify(result).length;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+const UNKNOWN_OUTCOME_HINT = "Inspect the browser/session state before retrying. Do not blindly re-run write commands such as navigate, click, type, or eval.";
+async function executeWithJournal(cmd, execute) {
+  const id = cmd.id;
+  if (!id) return execute(cmd);
+  const running = inFlight.get(id);
+  if (running) return running;
+  const run = (async () => {
+    const journal = await load();
+    const entry = journal[id];
+    if (entry?.status === "done") {
+      if (entry.result) return entry.result;
+      return {
+        id,
+        ok: false,
+        errorCode: "result_evicted",
+        error: "Command already executed, but its result was too large to record for replay.",
+        errorHint: UNKNOWN_OUTCOME_HINT
+      };
+    }
+    if (entry?.status === "started") {
+      return {
+        id,
+        ok: false,
+        errorCode: "command_lost",
+        error: "Command was interrupted mid-execution (extension or browser restarted); it may or may not have applied.",
+        errorHint: UNKNOWN_OUTCOME_HINT
+      };
+    }
+    journal[id] = { status: "started", ts: Date.now() };
+    trim(journal);
+    persist();
+    let result;
+    try {
+      result = await execute(cmd);
+    } catch (err) {
+      result = { id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    journal[id] = resultByteLength(result) <= JOURNAL_RESULT_MAX_BYTES ? { status: "done", ts: Date.now(), result } : { status: "done", ts: Date.now() };
+    persist();
+    return result;
+  })();
+  inFlight.set(id, run);
+  try {
+    return await run;
+  } finally {
+    inFlight.delete(id);
+  }
+}
+
 let ws = null;
 let reconnectTimer = null;
+let reconnectAttempts = 0;
 const CONTEXT_ID_KEY = "opencli_context_id_v1";
 let currentContextId = "default";
 let contextIdPromise = null;
@@ -753,7 +833,7 @@ async function connectAttempt() {
       scheduleReconnect();
       return;
     }
-    notifyDaemonReachable();
+    reconnectAttempts = 0;
   } catch {
     scheduleReconnect();
     return;
@@ -773,31 +853,32 @@ async function connectAttempt() {
   thisWs.onopen = () => {
     if (ws !== thisWs) return;
     console.log("[opencli] Connected to daemon");
-    reconnectPhaseStartedAt = 0;
+    reconnectAttempts = 0;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-    reconnectTimerDelayMs = null;
     safeSend(thisWs, {
       type: "hello",
       contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: ">=1.7.0"
     });
+    startWsKeepalive(thisWs);
   };
   thisWs.onmessage = async (event) => {
     if (ws !== thisWs) return;
     try {
       const command = JSON.parse(event.data);
-      const result = await handleCommand(command);
-      if (ws !== thisWs) return;
-      safeSend(thisWs, result);
+      const result = await executeWithJournal(command, handleCommand);
+      const target = ws && ws.readyState === WebSocket.OPEN ? ws : thisWs;
+      safeSend(target, result);
     } catch (err) {
       console.error("[opencli] Message handling error:", err);
     }
   };
   thisWs.onclose = () => {
+    stopWsKeepalive(thisWs);
     if (ws !== thisWs) return;
     console.log("[opencli] Disconnected from daemon");
     ws = null;
@@ -807,38 +888,40 @@ async function connectAttempt() {
     thisWs.close();
   };
 }
-const RECONNECT_FAST_INTERVAL_MS = 3e3;
-const RECONNECT_FAST_WINDOW_MS = 3e4;
-const RECONNECT_SLOW_INTERVAL_MS = 15e3;
-let reconnectPhaseStartedAt = 0;
-let reconnectTimerDelayMs = null;
-function nextReconnectDelayMs() {
-  const sinceLoss = Date.now() - reconnectPhaseStartedAt;
-  return sinceLoss < RECONNECT_FAST_WINDOW_MS ? RECONNECT_FAST_INTERVAL_MS : RECONNECT_SLOW_INTERVAL_MS;
+const WS_KEEPALIVE_INTERVAL_MS = 2e4;
+let wsKeepaliveTimer = null;
+let wsKeepaliveSocket = null;
+function startWsKeepalive(socket) {
+  if (wsKeepaliveTimer) clearInterval(wsKeepaliveTimer);
+  wsKeepaliveSocket = socket;
+  wsKeepaliveTimer = setInterval(() => {
+    if (socket !== ws || socket.readyState !== WebSocket.OPEN) {
+      stopWsKeepalive(socket);
+      return;
+    }
+    safeSend(socket, { type: "ping", ts: Date.now() });
+  }, WS_KEEPALIVE_INTERVAL_MS);
 }
-function scheduleReconnect(opts = {}) {
-  if (reconnectTimer) {
-    if (!opts.replaceExisting) return;
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-    reconnectTimerDelayMs = null;
-  }
-  if (reconnectPhaseStartedAt === 0) {
-    reconnectPhaseStartedAt = Date.now();
-  }
+function stopWsKeepalive(socket) {
+  if (wsKeepaliveSocket !== socket) return;
+  if (wsKeepaliveTimer) clearInterval(wsKeepaliveTimer);
+  wsKeepaliveTimer = null;
+  wsKeepaliveSocket = null;
+}
+const RECONNECT_BASE_DELAY_MS = 1e3;
+const RECONNECT_MAX_DELAY_MS = 15e3;
+function nextReconnectDelayMs() {
+  const exp = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** Math.min(reconnectAttempts, 6));
+  return exp + Math.floor(Math.random() * 500);
+}
+function scheduleReconnect() {
+  if (reconnectTimer) return;
   const delay = nextReconnectDelayMs();
-  reconnectTimerDelayMs = delay;
+  reconnectAttempts++;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    reconnectTimerDelayMs = null;
     void connect();
   }, delay);
-}
-function notifyDaemonReachable() {
-  reconnectPhaseStartedAt = Date.now();
-  if (reconnectTimer && reconnectTimerDelayMs !== RECONNECT_FAST_INTERVAL_MS) {
-    scheduleReconnect({ replaceExisting: true });
-  }
 }
 const automationSessions = /* @__PURE__ */ new Map();
 const IDLE_TIMEOUT_DEFAULT = 3e4;
@@ -866,9 +949,11 @@ class CommandFailure extends Error {
     this.name = "CommandFailure";
   }
 }
-const sessionTimeoutOverrides = /* @__PURE__ */ new Map();
-const sessionWindowModeOverrides = /* @__PURE__ */ new Map();
-const sessionLifecycleOverrides = /* @__PURE__ */ new Map();
+const sessionOverrides = /* @__PURE__ */ new Map();
+function setSessionOverride(key, patch) {
+  sessionOverrides.set(key, { ...sessionOverrides.get(key), ...patch });
+}
+const activeCommandCounts = /* @__PURE__ */ new Map();
 const LEASE_KEY_SEPARATOR = "\0";
 function getLeaseKey(session, surface) {
   return `${surface}${LEASE_KEY_SEPARATOR}${encodeURIComponent(session)}`;
@@ -900,15 +985,15 @@ function getSessionFromKey(key) {
 function getIdleTimeout(key) {
   const session = automationSessions.get(key);
   if (session?.kind === "bound") return IDLE_TIMEOUT_NONE;
-  const adapterPersistent = getSurfaceFromKey(key) === "adapter" && (session?.lifecycle === "persistent" || sessionLifecycleOverrides.get(key) === "persistent");
+  const overrides = sessionOverrides.get(key);
+  const adapterPersistent = getSurfaceFromKey(key) === "adapter" && (session?.lifecycle === "persistent" || overrides?.lifecycle === "persistent");
   if (adapterPersistent) return IDLE_TIMEOUT_NONE;
-  const override = sessionTimeoutOverrides.get(key);
-  if (override !== void 0) return override;
+  if (overrides?.idleTimeoutMs !== void 0) return overrides.idleTimeoutMs;
   return getSurfaceFromKey(key) === "browser" ? IDLE_TIMEOUT_INTERACTIVE : IDLE_TIMEOUT_DEFAULT;
 }
 function getLeaseLifecycle(key, kind) {
   if (kind === "bound") return "pinned";
-  const override = sessionLifecycleOverrides.get(key);
+  const override = sessionOverrides.get(key)?.lifecycle;
   if (override) return override;
   return getSurfaceFromKey(key) === "browser" ? "persistent" : "ephemeral";
 }
@@ -919,7 +1004,7 @@ function getWindowRole(key, ownership) {
   return ownership === "borrowed" ? "borrowed-user" : getOwnedWindowRole(key);
 }
 function getWindowMode(key) {
-  return sessionWindowModeOverrides.get(key) ?? (getOwnedWindowRole(key) === "interactive" ? "foreground" : "background");
+  return sessionOverrides.get(key)?.windowMode ?? (getOwnedWindowRole(key) === "interactive" ? "foreground" : "background");
 }
 function makeAlarmName(leaseKey) {
   return `${LEASE_IDLE_ALARM_PREFIX}${encodeURIComponent(leaseKey)}`;
@@ -1053,9 +1138,7 @@ async function removeLeaseSession(leaseKey) {
   const existing = automationSessions.get(leaseKey);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   automationSessions.delete(leaseKey);
-  sessionTimeoutOverrides.delete(leaseKey);
-  sessionWindowModeOverrides.delete(leaseKey);
-  sessionLifecycleOverrides.delete(leaseKey);
+  sessionOverrides.delete(leaseKey);
   scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -1076,6 +1159,9 @@ function resetWindowIdleTimer(leaseKey, remainingMs) {
   session.idleDeadlineAt = Date.now() + interval;
   void persistRuntimeState();
   session.idleTimer = setTimeout(async () => {
+    if ((activeCommandCounts.get(leaseKey) ?? 0) > 0) {
+      return;
+    }
     await releaseLease(leaseKey, "idle timeout");
   }, interval);
 }
@@ -1440,9 +1526,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       console.log(`[opencli] ${session.surface} container closed (session=${session.session})`);
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
-      sessionTimeoutOverrides.delete(leaseKey);
-      sessionWindowModeOverrides.delete(leaseKey);
-      sessionLifecycleOverrides.delete(leaseKey);
+      sessionOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     }
   }
@@ -1454,9 +1538,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
     if (session.preferredTabId === tabId) {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
-      sessionTimeoutOverrides.delete(leaseKey);
-      sessionWindowModeOverrides.delete(leaseKey);
-      sessionLifecycleOverrides.delete(leaseKey);
+      sessionOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
       console.log(`[opencli] Session ${session.session} detached from tab ${tabId} (tab closed)`);
     }
@@ -1491,7 +1573,12 @@ initialize();
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "keepalive") void connect();
   const leaseKey = leaseKeyFromAlarmName(alarm.name);
-  if (leaseKey) await releaseLease(leaseKey, "idle alarm");
+  if (!leaseKey) return;
+  if ((activeCommandCounts.get(leaseKey) ?? 0) > 0) {
+    resetWindowIdleTimer(leaseKey);
+    return;
+  }
+  await releaseLease(leaseKey, "idle alarm");
 });
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "getStatus") {
@@ -1531,15 +1618,16 @@ async function handleCommand(cmd) {
   const surface = getCommandSurface(cmd);
   const leaseKey = getLeaseKey(session, surface);
   if (cmd.windowMode === "foreground" || cmd.windowMode === "background") {
-    sessionWindowModeOverrides.set(leaseKey, cmd.windowMode);
+    setSessionOverride(leaseKey, { windowMode: cmd.windowMode });
   }
   if (surface === "adapter" && (cmd.siteSession === "persistent" || cmd.siteSession === "ephemeral")) {
-    sessionLifecycleOverrides.set(leaseKey, cmd.siteSession);
+    setSessionOverride(leaseKey, { lifecycle: cmd.siteSession });
   }
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
-    sessionTimeoutOverrides.set(leaseKey, cmd.idleTimeout * 1e3);
+    setSessionOverride(leaseKey, { idleTimeoutMs: cmd.idleTimeout * 1e3 });
   }
   resetWindowIdleTimer(leaseKey);
+  activeCommandCounts.set(leaseKey, (activeCommandCounts.get(leaseKey) ?? 0) + 1);
   try {
     switch (cmd.action) {
       case "exec":
@@ -1574,13 +1662,12 @@ async function handleCommand(cmd) {
         return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
     }
   } catch (err) {
-    return {
-      id: cmd.id,
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-      ...err instanceof CommandFailure ? { errorCode: err.code } : {},
-      ...err instanceof CommandFailure && err.hint ? { errorHint: err.hint } : {}
-    };
+    return errorResult(cmd.id, err);
+  } finally {
+    const remaining = (activeCommandCounts.get(leaseKey) ?? 1) - 1;
+    if (remaining <= 0) activeCommandCounts.delete(leaseKey);
+    else activeCommandCounts.set(leaseKey, remaining);
+    resetWindowIdleTimer(leaseKey);
   }
 }
 const BLANK_PAGE = "about:blank";
@@ -1779,10 +1866,29 @@ async function listAutomationWebTabs(leaseKey) {
   return tabs.filter((tab) => isDebuggableUrl(tab.url));
 }
 function commandCdpTimeoutMs(cmd) {
+  if (typeof cmd.deadlineAt === "number" && cmd.deadlineAt > 0) {
+    return Math.max(1e4, cmd.deadlineAt - Date.now() - 5e3);
+  }
   if (typeof cmd.timeout === "number" && cmd.timeout > 0) {
     return Math.max(1e4, cmd.timeout * 1e3 - 5e3);
   }
   return void 0;
+}
+function classifyExtensionError(message) {
+  if (/Inspected target navigated|Target closed/.test(message)) return "target_navigated";
+  if (/Detached while handling command/.test(message)) return "detached_mid_command";
+  if (/CDP command .* timed out/.test(message)) return "cdp_timeout";
+  if (/attach failed|Debugger is not attached/.test(message)) return "attach_failed";
+  if (/No tab with id|no longer exists|No window with id/.test(message)) return "tab_gone";
+  return void 0;
+}
+function errorResult(id, err) {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof CommandFailure) {
+    return { id, ok: false, error: message, errorCode: err.code, ...err.hint ? { errorHint: err.hint } : {} };
+  }
+  const errorCode = classifyExtensionError(message);
+  return { id, ok: false, error: message, ...errorCode ? { errorCode } : {} };
 }
 async function handleExec(cmd, leaseKey) {
   if (!cmd.code) return { id: cmd.id, ok: false, error: "Missing code" };
@@ -1802,7 +1908,7 @@ async function handleExec(cmd, leaseKey) {
     const data = await evaluateAsync(tabId, cmd.code, aggressive, commandCdpTimeoutMs(cmd));
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleFrames(cmd, leaseKey) {
@@ -1812,7 +1918,7 @@ async function handleFrames(cmd, leaseKey) {
     const tree = await getFrameTree(tabId);
     return { id: cmd.id, ok: true, data: enumerateCrossOriginFrames(tree) };
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleNavigate(cmd, leaseKey) {
@@ -2021,7 +2127,7 @@ async function handleScreenshot(cmd, leaseKey) {
     });
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 const CDP_ALLOWLIST = /* @__PURE__ */ new Set([
@@ -2073,7 +2179,7 @@ async function handleCdp(cmd, leaseKey) {
     );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 function stripOpenCliFrameRoutingParams(params, stripFrameId) {
@@ -2096,7 +2202,7 @@ async function handleSetFileInput(cmd, leaseKey) {
     await setFileInputFiles(tabId, cmd.files, cmd.selector);
     return pageScopedResult(cmd.id, tabId, { count: cmd.files.length });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleInsertText(cmd, leaseKey) {
@@ -2109,7 +2215,7 @@ async function handleInsertText(cmd, leaseKey) {
     await insertText(tabId, cmd.text);
     return pageScopedResult(cmd.id, tabId, { inserted: true });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleNetworkCaptureStart(cmd, leaseKey) {
@@ -2119,7 +2225,7 @@ async function handleNetworkCaptureStart(cmd, leaseKey) {
     await startNetworkCapture(tabId, cmd.pattern);
     return pageScopedResult(cmd.id, tabId, { started: true });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleNetworkCaptureRead(cmd, leaseKey) {
@@ -2129,7 +2235,7 @@ async function handleNetworkCaptureRead(cmd, leaseKey) {
     const data = await readNetworkCapture(tabId);
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function handleWaitDownload(cmd) {
@@ -2137,15 +2243,13 @@ async function handleWaitDownload(cmd) {
     const data = await waitForDownload(cmd.pattern ?? "", cmd.timeoutMs ?? 3e4);
     return { id: cmd.id, ok: true, data };
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 async function releaseLease(leaseKey, reason = "released") {
   const session = automationSessions.get(leaseKey);
   if (!session) {
-    sessionTimeoutOverrides.delete(leaseKey);
-    sessionWindowModeOverrides.delete(leaseKey);
-    sessionLifecycleOverrides.delete(leaseKey);
+    sessionOverrides.delete(leaseKey);
     scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     await persistRuntimeState();
     return;
@@ -2184,9 +2288,7 @@ async function releaseLease(leaseKey, reason = "released") {
     console.log(`[opencli] Detached borrowed tab lease ${session.preferredTabId} (session=${session.session}, surface=${session.surface}, ${reason})`);
   }
   automationSessions.delete(leaseKey);
-  sessionTimeoutOverrides.delete(leaseKey);
-  sessionWindowModeOverrides.delete(leaseKey);
-  sessionLifecycleOverrides.delete(leaseKey);
+  sessionOverrides.delete(leaseKey);
   await persistRuntimeState();
 }
 async function reconcileTargetLeaseRegistry() {
@@ -2212,7 +2314,7 @@ async function reconcileTargetLeaseRegistry() {
       const tab = await chrome.tabs.get(tabId);
       if (!isDebuggableUrl(tab.url)) continue;
       if (stored.lifecycle === "ephemeral" || stored.lifecycle === "persistent" || stored.lifecycle === "pinned") {
-        sessionLifecycleOverrides.set(leaseKey, stored.lifecycle);
+        setSessionOverride(leaseKey, { lifecycle: stored.lifecycle });
       }
       const session = makeSession(leaseKey, {
         session: typeof stored.session === "string" ? stored.session : getSessionFromKey(leaseKey),

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -821,30 +821,43 @@ describe('background tab isolation', () => {
     expect(chrome.alarms.create).toHaveBeenCalledWith('keepalive', { periodInMinutes: 0.5 });
   });
 
-  it('reschedules a pending slow reconnect timer to fast cadence after daemon ping succeeds', async () => {
+  it('reconnect delay backs off exponentially with a 15s cap and resets on success', async () => {
     const { chrome } = createChromeMock();
-    vi.useFakeTimers();
-    vi.setSystemTime(100_000);
     vi.stubGlobal('chrome', chrome);
-    const fetchMock = vi.fn()
-      .mockRejectedValueOnce(new Error('daemon down'))
-      .mockResolvedValue({ ok: true });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
 
     const mod = await import('./background');
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
-
     mod.__test__.resetReconnectState();
-    mod.__test__.setReconnectPhaseStartedAt(Date.now() - 31_000);
-    mod.__test__.scheduleReconnectForTest();
-    expect(mod.__test__.getReconnectTimerDelay()).toBe(15_000);
+
+    mod.__test__.setReconnectAttempts(0);
+    const first = mod.__test__.nextReconnectDelayMs();
+    expect(first).toBeGreaterThanOrEqual(1_000);
+    expect(first).toBeLessThan(1_500);
+
+    mod.__test__.setReconnectAttempts(3);
+    const fourth = mod.__test__.nextReconnectDelayMs();
+    expect(fourth).toBeGreaterThanOrEqual(8_000);
+    expect(fourth).toBeLessThan(8_500);
+
+    mod.__test__.setReconnectAttempts(10);
+    const capped = mod.__test__.nextReconnectDelayMs();
+    expect(capped).toBeGreaterThanOrEqual(15_000);
+    expect(capped).toBeLessThan(15_500);
+  });
+
+  it('a successful daemon ping resets the backoff before the WebSocket attempt', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+
+    const mod = await import('./background');
+    mod.__test__.resetReconnectState();
+    mod.__test__.setReconnectAttempts(5);
 
     await mod.__test__.connectForTest();
 
-    expect(MockWebSocket.instances).toHaveLength(1);
-    expect(mod.__test__.getReconnectTimerDelay()).toBe(3_000);
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(1);
+    expect(mod.__test__.getReconnectAttempts()).toBe(0);
   });
 
   it('ignores daemon commands delivered to a superseded WebSocket', async () => {
@@ -1590,7 +1603,7 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getSession(browserKey('default'))).toBeNull();
   });
 
-  it('clears sessionTimeoutOverrides on idle expiry', async () => {
+  it('clears session overrides on idle expiry', async () => {
     const { chrome } = createChromeMock();
     vi.useFakeTimers();
     vi.stubGlobal('chrome', chrome);
@@ -1599,7 +1612,7 @@ describe('background tab isolation', () => {
     mod.__test__.setAutomationWindowId(browserKey('default'), 1);
 
     // Set a custom timeout override
-    mod.__test__.sessionTimeoutOverrides.set(browserKey('default'), 120_000);
+    mod.__test__.sessionOverrides.set(browserKey('default'), { idleTimeoutMs: 120_000 });
     expect(mod.__test__.getIdleTimeout(browserKey('default'))).toBe(120_000);
 
     // Trigger idle timer with the custom timeout
@@ -1607,19 +1620,19 @@ describe('background tab isolation', () => {
     await vi.advanceTimersByTimeAsync(120001);
 
     // Override should be cleaned up
-    expect(mod.__test__.sessionTimeoutOverrides.has(browserKey('default'))).toBe(false);
+    expect(mod.__test__.sessionOverrides.has(browserKey('default'))).toBe(false);
     expect(mod.__test__.getSession(browserKey('default'))).toBeNull();
     // Should fall back to default interactive timeout
     expect(mod.__test__.getIdleTimeout(browserKey('default'))).toBe(600_000);
   });
 
-  it('clears sessionTimeoutOverrides on explicit close', async () => {
+  it('clears session overrides on explicit close', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
     const mod = await import('./background');
     mod.__test__.setAutomationWindowId(browserKey('default'), 1);
-    mod.__test__.sessionTimeoutOverrides.set(browserKey('default'), 300_000);
+    mod.__test__.sessionOverrides.set(browserKey('default'), { idleTimeoutMs: 300_000 });
 
     const result = await mod.__test__.handleCommand({
       id: 'close-1',
@@ -1629,7 +1642,7 @@ describe('background tab isolation', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(mod.__test__.sessionTimeoutOverrides.has(browserKey('default'))).toBe(false);
+    expect(mod.__test__.sessionOverrides.has(browserKey('default'))).toBe(false);
   });
 
   it('applies idleTimeout from command to session override', async () => {
@@ -1656,7 +1669,7 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getIdleTimeout(browserKey('default'))).toBe(120_000);
   });
 
-  it('clears sessionTimeoutOverrides when user manually closes the automation container', async () => {
+  it('clears session overrides when user manually closes the automation container', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
 
@@ -1664,7 +1677,7 @@ describe('background tab isolation', () => {
 
     // Set up a session with window ID 42 and a custom timeout override
     mod.__test__.setAutomationWindowId(browserKey('default'), 42);
-    mod.__test__.sessionTimeoutOverrides.set(browserKey('default'), 180_000);
+    mod.__test__.sessionOverrides.set(browserKey('default'), { idleTimeoutMs: 180_000 });
     expect(mod.__test__.getIdleTimeout(browserKey('default'))).toBe(180_000);
 
     // Simulate user closing the window — invoke the onRemoved listener
@@ -1673,7 +1686,7 @@ describe('background tab isolation', () => {
 
     // Session and override should both be cleaned up
     expect(mod.__test__.getSession(browserKey('default'))).toBeNull();
-    expect(mod.__test__.sessionTimeoutOverrides.has(browserKey('default'))).toBe(false);
+    expect(mod.__test__.sessionOverrides.has(browserKey('default'))).toBe(false);
     // Should fall back to default interactive timeout
     expect(mod.__test__.getIdleTimeout(browserKey('default'))).toBe(600_000);
   });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -11,6 +11,7 @@ import type { Command, Result } from './protocol';
 import { DAEMON_HOST, DAEMON_PORT, DAEMON_WS_URL, DAEMON_PING_URL } from './protocol';
 import * as executor from './cdp';
 import * as identity from './identity';
+import { executeWithJournal } from './journal';
 
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -122,7 +123,8 @@ async function connectAttempt(): Promise<void> {
       scheduleReconnect();
       return; // unexpected response — not our daemon, but keep polling.
     }
-    notifyDaemonReachable();
+    // Daemon is reachable — proceed straight to the WebSocket below.
+    reconnectAttempts = 0;
   } catch {
     scheduleReconnect();
     return; // daemon not running — keep polling until the next daemon spawn.
@@ -145,12 +147,10 @@ async function connectAttempt(): Promise<void> {
     if (ws !== thisWs) return;
     console.log('[opencli] Connected to daemon');
     reconnectAttempts = 0; // Reset on successful connection
-    reconnectPhaseStartedAt = 0;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-    reconnectTimerDelayMs = null;
     // Send version + compatibility range so the daemon can report mismatches to the CLI
     safeSend(thisWs, {
       type: 'hello',
@@ -158,21 +158,30 @@ async function connectAttempt(): Promise<void> {
       version: chrome.runtime.getManifest().version,
       compatRange: __OPENCLI_COMPAT_RANGE__,
     });
+    // Application-level keepalive. Chrome (116+) extends the service worker's
+    // lifetime on WebSocket ACTIVITY — an idle OPEN socket does not count, so
+    // without this the worker lives on a knife-edge between the 30s idle kill
+    // and the 30s keepalive alarm. The daemon ignores `ping` messages.
+    startWsKeepalive(thisWs);
   };
 
   thisWs.onmessage = async (event) => {
     if (ws !== thisWs) return;
     try {
       const command = JSON.parse(event.data as string) as Command;
-      const result = await handleCommand(command);
-      if (ws !== thisWs) return;
-      safeSend(thisWs, result);
+      const result = await executeWithJournal(command, handleCommand);
+      // The socket may have been replaced while a long command ran. Deliver
+      // the result on the freshest open socket — the daemon correlates by id,
+      // and the journal replays it if this delivery is lost too.
+      const target = ws && ws.readyState === WebSocket.OPEN ? ws : thisWs;
+      safeSend(target, result);
     } catch (err) {
       console.error('[opencli] Message handling error:', err);
     }
   };
 
   thisWs.onclose = () => {
+    stopWsKeepalive(thisWs);
     if (ws !== thisWs) return;
     console.log('[opencli] Disconnected from daemon');
     ws = null;
@@ -184,55 +193,55 @@ async function connectAttempt(): Promise<void> {
   };
 }
 
+// ─── WebSocket keepalive ─────────────────────────────────────────────
+
+const WS_KEEPALIVE_INTERVAL_MS = 20_000;
+let wsKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
+let wsKeepaliveSocket: WebSocket | null = null;
+
+function startWsKeepalive(socket: WebSocket): void {
+  if (wsKeepaliveTimer) clearInterval(wsKeepaliveTimer);
+  wsKeepaliveSocket = socket;
+  wsKeepaliveTimer = setInterval(() => {
+    if (socket !== ws || socket.readyState !== WebSocket.OPEN) {
+      stopWsKeepalive(socket);
+      return;
+    }
+    safeSend(socket, { type: 'ping', ts: Date.now() });
+  }, WS_KEEPALIVE_INTERVAL_MS);
+}
+
+function stopWsKeepalive(socket: WebSocket): void {
+  if (wsKeepaliveSocket !== socket) return;
+  if (wsKeepaliveTimer) clearInterval(wsKeepaliveTimer);
+  wsKeepaliveTimer = null;
+  wsKeepaliveSocket = null;
+}
+
 /**
- * Reconnect cadence is phased and never gives up while Chrome keeps the
- * service worker alive:
- *
- * - fast phase: every 3s for 30s after a disconnect/failure;
- * - slow phase: every 15s after the fast window expires;
- * - durable wake path: chrome.alarms. Production Chrome currently enforces a
- *   30s minimum alarm interval, so alarms wake the service worker after idle
- *   eviction while setTimeout provides the faster path only when the worker
- *   remains alive.
+ * Reconnect cadence: plain exponential backoff with jitter, never giving up
+ * while Chrome keeps the service worker alive. 1s → 2s → 4s → … capped at 15s
+ * (+0-500ms jitter); attempts reset on a successful WS open. The durable wake
+ * path is chrome.alarms: production Chrome enforces a ~30s minimum alarm
+ * interval, so alarms wake the worker after idle eviction while setTimeout
+ * provides the faster path only when the worker remains alive.
  */
-const RECONNECT_FAST_INTERVAL_MS = 3000;
-const RECONNECT_FAST_WINDOW_MS = 30000;
-const RECONNECT_SLOW_INTERVAL_MS = 15000;
-let reconnectPhaseStartedAt = 0;
-let reconnectTimerDelayMs: number | null = null;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 15000;
 
 function nextReconnectDelayMs(): number {
-  const sinceLoss = Date.now() - reconnectPhaseStartedAt;
-  return sinceLoss < RECONNECT_FAST_WINDOW_MS
-    ? RECONNECT_FAST_INTERVAL_MS
-    : RECONNECT_SLOW_INTERVAL_MS;
+  const exp = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** Math.min(reconnectAttempts, 6));
+  return exp + Math.floor(Math.random() * 500);
 }
 
-function scheduleReconnect(opts: { replaceExisting?: boolean } = {}): void {
-  if (reconnectTimer) {
-    if (!opts.replaceExisting) return;
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-    reconnectTimerDelayMs = null;
-  }
-  reconnectAttempts++;
-  if (reconnectPhaseStartedAt === 0) {
-    reconnectPhaseStartedAt = Date.now();
-  }
+function scheduleReconnect(): void {
+  if (reconnectTimer) return;
   const delay = nextReconnectDelayMs();
-  reconnectTimerDelayMs = delay;
+  reconnectAttempts++;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    reconnectTimerDelayMs = null;
     void connect();
   }, delay);
-}
-
-function notifyDaemonReachable(): void {
-  reconnectPhaseStartedAt = Date.now();
-  if (reconnectTimer && reconnectTimerDelayMs !== RECONNECT_FAST_INTERVAL_MS) {
-    scheduleReconnect({ replaceExisting: true });
-  }
 }
 
 // ─── Browser target leases ───────────────────────────────────────────
@@ -308,10 +317,24 @@ class CommandFailure extends Error {
   }
 }
 
-/** Per-session custom timeout overrides set via command.idleTimeout */
-const sessionTimeoutOverrides = new Map<string, number>();
-const sessionWindowModeOverrides = new Map<string, WindowMode>();
-const sessionLifecycleOverrides = new Map<string, LeaseLifecycle>();
+/**
+ * Per-session overrides set via command fields (idleTimeout / windowMode /
+ * siteSession). One record per lease key — a single map so create/clear
+ * stay in lockstep.
+ */
+type SessionOverrides = {
+  idleTimeoutMs?: number;
+  windowMode?: WindowMode;
+  lifecycle?: LeaseLifecycle;
+};
+const sessionOverrides = new Map<string, SessionOverrides>();
+
+function setSessionOverride(key: string, patch: SessionOverrides): void {
+  sessionOverrides.set(key, { ...sessionOverrides.get(key), ...patch });
+}
+
+/** Commands currently executing per lease — idle release is deferred while > 0. */
+const activeCommandCounts = new Map<string, number>();
 const LEASE_KEY_SEPARATOR = '\u0000';
 
 function getLeaseKey(session: string, surface: BrowserSurface): string {
@@ -349,17 +372,17 @@ function getSessionFromKey(key: string): string {
 function getIdleTimeout(key: string): number {
   const session = automationSessions.get(key);
   if (session?.kind === 'bound') return IDLE_TIMEOUT_NONE;
+  const overrides = sessionOverrides.get(key);
   const adapterPersistent = getSurfaceFromKey(key) === 'adapter'
-    && (session?.lifecycle === 'persistent' || sessionLifecycleOverrides.get(key) === 'persistent');
+    && (session?.lifecycle === 'persistent' || overrides?.lifecycle === 'persistent');
   if (adapterPersistent) return IDLE_TIMEOUT_NONE;
-  const override = sessionTimeoutOverrides.get(key);
-  if (override !== undefined) return override;
+  if (overrides?.idleTimeoutMs !== undefined) return overrides.idleTimeoutMs;
   return getSurfaceFromKey(key) === 'browser' ? IDLE_TIMEOUT_INTERACTIVE : IDLE_TIMEOUT_DEFAULT;
 }
 
 function getLeaseLifecycle(key: string, kind: LeaseKind): LeaseLifecycle {
   if (kind === 'bound') return 'pinned';
-  const override = sessionLifecycleOverrides.get(key);
+  const override = sessionOverrides.get(key)?.lifecycle;
   if (override) return override;
   return getSurfaceFromKey(key) === 'browser' ? 'persistent' : 'ephemeral';
 }
@@ -373,7 +396,7 @@ function getWindowRole(key: string, ownership: LeaseOwnership): WindowRole {
 }
 
 function getWindowMode(key: string): WindowMode {
-  return sessionWindowModeOverrides.get(key)
+  return sessionOverrides.get(key)?.windowMode
     ?? (getOwnedWindowRole(key) === 'interactive' ? 'foreground' : 'background');
 }
 
@@ -527,9 +550,7 @@ async function removeLeaseSession(leaseKey: string): Promise<void> {
   const existing = automationSessions.get(leaseKey);
   if (existing?.idleTimer) clearTimeout(existing.idleTimer);
   automationSessions.delete(leaseKey);
-  sessionTimeoutOverrides.delete(leaseKey);
-  sessionWindowModeOverrides.delete(leaseKey);
-  sessionLifecycleOverrides.delete(leaseKey);
+  sessionOverrides.delete(leaseKey);
   scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
   await persistRuntimeState();
 }
@@ -557,6 +578,11 @@ function resetWindowIdleTimer(leaseKey: string, remainingMs?: number): void {
   session.idleDeadlineAt = Date.now() + interval;
   void persistRuntimeState();
   session.idleTimer = setTimeout(async () => {
+    if ((activeCommandCounts.get(leaseKey) ?? 0) > 0) {
+      // A command is still executing on this lease — never tear the tab down
+      // from under it. Its completion re-arms the timer.
+      return;
+    }
     await releaseLease(leaseKey, 'idle timeout');
   }, interval);
 }
@@ -1061,9 +1087,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
       console.log(`[opencli] ${session.surface} container closed (session=${session.session})`);
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
-      sessionTimeoutOverrides.delete(leaseKey);
-      sessionWindowModeOverrides.delete(leaseKey);
-      sessionLifecycleOverrides.delete(leaseKey);
+      sessionOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     }
   }
@@ -1077,9 +1101,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
     if (session.preferredTabId === tabId) {
       if (session.idleTimer) clearTimeout(session.idleTimer);
       automationSessions.delete(leaseKey);
-      sessionTimeoutOverrides.delete(leaseKey);
-      sessionWindowModeOverrides.delete(leaseKey);
-      sessionLifecycleOverrides.delete(leaseKey);
+      sessionOverrides.delete(leaseKey);
       scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
       console.log(`[opencli] Session ${session.session} detached from tab ${tabId} (tab closed)`);
     }
@@ -1126,7 +1148,14 @@ initialize();
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === 'keepalive') void connect();
   const leaseKey = leaseKeyFromAlarmName(alarm.name);
-  if (leaseKey) await releaseLease(leaseKey, 'idle alarm');
+  if (!leaseKey) return;
+  if ((activeCommandCounts.get(leaseKey) ?? 0) > 0) {
+    // A command is mid-flight (the alarm can fire while a long command runs
+    // in a woken worker) — defer; command completion re-arms the idle timer.
+    resetWindowIdleTimer(leaseKey);
+    return;
+  }
+  await releaseLease(leaseKey, 'idle alarm');
 });
 
 // ─── Popup status API ───────────────────────────────────────────────
@@ -1178,17 +1207,21 @@ async function handleCommand(cmd: Command): Promise<Result> {
   const surface = getCommandSurface(cmd);
   const leaseKey = getLeaseKey(session, surface);
   if (cmd.windowMode === 'foreground' || cmd.windowMode === 'background') {
-    sessionWindowModeOverrides.set(leaseKey, cmd.windowMode);
+    setSessionOverride(leaseKey, { windowMode: cmd.windowMode });
   }
   if (surface === 'adapter' && (cmd.siteSession === 'persistent' || cmd.siteSession === 'ephemeral')) {
-    sessionLifecycleOverrides.set(leaseKey, cmd.siteSession);
+    setSessionOverride(leaseKey, { lifecycle: cmd.siteSession });
   }
   // Apply custom idle timeout if specified in the command
   if (cmd.idleTimeout != null && cmd.idleTimeout > 0) {
-    sessionTimeoutOverrides.set(leaseKey, cmd.idleTimeout * 1000);
+    setSessionOverride(leaseKey, { idleTimeoutMs: cmd.idleTimeout * 1000 });
   }
-  // Reset idle timer on every command (window stays alive while active)
+  // Reset idle timer on every command (window stays alive while active).
+  // The in-flight refcount below additionally blocks idle release while a
+  // long command is still executing — otherwise a 30s idle timer could tear
+  // the tab down mid-command.
   resetWindowIdleTimer(leaseKey);
+  activeCommandCounts.set(leaseKey, (activeCommandCounts.get(leaseKey) ?? 0) + 1);
   try {
     switch (cmd.action) {
       case 'exec':
@@ -1223,13 +1256,13 @@ async function handleCommand(cmd: Command): Promise<Result> {
         return { id: cmd.id, ok: false, error: `Unknown action: ${cmd.action}` };
     }
   } catch (err) {
-    return {
-      id: cmd.id,
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-      ...(err instanceof CommandFailure ? { errorCode: err.code } : {}),
-      ...(err instanceof CommandFailure && err.hint ? { errorHint: err.hint } : {}),
-    };
+    return errorResult(cmd.id, err);
+  } finally {
+    const remaining = (activeCommandCounts.get(leaseKey) ?? 1) - 1;
+    if (remaining <= 0) activeCommandCounts.delete(leaseKey);
+    else activeCommandCounts.set(leaseKey, remaining);
+    // Grant a fresh idle window measured from command COMPLETION, not start.
+    resetWindowIdleTimer(leaseKey);
   }
 }
 
@@ -1491,17 +1524,49 @@ async function listAutomationWebTabs(leaseKey: string): Promise<chrome.tabs.Tab[
 }
 
 /**
- * Derive the per-command CDP deadline from the daemon-side timeout (seconds)
- * the CLI transport put on the command. Undercut it by 5s so this (more
+ * Derive the per-command CDP deadline from the command's absolute deadline
+ * (preferred — remaining budget absorbs service-worker wake and queueing
+ * latency) or the legacy duration field. Undercut by 5s so this (more
  * specific) error reaches the CLI before the daemon's generic timer fires.
- * Returns undefined when the command carries no timeout — callers fall back
- * to the executor's default deadline.
+ * Returns undefined when the command carries neither — callers fall back to
+ * the executor's default deadline.
  */
 function commandCdpTimeoutMs(cmd: Command): number | undefined {
+  if (typeof cmd.deadlineAt === 'number' && cmd.deadlineAt > 0) {
+    return Math.max(10_000, cmd.deadlineAt - Date.now() - 5_000);
+  }
   if (typeof cmd.timeout === 'number' && cmd.timeout > 0) {
     return Math.max(10_000, cmd.timeout * 1000 - 5_000);
   }
   return undefined;
+}
+
+/**
+ * Map an executor error to a machine-readable code so the CLI can decide
+ * retry safety without regex-matching message text:
+ * - `attach_failed` / `tab_gone`: failed BEFORE any page code ran — a new
+ *   logical attempt is safe;
+ * - `target_navigated`: the document changed under the command — the page
+ *   layer decides whether to settle-retry;
+ * - `detached_mid_command` / `cdp_timeout`: died MID-execution — the outcome
+ *   is unknown, a blind re-run could double-apply a write.
+ */
+function classifyExtensionError(message: string): string | undefined {
+  if (/Inspected target navigated|Target closed/.test(message)) return 'target_navigated';
+  if (/Detached while handling command/.test(message)) return 'detached_mid_command';
+  if (/CDP command .* timed out/.test(message)) return 'cdp_timeout';
+  if (/attach failed|Debugger is not attached/.test(message)) return 'attach_failed';
+  if (/No tab with id|no longer exists|No window with id/.test(message)) return 'tab_gone';
+  return undefined;
+}
+
+function errorResult(id: string, err: unknown): Result {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof CommandFailure) {
+    return { id, ok: false, error: message, errorCode: err.code, ...(err.hint ? { errorHint: err.hint } : {}) };
+  }
+  const errorCode = classifyExtensionError(message);
+  return { id, ok: false, error: message, ...(errorCode ? { errorCode } : {}) };
 }
 
 async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
@@ -1522,7 +1587,7 @@ async function handleExec(cmd: Command, leaseKey: string): Promise<Result> {
     const data = await executor.evaluateAsync(tabId, cmd.code, aggressive, commandCdpTimeoutMs(cmd));
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1533,7 +1598,7 @@ async function handleFrames(cmd: Command, leaseKey: string): Promise<Result> {
     const tree = await executor.getFrameTree(tabId);
     return { id: cmd.id, ok: true, data: enumerateCrossOriginFrames(tree) };
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1773,7 +1838,7 @@ async function handleScreenshot(cmd: Command, leaseKey: string): Promise<Result>
     });
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1832,7 +1897,7 @@ async function handleCdp(cmd: Command, leaseKey: string): Promise<Result> {
       );
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1858,7 +1923,7 @@ async function handleSetFileInput(cmd: Command, leaseKey: string): Promise<Resul
     await executor.setFileInputFiles(tabId, cmd.files, cmd.selector);
     return pageScopedResult(cmd.id, tabId, { count: cmd.files.length });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1872,7 +1937,7 @@ async function handleInsertText(cmd: Command, leaseKey: string): Promise<Result>
     await executor.insertText(tabId, cmd.text);
     return pageScopedResult(cmd.id, tabId, { inserted: true });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1883,7 +1948,7 @@ async function handleNetworkCaptureStart(cmd: Command, leaseKey: string): Promis
     await executor.startNetworkCapture(tabId, cmd.pattern);
     return pageScopedResult(cmd.id, tabId, { started: true });
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1894,7 +1959,7 @@ async function handleNetworkCaptureRead(cmd: Command, leaseKey: string): Promise
     const data = await executor.readNetworkCapture(tabId);
     return pageScopedResult(cmd.id, tabId, data);
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
@@ -1903,16 +1968,14 @@ async function handleWaitDownload(cmd: Command): Promise<Result> {
     const data = await executor.waitForDownload(cmd.pattern ?? '', cmd.timeoutMs ?? 30000);
     return { id: cmd.id, ok: true, data };
   } catch (err) {
-    return { id: cmd.id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    return errorResult(cmd.id, err);
   }
 }
 
 async function releaseLease(leaseKey: string, reason: string = 'released'): Promise<void> {
   const session = automationSessions.get(leaseKey);
   if (!session) {
-    sessionTimeoutOverrides.delete(leaseKey);
-    sessionWindowModeOverrides.delete(leaseKey);
-    sessionLifecycleOverrides.delete(leaseKey);
+    sessionOverrides.delete(leaseKey);
     scheduleIdleAlarm(leaseKey, IDLE_TIMEOUT_NONE);
     await persistRuntimeState();
     return;
@@ -1955,9 +2018,7 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
   }
 
   automationSessions.delete(leaseKey);
-  sessionTimeoutOverrides.delete(leaseKey);
-  sessionWindowModeOverrides.delete(leaseKey);
-  sessionLifecycleOverrides.delete(leaseKey);
+  sessionOverrides.delete(leaseKey);
 
   await persistRuntimeState();
 }
@@ -1986,7 +2047,7 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
       const tab = await chrome.tabs.get(tabId);
       if (!isDebuggableUrl(tab.url)) continue;
       if (stored.lifecycle === 'ephemeral' || stored.lifecycle === 'persistent' || stored.lifecycle === 'pinned') {
-        sessionLifecycleOverrides.set(leaseKey, stored.lifecycle);
+        setSessionOverride(leaseKey, { lifecycle: stored.lifecycle });
       }
       const session = makeSession(leaseKey, {
         session: typeof stored.session === 'string' ? stored.session : getSessionFromKey(leaseKey),
@@ -2084,20 +2145,21 @@ export const __test__ = {
   getCommandSurface,
   getIdleTimeout,
   getLeaseKey,
-  sessionTimeoutOverrides,
+  sessionOverrides,
   reconcileTargetLeaseRegistry,
   ensureOwnedContainerGroup,
   connectForTest: connect,
   scheduleReconnectForTest: () => scheduleReconnect(),
-  notifyDaemonReachableForTest: notifyDaemonReachable,
-  getReconnectTimerDelay: () => reconnectTimerDelayMs,
-  setReconnectPhaseStartedAt: (value: number) => { reconnectPhaseStartedAt = value; },
+  getReconnectAttempts: () => reconnectAttempts,
+  setReconnectAttempts: (value: number) => { reconnectAttempts = value; },
+  nextReconnectDelayMs,
   resetReconnectState: () => {
     if (reconnectTimer) clearTimeout(reconnectTimer);
     reconnectTimer = null;
-    reconnectTimerDelayMs = null;
     reconnectAttempts = 0;
-    reconnectPhaseStartedAt = 0;
+    if (wsKeepaliveTimer) clearInterval(wsKeepaliveTimer);
+    wsKeepaliveTimer = null;
+    wsKeepaliveSocket = null;
     connectInFlight = null;
     ws = null;
   },

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -230,47 +230,38 @@ export async function evaluate(
   aggressiveRetry: boolean = false,
   timeoutMs: number = CDP_COMMAND_TIMEOUT_MS,
 ): Promise<unknown> {
-  // Retry the entire evaluate (attach + command).
-  // Normal: 2 retries. Browser: 3 retries (tolerates extension interference).
-  const MAX_EVAL_RETRIES = aggressiveRetry ? 3 : 2;
-  for (let attempt = 1; attempt <= MAX_EVAL_RETRIES; attempt++) {
-    try {
-      await ensureAttached(tabId, aggressiveRetry);
+  // No retry loop here: failures carry a machine-readable errorCode (see
+  // classifyExtensionError in background.ts) and the CLI decides whether a
+  // NEW logical attempt is safe. ensureAttached still does its own local
+  // attach retries; a debugger error mid-evaluate invalidates the attach
+  // cache so the next attempt re-attaches.
+  try {
+    await ensureAttached(tabId, aggressiveRetry);
 
-      const result = await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
-        expression,
-        returnByValue: true,
-        awaitPromise: true,
-      }, timeoutMs) as {
-        result?: { type: string; value?: unknown; description?: string; subtype?: string };
-        exceptionDetails?: { exception?: { description?: string }; text?: string };
-      };
+    const result = await sendDebuggerCommand({ tabId }, 'Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    }, timeoutMs) as {
+      result?: { type: string; value?: unknown; description?: string; subtype?: string };
+      exceptionDetails?: { exception?: { description?: string }; text?: string };
+    };
 
-      if (result.exceptionDetails) {
-        const errMsg = result.exceptionDetails.exception?.description
-          || result.exceptionDetails.text
-          || 'Eval error';
-        throw new Error(errMsg);
-      }
-
-      return result.result?.value;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      // Only retry on attach/debugger errors, not on JS eval errors
-      const isNavigateError = msg.includes('Inspected target navigated') || msg.includes('Target closed');
-      const isAttachError = isNavigateError || msg.includes('attach failed') || msg.includes('Debugger is not attached')
-        || msg.includes('chrome-extension://');
-      if (isAttachError && attempt < MAX_EVAL_RETRIES) {
-        attached.delete(tabId); // Force re-attach on next attempt
-        // SPA navigations recover quickly; debugger detach needs longer
-        const retryMs = isNavigateError ? 200 : 500;
-        await new Promise(resolve => setTimeout(resolve, retryMs));
-        continue;
-      }
-      throw e;
+    if (result.exceptionDetails) {
+      const errMsg = result.exceptionDetails.exception?.description
+        || result.exceptionDetails.text
+        || 'Eval error';
+      throw new Error(errMsg);
     }
+
+    return result.result?.value;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('Detached') || msg.includes('Debugger is not attached') || msg.includes('Target closed')) {
+      attached.delete(tabId); // Force re-attach on the next command
+    }
+    throw e;
   }
-  throw new Error('evaluate: max retries exhausted');
 }
 
 export const evaluateAsync = evaluate;

--- a/extension/src/journal.test.ts
+++ b/extension/src/journal.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Command, Result } from './protocol';
+import { executeWithJournal, __test__ } from './journal';
+
+function makeCmd(id: string): Command {
+  return { id, action: 'exec', code: '1 + 1', session: 's', surface: 'browser' };
+}
+
+function makeSessionStorageMock() {
+  let store: Record<string, unknown> = {};
+  return {
+    get: vi.fn(async (key: string) => ({ [key]: store[key] })),
+    set: vi.fn(async (items: Record<string, unknown>) => { store = { ...store, ...items }; }),
+    _dump: () => store,
+    _load: (items: Record<string, unknown>) => { store = items; },
+  };
+}
+
+describe('command journal', () => {
+  let sessionStorage: ReturnType<typeof makeSessionStorageMock>;
+
+  beforeEach(() => {
+    __test__.reset();
+    sessionStorage = makeSessionStorageMock();
+    vi.stubGlobal('chrome', { storage: { session: sessionStorage } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('executes a fresh id once and replays the recorded result for duplicates', async () => {
+    const execute = vi.fn(async (cmd: Command): Promise<Result> => ({ id: cmd.id, ok: true, data: 42 }));
+
+    const first = await executeWithJournal(makeCmd('cmd-1'), execute);
+    const replay = await executeWithJournal(makeCmd('cmd-1'), execute);
+
+    expect(first).toEqual({ id: 'cmd-1', ok: true, data: 42 });
+    expect(replay).toEqual(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('attaches concurrent duplicates to the in-flight execution', async () => {
+    let release: (r: Result) => void;
+    const gate = new Promise<Result>((resolve) => { release = resolve; });
+    const execute = vi.fn(() => gate);
+
+    const a = executeWithJournal(makeCmd('cmd-2'), execute);
+    const b = executeWithJournal(makeCmd('cmd-2'), execute);
+    release!({ id: 'cmd-2', ok: true, data: 'once' });
+
+    expect(await a).toEqual({ id: 'cmd-2', ok: true, data: 'once' });
+    expect(await b).toEqual({ id: 'cmd-2', ok: true, data: 'once' });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports command_lost when a started entry survives a worker restart', async () => {
+    // Simulate: previous worker persisted 'started', then died mid-execution.
+    sessionStorage._load({
+      opencli_command_journal_v1: { 'cmd-3': { status: 'started', ts: Date.now() } },
+    });
+
+    const execute = vi.fn();
+    const result = await executeWithJournal(makeCmd('cmd-3'), execute);
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe('command_lost');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('replays a completed result persisted by a previous worker', async () => {
+    const recorded: Result = { id: 'cmd-4', ok: true, data: 'from-previous-worker' };
+    sessionStorage._load({
+      opencli_command_journal_v1: { 'cmd-4': { status: 'done', ts: Date.now(), result: recorded } },
+    });
+
+    const execute = vi.fn();
+    const result = await executeWithJournal(makeCmd('cmd-4'), execute);
+
+    expect(result).toEqual(recorded);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('reports result_evicted for oversized results instead of re-executing', async () => {
+    const huge = 'x'.repeat(65 * 1024);
+    const execute = vi.fn(async (cmd: Command): Promise<Result> => ({ id: cmd.id, ok: true, data: huge }));
+
+    const first = await executeWithJournal(makeCmd('cmd-5'), execute);
+    const replay = await executeWithJournal(makeCmd('cmd-5'), execute);
+
+    expect(first.ok).toBe(true);
+    expect(replay.ok).toBe(false);
+    expect(replay.errorCode).toBe('result_evicted');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a thrown execution as a done error result and replays it', async () => {
+    const execute = vi.fn(async () => { throw new Error('boom'); });
+
+    const first = await executeWithJournal(makeCmd('cmd-6'), execute);
+    const replay = await executeWithJournal(makeCmd('cmd-6'), execute);
+
+    expect(first).toMatchObject({ id: 'cmd-6', ok: false, error: 'boom' });
+    expect(replay).toEqual(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades to in-memory when chrome.storage.session is unavailable', async () => {
+    vi.stubGlobal('chrome', {});
+    __test__.reset();
+    const execute = vi.fn(async (cmd: Command): Promise<Result> => ({ id: cmd.id, ok: true, data: 1 }));
+
+    const first = await executeWithJournal(makeCmd('cmd-7'), execute);
+    const replay = await executeWithJournal(makeCmd('cmd-7'), execute);
+
+    expect(first.ok).toBe(true);
+    expect(replay).toEqual(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/src/journal.ts
+++ b/extension/src/journal.ts
@@ -1,0 +1,146 @@
+/**
+ * Command journal — the executor-side half of the transport's retry contract.
+ *
+ * The CLI retries a failed transport attempt with the SAME command id; this
+ * journal makes that retry safe by making execution idempotent per id:
+ *
+ * - a command currently executing attaches to the in-flight promise;
+ * - a completed command replays its recorded Result instead of re-executing;
+ * - a command that started but never finished (service worker died mid-way)
+ *   reports `command_lost` instead of silently re-executing a write.
+ *
+ * Persisted in chrome.storage.session: survives service-worker restarts,
+ * cleared when the browser exits — exactly the lifetime of "results a retry
+ * might still ask for". When storage is unavailable (tests, very old Chrome)
+ * the journal degrades to in-memory only.
+ */
+
+import type { Command, Result } from './protocol';
+
+const JOURNAL_KEY = 'opencli_command_journal_v1';
+const JOURNAL_MAX_ENTRIES = 64;
+/** Results larger than this are not recorded; a replayed id re-fails honestly. */
+const JOURNAL_RESULT_MAX_BYTES = 64 * 1024;
+
+type JournalEntry =
+  | { status: 'started'; ts: number }
+  | { status: 'done'; ts: number; result?: Result };
+
+type JournalMap = Record<string, JournalEntry>;
+
+let cache: JournalMap | null = null;
+let writeQueue: Promise<void> = Promise.resolve();
+const inFlight = new Map<string, Promise<Result>>();
+
+async function load(): Promise<JournalMap> {
+  if (cache) return cache;
+  try {
+    const stored = await chrome.storage.session.get(JOURNAL_KEY);
+    cache = (stored?.[JOURNAL_KEY] as JournalMap | undefined) ?? {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+function persist(): void {
+  const snapshot = cache;
+  if (!snapshot) return;
+  writeQueue = writeQueue.then(async () => {
+    try {
+      await chrome.storage.session.set({ [JOURNAL_KEY]: snapshot });
+    } catch {
+      // Storage unavailable — journal stays in-memory for this worker's lifetime.
+    }
+  });
+}
+
+function trim(journal: JournalMap): void {
+  const ids = Object.keys(journal);
+  if (ids.length <= JOURNAL_MAX_ENTRIES) return;
+  ids.sort((a, b) => journal[a].ts - journal[b].ts);
+  for (const id of ids.slice(0, ids.length - JOURNAL_MAX_ENTRIES)) delete journal[id];
+}
+
+function resultByteLength(result: Result): number {
+  try {
+    return JSON.stringify(result).length;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+const UNKNOWN_OUTCOME_HINT =
+  'Inspect the browser/session state before retrying. Do not blindly re-run write commands such as navigate, click, type, or eval.';
+
+/**
+ * Execute a command exactly once per id. Duplicate deliveries of the same id
+ * (transport retries after a dropped connection) replay the recorded outcome.
+ */
+export async function executeWithJournal(
+  cmd: Command,
+  execute: (cmd: Command) => Promise<Result>,
+): Promise<Result> {
+  const id = cmd.id;
+  if (!id) return execute(cmd);
+
+  const running = inFlight.get(id);
+  if (running) return running;
+
+  // Register in-flight SYNCHRONOUSLY (before any await) so a duplicate
+  // arriving in the same tick attaches here instead of racing past the
+  // journal check and misreading our own 'started' marker as a lost command.
+  const run = (async (): Promise<Result> => {
+    const journal = await load();
+    const entry = journal[id];
+    if (entry?.status === 'done') {
+      if (entry.result) return entry.result;
+      return {
+        id,
+        ok: false,
+        errorCode: 'result_evicted',
+        error: 'Command already executed, but its result was too large to record for replay.',
+        errorHint: UNKNOWN_OUTCOME_HINT,
+      };
+    }
+    if (entry?.status === 'started') {
+      return {
+        id,
+        ok: false,
+        errorCode: 'command_lost',
+        error: 'Command was interrupted mid-execution (extension or browser restarted); it may or may not have applied.',
+        errorHint: UNKNOWN_OUTCOME_HINT,
+      };
+    }
+
+    journal[id] = { status: 'started', ts: Date.now() };
+    trim(journal);
+    persist();
+    let result: Result;
+    try {
+      result = await execute(cmd);
+    } catch (err) {
+      result = { id, ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    journal[id] = resultByteLength(result) <= JOURNAL_RESULT_MAX_BYTES
+      ? { status: 'done', ts: Date.now(), result }
+      : { status: 'done', ts: Date.now() };
+    persist();
+    return result;
+  })();
+
+  inFlight.set(id, run);
+  try {
+    return await run;
+  } finally {
+    inFlight.delete(id);
+  }
+}
+
+export const __test__ = {
+  reset(): void {
+    cache = null;
+    inFlight.clear();
+    writeQueue = Promise.resolve();
+  },
+};

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -81,8 +81,16 @@ export interface Command {
    * Daemon-side command timeout in seconds, set by the CLI transport. The
    * extension derives its CDP deadline from this so it fails just before the
    * daemon timer and its (more specific) error wins.
+   * Kept alongside `deadlineAt` for older daemons; new code prefers deadlineAt.
    */
   timeout?: number;
+  /**
+   * Absolute command deadline (epoch ms), set by the CLI transport. All hops
+   * run on the same machine, so every layer derives its remaining budget as
+   * `deadlineAt - Date.now()` — queueing and service-worker wake latency are
+   * absorbed instead of silently shrinking the innermost budget.
+   */
+  deadlineAt?: number;
 }
 
 export interface Result {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -384,6 +384,44 @@ describe('daemon-client', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('sendCommand retries daemon_shutting_down with the same id when the extension journals ids', async () => {
+    mockEnsureReady('1.0.22');
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ ok: false, errorCode: 'daemon_shutting_down', error: 'Daemon shutting down before the command completed.' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: true, data: 'replayed' }),
+      } as Response);
+
+    await expect(sendCommand('navigate', { url: 'https://example.com' })).resolves.toBe('replayed');
+
+    const ids = fetchMock.mock.calls.map(([, init]) => (JSON.parse(String(init?.body)) as { id: string }).id);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it('sendCommand does NOT resend daemon_shutting_down on a legacy extension — outcome unknown', async () => {
+    mockEnsureReady('1.0.21');
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({ ok: false, errorCode: 'daemon_shutting_down', error: 'Daemon shutting down before the command completed.' }),
+    } as Response);
+
+    await expect(sendCommand('navigate', { url: 'https://example.com' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: 'command_result_unknown',
+    } satisfies Partial<BrowserCommandError>);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('sendCommand does NOT resend a bare TypeError on a legacy extension', async () => {
     const ensureSpy = mockEnsureReady('1.0.15');
     vi.mocked(fetch).mockRejectedValueOnce(new TypeError('fetch failed'));

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -221,14 +221,13 @@ describe('daemon-client', () => {
     expect(body.windowMode).toBe('background');
   });
 
-  it('sendCommand retries with a new id when daemon reports a duplicate pending id', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_123);
+  it('sendCommand retries executor-transient errors ONCE with a NEW id (re-execution is a new logical attempt)', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock
       .mockResolvedValueOnce({
         ok: false,
-        status: 409,
-        json: () => Promise.resolve({ ok: false, error: 'Duplicate command id already pending; retry' }),
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: false, error: 'attach failed: interference', errorCode: 'attach_failed' }),
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
@@ -244,6 +243,21 @@ describe('daemon-client', () => {
       return body.id;
     });
     expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('sendCommand does NOT retry mid-execution failures (detached_mid_command) — outcome is unknown', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: false, error: 'Detached while handling command', errorCode: 'detached_mid_command' }),
+    } as Response);
+
+    await expect(sendCommand('exec', { code: 'submit()' })).rejects.toMatchObject({
+      name: 'BrowserCommandError',
+      code: 'detached_mid_command',
+    } satisfies Partial<BrowserCommandError>);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('sendCommand does not retry command_result_unknown even when the message looks transient', async () => {
@@ -268,9 +282,8 @@ describe('daemon-client', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('sendCommand runs full bridge ensure on a pre-dispatch failure, then resends with a fresh id', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_321);
-    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady').mockResolvedValue({
+  function mockEnsureReady(extensionVersion?: string) {
+    return vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady').mockResolvedValue({
       health: {
         state: 'ready',
         status: {
@@ -278,6 +291,7 @@ describe('daemon-client', () => {
           pid: 1,
           uptime: 1,
           extensionConnected: true,
+          ...(extensionVersion && { extensionVersion }),
           pending: 0,
           memoryMB: 0,
           port: 19825,
@@ -285,6 +299,11 @@ describe('daemon-client', () => {
       },
       spawnedProcess: null,
     });
+  }
+
+  it('sendCommand runs full bridge ensure on a pre-dispatch failure, then resends the SAME id', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_321);
+    const ensureSpy = mockEnsureReady('1.0.22');
     const fetchMock = vi.mocked(fetch);
     fetchMock
       .mockResolvedValueOnce({
@@ -307,25 +326,12 @@ describe('daemon-client', () => {
     expect(ensureSpy).toHaveBeenCalledWith(expect.objectContaining({ contextId: 'work', verbose: false }));
     const ids = fetchMock.mock.calls.map(([, init]) => (JSON.parse(String(init?.body)) as { id: string }).id);
     expect(ids).toHaveLength(2);
-    expect(ids[0]).not.toBe(ids[1]);
+    // Transport retries keep the id stable so the executor's journal can dedupe.
+    expect(ids[0]).toBe(ids[1]);
   });
 
   it('sendCommand runs full bridge ensure on a pre-connect TypeError (ECONNREFUSED) before resending', async () => {
-    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady').mockResolvedValue({
-      health: {
-        state: 'ready',
-        status: {
-          ok: true,
-          pid: 1,
-          uptime: 1,
-          extensionConnected: true,
-          pending: 0,
-          memoryMB: 0,
-          port: 19825,
-        },
-      },
-      spawnedProcess: null,
-    });
+    const ensureSpy = mockEnsureReady();
     const refused = new TypeError('fetch failed');
     (refused as { cause?: unknown }).cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:19825'), { code: 'ECONNREFUSED' });
     const fetchMock = vi.mocked(fetch);
@@ -343,8 +349,28 @@ describe('daemon-client', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('sendCommand does NOT resend on a post-connect TypeError (ECONNRESET) — surfaces command_result_unknown', async () => {
-    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
+  it('sendCommand retries a post-connect drop with the SAME id when the extension journals ids', async () => {
+    mockEnsureReady('1.0.22');
+    const reset = new TypeError('fetch failed');
+    (reset as { cause?: unknown }).cause = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockRejectedValueOnce(reset)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: true, data: 'replayed' }),
+      } as Response);
+
+    await expect(sendCommand('navigate', { url: 'https://example.com' })).resolves.toBe('replayed');
+
+    const ids = fetchMock.mock.calls.map(([, init]) => (JSON.parse(String(init?.body)) as { id: string }).id);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it('sendCommand does NOT resend a post-connect drop when the extension predates the journal', async () => {
+    const ensureSpy = mockEnsureReady('1.0.21');
     const reset = new TypeError('fetch failed');
     (reset as { cause?: unknown }).cause = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
     vi.mocked(fetch).mockRejectedValueOnce(reset);
@@ -354,12 +380,12 @@ describe('daemon-client', () => {
       code: 'command_result_unknown',
     } satisfies Partial<BrowserCommandError>);
 
-    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(ensureSpy).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('sendCommand does NOT resend on a bare TypeError with no pre-connect cause', async () => {
-    const ensureSpy = vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady');
+  it('sendCommand does NOT resend a bare TypeError on a legacy extension', async () => {
+    const ensureSpy = mockEnsureReady('1.0.15');
     vi.mocked(fetch).mockRejectedValueOnce(new TypeError('fetch failed'));
 
     await expect(sendCommand('exec', { code: 'window.__mutate = true' })).rejects.toMatchObject({
@@ -367,7 +393,7 @@ describe('daemon-client', () => {
       code: 'command_result_unknown',
     } satisfies Partial<BrowserCommandError>);
 
-    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(ensureSpy).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -240,8 +240,11 @@ async function sendCommandRaw(
   let executorJournaled: boolean | null = null;
 
   const ensureBridge = async (): Promise<void> => {
+    // Bound the connect wait by the command's remaining budget so repeated
+    // daemon failures cannot stretch the total wall time far past --timeout.
+    const remainingSeconds = Math.ceil((deadlineAt - Date.now()) / 1000);
     const ready = await ensureBrowserBridgeReady({
-      timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
+      timeoutSeconds: Math.max(1, Math.min(DEFAULT_BROWSER_CONNECT_TIMEOUT, remainingSeconds)),
       contextId,
       verbose: false,
     });
@@ -282,10 +285,25 @@ async function sendCommandRaw(
         throw new BrowserCommandError(result.error ?? 'Browser command result is unknown', result.errorCode, result.errorHint);
       }
 
-      if ((isPreDispatchError(result.errorCode) || result.errorCode === 'daemon_shutting_down') && !ensureUsed) {
+      if (isPreDispatchError(result.errorCode) && !ensureUsed) {
+        // Never dispatched — resending the same id is safe on any extension.
         ensureUsed = true;
         await ensureBridge();
         continue;
+      }
+
+      if (result.errorCode === 'daemon_shutting_down' && !ensureUsed) {
+        // The command WAS dispatched and the daemon died before the result
+        // came back. Resending the same id is only safe when the extension
+        // journals ids; otherwise the outcome is genuinely unknown.
+        ensureUsed = true;
+        await ensureBridge();
+        if (executorJournaled) continue;
+        throw new BrowserCommandError(
+          result.error ?? 'Daemon shut down mid-command; the command may have already been applied.',
+          COMMAND_RESULT_UNKNOWN_CODE,
+          COMMAND_RESULT_UNKNOWN_HINT,
+        );
       }
 
       const advice = classifyBrowserError(new BrowserCommandError(result.error ?? '', result.errorCode));

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -62,6 +62,31 @@ function effectiveCommandTimeoutSeconds(params: Omit<DaemonCommand, 'id' | 'acti
 }
 
 /**
+ * First extension version with the command journal (see extension/src/
+ * journal.ts). From this version on, re-sending the SAME command id is safe:
+ * the executor replays the recorded result instead of re-executing.
+ */
+const MIN_JOURNAL_EXTENSION_VERSION = '1.0.22';
+
+function versionAtLeast(version: string | null | undefined, min: string): boolean {
+  if (!version) return false;
+  const a = version.replace(/^v/, '').split('-')[0].split('.').map(Number);
+  const b = min.split('.').map(Number);
+  if (a.length < 3 || a.some(Number.isNaN)) return false;
+  for (let i = 0; i < 3; i++) {
+    const d = a[i] - (b[i] ?? 0);
+    if (d !== 0) return d > 0;
+  }
+  return true;
+}
+
+/** Error codes meaning the executor's outcome is genuinely unknown — never auto-retry. */
+const UNKNOWN_OUTCOME_CODES = new Set(['command_result_unknown', 'command_lost', 'result_evicted']);
+
+/** Max transport attempts for one logical command (same id throughout). */
+const TRANSPORT_MAX_ATTEMPTS = 4;
+
+/**
  * undici surfaces network failures as `TypeError: fetch failed` with the real
  * error in `.cause` (possibly an AggregateError). Only failures that happen
  * before the request could reach the daemon are safe to auto-retry — a reset
@@ -135,10 +160,16 @@ export interface DaemonCommand {
   contextId?: string;
   /**
    * Daemon-side command timeout in seconds. Set by the transport layer from
-   * the effective command deadline; the extension derives its CDP deadline
-   * from the same value.
+   * the effective command deadline; kept for older daemons — new code prefers
+   * `deadlineAt`.
    */
   timeout?: number;
+  /**
+   * Absolute command deadline (epoch ms). All hops run on one machine, so
+   * every layer derives its remaining budget as `deadlineAt - Date.now()`,
+   * absorbing queueing and service-worker wake latency.
+   */
+  deadlineAt?: number;
 }
 
 export interface DaemonResult {
@@ -171,40 +202,67 @@ export {
 /**
  * Internal: send a command to the daemon and return the raw `DaemonResult`.
  *
- * Retry policy is explicit:
- * - pre-dispatch bridge/profile errors: run the full daemon/extension ensure
- *   path, then resend with a fresh transport id;
- * - fetch TypeError whose cause is a pre-connect failure (ECONNREFUSED etc.):
- *   same full ensure path, because the daemon may be stopped/stale and needs
- *   spawn/replacement — the request never reached it, so resending is safe;
- * - fetch TypeError after connect (ECONNRESET / socket hang-up): NOT retried —
- *   the daemon may have already dispatched the command to the browser, so this
- *   surfaces as `command_result_unknown` instead of risking a double write;
- * - `command_result_unknown` and AbortError: never retry automatically.
+ * There are exactly two retry classes, with different id semantics:
+ *
+ * TRANSPORT retries — the SAME command id, so the executor's journal replays
+ * an already-executed command instead of re-running it:
+ * - fetch failures (daemon down/replaced/crashed): run the ensure path (which
+ *   also spawns the daemon and tells us the extension version), then resend.
+ *   Requires a journaling extension unless the failure was pre-connect;
+ * - pre-dispatch bridge/profile errors and `daemon_shutting_down`;
+ * - a duplicate id landing on a still-pending command attaches to it in the
+ *   daemon (no re-dispatch), so same-id resends never double-execute.
+ *
+ * SEMANTIC retry — ONE new logical attempt with a NEW id, only for executor
+ * errors that happened before any page code ran (`attach_failed`/`tab_gone`).
+ * `target_navigated` is the page layer's decision, not ours.
+ *
+ * Never retried: `command_result_unknown` / `command_lost` / `result_evicted`
+ * (the outcome is genuinely unknown) and client-side AbortError (the shared
+ * deadline is already exhausted).
  */
 async function sendCommandRaw(
   action: DaemonCommand['action'],
   params: Omit<DaemonCommand, 'id' | 'action'>,
 ): Promise<DaemonResult> {
-  const maxAttempts = 4;
-  let dispatchRecoveryUsed = false;
-  let duplicateIdRetryUsed = false;
-  let transientRetryUsed = false;
+  const timeoutSeconds = effectiveCommandTimeoutSeconds(params);
+  const deadlineAt = Date.now() + timeoutSeconds * 1000;
+  const rawWindowMode = process.env.OPENCLI_WINDOW;
+  const envWindowMode = rawWindowMode === 'foreground' || rawWindowMode === 'background'
+    ? rawWindowMode
+    : undefined;
+  const contextId = params.contextId ?? resolveProfileContextId();
+  const windowMode = params.windowMode ?? envWindowMode;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const id = generateId();
-    const rawWindowMode = process.env.OPENCLI_WINDOW;
-    const envWindowMode = rawWindowMode === 'foreground' || rawWindowMode === 'background'
-      ? rawWindowMode
-      : undefined;
-    const contextId = params.contextId ?? resolveProfileContextId();
-    const windowMode = params.windowMode ?? envWindowMode;
-    const timeoutSeconds = effectiveCommandTimeoutSeconds(params);
+  let id = generateId();
+  let ensureUsed = false;
+  let semanticRetryUsed = false;
+  let executorJournaled: boolean | null = null;
+
+  const ensureBridge = async (): Promise<void> => {
+    const ready = await ensureBrowserBridgeReady({
+      timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
+      contextId,
+      verbose: false,
+    });
+    executorJournaled = versionAtLeast(ready.health.status?.extensionVersion, MIN_JOURNAL_EXTENSION_VERSION);
+  };
+
+  for (let attempt = 1; attempt <= TRANSPORT_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 1 && Date.now() >= deadlineAt) {
+      throw new BrowserCommandError(
+        'Browser command deadline exhausted across transport retries.',
+        COMMAND_RESULT_UNKNOWN_CODE,
+        COMMAND_RESULT_UNKNOWN_HINT,
+      );
+    }
+    const remainingMs = Math.max(1000, deadlineAt - Date.now());
     const command: DaemonCommand = {
       id,
       action,
       ...params,
       timeout: timeoutSeconds,
+      deadlineAt,
       ...(contextId && { contextId }),
       ...(windowMode && { windowMode }),
     };
@@ -213,38 +271,27 @@ async function sendCommandRaw(
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(command),
-        timeout: timeoutSeconds * 1000 + HTTP_TIMEOUT_MARGIN_MS,
+        timeout: remainingMs + HTTP_TIMEOUT_MARGIN_MS,
       });
 
       const result = (await res.json()) as DaemonResult;
 
       if (result.ok) return result;
 
-      if (result.errorCode === 'command_result_unknown') {
+      if (result.errorCode && UNKNOWN_OUTCOME_CODES.has(result.errorCode)) {
         throw new BrowserCommandError(result.error ?? 'Browser command result is unknown', result.errorCode, result.errorHint);
       }
 
-      if (!dispatchRecoveryUsed && isPreDispatchError(result.errorCode)) {
-        dispatchRecoveryUsed = true;
-        await ensureBrowserBridgeReady({
-          timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
-          contextId,
-          verbose: false,
-        });
+      if ((isPreDispatchError(result.errorCode) || result.errorCode === 'daemon_shutting_down') && !ensureUsed) {
+        ensureUsed = true;
+        await ensureBridge();
         continue;
       }
 
-      const isDuplicateCommandId = res.status === 409
-        && !result.errorCode
-        && (result.error ?? '').includes('Duplicate command id');
-      if (isDuplicateCommandId && !duplicateIdRetryUsed) {
-        duplicateIdRetryUsed = true;
-        continue;
-      }
-
-      const advice = classifyBrowserError(new Error(result.error ?? ''));
-      if (advice.retryable && !transientRetryUsed) {
-        transientRetryUsed = true;
+      const advice = classifyBrowserError(new BrowserCommandError(result.error ?? '', result.errorCode));
+      if (advice.kind === 'extension-transient' && !semanticRetryUsed) {
+        semanticRetryUsed = true;
+        id = generateId();
         await sleep(advice.delayMs);
         continue;
       }
@@ -256,40 +303,24 @@ async function sendCommandRaw(
       if (err instanceof Error && err.name === 'AbortError') {
         throw new BrowserCommandError(
           'Browser command timed out client-side; the page may still have applied it.',
-          'command_result_unknown',
-          'Inspect the page state before retrying. Idempotent reads are safe to retry; non-idempotent writes may have already happened.',
+          COMMAND_RESULT_UNKNOWN_CODE,
+          COMMAND_RESULT_UNKNOWN_HINT,
         );
       }
 
       if (err instanceof TypeError) {
-        if (!isPreConnectFetchError(err)) {
-          // Connection dropped after the request may have reached the daemon
-          // (ECONNRESET / socket hang-up) — the command may already be running
-          // in the browser, so resending would risk a double write.
-          throw new BrowserCommandError(
-            'Connection to the daemon was lost mid-command; it may have already been applied.',
-            COMMAND_RESULT_UNKNOWN_CODE,
-            COMMAND_RESULT_UNKNOWN_HINT,
-          );
-        }
-        if (!dispatchRecoveryUsed) {
-          dispatchRecoveryUsed = true;
-          await ensureBrowserBridgeReady({
-            timeoutSeconds: DEFAULT_BROWSER_CONNECT_TIMEOUT,
-            contextId,
-            verbose: false,
-          });
-          continue;
-        }
-      }
-
-      if (err instanceof Error) {
-        const advice = classifyBrowserError(err);
-        if (advice.retryable && !transientRetryUsed) {
-          transientRetryUsed = true;
-          await sleep(advice.delayMs);
-          continue;
-        }
+        // Transport failure — the request may or may not have reached the
+        // daemon. Bring the bridge back up (spawns a daemon if none is
+        // running) and learn whether the extension journals command ids.
+        await ensureBridge();
+        // Same-id resend is safe when the request never connected, or when
+        // the executor dedupes ids. Otherwise the outcome is unknown.
+        if (executorJournaled || isPreConnectFetchError(err)) continue;
+        throw new BrowserCommandError(
+          'Connection to the daemon was lost mid-command; it may have already been applied.',
+          COMMAND_RESULT_UNKNOWN_CODE,
+          COMMAND_RESULT_UNKNOWN_HINT,
+        );
       }
 
       throw err;

--- a/src/browser/errors.ts
+++ b/src/browser/errors.ts
@@ -64,11 +64,36 @@ function errorMessage(err: unknown): string {
 }
 
 /**
+ * Machine-readable error codes set by the extension at the failure site.
+ * These are authoritative — the message-pattern tables below are only a
+ * fallback for extensions that predate error codes.
+ *
+ * `detached_mid_command` and `cdp_timeout` are deliberately non-retryable:
+ * both mean execution died MID-command, so a blind re-run could double-apply
+ * a write. (The legacy pattern table still retries "Detached while handling
+ * command" because old extensions cannot distinguish pre- from mid-execution.)
+ */
+const ERROR_CODE_ADVICE: Record<string, RetryAdvice> = {
+  attach_failed: { kind: 'extension-transient', retryable: true, delayMs: 1500 },
+  tab_gone: { kind: 'extension-transient', retryable: true, delayMs: 1500 },
+  target_navigated: { kind: 'target-navigation', retryable: true, delayMs: 200 },
+  detached_mid_command: { kind: 'non-retryable', retryable: false, delayMs: 0 },
+  cdp_timeout: { kind: 'non-retryable', retryable: false, delayMs: 0 },
+};
+
+/**
  * Classify a browser error and return retry advice.
  *
  * Single source of truth for "is this error transient?" across all layers.
+ * Prefers the machine-readable `code` carried by BrowserCommandError; falls
+ * back to message patterns for legacy extensions.
  */
 export function classifyBrowserError(err: unknown): RetryAdvice {
+  const code = err && typeof err === 'object' ? (err as { code?: unknown }).code : undefined;
+  if (typeof code === 'string' && ERROR_CODE_ADVICE[code]) {
+    return ERROR_CODE_ADVICE[code];
+  }
+
   const msg = errorMessage(err);
 
   // Extension/daemon transient errors — longer recovery time

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,14 +52,33 @@ type ExtensionProfileConnection = {
 };
 
 const extensionProfiles = new Map<string, ExtensionProfileConnection>();
-const pending = new Map<string, {
+type PendingSettler = {
+  resolve: (data: unknown) => void;
+  reject: (error: Error) => void;
+};
+type PendingEntry = {
   contextId: string;
   action: string;
   dispatched: boolean;
-  resolve: (data: unknown) => void;
-  reject: (error: Error) => void;
+  /**
+   * All HTTP requests waiting on this command id. The first settler is the
+   * original request; transport retries with the same id attach here instead
+   * of re-dispatching, so a retry never re-executes a command that is still
+   * running.
+   */
+  settlers: PendingSettler[];
   timer: ReturnType<typeof setTimeout>;
-}>();
+};
+const pending = new Map<string, PendingEntry>();
+
+function settlePending(id: string, entry: PendingEntry, outcome: { data?: unknown; error?: Error }): void {
+  clearTimeout(entry.timer);
+  pending.delete(id);
+  for (const settler of entry.settlers) {
+    if (outcome.error) settler.reject(outcome.error);
+    else settler.resolve(outcome.data);
+  }
+}
 let commandResultUnknownCount = 0;
 // Extension log ring buffer
 interface LogEntry { level: string; msg: string; ts: number; }
@@ -148,7 +167,6 @@ function unregisterExtensionConnection(ws: WebSocket): void {
     extensionProfiles.delete(contextId);
     for (const [id, p] of pending) {
       if (p.contextId !== contextId) continue;
-      clearTimeout(p.timer);
       const failure = buildExtensionDisconnectFailure({
         contextId,
         action: p.action,
@@ -158,8 +176,7 @@ function unregisterExtensionConnection(ws: WebSocket): void {
         commandResultUnknownCount++;
         log.warn(`[daemon] Command result unknown after extension disconnect (id=${id}, action=${p.action}, context=${contextId})`);
       }
-      p.reject(new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status));
-      pending.delete(id);
+      settlePending(id, p, { error: new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status) });
     }
   }
 }
@@ -314,43 +331,46 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
-      const timeoutMs = typeof body.timeout === 'number' && body.timeout > 0
-        ? body.timeout * 1000
-        : 120000;
-      if (pending.has(body.id)) {
-        jsonResponse(res, 409, {
-          id: body.id,
-          ok: false,
-          error: 'Duplicate command id already pending; retry',
+      // Absolute deadline wins over the legacy duration field: all hops share
+      // one wall clock, so remaining budget absorbs queueing/transit time.
+      const timeoutMs = typeof body.deadlineAt === 'number' && body.deadlineAt > 0
+        ? Math.max(1000, body.deadlineAt - Date.now())
+        : (typeof body.timeout === 'number' && body.timeout > 0 ? body.timeout * 1000 : 120000);
+
+      // A transport retry of an in-flight command attaches to it instead of
+      // re-dispatching — the extension is already executing this id.
+      const existing = pending.get(body.id);
+      if (existing) {
+        const result = await new Promise<unknown>((resolve, reject) => {
+          existing.settlers.push({ resolve, reject });
         });
+        jsonResponse(res, 200, result);
         return;
       }
+
       const result = await new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           const entry = pending.get(body.id);
-          pending.delete(body.id);
-          const failure = buildCommandTimeoutFailure(entry?.action ?? 'unknown', timeoutMs);
-          if (failure.countAsCommandResultUnknown && entry?.dispatched) {
+          if (!entry) return;
+          const failure = buildCommandTimeoutFailure(entry.action, timeoutMs);
+          if (failure.countAsCommandResultUnknown && entry.dispatched) {
             commandResultUnknownCount++;
             log.warn(`[daemon] Command timed out after dispatch (id=${body.id}, action=${entry.action}, timeout=${timeoutMs}ms)`);
           }
-          reject(new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status));
+          settlePending(body.id, entry, { error: new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status) });
         }, timeoutMs);
-        const entry = {
+        const entry: PendingEntry = {
           contextId: route.connection!.contextId,
           action: typeof body.action === 'string' ? body.action : 'unknown',
           dispatched: false,
-          resolve,
-          reject,
+          settlers: [{ resolve, reject }],
           timer,
         };
         pending.set(body.id, entry);
         const failBeforeDispatch = (err: unknown) => {
           if (pending.get(body.id) !== entry) return;
           const failure = buildCommandDispatchFailure(entry.contextId);
-          clearTimeout(timer);
-          pending.delete(body.id);
-          reject(new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status));
+          settlePending(body.id, entry, { error: new DaemonCommandFailure(failure.message, failure.errorCode, failure.errorHint, failure.status) });
           log.warn(`[daemon] Failed to dispatch command ${body.id}: ${err instanceof Error ? err.message : String(err)}`);
         };
         try {
@@ -446,12 +466,14 @@ wss.on('connection', (ws: WebSocket) => {
         return;
       }
 
+      // Application-level keepalive from the extension — WS traffic is what
+      // keeps the MV3 service worker alive; nothing to do here.
+      if (msg.type === 'ping') return;
+
       // Handle command results
       const p = pending.get(msg.id);
       if (p) {
-        clearTimeout(p.timer);
-        pending.delete(msg.id);
-        p.resolve(msg);
+        settlePending(msg.id, p, { data: msg });
       }
     } catch (err) {
       // Malformed message from the extension. Surface so protocol drift /
@@ -494,15 +516,28 @@ httpServer.on('error', (err: NodeJS.ErrnoException) => {
 
 // Graceful shutdown
 function shutdown(): void {
-  // Reject all pending requests so CLI doesn't hang
-  for (const [, p] of pending) {
-    clearTimeout(p.timer);
-    p.reject(new Error('Daemon shutting down'));
+  // Reject all pending requests so the CLI gets a structured response it can
+  // act on (spawn a replacement daemon, retry the same id) instead of a
+  // socket hang-up it must treat as result-unknown.
+  for (const [id, p] of pending) {
+    settlePending(id, p, {
+      error: new DaemonCommandFailure(
+        'Daemon shutting down before the command completed.',
+        'daemon_shutting_down',
+        'The daemon is being replaced; the command can be retried with the same id once a daemon is running again.',
+        503,
+      ),
+    });
   }
   pending.clear();
   for (const profile of extensionProfiles.values()) profile.ws.close();
-  httpServer.close();
-  process.exit(EXIT_CODES.SUCCESS);
+  // Let the rejection responses flush before exiting — a synchronous
+  // process.exit() would kill the queued microtasks that write them.
+  httpServer.close(() => process.exit(EXIT_CODES.SUCCESS));
+  setTimeout(() => {
+    httpServer.closeIdleConnections?.();
+    setTimeout(() => process.exit(EXIT_CODES.SUCCESS), 500).unref();
+  }, 100).unref();
 }
 
 process.on('SIGTERM', shutdown);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -517,17 +517,23 @@ httpServer.on('error', (err: NodeJS.ErrnoException) => {
 // Graceful shutdown
 function shutdown(): void {
   // Reject all pending requests so the CLI gets a structured response it can
-  // act on (spawn a replacement daemon, retry the same id) instead of a
-  // socket hang-up it must treat as result-unknown.
+  // act on instead of a socket hang-up it must treat as result-unknown.
+  // Not-yet-dispatched commands get the pre-dispatch contract (safe to resend
+  // anywhere); dispatched ones get `daemon_shutting_down`, which the client
+  // only resends when the extension journals ids.
   for (const [id, p] of pending) {
-    settlePending(id, p, {
-      error: new DaemonCommandFailure(
+    const failure = p.dispatched
+      ? new DaemonCommandFailure(
         'Daemon shutting down before the command completed.',
         'daemon_shutting_down',
-        'The daemon is being replaced; the command can be retried with the same id once a daemon is running again.',
+        'The daemon is being replaced; a journaling extension replays the command result on retry.',
         503,
-      ),
-    });
+      )
+      : (() => {
+        const contract = buildCommandDispatchFailure(p.contextId);
+        return new DaemonCommandFailure(contract.message, contract.errorCode, contract.errorHint, contract.status);
+      })();
+    settlePending(id, p, { error: failure });
   }
   pending.clear();
   for (const profile of extensionProfiles.values()) profile.ws.close();


### PR DESCRIPTION
## Why

The transport layer had accumulated overlapping compensation at every hop: 6 retry owners, 7 timeout owners with 5 hand-tuned margin constants, 3 parallel error-classification mechanisms, and 4 sibling session-override Maps. Each layer distrusted the one below it. This PR rebuilds the contract around one principle:

> **exactly-once = at-least-once retry + an idempotent executor.**

Once the executor dedupes command ids, re-sending is harmless — so most of the per-layer compensation becomes deletable, and `command_result_unknown` shrinks from "any connection blip" to "the browser itself exited".

## The three primitives

**1. Command journal** (`extension/src/journal.ts`, ~130 lines, `chrome.storage.session`)
Every command id executes exactly once: concurrent duplicates attach to the in-flight promise; completed ids replay the recorded result; ids whose service worker died mid-execution report `command_lost` honestly (write-ahead `started` marker). `storage.session` survives SW restarts and clears on browser exit — precisely the lifetime a retry cares about. Oversized results (>64KB) are not recorded; their replay returns `result_evicted` instead of silently re-executing.

**2. Stable ids + daemon waiters**
Transport retries keep the **same** id; the daemon attaches duplicate ids to the pending command (waiter list) instead of rejecting with 409. Retry coverage matrix:
- WS flap / SW keepalive jitter → in-memory dedup hits
- SW killed and restarted → `storage.session` journal hits
- daemon crash/restart → new daemon forwards, extension journal hits
- browser exit → honestly unknown (irreducible)

Gated on extension ≥ 1.0.22 (learned from the ensure path's health probe); legacy extensions keep the old conservative pre-connect-only retry. Semantic retries (`attach_failed`/`tab_gone` — failures **before** any page code ran) are the only place a new id is minted, once.

**3. Absolute deadline** (`deadlineAt`, epoch ms)
Same machine, one clock: every layer computes `remaining = deadlineAt - now`, so daemon queueing and SW wake latency no longer silently shrink the innermost budget or invert the layering. The legacy `timeout` (seconds) field is still sent for older daemons.

## Error contract: classify once, at the source

The extension tags failures with machine-readable codes (`attach_failed`, `tab_gone`, `target_navigated`, `detached_mid_command`, `cdp_timeout`); `errors.ts` prefers codes and keeps the message-pattern tables only as a legacy fallback. `detached_mid_command`/`cdp_timeout` are now correctly **non-retryable** — they die mid-execution, so a blind re-run could double-apply a write (previously "Detached while handling command" was blindly retried).

## Deleted / simplified

- extension `evaluate()`'s inner retry loop — the client owns semantic retries now (one owner per retry class: transport=same id, semantic=new id, target-navigation=page layer)
- the fast/slow phased reconnect window + `notifyDaemonReachable` rescheduling → plain exponential backoff with jitter (1s→…→15s cap, reset on success)
- the three parallel session-override Maps → one record per lease
- the three one-shot retry flags in `sendCommandRaw` → two explicit retry classes

## Stability fixes riding the same contract

- **WS application-level keepalive** (`{type:'ping'}` every 20s): Chrome 116+ only extends the SW lifetime on WS *activity*; an idle socket lived on a knife-edge between the 30s idle kill and the 30s keepalive alarm
- **idle-lease release deferred while a command executes** (refcount) — a 30s idle timer can no longer tear the tab down mid-command; the idle window now measures from command completion
- **daemon shutdown flushes structured 503s** (`daemon_shutting_down`) before exiting, instead of `process.exit()` killing the queued responses; clients re-ensure and retry the same id
- **results delivered on the freshest open socket** after a reconnect instead of being dropped when the executing socket was superseded

## Compatibility

- new CLI + old daemon: sends `timeout` alongside `deadlineAt`; old daemon's 409 path is only reachable from old clients (new clients never reuse an id against a still-pending old daemon without the ensure probe running first)
- new CLI + old extension: capability gate falls back to the previous conservative retry semantics
- old CLI + new daemon/extension: never reuses ids; journal and waiters are inert

## Testing

- Full suite: **545 files / 5913 tests green**; `tsc --noEmit` clean in both packages; extension `vite build` OK
- New: `journal.test.ts` (replay, in-flight attach, `command_lost` after WAL, `result_evicted`, storage-less degradation), same-id transport retry semantics, capability gating, executor-transient new-id retry, `detached_mid_command` non-retry, backoff shape tests
- Extension version bumped to **1.0.22** (= `MIN_JOURNAL_EXTENSION_VERSION`)