### PR TITLE
fix(cli): tolerate OPENCLI_DAEMON_PORT at the default port (unbrick OpenCLIApp installs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Each Chrome profile runs its own OpenCLI extension instance. If you use multiple
 opencli profile list
 opencli profile rename <contextId> work
 opencli profile use work
-opencli --profile work browser state
+opencli --profile work browser main state
 ```
 
 With only one connected profile, OpenCLI uses it automatically. With multiple connected profiles and no default, OpenCLI asks you to choose instead of guessing.

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -173,6 +173,27 @@ describe('daemon-client', () => {
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 
+  it('tolerates OPENCLI_DAEMON_PORT when it equals the default port (launchers inject it, #2068)', async () => {
+    vi.resetModules();
+    vi.stubEnv('OPENCLI_DAEMON_PORT', '19825');
+    const status = {
+      ok: true,
+      pid: 1,
+      uptime: 0,
+      extensionConnected: true,
+      pending: 0,
+      memoryMB: 1,
+      port: 19825,
+    };
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(status),
+    } as Response);
+
+    const freshClient = await import('./daemon-client.js');
+    await expect(freshClient.fetchDaemonStatus()).resolves.toEqual(status);
+  });
+
   it('sendCommand includes the current pid in generated command ids', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_763_000_000_000);
     vi.mocked(fetch).mockResolvedValue({

--- a/src/browser/daemon-transport.ts
+++ b/src/browser/daemon-transport.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DAEMON_PORT, unsupportedDaemonPortEnvMessage } from '../constants.js';
+import { DEFAULT_DAEMON_PORT, isIgnorableDaemonPortEnv, unsupportedDaemonPortEnvMessage } from '../constants.js';
 
 const DAEMON_PORT = DEFAULT_DAEMON_PORT;
 const DAEMON_URL = `http://127.0.0.1:${DAEMON_PORT}`;
@@ -13,7 +13,7 @@ class UnsupportedDaemonPortEnvError extends Error {
 
 function assertSupportedDaemonPortEnv(): void {
   const value = process.env.OPENCLI_DAEMON_PORT;
-  if (value !== undefined && value !== '') throw new UnsupportedDaemonPortEnvError(value);
+  if (!isIgnorableDaemonPortEnv(value)) throw new UnsupportedDaemonPortEnvError(value!);
 }
 
 export interface DaemonStatus {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,20 @@ export function unsupportedDaemonPortEnvMessage(value?: string): string {
     'Unset OPENCLI_DAEMON_PORT and rerun opencli.';
 }
 
+/**
+ * True when OPENCLI_DAEMON_PORT carries no real configuration: unset, empty,
+ * or equal to the default port. Launchers (notably OpenCLIApp) inject the
+ * variable with the default value into every CLI they manage — rejecting that
+ * harmless redundancy bricked all commands on fresh installs (#2068). Only a
+ * NON-default value is a genuine misconfiguration worth failing on.
+ */
+export function isIgnorableDaemonPortEnv(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  return Number(trimmed) === DEFAULT_DAEMON_PORT;
+}
+
 /** URL query params that are volatile/ephemeral and should be stripped from patterns */
 export const VOLATILE_PARAMS = new Set([
   'w_rid', 'wts', '_', 'callback', 'timestamp', 't', 'nonce', 'sign',

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,7 +22,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
-import { DEFAULT_DAEMON_PORT, unsupportedDaemonPortEnvMessage } from './constants.js';
+import { DEFAULT_DAEMON_PORT, isIgnorableDaemonPortEnv, unsupportedDaemonPortEnvMessage } from './constants.js';
 import { EXIT_CODES } from './errors.js';
 import { log } from './logger.js';
 import { PKG_VERSION } from './version.js';
@@ -36,7 +36,7 @@ import {
 } from './daemon-utils.js';
 
 const PORT = DEFAULT_DAEMON_PORT;
-if (process.env.OPENCLI_DAEMON_PORT) {
+if (!isIgnorableDaemonPortEnv(process.env.OPENCLI_DAEMON_PORT)) {
   log.error(unsupportedDaemonPortEnvMessage(process.env.OPENCLI_DAEMON_PORT));
   process.exit(EXIT_CODES.USAGE_ERROR);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { findPackageRoot, getCliManifestPath } from './package-paths.js';
 import { PKG_VERSION } from './version.js';
 import { EXIT_CODES } from './errors.js';
 import { isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-detect.js';
-import { unsupportedDaemonPortEnvMessage } from './constants.js';
+import { isIgnorableDaemonPortEnv, unsupportedDaemonPortEnvMessage } from './constants.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -47,7 +47,7 @@ if (typeof (globalThis as { Bun?: unknown }).Bun === 'undefined' && !isSupported
   process.exit(EXIT_CODES.CONFIG_ERROR);
 }
 
-if (process.env.OPENCLI_DAEMON_PORT) {
+if (!isIgnorableDaemonPortEnv(process.env.OPENCLI_DAEMON_PORT)) {
   process.stderr.write(`error: ${unsupportedDaemonPortEnvMessage(process.env.OPENCLI_DAEMON_PORT)}\n`);
   process.exit(EXIT_CODES.CONFIG_ERROR);
 }


### PR DESCRIPTION
Fixes #2068 (and its duplicate #2072). Also fixes #1893 in passing.

## Problem

OpenCLIApp injects `OPENCLI_DAEMON_PORT=19825` into the environment of the CLI it manages. Since the variable became unsupported, the CLI hard-rejects it **regardless of value** at three points (CLI entry, daemon startup, transport assert) — so on a fresh OpenCLIApp install *every* command fails with EX_CONFIG and the daemon never binds. Rejecting the harmless default value is what bricks the install.

## Fix

`isIgnorableDaemonPortEnv()` in constants.ts: unset / empty / `=== 19825` (the default) carry no configuration and are tolerated; any **non-default** value still fails loud with the existing message. All three rejection points share the helper.

Also: the README multi-profile example was missing the required `browser <session>` positional (`opencli --profile work browser state` → `opencli --profile work browser main state`) — #1893.

## Testing

- New regression test: `OPENCLI_DAEMON_PORT=19825` → transport works; existing test pins that `19999` still rejects.
- Full suite green (5929 tests), `tsc --noEmit` clean.

OpenCLIApp should still stop injecting the variable on its side, but this CLI-side change alone unbricks all affected installs.