### PR TITLE
test(e2e): stabilize headed Chrome gate

### DIFF
--- a/.github/actions/setup-chrome/action.yml
+++ b/.github/actions/setup-chrome/action.yml
@@ -13,7 +13,9 @@ runs:
       uses: browser-actions/setup-chrome@v2
       id: setup-chrome
       with:
-        chrome-version: latest
+        # Stable Chrome for Testing keeps headed E2E on a released browser.
+        # `latest` pulls Chromium snapshots, which can break extension startup.
+        chrome-version: stable
 
     - name: Verify Chrome installation
       shell: bash

--- a/tests/e2e/browser-ax-chrome.test.ts
+++ b/tests/e2e/browser-ax-chrome.test.ts
@@ -127,7 +127,7 @@ async function startFakeBridge(): Promise<FakeBridge | null> {
         server.close((err) => err ? reject(err) : resolve());
       });
     },
-    waitForExtension: () => withTimeout(connected, 15_000, 'Timed out waiting for Browser Bridge extension to connect'),
+    waitForExtension: () => withTimeout(connected, 45_000, 'Timed out waiting for Browser Bridge extension to connect'),
     sendCommand: async (command) => {
       if (!ws || ws.readyState !== ws.OPEN) throw new Error('Extension WebSocket is not connected');
       const id = `ax-e2e-${++nextId}`;
@@ -307,7 +307,7 @@ describe('Browser Bridge AX real Chrome smoke', () => {
       if (process.env.CI) throw new Error(message);
       skipReason = message;
     }
-  }, 30_000);
+  }, 60_000);
 
   afterAll(async () => {
     await killProcess(chrome);

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -36,7 +36,10 @@ export async function runCli(
   args: string[],
   opts: { timeout?: number; env?: Record<string, string>; maxBuffer?: number } = {},
 ): Promise<CliResult> {
-  const timeout = opts.timeout ?? 30_000;
+  // Keep the child timeout below the common 30s Vitest timeout so flaky
+  // network commands return a structured non-zero result instead of killing
+  // the whole test at the framework layer.
+  const timeout = opts.timeout ?? 25_000;
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER_BYTES;
   try {
     const runtime = process.env.OPENCLI_TEST_RUNTIME || 'node';


### PR DESCRIPTION
## Summary
- use stable Chrome for Testing in headed E2E instead of latest Chromium snapshots
- give the AX real-Chrome smoke more room for extension startup on hosted macOS runners
- keep default e2e child-process timeout below Vitest's common 30s test timeout so network stalls return structured results instead of framework timeouts

## Verification
- npm run typecheck
- npm run build
- npm run build --prefix extension
- npx vitest run --project e2e tests/e2e/public-commands.test.ts --reporter=verbose
- npx vitest run --project e2e tests/e2e/management.test.ts tests/e2e/output-formats.test.ts --reporter=verbose

Note: local macOS AX smoke still fails on the host-installed Chrome because that browser does not load the command-line unpacked extension in this environment; the PR intentionally switches CI to stable Chrome for Testing so the GitHub macOS headed job is the relevant gate.