### PR TITLE
feat: add U2 query adapters

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -38077,6 +38077,149 @@
     "siteSession": "persistent"
   },
   {
+    "site": "u2",
+    "name": "subtitles",
+    "description": "搜索 U2 字幕；默认列出当前页 30 条",
+    "access": "read",
+    "domain": "u2.dmhy.org",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "搜索关键词；省略时列出最新字幕"
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "语言：all 或语言 ID（1–32；简中 25，繁中 28/32）"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "页码：从 1 开始；网页第二页对应 --page 2"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "返回条数：1–30，默认 30（网页一页）"
+      }
+    ],
+    "columns": [
+      "id",
+      "language",
+      "title",
+      "publishedAt",
+      "size",
+      "downloads",
+      "uploader"
+    ],
+    "type": "js",
+    "modulePath": "u2/subtitles.js",
+    "sourceFile": "u2/subtitles.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "u2",
+    "name": "torrents",
+    "description": "搜索 U2 种子；默认列出当前页 50 条活种",
+    "access": "read",
+    "domain": "u2.dmhy.org",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "搜索关键词；省略时列出最新种子"
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "分类 ID，例如 16（BDMV）；默认全部"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "default": "alive",
+        "required": false,
+        "help": "种子状态：alive / dead / all"
+      },
+      {
+        "name": "promotion",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "优惠：all / normal / free / 2x / 2x-free / 50pct / 2x-50pct / 30pct / other"
+      },
+      {
+        "name": "bookmarked",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "收藏：all / only / exclude"
+      },
+      {
+        "name": "area",
+        "type": "string",
+        "default": "title",
+        "required": false,
+        "help": "搜索范围：title / description / uploader / anidb / hash"
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "default": "and",
+        "required": false,
+        "help": "匹配模式：and / or / exact"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "页码：从 1 开始；网页第二页对应 --page 2"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "返回条数：1–50，默认 50（网页一页）"
+      }
+    ],
+    "columns": [
+      "id",
+      "category",
+      "title",
+      "comments",
+      "publishedAt",
+      "size",
+      "seeders",
+      "leechers",
+      "snatched",
+      "promotion",
+      "detailsUrl"
+    ],
+    "type": "js",
+    "modulePath": "u2/torrents.js",
+    "sourceFile": "u2/torrents.js",
+    "navigateBefore": false
+  },
+  {
     "site": "uisdc",
     "name": "news",
     "description": "优设读报 - 最新 AI/设计行业新闻",

--- a/clis/u2/__fixtures__/subtitles.html
+++ b/clis/u2/__fixtures__/subtitles.html
@@ -1,0 +1,7 @@
+<!doctype html><meta charset="utf-8">
+<a href="logout.php">退出</a><a href="subtitles.php">字幕</a>
+<table class="mainouter"><tr><td><table width="940" border="1">
+<tr><td class="colhead">语言</td><td class="colhead">标题</td><td class="colhead">添加时间</td><td class="colhead">大小</td><td class="colhead">点击</td><td class="colhead">上传者</td><td class="colhead">报错</td></tr>
+<tr><td class="rowfollow"><img src="pic/flag/china.gif" alt="S.Chinese(简体中文)"></td><td class="rowfollow"><a href="javascript:void(0);" onclick="show_detail(10270);"><b>[KissSub][Steins;Gate]</b></a></td><td class="rowfollow"><time title="2026-07-02 15:54:33">1天前</time></td><td class="rowfollow">648.533&nbsp;KiB</td><td class="rowfollow">0</td><td class="rowfollow"><a href="userdetails.php?id=62047">UploaderA</a></td><td></td></tr>
+<tr><td class="rowfollow"><img src="pic/flag/hongkong.gif" alt="T.Chinese(繁體中文)"></td><td class="rowfollow"><a onclick="javascript:show_detail(10269);"><b>Example &amp; Two</b></a></td><td class="rowfollow"><time title="2026-06-29 10:15:10">4天前</time></td><td class="rowfollow">117.214&nbsp;KiB</td><td class="rowfollow">23</td><td class="rowfollow"><i>匿名</i></td><td></td></tr>
+</table></td></tr></table>

--- a/clis/u2/__fixtures__/torrents.html
+++ b/clis/u2/__fixtures__/torrents.html
@@ -1,0 +1,15 @@
+<!doctype html><meta charset="utf-8">
+<a href="logout.php">退出</a><a href="torrents.php">种子</a>
+<table class="mainouter"><tr><td><table class="torrents">
+<tr><td class="colhead">分类</td><td class="colhead">名称</td><td class="colhead">评论</td><td class="colhead">时间</td><td class="colhead">大小</td><td class="colhead">种子数</td><td class="colhead">下载数</td><td class="colhead">完成数</td></tr>
+<tr>
+<td class="rowfollow"><a href="?cat=16">BDMV</a></td>
+<td class="rowfollow"><table class="torrentname"><tr><td><a href="details.php?id=65431&amp;hit=1" title="Example &amp; One">Example &amp; One</a></td></tr><tr><td><img class="pro_2up" alt="2X"><span title="demo">demo</span></td></tr></table></td>
+<td class="rowfollow">1</td><td class="rowfollow"><time title="2026-07-03 09:45:57">19小时</time></td><td class="rowfollow">32.600<br>GiB</td><td class="rowfollow">28</td><td class="rowfollow">0</td><td class="rowfollow">65</td>
+</tr>
+<tr>
+<td class="rowfollow"><a href="?cat=40">Other</a></td>
+<td class="rowfollow"><table class="torrentname"><tr><td><a href="details.php?id=36728&amp;hit=1" title="Second title">Second title</a></td></tr><tr><td><img class="pro_free2up" alt="2X Free"><span>note</span></td></tr></table></td>
+<td class="rowfollow">3</td><td class="rowfollow"><time title="2019-12-01 00:37:29">6年</time></td><td class="rowfollow">9.328<br>GiB</td><td class="rowfollow">0</td><td class="rowfollow">29</td><td class="rowfollow">119</td>
+</tr>
+</table></td></tr></table>

--- a/clis/u2/subtitles.js
+++ b/clis/u2/subtitles.js
@@ -1,0 +1,53 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { BASE, normalizeLimit, normalizePositiveInteger, getCookie, fetchHtml, assertAuthenticated, parseSubtitleRows } from './utils.js';
+
+export function buildSubtitleQuery(args = {}) {
+  const limit = normalizeLimit(args.limit, 30, 30);
+  const page = normalizePositiveInteger(args.page, 1, 'page');
+  const searchParams = new URLSearchParams();
+  const query = String(args.query ?? '').trim();
+  if (query) searchParams.set('search', query);
+  const language = String(args.language ?? 'all').trim().toLowerCase();
+  if (language === 'all') {
+    searchParams.set('lang_id', '0');
+  } else {
+    const languageId = Number(language);
+    if (!Number.isInteger(languageId) || languageId < 1 || languageId > 32) {
+      throw new ArgumentError('language must be all or a numeric ID from 1 to 32');
+    }
+    searchParams.set('lang_id', String(languageId));
+  }
+  if (page > 1) searchParams.set('page', String(page - 1));
+  return { searchParams, limit };
+}
+
+cli({
+  site: 'u2',
+  name: 'subtitles',
+  access: 'read',
+  description: '搜索 U2 字幕；默认列出当前页 30 条',
+  domain: 'u2.dmhy.org',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'query', positional: true, required: false, help: '搜索关键词；省略时列出最新字幕' },
+    { name: 'language', type: 'string', default: 'all', help: '语言：all 或语言 ID（1–32；简中 25，繁中 28/32）' },
+    { name: 'page', type: 'int', default: 1, help: '页码：从 1 开始；网页第二页对应 --page 2' },
+    { name: 'limit', type: 'int', default: 30, help: '返回条数：1–30，默认 30（网页一页）' },
+  ],
+  columns: ['id', 'language', 'title', 'publishedAt', 'size', 'downloads', 'uploader'],
+  func: async (page, args) => {
+    const { searchParams, limit } = buildSubtitleQuery(args);
+    const cookie = await getCookie(page);
+    const html = await fetchHtml(`${BASE}/subtitles.php?${searchParams}`, { cookie });
+    assertAuthenticated(html);
+    const rows = parseSubtitleRows(html);
+    if (rows.length === 0) {
+      const query = String(args.query ?? '').trim();
+      throw new EmptyResultError('u2 subtitles', query ? `No subtitles found for "${query}"` : 'No subtitles found');
+    }
+    return rows.slice(0, limit);
+  },
+});

--- a/clis/u2/subtitles.test.js
+++ b/clis/u2/subtitles.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSubtitleQuery } from './subtitles.js';
+
+test('buildSubtitleQuery maps keyword and language ID', () => {
+  const params = buildSubtitleQuery({ query: 'Steins Gate', language: '25', limit: 12, page: 3 });
+  assert.equal(params.limit, 12);
+  assert.deepEqual(Object.fromEntries(params.searchParams), { search: 'Steins Gate', lang_id: '25', page: '2' });
+});
+
+test('buildSubtitleQuery defaults to all languages', () => {
+  const params = buildSubtitleQuery({});
+  assert.equal(params.limit, 30);
+  assert.deepEqual(Object.fromEntries(params.searchParams), { lang_id: '0' });
+});
+
+for (const [label, args] of [
+  ['language', { language: 'zh' }],
+  ['language', { language: '0' }],
+  ['language', { language: '33' }],
+  ['page', { page: 0 }],
+  ['limit', { limit: -1 }],
+  ['limit', { limit: 31 }],
+]) {
+  test(`buildSubtitleQuery rejects invalid ${label}`, () => {
+    assert.throws(() => buildSubtitleQuery(args), /must be|invalid/i);
+  });
+}

--- a/clis/u2/torrents.js
+++ b/clis/u2/torrents.js
@@ -1,0 +1,73 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { BASE, normalizeLimit, normalizePositiveInteger, getCookie, fetchHtml, assertAuthenticated, parseTorrentRows } from './utils.js';
+
+const ENUMS = {
+  status: { alive: '1', dead: '2', all: '0' },
+  promotion: { all: '0', normal: '1', free: '2', '2x': '3', '2x-free': '4', '50pct': '5', '2x-50pct': '6', '30pct': '7', other: '8' },
+  bookmarked: { all: '0', only: '1', exclude: '2' },
+  area: { title: '0', description: '1', uploader: '3', anidb: '4', hash: '5' },
+  mode: { and: '0', or: '1', exact: '2' },
+};
+
+function enumValue(group, value, fallback) {
+  const selected = String(value ?? fallback).toLowerCase();
+  const mapped = ENUMS[group][selected];
+  if (mapped === undefined) throw new ArgumentError(`invalid ${group}: ${value}`);
+  return mapped;
+}
+
+export function buildTorrentQuery(args = {}) {
+  const limit = normalizeLimit(args.limit, 50, 50);
+  const page = normalizePositiveInteger(args.page, 1, 'page');
+  const searchParams = new URLSearchParams();
+  const query = String(args.query ?? '').trim();
+  if (query) searchParams.set('search', query);
+  const category = String(args.category ?? '').trim();
+  if (category) {
+    if (!/^[1-9]\d*$/.test(category)) throw new ArgumentError(`category must be a positive numeric ID`);
+    searchParams.set(`cat${category}`, '1');
+  }
+  searchParams.set('incldead', enumValue('status', args.status, 'alive'));
+  searchParams.set('spstate', enumValue('promotion', args.promotion, 'all'));
+  searchParams.set('inclbookmarked', enumValue('bookmarked', args.bookmarked, 'all'));
+  searchParams.set('search_area', enumValue('area', args.area, 'title'));
+  searchParams.set('search_mode', enumValue('mode', args.mode, 'and'));
+  if (page > 1) searchParams.set('page', String(page - 1));
+  return { searchParams, limit };
+}
+
+cli({
+  site: 'u2',
+  name: 'torrents',
+  access: 'read',
+  description: '搜索 U2 种子；默认列出当前页 50 条活种',
+  domain: 'u2.dmhy.org',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'query', positional: true, required: false, help: '搜索关键词；省略时列出最新种子' },
+    { name: 'category', type: 'string', default: '', help: '分类 ID，例如 16（BDMV）；默认全部' },
+    { name: 'status', type: 'string', default: 'alive', help: '种子状态：alive / dead / all' },
+    { name: 'promotion', type: 'string', default: 'all', help: '优惠：all / normal / free / 2x / 2x-free / 50pct / 2x-50pct / 30pct / other' },
+    { name: 'bookmarked', type: 'string', default: 'all', help: '收藏：all / only / exclude' },
+    { name: 'area', type: 'string', default: 'title', help: '搜索范围：title / description / uploader / anidb / hash' },
+    { name: 'mode', type: 'string', default: 'and', help: '匹配模式：and / or / exact' },
+    { name: 'page', type: 'int', default: 1, help: '页码：从 1 开始；网页第二页对应 --page 2' },
+    { name: 'limit', type: 'int', default: 50, help: '返回条数：1–50，默认 50（网页一页）' },
+  ],
+  columns: ['id', 'category', 'title', 'comments', 'publishedAt', 'size', 'seeders', 'leechers', 'snatched', 'promotion', 'detailsUrl'],
+  func: async (page, args) => {
+    const { searchParams, limit } = buildTorrentQuery(args);
+    const cookie = await getCookie(page);
+    const html = await fetchHtml(`${BASE}/torrents.php?${searchParams}`, { cookie });
+    assertAuthenticated(html);
+    const rows = parseTorrentRows(html);
+    if (rows.length === 0) {
+      const query = String(args.query ?? '').trim();
+      throw new EmptyResultError('u2 torrents', query ? `No torrents found for "${query}"` : 'No torrents found');
+    }
+    return rows.slice(0, limit);
+  },
+});

--- a/clis/u2/torrents.test.js
+++ b/clis/u2/torrents.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTorrentQuery } from './torrents.js';
+
+test('buildTorrentQuery maps friendly filters to U2 parameters', () => {
+  const params = buildTorrentQuery({
+    query: 'Steins Gate', category: '16', status: 'dead', promotion: 'free',
+    bookmarked: 'only', area: 'anidb', mode: 'exact', limit: 12, page: 2,
+  });
+  assert.equal(params.limit, 12);
+  assert.deepEqual(Object.fromEntries(params.searchParams), {
+    search: 'Steins Gate', cat16: '1', incldead: '2', spstate: '2',
+    inclbookmarked: '1', search_area: '4', search_mode: '2', page: '1',
+  });
+});
+
+test('buildTorrentQuery supports defaults and all categories', () => {
+  const params = buildTorrentQuery({});
+  assert.equal(params.limit, 50);
+  assert.deepEqual(Object.fromEntries(params.searchParams), {
+    incldead: '1', spstate: '0', inclbookmarked: '0', search_area: '0', search_mode: '0',
+  });
+});
+
+for (const [label, args] of [
+  ['status', { status: 'maybe' }],
+  ['promotion', { promotion: 'bonus' }],
+  ['bookmarked', { bookmarked: 'sometimes' }],
+  ['area', { area: 'body' }],
+  ['mode', { mode: 'fuzzy' }],
+  ['category', { category: 'x16' }],
+  ['page', { page: 0 }],
+  ['limit', { limit: 0 }],
+  ['limit', { limit: 51 }],
+]) {
+  test(`buildTorrentQuery rejects invalid ${label}`, () => {
+    assert.throws(() => buildTorrentQuery(args), /must be|invalid/i);
+  });
+}

--- a/clis/u2/utils.js
+++ b/clis/u2/utils.js
@@ -1,0 +1,221 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const BASE = 'https://u2.dmhy.org';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/146 Safari/537.36';
+
+export function normalizePositiveInteger(value, defaultValue, label = 'value') {
+  const n = Number(value ?? defaultValue);
+  if (!Number.isInteger(n) || n <= 0) throw new ArgumentError(`${label} must be a positive integer`);
+  return n;
+}
+
+export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+  const n = normalizePositiveInteger(value, defaultValue, label);
+  if (n > maxValue) throw new ArgumentError(`${label} must be <= ${maxValue}`);
+  return n;
+}
+
+export async function getCookie(page) {
+  const cookies = new Map();
+  if (typeof page?.getCookies === 'function') {
+    for (const options of [{ url: `${BASE}/` }, { domain: 'u2.dmhy.org' }, { domain: '.dmhy.org' }]) {
+      try {
+        for (const cookie of await page.getCookies(options) || []) {
+          if (cookie?.name && !cookies.has(cookie.name)) cookies.set(cookie.name, cookie.value);
+        }
+      } catch { /* try the next cookie scope */ }
+    }
+  }
+  if (cookies.size === 0) throw new AuthRequiredError('u2.dmhy.org', 'U2 browser cookies are missing; log in with Chrome first');
+  return [...cookies].map(([name, value]) => `${name}=${value}`).join('; ');
+}
+
+export async function fetchHtml(url, { cookie, headers = {} } = {}) {
+  let response;
+  try {
+    response = await fetch(url, {
+      method: 'GET', redirect: 'follow',
+      headers: {
+        'User-Agent': UA,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+        ...(cookie ? { Cookie: cookie } : {}),
+        Referer: `${BASE}/`,
+        ...headers,
+      },
+    });
+  } catch (error) {
+    throw new CommandExecutionError(`U2 request failed: ${error?.message || error}`);
+  }
+  if (!response.ok) throw new CommandExecutionError(`U2 request failed: HTTP ${response.status} ${response.statusText}`);
+  return response.text();
+}
+
+export function assertAuthenticated(html) {
+  const source = String(html || '');
+  const loginPage = /<form[^>]+(?:login\.php|takelogin\.php)/i.test(source)
+    || /href=["'][^"']*login\.php/i.test(source);
+  const loggedInMarker = /href=["'][^"']*logout\.php/i.test(source);
+  if (loginPage || !loggedInMarker) {
+    throw new AuthRequiredError('u2.dmhy.org', 'U2 session is missing or expired; log in with Chrome first');
+  }
+}
+
+const ENTITIES = { nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", '#39': "'" };
+
+export function decodeEntities(value) {
+  return String(value || '')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([\da-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&(nbsp|amp|lt|gt|quot|apos|#39);/gi, (all, name) => ENTITIES[name.toLowerCase()] ?? all)
+    .replace(/&amp(?=\s|$)/gi, '&');
+}
+
+function attribute(tag, name) {
+  const match = String(tag).match(new RegExp(`\\b${name}\\s*=\\s*(["'])([\\s\\S]*?)\\1`, 'i'));
+  return match ? decodeEntities(match[2]) : '';
+}
+
+function text(html) {
+  return decodeEntities(String(html || '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<[^>]+>/g, ' '))
+    .replace(/[\u00ad\u200b]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function balancedElement(source, start, tagName) {
+  const token = new RegExp(`<\\/?${tagName}\\b[^>]*>`, 'gi');
+  token.lastIndex = start;
+  let depth = 0;
+  let match;
+  while ((match = token.exec(source))) {
+    if (!match[0].startsWith('</')) depth += 1;
+    else depth -= 1;
+    if (depth === 0) return source.slice(start, token.lastIndex);
+  }
+  return '';
+}
+
+function allTables(html) {
+  const source = String(html || '');
+  const starts = [...source.matchAll(/<table\b[^>]*>/gi)];
+  const result = [];
+  for (const match of starts) {
+    const table = balancedElement(source, match.index, 'table');
+    if (table) result.push(table);
+  }
+  return result;
+}
+
+function directRows(table) {
+  const tags = /<\/?(?:table|tr)\b[^>]*>/gi;
+  const rows = [];
+  let tableDepth = 0;
+  let rowStart = -1;
+  let match;
+  while ((match = tags.exec(table))) {
+    const closing = match[0].startsWith('</');
+    const name = /^<\/?([a-z]+)/i.exec(match[0])?.[1].toLowerCase();
+    if (name === 'table') tableDepth += closing ? -1 : 1;
+    if (name === 'tr' && tableDepth === 1) {
+      if (!closing && rowStart < 0) rowStart = match.index;
+      if (closing && rowStart >= 0) {
+        rows.push(table.slice(rowStart, tags.lastIndex));
+        rowStart = -1;
+      }
+    }
+  }
+  return rows;
+}
+
+function directCells(row) {
+  const tags = /<\/?(?:table|td|th)\b[^>]*>/gi;
+  const cells = [];
+  let tableDepth = 0;
+  let cellStart = -1;
+  let match;
+  while ((match = tags.exec(row))) {
+    const closing = match[0].startsWith('</');
+    const name = /^<\/?([a-z]+)/i.exec(match[0])?.[1].toLowerCase();
+    if (name === 'table') tableDepth += closing ? -1 : 1;
+    if ((name === 'td' || name === 'th') && tableDepth === 0) {
+      if (!closing && cellStart < 0) cellStart = match.index;
+      if (closing && cellStart >= 0) {
+        cells.push(row.slice(cellStart, tags.lastIndex));
+        cellStart = -1;
+      }
+    }
+  }
+  return cells;
+}
+
+function isoU2Time(value) {
+  const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);
+  return match ? `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}+08:00` : null;
+}
+
+function intCell(cell) {
+  const value = text(cell).replace(/,/g, '');
+  return /^\d+$/.test(value) ? Number(value) : 0;
+}
+
+export function parseTorrentRows(html) {
+  const table = allTables(html).find(item => /class=["'][^"']*\btorrents\b/i.test(item.match(/^<table\b[^>]*>/i)?.[0] || ''));
+  if (!table) return [];
+  const rows = [];
+  for (const row of directRows(table).slice(1)) {
+    const cells = directCells(row);
+    if (cells.length !== 8) continue;
+    const linkTags = [...cells[1].matchAll(/<a\b[^>]*>/gi)].map(match => match[0]);
+    const detailTag = linkTags.find(tag => /details\.php\?id=\d+/i.test(attribute(tag, 'href')));
+    const href = detailTag ? attribute(detailTag, 'href') : '';
+    const id = href.match(/[?&]id=(\d+)/)?.[1];
+    if (!id) continue;
+    const title = attribute(detailTag, 'title') || text(cells[1].match(/<a\b[^>]*details\.php[\s\S]*?<\/a>/i)?.[0]);
+    const timeTag = cells[3].match(/<time\b[^>]*>/i)?.[0] || '';
+    const promotionTag = [...cells[1].matchAll(/<img\b[^>]*>/gi)].map(match => match[0])
+      .find(tag => /\bpro_/i.test(attribute(tag, 'class')));
+    rows.push({
+      id,
+      category: text(cells[0]),
+      title,
+      comments: intCell(cells[2]),
+      publishedAt: isoU2Time(attribute(timeTag, 'title')),
+      size: text(cells[4]),
+      seeders: intCell(cells[5]),
+      leechers: intCell(cells[6]),
+      snatched: intCell(cells[7]),
+      promotion: promotionTag ? attribute(promotionTag, 'alt') || null : null,
+      detailsUrl: `${BASE}/details.php?id=${id}`,
+    });
+  }
+  return rows;
+}
+
+export function parseSubtitleRows(html) {
+  const table = allTables(html).filter(item => /语言/.test(item) && /上传者/.test(item) && /添加时间/.test(item)).at(-1);
+  if (!table) return [];
+  const rows = [];
+  for (const row of directRows(table).slice(1)) {
+    const cells = directCells(row);
+    if (cells.length !== 7) continue;
+    const titleLink = cells[1].match(/<a\b[^>]*>/i)?.[0] || '';
+    const onclick = attribute(titleLink, 'onclick');
+    const id = onclick.match(/show_detail\s*\(\s*(\d+)\s*\)/i)?.[1];
+    if (!id) continue;
+    const languageTag = cells[0].match(/<img\b[^>]*>/i)?.[0] || '';
+    const timeTag = cells[2].match(/<time\b[^>]*>/i)?.[0] || '';
+    rows.push({
+      id,
+      language: attribute(languageTag, 'alt'),
+      title: text(cells[1]),
+      publishedAt: isoU2Time(attribute(timeTag, 'title')),
+      size: text(cells[3]),
+      downloads: intCell(cells[4]),
+      uploader: text(cells[5]),
+    });
+  }
+  return rows;
+}

--- a/clis/u2/utils.test.js
+++ b/clis/u2/utils.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { assertAuthenticated, decodeEntities, getCookie, parseTorrentRows, parseSubtitleRows } from './utils.js';
+
+const fixture = name => readFile(new URL(`./__fixtures__/${name}`, import.meta.url), 'utf8');
+
+test('parseTorrentRows extracts stable torrent fields', async () => {
+  const rows = parseTorrentRows(await fixture('torrents.html'));
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], {
+    id: '65431', category: 'BDMV', title: 'Example & One', comments: 1,
+    publishedAt: '2026-07-03T09:45:57+08:00', size: '32.600 GiB',
+    seeders: 28, leechers: 0, snatched: 65, promotion: '2X',
+    detailsUrl: 'https://u2.dmhy.org/details.php?id=65431',
+  });
+  assert.equal(rows[1].promotion, '2X Free');
+});
+
+test('parseSubtitleRows extracts stable subtitle fields', async () => {
+  const rows = parseSubtitleRows(await fixture('subtitles.html'));
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], {
+    id: '10270', language: 'S.Chinese(简体中文)', title: '[KissSub][Steins;Gate]',
+    publishedAt: '2026-07-02T15:54:33+08:00', size: '648.533 KiB',
+    downloads: 0, uploader: 'UploaderA',
+  });
+  assert.equal(rows[1].uploader, '匿名');
+  assert.equal(rows[1].title, 'Example & Two');
+});
+
+test('parsers return no rows for unrelated HTML', () => {
+  assert.deepEqual(parseTorrentRows('<html><body>none</body></html>'), []);
+  assert.deepEqual(parseSubtitleRows('<html><body>none</body></html>'), []);
+});
+
+test('decodeEntities accepts semicolonless ampersands emitted by U2', () => {
+  assert.equal(decodeEntities('SC-OL&amp 1-24'), 'SC-OL& 1-24');
+});
+
+test('assertAuthenticated rejects the U2 login page', () => {
+  assert.throws(
+    () => assertAuthenticated('<form action="takelogin.php"><input name="username"></form>'),
+    error => error?.code === 'AUTH_REQUIRED' && error?.exitCode === 77,
+  );
+});
+
+test('getCookie rejects a browser session without U2 cookies', async () => {
+  await assert.rejects(
+    () => getCookie({ getCookies: async () => [] }),
+    error => error?.code === 'AUTH_REQUIRED' && error?.exitCode === 77,
+  );
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes and link to any related issues. -->

Related issue:

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [ ] I ran the checks relevant to this PR
- [ ] I updated tests or docs if needed
- [ ] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

<!-- If applicable, paste CLI output or screenshots here. -->
