### PR TITLE
ci(e2e): pin macOS headed runner

### DIFF
--- a/.github/workflows/e2e-headed.yml
+++ b/.github/workflows/e2e-headed.yml
@@ -36,7 +36,9 @@ jobs:
       matrix:
         # NOTE: Windows excluded — browser-actions/setup-chrome hangs during
         # Chrome MSI installation on Windows runners (known issue).
-        os: [ubuntu-latest, macos-latest]
+        # Pin macOS instead of following macos-latest: the macOS 26 hosted
+        # image has been flaky for command-line unpacked extension startup.
+        os: [ubuntu-latest, macos-15]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- pin headed E2E macOS coverage to macos-15 instead of macos-latest
- keep Linux coverage on ubuntu-latest

## Why
The current macos-latest hosted image is macOS 26 and the AX real-Chrome smoke fails before the extension connects. GitHub also annotates the run with the macos-latest migration notice. This release gate should cover OpenCLI's macOS path on a stable hosted image instead of tracking a moving preview runner.

## Verification
- git diff --check