### PR TITLE
fix(browser): stale default profile must not veto live connections

### DIFF
--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -75,8 +75,14 @@ export interface Command {
   idleTimeout?: number;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
-  /** Browser profile/context selected by the CLI. Used by the daemon for routing. */
+  /** Browser profile/context REQUIRED by the CLI (--profile / env). Used by the daemon for strict routing. */
   contextId?: string;
+  /**
+   * Browser profile/context PREFERRED by the CLI (persisted config default).
+   * Daemon-only routing hint: used when connected, otherwise the daemon falls
+   * back to the only connected profile. The extension ignores this field.
+   */
+  preferredContextId?: string;
   /**
    * Daemon-side command timeout in seconds, set by the CLI transport. The
    * extension derives its CDP deadline from this so it fails just before the

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -6,7 +6,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { IPage } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { Page } from './page.js';
-import { resolveProfileContextId } from './profile.js';
+import { profileRouteParams, resolveProfileSelection } from './profile.js';
 import { ensureBrowserBridgeReady } from './daemon-lifecycle.js';
 
 const DAEMON_SPAWN_TIMEOUT = 10000; // 10s to wait for daemon + extension
@@ -25,7 +25,7 @@ export class BrowserBridge implements IBrowserFactory {
     return this._state;
   }
 
-  async connect(opts: { timeout?: number; session?: string; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' } = {}): Promise<IPage> {
+  async connect(opts: { timeout?: number; session?: string; idleTimeout?: number; contextId?: string; preferredContextId?: string; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' } = {}): Promise<IPage> {
     if (this._state === 'connected' && this._page) return this._page;
     if (this._state === 'connecting') throw new Error('Already connecting');
     if (this._state === 'closing') throw new Error('Session is closing');
@@ -34,10 +34,16 @@ export class BrowserBridge implements IBrowserFactory {
     this._state = 'connecting';
 
     try {
-      const contextId = opts.contextId ?? resolveProfileContextId();
-      await this._ensureDaemon(opts.timeout, contextId);
+      // Requirement vs preference: only an explicit contextId pins daemon
+      // readiness and command routing to a specific profile. A preferred one
+      // (config default) is arbitrated by the daemon against live connections,
+      // so a stale default cannot make connect() wait for a dead profile.
+      const routing = opts.contextId || opts.preferredContextId
+        ? { contextId: opts.contextId, preferredContextId: opts.preferredContextId }
+        : profileRouteParams(resolveProfileSelection());
+      await this._ensureDaemon(opts.timeout, routing.contextId);
       if (!opts.session?.trim()) throw new Error('Browser session is required');
-      this._page = new Page(opts.session.trim(), opts.idleTimeout, contextId, opts.windowMode, opts.surface, opts.siteSession);
+      this._page = new Page(opts.session.trim(), opts.idleTimeout, routing.contextId, opts.windowMode, opts.surface, opts.siteSession, routing.preferredContextId);
       this._state = 'connected';
       return this._page;
     } catch (err) {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -194,7 +194,7 @@ describe('daemon-client', () => {
     expect(ids[0]).not.toBe(ids[1]);
   });
 
-  it('sendCommand forwards OPENCLI_PROFILE as command contextId', async () => {
+  it('sendCommand forwards OPENCLI_PROFILE as a hard contextId requirement', async () => {
     vi.stubEnv('OPENCLI_PROFILE', 'work');
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
     vi.mocked(fetch).mockResolvedValue({
@@ -204,8 +204,36 @@ describe('daemon-client', () => {
 
     await sendCommand('exec', { code: '1 + 1' });
 
-    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { contextId?: string };
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { contextId?: string; preferredContextId?: string };
     expect(body.contextId).toBe('work');
+    expect(body.preferredContextId).toBeUndefined();
+  });
+
+  it('sendCommand forwards the config default as a soft preferredContextId, not a requirement', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-dc-profile-'));
+    fs.writeFileSync(
+      path.join(configDir, 'browser-profiles.json'),
+      JSON.stringify({ version: 1, aliases: {}, defaultContextId: 'zvypsyje' }),
+    );
+    vi.stubEnv('OPENCLI_CONFIG_DIR', configDir);
+    vi.stubEnv('OPENCLI_PROFILE', '');
+    try {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+      } as Response);
+
+      await sendCommand('exec', { code: '1 + 1' });
+
+      const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { contextId?: string; preferredContextId?: string };
+      expect(body.preferredContextId).toBe('zvypsyje');
+      expect(body.contextId).toBeUndefined();
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
   });
 
   it('sendCommand uses explicit windowMode before OPENCLI_WINDOW env fallback', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -8,7 +8,7 @@ import { sleep } from '../utils.js';
 import { BrowserConnectError } from '../errors.js';
 import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT } from '../daemon-utils.js';
 import { classifyBrowserError } from './errors.js';
-import { resolveProfileContextId } from './profile.js';
+import { profileRouteParams, resolveProfileSelection } from './profile.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './config.js';
 import { ensureBrowserBridgeReady } from './daemon-lifecycle.js';
 import { isPreDispatchError } from './bridge-readiness.js';
@@ -156,8 +156,15 @@ export interface DaemonCommand {
   idleTimeout?: number;
   /** Frame index for cross-frame operations (0-based, from 'frames' action) */
   frameIndex?: number;
-  /** Browser profile/context to route the command to. */
+  /** Browser profile/context REQUIRED for this command (--profile / OPENCLI_PROFILE). Fails loud when offline. */
   contextId?: string;
+  /**
+   * Browser profile/context PREFERRED for this command (persisted config
+   * default). The daemon uses it when connected, and falls back to the only
+   * connected profile when it is not — a stale default must never veto live
+   * reality. Mutually exclusive with `contextId`.
+   */
+  preferredContextId?: string;
   /**
    * Daemon-side command timeout in seconds. Set by the transport layer from
    * the effective command deadline; kept for older daemons — new code prefers
@@ -231,7 +238,13 @@ async function sendCommandRaw(
   const envWindowMode = rawWindowMode === 'foreground' || rawWindowMode === 'background'
     ? rawWindowMode
     : undefined;
-  const contextId = params.contextId ?? resolveProfileContextId();
+  // Requirement vs preference: an explicit contextId routes strictly; a
+  // preferred one is arbitrated by the daemon against live connections.
+  const routing = params.contextId || params.preferredContextId
+    ? { contextId: params.contextId, preferredContextId: params.preferredContextId }
+    : profileRouteParams(resolveProfileSelection());
+  const contextId = routing.contextId;
+  const preferredContextId = routing.preferredContextId;
   const windowMode = params.windowMode ?? envWindowMode;
 
   let id = generateId();
@@ -245,6 +258,9 @@ async function sendCommandRaw(
     const remainingSeconds = Math.ceil((deadlineAt - Date.now()) / 1000);
     const ready = await ensureBrowserBridgeReady({
       timeoutSeconds: Math.max(1, Math.min(DEFAULT_BROWSER_CONNECT_TIMEOUT, remainingSeconds)),
+      // Only an explicit requirement pins readiness to a specific profile —
+      // waiting for a stale preferred profile to come back would hang the
+      // ensure path even though the daemon can already serve the command.
       contextId,
       verbose: false,
     });
@@ -267,6 +283,7 @@ async function sendCommandRaw(
       timeout: timeoutSeconds,
       deadlineAt,
       ...(contextId && { contextId }),
+      ...(preferredContextId && { preferredContextId }),
       ...(windowMode && { windowMode }),
     };
     try {

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -49,6 +49,8 @@ export class Page extends BasePage {
     private readonly windowMode?: 'foreground' | 'background',
     private readonly surface: 'browser' | 'adapter' = 'browser',
     private readonly siteSession?: 'ephemeral' | 'persistent',
+    /** Soft profile preference (config default) — daemon arbitrates; see profileRouteParams. */
+    public readonly preferredContextId?: string,
   ) {
     super();
     this._idleTimeout = idleTimeout;
@@ -60,11 +62,12 @@ export class Page extends BasePage {
   private _networkCaptureWarned = false;
 
   /** Helper: spread session into command params */
-  private _sessionOpts(): { session: string; surface: 'browser' | 'adapter'; idleTimeout?: number; contextId?: string; windowMode?: 'foreground' | 'background'; siteSession?: 'ephemeral' | 'persistent' } {
+  private _sessionOpts(): { session: string; surface: 'browser' | 'adapter'; idleTimeout?: number; contextId?: string; preferredContextId?: string; windowMode?: 'foreground' | 'background'; siteSession?: 'ephemeral' | 'persistent' } {
     return {
       session: this.session,
       surface: this.surface,
       ...(this.contextId && { contextId: this.contextId }),
+      ...(this.preferredContextId && { preferredContextId: this.preferredContextId }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
       ...(this.windowMode && { windowMode: this.windowMode }),
       ...(this.siteSession && { siteSession: this.siteSession }),
@@ -77,6 +80,7 @@ export class Page extends BasePage {
       session: this.session,
       surface: this.surface,
       ...(this.contextId && { contextId: this.contextId }),
+      ...(this.preferredContextId && { preferredContextId: this.preferredContextId }),
       ...(this._page !== undefined && { page: this._page }),
       ...(this._idleTimeout != null && { idleTimeout: this._idleTimeout }),
       ...(this.windowMode && { windowMode: this.windowMode }),

--- a/src/browser/profile.test.ts
+++ b/src/browser/profile.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { profileRouteParams, resolveProfileSelection } from './profile.js';
+
+describe('profile selection (requirement vs preference)', () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-profile-test-'));
+    vi.stubEnv('OPENCLI_CONFIG_DIR', configDir);
+    vi.stubEnv('OPENCLI_PROFILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(config: object): void {
+    fs.writeFileSync(path.join(configDir, 'browser-profiles.json'), JSON.stringify(config));
+  }
+
+  it('tags an explicit --profile argument as explicit and resolves aliases', () => {
+    writeConfig({ version: 1, aliases: { work: 'zvypsyje' } });
+    expect(resolveProfileSelection('work')).toEqual({ contextId: 'zvypsyje', source: 'explicit' });
+  });
+
+  it('tags OPENCLI_PROFILE env as explicit', () => {
+    vi.stubEnv('OPENCLI_PROFILE', 'pavmrekj');
+    expect(resolveProfileSelection()).toEqual({ contextId: 'pavmrekj', source: 'explicit' });
+  });
+
+  it('tags the persisted config default as preferred, not explicit', () => {
+    writeConfig({ version: 1, aliases: {}, defaultContextId: 'zvypsyje' });
+    expect(resolveProfileSelection()).toEqual({ contextId: 'zvypsyje', source: 'preferred' });
+  });
+
+  it('explicit argument beats env beats config default', () => {
+    vi.stubEnv('OPENCLI_PROFILE', 'from-env');
+    writeConfig({ version: 1, aliases: {}, defaultContextId: 'from-config' });
+    expect(resolveProfileSelection('from-arg')).toEqual({ contextId: 'from-arg', source: 'explicit' });
+    expect(resolveProfileSelection()).toEqual({ contextId: 'from-env', source: 'explicit' });
+  });
+
+  it('returns undefined with no argument, env, or config default', () => {
+    expect(resolveProfileSelection()).toBeUndefined();
+  });
+
+  it('profileRouteParams maps explicit → contextId and preferred → preferredContextId', () => {
+    expect(profileRouteParams({ contextId: 'a', source: 'explicit' })).toEqual({ contextId: 'a' });
+    expect(profileRouteParams({ contextId: 'b', source: 'preferred' })).toEqual({ preferredContextId: 'b' });
+    expect(profileRouteParams(undefined)).toEqual({});
+  });
+});

--- a/src/browser/profile.ts
+++ b/src/browser/profile.ts
@@ -53,13 +53,45 @@ export function saveProfileConfig(config: ProfileConfig): void {
   fs.writeFileSync(target, JSON.stringify(config, null, 2) + '\n', 'utf-8');
 }
 
-export function resolveProfileContextId(profile?: string): string | undefined {
+export type ProfileSelection = {
+  contextId: string;
+  /**
+   * 'explicit' — the user demanded this profile right now (--profile argument
+   * or OPENCLI_PROFILE env): route strictly and fail loud if it is offline.
+   * 'preferred' — the persisted default from browser-profiles.json. A default
+   * is a preference, not a requirement: its lifetime routinely exceeds the
+   * extension instance it names (reinstalling the extension regenerates the
+   * contextId), so the daemon may fall back to the only connected profile
+   * when the preferred one is offline.
+   */
+  source: 'explicit' | 'preferred';
+};
+
+export function resolveProfileSelection(profile?: string): ProfileSelection | undefined {
   const config = loadProfileConfig();
-  const requested = normalizeContextId(profile)
-    ?? normalizeContextId(process.env.OPENCLI_PROFILE)
-    ?? normalizeContextId(config.defaultContextId);
-  if (!requested) return undefined;
-  return config.aliases[requested] ?? requested;
+  const explicit = normalizeContextId(profile) ?? normalizeContextId(process.env.OPENCLI_PROFILE);
+  if (explicit) return { contextId: config.aliases[explicit] ?? explicit, source: 'explicit' };
+  const preferred = normalizeContextId(config.defaultContextId);
+  if (preferred) return { contextId: config.aliases[preferred] ?? preferred, source: 'preferred' };
+  return undefined;
+}
+
+/**
+ * Map a selection to wire/connect routing params. Exactly one of the two
+ * fields is set — `contextId` is a hard requirement, `preferredContextId`
+ * lets the daemon arbitrate against live connections.
+ */
+export function profileRouteParams(
+  selection: ProfileSelection | undefined,
+): { contextId?: string; preferredContextId?: string } {
+  if (!selection) return {};
+  return selection.source === 'explicit'
+    ? { contextId: selection.contextId }
+    : { preferredContextId: selection.contextId };
+}
+
+export function resolveProfileContextId(profile?: string): string | undefined {
+  return resolveProfileSelection(profile)?.contextId;
 }
 
 export function aliasForContextId(config: ProfileConfig, contextId: string): string | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -603,8 +603,15 @@ function getPageSession(page: import('./types.js').IPage): string {
 }
 
 function getPageScope(page: import('./types.js').IPage): string {
-  const contextId = (page as unknown as { contextId?: unknown }).contextId;
-  return getBrowserScope(getPageSession(page), typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined);
+  // Scope is keyed by the SELECTED profile (explicit or preferred), matching
+  // getBrowserPage's targetScope — reading only the explicit contextId would
+  // save and look up the remembered tab under different keys whenever the
+  // profile came from the config default.
+  const { contextId, preferredContextId } = page as unknown as { contextId?: unknown; preferredContextId?: unknown };
+  const selected = typeof contextId === 'string' && contextId.trim()
+    ? contextId.trim()
+    : (typeof preferredContextId === 'string' && preferredContextId.trim() ? preferredContextId.trim() : undefined);
+  return getBrowserScope(getPageSession(page), selected);
 }
 
 type SnapshotSource = 'dom' | 'ax';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,7 @@ import { daemonRestart, daemonStatus, daemonStop } from './commands/daemon.js';
 import { log } from './logger.js';
 import { bindTab, BrowserCommandError, sendCommand } from './browser/daemon-client.js';
 import { fetchDaemonStatus } from './browser/daemon-transport.js';
-import { aliasForContextId, loadProfileConfig, renameProfile, resolveProfileContextId, setDefaultProfile } from './browser/profile.js';
+import { aliasForContextId, loadProfileConfig, profileRouteParams, renameProfile, resolveProfileSelection, setDefaultProfile, type ProfileSelection } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './browser/config.js';
 import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './types.js';
@@ -519,7 +519,7 @@ async function resolveStoredBrowserTarget(page: import('./types.js').IPage, scop
 async function getBrowserPage(
   session: string,
   targetPage?: string,
-  contextId?: string,
+  profileSelection?: ProfileSelection,
   opts: { windowMode?: BrowserWindowMode } = {},
 ): Promise<import('./types.js').IPage> {
   const { BrowserBridge } = await import('./browser/index.js');
@@ -531,11 +531,11 @@ async function getBrowserPage(
     timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
     session,
     surface: 'browser',
-    ...(contextId && { contextId }),
+    ...profileRouteParams(profileSelection),
     ...(idleTimeout && idleTimeout > 0 && { idleTimeout }),
     windowMode: opts.windowMode ?? getBrowserWindowMode(undefined, 'foreground'),
   });
-  const targetScope = getBrowserScope(session, contextId);
+  const targetScope = getBrowserScope(session, profileSelection?.contextId);
   const resolvedTargetPage = targetPage
     ? await resolveBrowserTargetInSession(page, targetPage, { scope: targetScope, source: 'explicit' })
     : await resolveStoredBrowserTarget(page, targetScope);
@@ -591,9 +591,9 @@ function getBrowserSession(command?: Command): string {
   throw new Error('<session> is a required positional argument: opencli browser <session> <command>');
 }
 
-function getBrowserContextId(command?: Command): string | undefined {
+function getBrowserProfileSelection(command?: Command): ProfileSelection | undefined {
   const raw = getCommandOption(command, 'profile');
-  return resolveProfileContextId(typeof raw === 'string' && raw.trim() ? raw.trim() : undefined);
+  return resolveProfileSelection(typeof raw === 'string' && raw.trim() ? raw.trim() : undefined);
 }
 
 function getPageSession(page: import('./types.js').IPage): string {
@@ -1005,9 +1005,9 @@ Examples:
         const command = args.at(-1) instanceof Command ? args.at(-1) as Command : undefined;
         const targetPage = getBrowserTargetId(command);
         const session = getBrowserSession(command);
-        const contextId = getBrowserContextId(command);
+        const profileSelection = getBrowserProfileSelection(command);
         const windowMode = getBrowserWindowMode(command, 'foreground');
-        page = await getBrowserPage(session, targetPage, contextId, { windowMode });
+        page = await getBrowserPage(session, targetPage, profileSelection, { windowMode });
         await fn(page, ...args);
       } catch (err) {
         if (err instanceof BrowserConnectError) {
@@ -1050,11 +1050,12 @@ Examples:
     return async (optsOrCommand: unknown, maybeCommand?: Command) => {
       const command = optsOrCommand instanceof Command ? optsOrCommand : maybeCommand;
       const session = getBrowserSession(command);
-      const contextId = getBrowserContextId(command);
+      const profileSelection = getBrowserProfileSelection(command);
+      const contextId = profileSelection?.contextId;
       try {
         const { BrowserBridge } = await import('./browser/index.js');
         const bridge = new BrowserBridge();
-        await bridge.connect({ timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT, session, surface: 'browser', ...(contextId && { contextId }) });
+        await bridge.connect({ timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT, session, surface: 'browser', ...profileRouteParams(profileSelection) });
         await fn({ session, contextId });
       } catch (err) {
         if (err instanceof BrowserCommandError) {

--- a/src/daemon-utils.ts
+++ b/src/daemon-utils.ts
@@ -35,6 +35,68 @@ export function buildExtensionDisconnectFailure(input: {
   return buildCommandDispatchFailure(input.contextId);
 }
 
+export type ProfileRouteInput = {
+  /** Hard requirement (--profile / OPENCLI_PROFILE) — never falls back. */
+  requestedContextId?: string;
+  /** Soft preference (config defaultContextId) — arbitrated against live state. */
+  preferredContextId?: string;
+  /** contextIds of currently connected extension profiles. */
+  connectedContextIds: string[];
+};
+
+export type ProfileRouteResult =
+  | { ok: true; contextId: string; /** set when a stale preference was overridden by the only live profile */ fallbackFrom?: string }
+  | { ok: false; errorCode: 'profile_disconnected' | 'profile_required' | 'extension_not_connected'; error: string; errorHint?: string };
+
+/**
+ * Decide which extension profile serves a command. The arbiter lives with the
+ * daemon because the daemon is the only component that knows live connections:
+ * a REQUIREMENT fails loud when offline, a PREFERENCE falls back to the only
+ * connected profile — which keeps the documented promise "with only one
+ * connected profile, OpenCLI uses it automatically" true even when a persisted
+ * default outlives the extension instance it names.
+ */
+export function resolveProfileRoute(input: ProfileRouteInput): ProfileRouteResult {
+  const requested = input.requestedContextId?.trim() || undefined;
+  const preferred = input.preferredContextId?.trim() || undefined;
+  const connected = input.connectedContextIds;
+
+  if (requested) {
+    if (connected.includes(requested)) return { ok: true, contextId: requested };
+    return {
+      ok: false,
+      errorCode: 'profile_disconnected',
+      error: `Browser profile "${requested}" is not connected.`,
+      errorHint: PROFILE_DISCONNECTED_HINT,
+    };
+  }
+
+  if (preferred && connected.includes(preferred)) return { ok: true, contextId: preferred };
+
+  if (connected.length === 1) {
+    return { ok: true, contextId: connected[0], ...(preferred ? { fallbackFrom: preferred } : {}) };
+  }
+
+  if (connected.length > 1) {
+    return {
+      ok: false,
+      errorCode: 'profile_required',
+      error: preferred
+        ? `Default browser profile "${preferred}" is not connected and multiple profiles are available; choose one with --profile.`
+        : 'Multiple Browser Bridge profiles are connected; choose one with --profile.',
+      errorHint: preferred
+        ? 'Run opencli profile list, then update the stale default with opencli profile use <name> or pass --profile <name>.'
+        : 'Run opencli profile list, then use opencli --profile <name> ... or opencli profile use <name>.',
+    };
+  }
+
+  return {
+    ok: false,
+    errorCode: 'extension_not_connected',
+    error: 'Extension not connected. Please install the opencli Browser Bridge extension.',
+  };
+}
+
 export function buildCommandTimeoutFailure(action: string, timeoutMs: number): DaemonFailureContract {
   return {
     message: `Browser ${action} command timed out after ${Math.round(timeoutMs / 1000)}s; it may still complete in the browser.`,

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -8,6 +8,7 @@ import {
   buildExtensionDisconnectFailure,
   commandResultUnknownMessage,
   getResponseCorsHeaders,
+  resolveProfileRoute,
 } from './daemon-utils.js';
 
 describe('getResponseCorsHeaders', () => {
@@ -73,6 +74,48 @@ describe('daemon command dispatch', () => {
       status: 503,
       countAsCommandResultUnknown: false,
     });
+  });
+
+  it('routes a REQUESTED profile strictly — fails loud when offline, even with one live profile', () => {
+    expect(resolveProfileRoute({ requestedContextId: 'zvypsyje', connectedContextIds: ['pavmrekj'] })).toMatchObject({
+      ok: false,
+      errorCode: 'profile_disconnected',
+    });
+    expect(resolveProfileRoute({ requestedContextId: 'pavmrekj', connectedContextIds: ['pavmrekj'] })).toEqual({
+      ok: true,
+      contextId: 'pavmrekj',
+    });
+  });
+
+  it('uses a PREFERRED profile when connected', () => {
+    expect(resolveProfileRoute({ preferredContextId: 'zvypsyje', connectedContextIds: ['zvypsyje', 'other'] })).toEqual({
+      ok: true,
+      contextId: 'zvypsyje',
+    });
+  });
+
+  it('falls back to the only connected profile when the preferred one is stale', () => {
+    expect(resolveProfileRoute({ preferredContextId: 'zvypsyje', connectedContextIds: ['pavmrekj'] })).toEqual({
+      ok: true,
+      contextId: 'pavmrekj',
+      fallbackFrom: 'zvypsyje',
+    });
+  });
+
+  it('asks the user to choose when the preferred profile is stale and multiple are connected', () => {
+    const route = resolveProfileRoute({ preferredContextId: 'zvypsyje', connectedContextIds: ['a', 'b'] });
+    expect(route).toMatchObject({ ok: false, errorCode: 'profile_required' });
+    if (!route.ok) {
+      expect(route.error).toContain('zvypsyje');
+      expect(route.errorHint).toContain('opencli profile use');
+    }
+  });
+
+  it('keeps the legacy no-selection behavior: single auto-use, multiple ask, none error', () => {
+    expect(resolveProfileRoute({ connectedContextIds: ['only'] })).toEqual({ ok: true, contextId: 'only' });
+    expect(resolveProfileRoute({ connectedContextIds: ['a', 'b'] })).toMatchObject({ ok: false, errorCode: 'profile_required' });
+    expect(resolveProfileRoute({ connectedContextIds: [] })).toMatchObject({ ok: false, errorCode: 'extension_not_connected' });
+    expect(resolveProfileRoute({ preferredContextId: 'gone', connectedContextIds: [] })).toMatchObject({ ok: false, errorCode: 'extension_not_connected' });
   });
 
   it('classifies daemon-side command timeouts as command_result_unknown with a 408', () => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -29,10 +29,12 @@ import { PKG_VERSION } from './version.js';
 import { DEFAULT_CONTEXT_ID } from './browser/profile.js';
 import { recordExtensionVersion } from './update-check.js';
 import {
+  PROFILE_DISCONNECTED_HINT,
   buildCommandDispatchFailure,
   buildCommandTimeoutFailure,
   buildExtensionDisconnectFailure,
   getResponseCorsHeaders,
+  resolveProfileRoute,
 } from './daemon-utils.js';
 
 const PORT = DEFAULT_DAEMON_PORT;
@@ -106,35 +108,37 @@ function activeProfiles(): ExtensionProfileConnection[] {
   return [...extensionProfiles.values()].filter((entry) => entry.ws.readyState === WebSocket.OPEN);
 }
 
-function resolveExtensionConnection(contextId?: string): {
+/** Stale defaults we already warned about — one log line per daemon lifetime. */
+const staleDefaultWarned = new Set<string>();
+
+function resolveExtensionConnection(contextId?: string, preferredContextId?: string): {
   connection?: ExtensionProfileConnection;
   errorCode?: 'extension_not_connected' | 'profile_required' | 'profile_disconnected';
   error?: string;
   errorHint?: string;
 } {
-  const requestedContextId = typeof contextId === 'string' && contextId.trim() ? contextId.trim() : undefined;
-  if (requestedContextId) {
-    const connection = extensionProfiles.get(requestedContextId);
-    if (connection?.ws.readyState === WebSocket.OPEN) return { connection };
-    return {
-      errorCode: 'profile_disconnected',
-      error: `Browser profile "${requestedContextId}" is not connected.`,
-      errorHint: 'Open that Chrome profile and make sure the OpenCLI extension is enabled, or choose another profile with opencli profile use <name>.',
-    };
+  const route = resolveProfileRoute({
+    requestedContextId: typeof contextId === 'string' ? contextId : undefined,
+    preferredContextId: typeof preferredContextId === 'string' ? preferredContextId : undefined,
+    connectedContextIds: activeProfiles().map((entry) => entry.contextId),
+  });
+  if (!route.ok) {
+    return { errorCode: route.errorCode, error: route.error, ...(route.errorHint ? { errorHint: route.errorHint } : {}) };
   }
-
-  const connected = activeProfiles();
-  if (connected.length === 1) return { connection: connected[0] };
-  if (connected.length > 1) {
-    return {
-      errorCode: 'profile_required',
-      error: 'Multiple Browser Bridge profiles are connected; choose one with --profile.',
-      errorHint: 'Run opencli profile list, then use opencli --profile <name> ... or opencli profile use <name>.',
-    };
+  if (route.fallbackFrom && !staleDefaultWarned.has(route.fallbackFrom)) {
+    staleDefaultWarned.add(route.fallbackFrom);
+    log.warn(
+      `[daemon] Default profile "${route.fallbackFrom}" is not connected; ` +
+      `using the only connected profile "${route.contextId}". Update the default with: opencli profile use <name>`,
+    );
   }
+  const connection = extensionProfiles.get(route.contextId);
+  if (connection?.ws.readyState === WebSocket.OPEN) return { connection };
+  // Connection raced away between arbitration and lookup.
   return {
-    errorCode: 'extension_not_connected',
-    error: 'Extension not connected. Please install the opencli Browser Bridge extension.',
+    errorCode: 'profile_disconnected',
+    error: `Browser profile "${route.contextId}" is not connected.`,
+    errorHint: PROFILE_DISCONNECTED_HINT,
   };
 }
 
@@ -319,7 +323,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
-      const route = resolveExtensionConnection(typeof body.contextId === 'string' ? body.contextId : undefined);
+      const route = resolveExtensionConnection(
+        typeof body.contextId === 'string' ? body.contextId : undefined,
+        typeof body.preferredContextId === 'string' ? body.preferredContextId : undefined,
+      );
       if (!route.connection) {
         jsonResponse(res, route.errorCode === 'profile_required' ? 409 : 503, {
           id: body.id,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -181,6 +181,38 @@ describe('doctor report rendering', () => {
     ]));
   });
 
+  it('reports a stale default profile when it is not among the connected profiles', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-doctor-profile-'));
+    fs.writeFileSync(
+      path.join(configDir, 'browser-profiles.json'),
+      JSON.stringify({ version: 1, aliases: { work: 'zvypsyje' }, defaultContextId: 'zvypsyje' }),
+    );
+    vi.stubEnv('OPENCLI_CONFIG_DIR', configDir);
+    try {
+      mockGetDaemonHealth.mockResolvedValueOnce({
+        state: 'ready',
+        status: {
+          extensionConnected: true,
+          extensionVersion: '1.0.22',
+          profiles: [{ contextId: 'pavmrekj', extensionConnected: true }],
+        },
+      });
+
+      const report = await runBrowserDoctor();
+
+      expect(report.issues).toEqual(expect.arrayContaining([
+        expect.stringContaining('Default browser profile is stale: work (zvypsyje)'),
+      ]));
+      expect(report.issues.join('\n')).toContain('fall back to the only connected profile: pavmrekj');
+    } finally {
+      vi.unstubAllEnvs();
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
   it('reports flapping when live check succeeds but final status shows extension disconnected', async () => {
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'no-extension', status: { extensionConnected: false } });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -171,6 +171,24 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   if (!connectivity.ok) {
     issues.push(`Browser connectivity test failed: ${connectivity.error ?? 'unknown'}`);
   }
+  // Stale default detection: a persisted default profile routinely outlives
+  // the extension instance it names (reinstalls regenerate the contextId).
+  // Commands keep working via the daemon's single-profile fallback, but the
+  // user should refresh the default so multi-profile setups stay predictable.
+  const profileConfig = loadProfileConfig();
+  const staleDefault = profileConfig.defaultContextId;
+  if (staleDefault && profiles?.length && !profiles.some((p) => p.contextId === staleDefault)) {
+    const alias = aliasForContextId(profileConfig, staleDefault);
+    const label = alias ? `${alias} (${staleDefault})` : staleDefault;
+    const fallbackNote = profiles.length === 1
+      ? `Commands currently fall back to the only connected profile: ${profiles[0].contextId}.`
+      : 'Multiple profiles are connected, so commands will ask you to choose.';
+    issues.push(
+      `Default browser profile is stale: ${label} is not connected (the extension instance it names no longer exists).\n` +
+      `  ${fallbackNote}\n` +
+      '  Refresh it with: opencli profile list, then opencli profile use <name>.',
+    );
+  }
   const extensionCompatRange = health.status?.extensionCompatRange;
   if (extensionVersion && opts.cliVersion && extensionCompatRange) {
     if (!satisfiesRange(opts.cliVersion, extensionCompatRange)) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -29,7 +29,7 @@ import { executePipeline } from './pipeline/index.js';
 import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
-import { resolveProfileContextId } from './browser/profile.js';
+import { profileRouteParams, resolveProfileSelection } from './browser/profile.js';
 import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
@@ -255,7 +255,11 @@ export async function executeCommand(
       }
 
       const BrowserFactory = getBrowserFactory(cmd.site);
-      const contextId = resolveProfileContextId(opts.profile);
+      // Requirement vs preference: --profile / OPENCLI_PROFILE route strictly;
+      // the config default is a soft preference the daemon arbitrates.
+      const profileSelection = resolveProfileSelection(opts.profile);
+      const profileRouting = profileRouteParams(profileSelection);
+      const contextId = profileSelection?.contextId;
       const internal = cmd as InternalCliCommand;
       const siteSession = resolveSiteSession(cmd, opts.siteSession);
       const session = resolveAdapterBrowserSession(cmd, siteSession);
@@ -375,7 +379,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, contextId, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -54,14 +54,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
+  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -70,6 +70,7 @@ export async function browserSession<T>(
       session: opts.session,
       cdpEndpoint: opts.cdpEndpoint,
       contextId: opts.contextId,
+      preferredContextId: opts.preferredContextId,
       idleTimeout: opts.idleTimeout,
       windowMode: opts.windowMode,
       surface: opts.surface,


### PR DESCRIPTION
## The bug (user report)

`browser-profiles.json` has `defaultContextId: zvypsyje` from an old `opencli profile use`; the extension was since reinstalled and the only connected profile is `pavmrekj`. Every command — including `doctor` — fails with `profile_disconnected`, violating the README promise: *"With only one connected profile, OpenCLI uses it automatically."*

Introduced by #1235 (v1.7.10): the multi-profile feature folded three inputs of very different nature — `--profile` argument, `OPENCLI_PROFILE` env, and the persisted config default — into one hard `contextId` on every wire command. The daemon's single-profile auto-use branch is only reachable when NO contextId is requested, so a stale default silently converts a *preference* into a *requirement*. Worse, the ensure path then waits for the dead profile until the connect timeout, so `doctor` hangs before failing.

## First-principles fix

**A persisted default's lifetime routinely exceeds the extension instance it names** (reinstalls regenerate the contextId) — so a default must never have veto power over live state. The fix separates REQUIREMENT from PREFERENCE end to end, and moves arbitration to the only component that knows live connections:

- `profile.ts` resolves a `ProfileSelection` tagged `explicit` (`--profile` arg / `OPENCLI_PROFILE` env → strict, fail loud) or `preferred` (config default); `profileRouteParams()` maps it onto the wire.
- New wire field `preferredContextId` (kept mutually exclusive with the strict `contextId`).
- Daemon arbitrates via a pure `resolveProfileRoute()` (daemon-utils, fully unit-tested):
  - requested → strict match, unchanged;
  - preferred → use when connected; **fall back to the only connected profile when stale** (warned once per stale id in the daemon log); `profile_required` with a stale-default hint when multiple are connected;
  - none → existing behavior.
- `bridge.connect`/ensure pin readiness to a profile **only for explicit requirements** — a stale preference no longer makes `connect()`/`doctor` wait for a dead profile.
- `doctor` now surfaces the stale default explicitly: which alias/id is stale, what commands currently fall back to, and the recovery command (`opencli profile use`).

## Compatibility

- **New CLI + old daemon**: old daemon ignores `preferredContextId` → equivalent to sending no contextId → single-profile auto-use, which is exactly the documented behavior (better than today). Multi-profile setups get `profile_required` until the daemon is replaced (daemons are version-matched and auto-replaced).
- **Old CLI + new daemon**: unchanged (old clients only send the strict `contextId`).
- Extension ignores the new field entirely; no version bump needed.

## Testing

- Full suite green: **546 files / 5928 tests**; both packages `tsc --noEmit` clean; extension `vite build` OK.
- New: `profile.test.ts` (selection source-tagging matrix, alias resolution, route param mapping), `resolveProfileRoute` arbitration matrix (strict/fallback/multi/none), wire-level split (`OPENCLI_PROFILE` → `contextId`, config default → `preferredContextId`), doctor stale-default report with fallback note.

Reproduces the reporter's exact scenario in tests: `preferred=zvypsyje, connected=[pavmrekj]` → routes to `pavmrekj` with `fallbackFrom: zvypsyje`.