### PR TITLE
chore(release): bump version to 1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- bump @jackwener/opencli from 1.8.5 to 1.8.6

## Verification
- npm run build
- npm run typecheck

Release notes since v1.8.5 include browser transport reliability, profile routing fixes, ChatGPT/Gemini/HLTV/Weibo/Twitter adapter updates, and headed E2E gate stabilization.