### PR TITLE
ci(e2e): place each e2e gate where its runner can run it deterministically (fix red main)

### DIFF
--- a/.github/workflows/e2e-headed.yml
+++ b/.github/workflows/e2e-headed.yml
@@ -34,11 +34,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # NOTE: Windows excluded — browser-actions/setup-chrome hangs during
-        # Chrome MSI installation on Windows runners (known issue).
-        # Pin macOS instead of following macos-latest: the macOS 26 hosted
-        # image has been flaky for command-line unpacked extension startup.
-        os: [ubuntu-latest, macos-15]
+        # Gate placement by what each runner can run deterministically:
+        # - the real-browser extension smoke needs a Chrome that reliably runs
+        #   an MV3 extension, which only Linux+xvfb provides on hosted runners
+        #   (headed macOS crashes on Mach port rendezvous outside an Aqua
+        #   session; headless does not connect the extension SW there);
+        # - the daemon transport contracts need no browser and run blocking on
+        #   every OS, so macOS/Windows get a real gate, not a skipped one.
+        # macOS pinned to 15 while the macOS 26 image stabilizes.
+        os: [ubuntu-latest, macos-15, windows-latest]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +55,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Linux runs the extension smoke and macOS runs the full real-site e2e
+      # suite; both need a real Chrome. Windows runs only the browser-free
+      # transport gate, and the setup-chrome action hangs on Windows anyway.
       - name: Setup Chrome
+        if: runner.os != 'Windows'
         uses: ./.github/actions/setup-chrome
         id: setup-chrome
 
@@ -61,23 +69,26 @@ jobs:
       - name: Build extension
         run: npm run build --prefix extension
 
-      # The AX smoke runs Chrome in new-headless mode: a full browser (MV3
-      # service worker + chrome.debugger + --load-extension) with no display
-      # server or GUI-session dependency, so the same command is release-
-      # blocking on every OS. Headed Chrome on hosted macOS fails Mach port
-      # rendezvous for child processes (CI jobs run outside a regular Aqua
-      # session); headless removes that entire failure class instead of
-      # skipping the platform.
-      - name: Run AX Chrome smoke (headless, all platforms)
+      # Real-browser extension smoke: Linux under xvfb is the one hosted
+      # environment where a real Chrome reliably starts an MV3 extension, so
+      # this is the release-blocking browser gate. Headed (not headless):
+      # headless does not connect the extension service worker on hosted
+      # runners. See the matrix comment for why macOS/Windows don't run it.
+      - name: Run AX Chrome smoke (Linux, real extension via xvfb)
+        if: runner.os == 'Linux'
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
           OPENCLI_AX_E2E: '1'
-        run: npx vitest run --project e2e tests/e2e/browser-ax-chrome.test.ts --reporter=verbose
+          OPENCLI_E2E_HEADED: '1'
+        run: |
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
+            npx vitest run --project e2e tests/e2e/browser-ax-chrome.test.ts --reporter=verbose
 
       # Transport contract E2E: real daemon process + scripted fake extension.
       # Pins the cross-layer contracts (waiter attach, deadline 408, dispatched
       # disconnect, profile fallback, graceful shutdown) end to end with the
-      # actual daemon binary — no browser required, deterministic on every OS.
+      # actual daemon binary — no browser required, so this is the blocking
+      # gate on EVERY OS, including macOS and Windows.
       - name: Run daemon transport contract E2E
         run: npx vitest run --project e2e-fixed-port tests/e2e/daemon-transport.test.ts --reporter=verbose
 
@@ -89,8 +100,10 @@ jobs:
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
             npx vitest run tests/e2e/ --reporter=verbose
 
-      - name: Run E2E tests (macOS / Windows)
-        if: runner.os != 'Linux'
+      # Real-site adapter e2e stays on Linux/macOS; Windows runs the two
+      # deterministic gates above (unit coverage in ci.yml already spans it).
+      - name: Run E2E tests (macOS)
+        if: runner.os == 'macOS'
         env:
           OPENCLI_AX_E2E: '0'
         run: npx vitest run tests/e2e/ --reporter=verbose

--- a/tests/e2e/browser-ax-chrome.test.ts
+++ b/tests/e2e/browser-ax-chrome.test.ts
@@ -206,16 +206,14 @@ function findChromeExecutable(): string | null {
 
 function launchChrome(chromePath: string, userDataDir: string, startUrl: string): ChildProcess {
   return spawn(chromePath, [
-    // This smoke's contract is "the extension bridge works in a real Chrome",
-    // not "a window appears": new headless is a full browser (MV3 service
-    // worker + chrome.debugger + --load-extension all supported) with no
-    // dependency on a display server or a GUI login session. That dependency
-    // is exactly what broke hosted runners: Linux needed xvfb, and macOS
-    // runners fail Mach port rendezvous for Chrome's child processes because
-    // CI jobs do not run in a regular Aqua session (bootstrap_look_up
-    // MachPortRendezvousServer → "Unknown service name"). Headed mode stays
-    // available for local debugging via OPENCLI_E2E_HEADED=1.
-    ...(process.env.OPENCLI_E2E_HEADED === '1' ? [] : ['--headless=new']),
+    // Headed by default under a real/virtual display (CI Linux runs this under
+    // xvfb). New-headless is convenient locally — no display needed — but on
+    // hosted runners it does not reliably start the MV3 extension service
+    // worker, so CI forces headed via OPENCLI_E2E_HEADED=1. Set OPENCLI_E2E_
+    // HEADLESS=1 to opt into headless locally.
+    ...(process.env.OPENCLI_E2E_HEADLESS === '1' && process.env.OPENCLI_E2E_HEADED !== '1'
+      ? ['--headless=new']
+      : []),
     `--user-data-dir=${userDataDir}`,
     `--disable-extensions-except=${EXTENSION_DIR}`,
     `--load-extension=${EXTENSION_DIR}`,
@@ -280,9 +278,11 @@ function axText(axTree: unknown): string {
 }
 
 function shouldFailOnBridgeUnavailable(): boolean {
-  // Release-blocking on every CI platform: with the smoke running Chrome in
-  // new-headless mode there is no display-server/GUI-session dependency left,
-  // so an unavailable bridge means a real product or packaging regression.
+  // In CI this smoke is scheduled only on Linux (headed under xvfb — the one
+  // hosted environment where a real Chrome reliably starts an MV3 extension),
+  // so any bridge failure there is a real product/packaging regression and
+  // must block. macOS/Windows gate on the browser-free transport contracts
+  // instead; see the e2e-headed workflow for the rationale.
   return process.env.CI === 'true';
 }
 


### PR DESCRIPTION
## Context — main is currently red

#2081 merged the "run the AX smoke `--headless=new` on every OS" approach. That removed headed macOS's Mach-port crash, but hosted runners **don't reliably start the MV3 extension service worker in headless** either, so `browser-ax-chrome` still times out on the macOS runner and main went red. Locally headless connects in <2s; on the hosted macOS image it never connects (empty Chrome stderr, 45s timeout). Chasing headless reliability across runner images is the wrong axis.

## First principles

Gate each check on the environment that can run it **deterministically**, and make sure **every OS has a real blocking gate** — the opposite of #2079's skip, which left macOS with a green check that proved nothing.

| Gate | Needs | Runs blocking on | Why |
|---|---|---|---|
| Real-browser AX smoke (AX tree + cross-frame CDP, real extension) | a Chrome that reliably starts an MV3 extension | **Linux** (headed, xvfb) | The one hosted env where that works. Headed macOS crashes on Mach port rendezvous outside an Aqua session; headless connects no SW. |
| Daemon transport contracts (real daemon + fake extension, no browser) | nothing but Node | **Linux + macOS + Windows** | Deterministic everywhere, and it covers the exact layer our recent bugs lived in (#2067/#2070/#2073). |
| Real-site adapter e2e | a browser | Linux + macOS | unchanged |

**macOS and Windows are no longer skipped** — they gate on the transport contracts (a real, always-run check), instead of a browser test that cannot run deterministically there. Windows joins the matrix for the first time; `setup-chrome` is skipped there (it hangs on the MSI path and Windows needs no browser for the transport gate).

Local Chrome launch stays headed by default (`OPENCLI_E2E_HEADLESS=1` opts into headless for display-less local runs).

## Verification

- Local: headed AX smoke ✅ (CI mode) + transport contracts ✅ (6/6) against CI's Chrome for Testing stable; full unit suite 548 files / 5952 tests green; `tsc --noEmit` clean.
- Three-OS workflow dispatched on this branch to prove the placement green on real runners: https://github.com/jackwener/OpenCLI/actions/runs/28676429421

Supersedes the headless approach from #2081.