### PR TITLE
fix(external): Windows .cmd shim passthrough + non-zero exit on signal death

### DIFF
--- a/src/external.test.ts
+++ b/src/external.test.ts
@@ -146,3 +146,54 @@ describe('installExternalCli', () => {
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
   });
 });
+
+const { spawnSync } = await import('node:child_process');
+const { executeExternalCli } = await import('./external.js');
+
+describe('executeExternalCli passthrough', () => {
+  const spawnMock = vi.mocked(spawnSync);
+  const cli: ExternalCliConfig = { name: 'tg', binary: 'tg', description: '' } as ExternalCliConfig;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    mockExecFileSync.mockReset();
+    mockExecFileSync.mockReturnValue(Buffer.from('')); // isBinaryInstalled → true
+    process.exitCode = undefined;
+  });
+
+  it('retries through the shell on Windows when the binary is a .cmd shim (EINVAL)', () => {
+    mockPlatform.mockReturnValue('win32');
+    const einval = Object.assign(new Error('spawnSync tg EINVAL'), { code: 'EINVAL' });
+    spawnMock
+      .mockReturnValueOnce({ error: einval, status: null, signal: null } as unknown as ReturnType<typeof spawnSync>)
+      .mockReturnValueOnce({ status: 0, signal: null } as unknown as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('tg', ['send', 'hello world', '--to', 'a"b'], [cli]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock).toHaveBeenNthCalledWith(1, 'tg', ['send', 'hello world', '--to', 'a"b'], { stdio: 'inherit' });
+    // Shell fallback: one quoted command string, tokens with spaces/quotes wrapped for cmd.exe.
+    expect(spawnMock).toHaveBeenNthCalledWith(2, 'tg send "hello world" --to "a""b"', { stdio: 'inherit', shell: true });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('does not retry through the shell on non-Windows platforms', () => {
+    mockPlatform.mockReturnValue('darwin');
+    const einval = Object.assign(new Error('spawnSync tg EINVAL'), { code: 'EINVAL' });
+    spawnMock.mockReturnValueOnce({ error: einval, status: null, signal: null } as unknown as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('tg', [], [cli]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a non-zero exit code when the child dies from a signal', () => {
+    mockPlatform.mockReturnValue('darwin');
+    spawnMock.mockReturnValueOnce({ status: null, signal: 'SIGKILL' } as unknown as ReturnType<typeof spawnSync>);
+
+    executeExternalCli('tg', [], [cli]);
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/external.ts
+++ b/src/external.ts
@@ -197,16 +197,46 @@ export function executeExternalCli(name: string, args: string[], preloaded?: Ext
   }
 
   // 3. Passthrough execution with stdio inherited
-  const result = spawnSync(cli.binary, args, { stdio: 'inherit' });
+  const result = spawnPassthrough(cli.binary, args);
   if (result.error) {
     log.error(`Failed to execute '${cli.binary}': ${result.error.message}`);
     process.exitCode = EXIT_CODES.GENERIC_ERROR;
     return;
   }
-  
+
+  if (result.signal) {
+    // Killed by a signal — never report success to the calling shell/agent.
+    process.exitCode = EXIT_CODES.GENERIC_ERROR;
+    return;
+  }
   if (result.status !== null) {
     process.exitCode = result.status;
   }
+}
+
+/** Quote a token for cmd.exe: wrap when it contains shell-significant chars, doubling inner quotes. */
+function quoteForCmdShell(token: string): string {
+  if (token !== '' && !/[\s"^&|<>%()]/.test(token)) return token;
+  return `"${token.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Run an external CLI with stdio inherited.
+ *
+ * On Windows, npm-installed CLIs are `.cmd` shims: `where` finds them (so the
+ * installed-check passes), but Node refuses to spawn them directly since the
+ * CVE-2024-27980 hardening — spawnSync fails with EINVAL (or ENOENT when
+ * PATHEXT resolution is skipped). Fall back to running through the shell in
+ * that case, quoting each token for cmd.exe.
+ */
+function spawnPassthrough(binary: string, args: string[]): ReturnType<typeof spawnSync> {
+  const direct = spawnSync(binary, args, { stdio: 'inherit' });
+  const errorCode = (direct.error as NodeJS.ErrnoException | undefined)?.code;
+  if (os.platform() === 'win32' && (errorCode === 'EINVAL' || errorCode === 'ENOENT')) {
+    const command = [binary, ...args].map(quoteForCmdShell).join(' ');
+    return spawnSync(command, { stdio: 'inherit', shell: true });
+  }
+  return direct;
 }
 
 export interface RegisterOptions {


### PR DESCRIPTION
Fixes #1958.

## Problem

npm-installed CLIs on Windows are `.cmd` shims. `isBinaryInstalled` uses `where`, which finds them — but since Node's CVE-2024-27980 hardening, `spawnSync(binary, args)` refuses to execute `.cmd`/`.bat` files directly and fails with `EINVAL` (or `ENOENT` when PATHEXT resolution is skipped). Net effect: every CLI-hub passthrough to an npm-installed tool is broken on Windows, while the installed-check says everything is fine.

## Fix

`spawnPassthrough()`: try the direct spawn first (unchanged fast path for `.exe`/unix); on Windows-only `EINVAL`/`ENOENT`, retry through the shell with each token quoted for cmd.exe (wrap on shell-significant chars, double inner quotes). Injection surface is unchanged — the tokens come from the user's own argv.

Also fixes a related exit-code lie in the same function: a child killed by a signal leaves `status === null`, and opencli exited `0`, reporting success to the calling shell/agent. Signal death now maps to a non-zero exit.

## Testing

New tests: EINVAL on win32 → single shell retry with correct cmd.exe quoting (spaces + embedded quotes); no shell retry on darwin; signal death → non-zero exit. Full suite green (5925 tests), `tsc --noEmit` clean.