### PR TITLE
feat(xiaohongshu): add collect, collect-boards, collect-board commands

### DIFF
--- a/clis/xiaohongshu/collect-board.js
+++ b/clis/xiaohongshu/collect-board.js
@@ -1,0 +1,116 @@
+/**
+ * Xiaohongshu Notes in a Collection Board — 某个收藏专辑下的笔记.
+ *
+ *   opencli xiaohongshu collect-board "AI"        # by album name
+ *   opencli xiaohongshu collect-board <board_id>  # by album id / board URL
+ *
+ * We open the profile → 收藏 → 专辑 list (which also lets us resolve a name to a
+ * board id), then SPA-click the board card. A full-page goto to /board/<id>
+ * SSR-renders the first page but fires no API, so we drive it via SPA click and
+ * INTERCEPT the board/note requests, plus read the SSR store as a fallback.
+ *
+ * Notes are served by GET edith.xiaohongshu.com/api/sns/web/v1/board/note
+ * (x-s signed). Targets the logged-in user's own 收藏 专辑.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrap, mapCollectedNote, matchBoard, resolveLoggedInUserId, fetchBoards } from './collect-helpers.js';
+
+// Read the SSR-hydrated first page of board notes from the Pinia store.
+async function readBoardStateNotes(page, boardId) {
+    const notes = await page.evaluate(`
+        (() => {
+            const s = window.__INITIAL_STATE__ || {};
+            const g = (x) => (x && x._value !== undefined ? x._value : x);
+            const fm = g((g(s.board) || {}).boardFeedsMap) || {};
+            const entry = g(fm[${JSON.stringify(boardId)}]) || {};
+            return Array.isArray(entry.notes) ? entry.notes : [];
+        })()
+    `);
+    return Array.isArray(notes) ? notes : [];
+}
+
+cli({
+    site: 'xiaohongshu',
+    name: 'collect-board',
+    description: '小红书某个收藏专辑下的笔记 (收藏 > 专辑 > 笔记)',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    args: [
+        { name: 'board', type: 'string', positional: true, required: true, help: 'Board name, board id, or /board/<id> URL' },
+        { name: 'limit', type: 'int', default: 30, help: 'Number of notes to return' },
+    ],
+    columns: ['rank', 'id', 'title', 'author', 'type', 'likes', 'url'],
+    func: async (page, kwargs) => {
+        const limit = Math.max(1, Number(kwargs.limit ?? 30));
+
+        // Open profile → 收藏 → 专辑 and list the boards (also resolves a name).
+        await page.goto('https://www.xiaohongshu.com/');
+        const userId = await resolveLoggedInUserId(page);
+        const boards = await fetchBoards(page, userId);
+
+        const board = matchBoard(boards, String(kwargs.board));
+        if (!board) {
+            const names = boards.map((b) => b.name).filter(Boolean);
+            throw new ArgumentError(`No collection board named "${kwargs.board}". Available: ${names.length ? names.join(', ') : '(none)'}`);
+        }
+        const boardId = board.id;
+
+        // Intercept the paginated board/note API, then SPA-click the board card
+        // (preserves JS context, unlike a full goto) to trigger it.
+        await page.installInterceptor('board/note');
+        const clicked = await page.evaluate(`
+            (() => {
+                const link = document.querySelector('a[href*="/board/${boardId}"]');
+                if (link) { link.click(); return true; }
+                return false;
+            })()
+        `);
+        if (!clicked) {
+            // Fallback: navigate directly (first page comes from the SSR store).
+            await page.goto(`https://www.xiaohongshu.com/board/${boardId}?source=web_user_page`);
+        }
+        await page.wait(2);
+        try {
+            await page.waitForCapture(6);
+        } catch {
+            // Direct-goto path fires no API; the SSR store still has page 1.
+        }
+
+        const seen = new Set();
+        const rows = [];
+        const collect = (note) => {
+            const row = mapCollectedNote(note);
+            if (!row || seen.has(row.id))
+                return;
+            seen.add(row.id);
+            rows.push(row);
+        };
+
+        const maxScrolls = Math.ceil(limit / 30) + 5;
+        for (let i = 0; i < maxScrolls; i++) {
+            // Channel 1: intercepted board/note responses (snake_case).
+            const requests = await page.getInterceptedRequests();
+            for (const req of Array.isArray(requests) ? requests : []) {
+                const notes = unwrap(req?.data)?.notes;
+                for (const note of Array.isArray(notes) ? notes : [])
+                    collect(note);
+            }
+            // Channel 2: SSR/store first page + appended pages (camelCase).
+            for (const note of await readBoardStateNotes(page, boardId))
+                collect(note);
+
+            if (rows.length >= limit)
+                break;
+            await page.autoScroll({ times: 1, delayMs: 1800 });
+            await page.wait(1);
+        }
+
+        if (rows.length === 0) {
+            throw new EmptyResultError(`No notes found in board "${board.name || boardId}". It may be empty or private.`);
+        }
+
+        return rows.slice(0, limit).map((row, i) => ({ rank: i + 1, ...row }));
+    },
+});

--- a/clis/xiaohongshu/collect-boards.js
+++ b/clis/xiaohongshu/collect-boards.js
@@ -1,0 +1,36 @@
+/**
+ * Xiaohongshu Collection Boards — 我的收藏 > 专辑 列表.
+ *
+ * Lists the collection albums (专辑) of a user, so you can grab a board id/name
+ * to feed into `xiaohongshu collect-board`.
+ *
+ * Served by GET edith.xiaohongshu.com/api/sns/web/v1/board/user (x-s signed),
+ * captured via INTERCEPT. Requires login for private boards / your own account.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeXhsUserId, resolveLoggedInUserId, fetchBoards } from './collect-helpers.js';
+
+cli({
+    site: 'xiaohongshu',
+    name: 'collect-boards',
+    description: '小红书「我的收藏」专辑列表 (收藏 > 专辑)',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    args: [
+        { name: 'user', type: 'string', positional: true, required: false, help: 'User id or profile URL (default: logged-in user)' },
+    ],
+    columns: ['id', 'name', 'count', 'privacy', 'desc'],
+    func: async (page, kwargs) => {
+        await page.goto('https://www.xiaohongshu.com/');
+        const userId = kwargs.user
+            ? normalizeXhsUserId(String(kwargs.user))
+            : await resolveLoggedInUserId(page);
+        const boards = await fetchBoards(page, userId);
+        if (boards.length === 0) {
+            throw new EmptyResultError('No collection boards found. Is this account signed in and does it have any 专辑?');
+        }
+        return boards;
+    },
+});

--- a/clis/xiaohongshu/collect-helpers.js
+++ b/clis/xiaohongshu/collect-helpers.js
@@ -1,0 +1,178 @@
+/**
+ * Shared helpers for the Xiaohongshu 收藏 (collection) adapters:
+ * collect / collect-boards / collect-board.
+ *
+ * All edith.xiaohongshu.com endpoints require an x-s signature, so a raw
+ * fetch() fails with "create invalid signature". The browser-driving helpers
+ * here let the page fire its own signed requests, which the adapters read back
+ * via the interceptor. The pure mapping/parsing helpers are unit-tested in
+ * collect-helpers.test.js.
+ */
+import { AuthRequiredError } from '@jackwener/opencli/errors';
+
+export function toStr(value) {
+    return typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
+}
+
+export function normalizeXhsUserId(input) {
+    const trimmed = toStr(input);
+    const withoutQuery = trimmed.replace(/[?#].*$/, '');
+    const matched = withoutQuery.match(/\/user\/profile\/([a-zA-Z0-9]+)/);
+    if (matched?.[1])
+        return matched[1];
+    return withoutQuery.replace(/\/+$/, '').split('/').pop() ?? withoutQuery;
+}
+
+export function normalizeBoardId(input) {
+    const trimmed = toStr(input);
+    const matched = trimmed.match(/\/board\/([0-9a-f]{24})/);
+    if (matched?.[1])
+        return matched[1];
+    return trimmed.replace(/[?#].*$/, '').replace(/\/+$/, '').split('/').pop() ?? trimmed;
+}
+
+// A 24-char hex string is a raw XHS object id (board id / note id).
+export function looksLikeId(value) {
+    return /^[0-9a-f]{24}$/.test(toStr(value));
+}
+
+export function buildExploreUrl(noteId, xsecToken) {
+    const id = toStr(noteId);
+    if (!id)
+        return '';
+    const url = new URL(`https://www.xiaohongshu.com/explore/${id}`);
+    const token = toStr(xsecToken);
+    if (token) {
+        url.searchParams.set('xsec_token', token);
+        url.searchParams.set('xsec_source', 'pc_user');
+    }
+    return url.toString();
+}
+
+// Intercepted payloads may be the full body ({code,data:{...}}) or the already
+// unwrapped data object; return the inner data either way.
+export function unwrap(payload) {
+    return payload?.data ?? payload ?? {};
+}
+
+// Map a raw board object from GET /api/sns/web/v1/board/user.
+export function mapBoard(board) {
+    return {
+        id: toStr(board?.id),
+        name: toStr(board?.name),
+        count: Number(board?.total ?? 0) || 0,
+        privacy: toStr(board?.privacy),
+        desc: toStr(board?.desc),
+    };
+}
+
+// Map a raw note object from board/note, note/collect/page (snake_case API), or
+// the SSR-hydrated store (camelCase). Handle all three shapes. Returns null when
+// the note has no id.
+export function mapCollectedNote(note) {
+    const id = toStr(note?.note_id ?? note?.noteId ?? note?.id);
+    if (!id)
+        return null;
+    const interact = note?.interact_info ?? note?.interactInfo ?? {};
+    const user = note?.user ?? {};
+    return {
+        id,
+        title: toStr(note?.display_title ?? note?.displayTitle ?? note?.title),
+        author: toStr(user.nickname ?? user.nick_name ?? user.nickName),
+        type: toStr(note?.type),
+        likes: toStr(interact.liked_count ?? interact.likedCount ?? '0') || '0',
+        url: buildExploreUrl(id, note?.xsec_token ?? note?.xsecToken),
+    };
+}
+
+// Pick a board out of a list by 24-hex id or by (case-insensitive) name, exact
+// match preferred over substring. Returns the matched board, a bare {id} stub
+// when an unknown id is given, or null when a name matches nothing.
+export function matchBoard(boards, boardArg) {
+    const list = Array.isArray(boards) ? boards : [];
+    const raw = normalizeBoardId(boardArg);
+    if (looksLikeId(raw)) {
+        return list.find((b) => b.id === raw) ?? { id: raw, name: '' };
+    }
+    const wanted = toStr(boardArg).toLowerCase();
+    return (list.find((b) => b.name.toLowerCase() === wanted)
+        ?? list.find((b) => b.name.toLowerCase().includes(wanted))
+        ?? null);
+}
+
+async function readMe(page) {
+    return await page.evaluate(`
+        (() => {
+            const u = window.__INITIAL_STATE__?.user || {};
+            const g = (x) => (x && x._value !== undefined ? x._value : x);
+            const me = g(u.userInfo) || {};
+            return { loggedIn: g(u.loggedIn) === true, userId: me.userId || '', guest: me.guest === true };
+        })()
+    `);
+}
+
+export async function resolveLoggedInUserId(page) {
+    let info = await readMe(page);
+    // The home/explore SSR may render the visitor as a guest even when the
+    // session cookie is valid; the own-profile route reliably hydrates userInfo.
+    if (!info || info.guest || !info.userId || !info.loggedIn) {
+        await page.goto('https://www.xiaohongshu.com/user/profile/');
+        await page.wait(2);
+        info = await readMe(page);
+    }
+    if (!info || info.guest || !info.userId || !info.loggedIn) {
+        throw new AuthRequiredError('www.xiaohongshu.com', 'Not logged in. Open www.xiaohongshu.com in Chrome and sign in first.');
+    }
+    return info.userId;
+}
+
+/**
+ * Drive profile → 收藏 → 专辑 and intercept the board list, returning mapped
+ * boards. Leaves the page on the 专辑 list so callers can SPA-click a card.
+ */
+export async function fetchBoards(page, userId) {
+    await page.goto(`https://www.xiaohongshu.com/user/profile/${userId}`);
+    await page.wait(2);
+    await page.installInterceptor('board/user');
+    // Click 收藏 (main tab), then 专辑 (sub-tab, label carries a "·N" count).
+    await page.evaluate(`
+        (() => {
+            const t = [...document.querySelectorAll('.reds-tab-item.sub-tab-list')]
+                .find((el) => el.textContent.trim() === '收藏');
+            if (t) t.click();
+        })()
+    `);
+    await page.wait(2);
+    await page.evaluate(`
+        (() => {
+            const b = [...document.querySelectorAll('.reds-tab-item')]
+                .find((el) => el.textContent.trim().startsWith('专辑'));
+            if (b) b.click();
+        })()
+    `);
+    await page.waitForCapture(6);
+    const boards = [];
+    const seen = new Set();
+    // Board lists are small (paginated 30/page); a few scrolls covers accounts
+    // with many albums.
+    const maxScrolls = 4;
+    for (let i = 0; i <= maxScrolls; i++) {
+        const requests = await page.getInterceptedRequests();
+        const before = boards.length;
+        for (const req of Array.isArray(requests) ? requests : []) {
+            const list = unwrap(req?.data)?.boards;
+            for (const raw of Array.isArray(list) ? list : []) {
+                const b = mapBoard(raw);
+                if (!b.id || seen.has(b.id))
+                    continue;
+                seen.add(b.id);
+                boards.push(b);
+            }
+        }
+        if (i === maxScrolls || (i > 0 && boards.length === before))
+            break;
+        await page.autoScroll({ times: 1, delayMs: 1500 });
+        await page.wait(1);
+    }
+    return boards;
+}

--- a/clis/xiaohongshu/collect-helpers.test.js
+++ b/clis/xiaohongshu/collect-helpers.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeXhsUserId, normalizeBoardId, looksLikeId, buildExploreUrl, unwrap, mapBoard, mapCollectedNote, matchBoard, } from './collect-helpers.js';
+
+// All ids below are synthetic 24-char hex placeholders, not real accounts.
+const USER_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const BOARD_A = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const BOARD_B = 'cccccccccccccccccccccccc';
+const BOARD_C = 'dddddddddddddddddddddddd';
+const NOTE_ID = 'eeeeeeeeeeeeeeeeeeeeeeee';
+
+describe('normalizeXhsUserId', () => {
+    it('extracts the profile id from a full URL', () => {
+        expect(normalizeXhsUserId(`https://www.xiaohongshu.com/user/profile/${USER_ID}?tab=fav`)).toBe(USER_ID);
+    });
+    it('keeps a bare id unchanged', () => {
+        expect(normalizeXhsUserId(USER_ID)).toBe(USER_ID);
+    });
+});
+
+describe('normalizeBoardId', () => {
+    it('extracts the board id from a /board/ URL with query', () => {
+        expect(normalizeBoardId(`https://www.xiaohongshu.com/board/${BOARD_A}?source=web_user_page`)).toBe(BOARD_A);
+    });
+    it('keeps a bare board id unchanged', () => {
+        expect(normalizeBoardId(BOARD_A)).toBe(BOARD_A);
+    });
+    it('returns non-id names untouched (so they can be name-matched)', () => {
+        expect(normalizeBoardId('AI')).toBe('AI');
+    });
+});
+
+describe('looksLikeId', () => {
+    it('accepts a 24-char hex id', () => {
+        expect(looksLikeId(BOARD_A)).toBe(true);
+    });
+    it('rejects a board name', () => {
+        expect(looksLikeId('AI')).toBe(false);
+        expect(looksLikeId('3d 打印')).toBe(false);
+    });
+    it('rejects the wrong length / non-hex', () => {
+        expect(looksLikeId('bbbbbbbb')).toBe(false);
+        expect(looksLikeId('zzzzzzzzzzzzzzzzzzzzzzzz')).toBe(false);
+    });
+});
+
+describe('buildExploreUrl', () => {
+    it('appends xsec token and source when present', () => {
+        expect(buildExploreUrl('note123', 'tok=456')).toBe('https://www.xiaohongshu.com/explore/note123?xsec_token=tok%3D456&xsec_source=pc_user');
+    });
+    it('omits query when no token', () => {
+        expect(buildExploreUrl('note123', '')).toBe('https://www.xiaohongshu.com/explore/note123');
+    });
+    it('returns empty string without a note id', () => {
+        expect(buildExploreUrl('', 'tok')).toBe('');
+    });
+});
+
+describe('unwrap', () => {
+    it('unwraps a full response body', () => {
+        expect(unwrap({ code: 0, data: { notes: [1] } })).toEqual({ notes: [1] });
+    });
+    it('passes through an already-unwrapped data object', () => {
+        expect(unwrap({ notes: [1] })).toEqual({ notes: [1] });
+    });
+    it('tolerates null', () => {
+        expect(unwrap(null)).toEqual({});
+    });
+});
+
+describe('mapBoard', () => {
+    it('maps a raw board with total -> count', () => {
+        expect(mapBoard({ id: BOARD_A, name: 'AI', total: 305, privacy: '0', desc: '暂无简介' })).toEqual({
+            id: BOARD_A,
+            name: 'AI',
+            count: 305,
+            privacy: '0',
+            desc: '暂无简介',
+        });
+    });
+    it('defaults count to 0 when total missing', () => {
+        expect(mapBoard({ id: BOARD_B, name: '游戏' }).count).toBe(0);
+    });
+});
+
+describe('mapCollectedNote', () => {
+    it('maps a snake_case API note (board/note, collect/page)', () => {
+        const row = mapCollectedNote({
+            note_id: NOTE_ID,
+            display_title: '徒步 vlog',
+            type: 'video',
+            xsec_token: 'ABtoken=',
+            user: { nick_name: 'creator-a' },
+            interact_info: { liked_count: '166', collected_count: '122' },
+        });
+        expect(row).toEqual({
+            id: NOTE_ID,
+            title: '徒步 vlog',
+            author: 'creator-a',
+            type: 'video',
+            likes: '166',
+            url: `https://www.xiaohongshu.com/explore/${NOTE_ID}?xsec_token=ABtoken%3D&xsec_source=pc_user`,
+        });
+    });
+    it('maps a camelCase SSR-store note (boardFeedsMap)', () => {
+        const row = mapCollectedNote({
+            noteId: NOTE_ID,
+            displayTitle: 'html 编辑器使用教程',
+            type: 'video',
+            xsecToken: 'AB2tz=',
+            user: { nickName: 'creator-b' },
+            interactInfo: { likedCount: '31' },
+        });
+        expect(row).toMatchObject({
+            id: NOTE_ID,
+            title: 'html 编辑器使用教程',
+            author: 'creator-b',
+            likes: '31',
+        });
+        expect(row.url).toContain('xsec_token=AB2tz%3D');
+    });
+    it('defaults likes to "0" and tolerates a missing user', () => {
+        const row = mapCollectedNote({ note_id: 'n1', display_title: 't' });
+        expect(row.likes).toBe('0');
+        expect(row.author).toBe('');
+    });
+    it('returns null for a note without an id', () => {
+        expect(mapCollectedNote({ display_title: 'no id' })).toBeNull();
+        expect(mapCollectedNote(null)).toBeNull();
+    });
+});
+
+describe('matchBoard', () => {
+    const boards = [
+        { id: BOARD_A, name: '打卡', count: 225 },
+        { id: BOARD_B, name: 'AI', count: 305 },
+        { id: BOARD_C, name: '3d 打印', count: 58 },
+    ];
+    it('matches by exact 24-hex id from a URL', () => {
+        expect(matchBoard(boards, `https://www.xiaohongshu.com/board/${BOARD_B}?source=x`)?.name).toBe('AI');
+    });
+    it('returns a bare stub for an unknown id', () => {
+        expect(matchBoard(boards, 'ffffffffffffffffffffffff')).toEqual({ id: 'ffffffffffffffffffffffff', name: '' });
+    });
+    it('matches by exact name case-insensitively', () => {
+        expect(matchBoard(boards, 'ai')?.id).toBe(BOARD_B);
+    });
+    it('falls back to substring name match', () => {
+        expect(matchBoard(boards, '打印')?.name).toBe('3d 打印');
+    });
+    it('returns null when a name matches nothing', () => {
+        expect(matchBoard(boards, '不存在')).toBeNull();
+    });
+});

--- a/clis/xiaohongshu/collect.js
+++ b/clis/xiaohongshu/collect.js
@@ -1,0 +1,88 @@
+/**
+ * Xiaohongshu Collected Notes — 我的收藏 > 笔记（当前登录用户收藏的笔记列表）.
+ *
+ * The collected-notes list is served by
+ *   GET edith.xiaohongshu.com/api/sns/web/v2/note/collect/page
+ * which requires XHS's x-s signature, so a raw fetch() fails with
+ * "create invalid signature". We therefore let the page fire its own signed
+ * requests (click 收藏 tab, then scroll to paginate) and INTERCEPT the
+ * responses.
+ *
+ * Requires: logged into www.xiaohongshu.com in Chrome (web_session cookie).
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeXhsUserId, resolveLoggedInUserId, unwrap, mapCollectedNote } from './collect-helpers.js';
+
+const COLLECT_API_PATH = 'note/collect/page';
+
+cli({
+    site: 'xiaohongshu',
+    name: 'collect',
+    description: '小红书「我的收藏」笔记列表 (收藏 > 笔记)',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    args: [
+        { name: 'user', type: 'string', positional: true, required: false, help: 'User id or profile URL (default: logged-in user)' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of notes to return' },
+    ],
+    columns: ['rank', 'id', 'title', 'author', 'type', 'likes', 'url'],
+    func: async (page, kwargs) => {
+        const limit = Math.max(1, Number(kwargs.limit ?? 20));
+
+        // 1. Land on the profile page (goto resets JS context).
+        const userId = kwargs.user
+            ? normalizeXhsUserId(String(kwargs.user))
+            : await resolveLoggedInUserId(page);
+        await page.goto(`https://www.xiaohongshu.com/user/profile/${userId}`);
+        await page.wait(2);
+
+        // 2. Install the interceptor AFTER goto but BEFORE the SPA tab click, so
+        //    the signed collect/page requests are captured.
+        await page.installInterceptor(COLLECT_API_PATH);
+
+        // 3. Click the 收藏 tab — defaults to its 笔记 sub-tab, which fires the
+        //    first collect/page request.
+        const clicked = await page.evaluate(`
+            (() => {
+                const tab = [...document.querySelectorAll('.reds-tab-item.sub-tab-list')]
+                    .find((el) => el.textContent.trim() === '收藏');
+                if (tab) { tab.click(); return true; }
+                return false;
+            })()
+        `);
+        if (!clicked) {
+            throw new EmptyResultError('Could not find the 收藏 tab on the profile page. The profile may be private or the layout changed.');
+        }
+        await page.waitForCapture(6);
+
+        // 4. Scroll to trigger paginated collect/page requests until we have enough.
+        const seen = new Set();
+        const rows = [];
+        const maxScrolls = Math.ceil(limit / 30) + 4;
+        for (let i = 0; i < maxScrolls; i++) {
+            const requests = await page.getInterceptedRequests();
+            for (const req of Array.isArray(requests) ? requests : []) {
+                const notes = unwrap(req?.data)?.notes;
+                for (const note of Array.isArray(notes) ? notes : []) {
+                    const row = mapCollectedNote(note);
+                    if (!row || seen.has(row.id))
+                        continue;
+                    seen.add(row.id);
+                    rows.push(row);
+                }
+            }
+            if (rows.length >= limit)
+                break;
+            await page.autoScroll({ times: 1, delayMs: 1800 });
+            await page.wait(1);
+        }
+
+        if (rows.length === 0) {
+            throw new AuthRequiredError('www.xiaohongshu.com', 'No collected notes found. Is this account signed in and does it have any 收藏?');
+        }
+
+        return rows.slice(0, limit).map((row, i) => ({ rank: i + 1, ...row }));
+    },
+});


### PR DESCRIPTION
## What

Adds three read-only commands for a Xiaohongshu user's **收藏 (collections)**:

| Command | What it returns |
|---|---|
| `xiaohongshu collect [user] [--limit N]` | Flat list of collected notes (收藏 › 笔记) |
| `xiaohongshu collect-boards [user]` | Collection albums (收藏 › 专辑) — id / name / count |
| `xiaohongshu collect-board <name\|id> [--limit N]` | Notes inside one album (收藏 › 专辑 › 笔记) |

`collect-board` accepts an album **name** (resolved to its id via the board list, exact match preferred over substring) or a raw **board id / `/board/<id>` URL**. An unknown name errors with the list of available albums. Output columns are shared across the note commands: `rank, id, title, author, type, likes, url` (the url carries `xsec_token` so it opens directly).

## How

All three data endpoints live on `edith.xiaohongshu.com` and require an `x-s` signature — a raw `fetch()` returns `create invalid signature`. So the adapters use `Strategy.INTERCEPT`: they drive the page to fire its **own** signed requests and read the responses back via the interceptor.

- `collect` → installs the interceptor, clicks the 收藏 tab (defaults to its 笔记 sub-tab, firing `note/collect/page`), then scrolls to paginate.
- `collect-boards` → clicks 收藏 › 专辑 and reads `board/user`.
- `collect-board` → lists boards, SPA-clicks the target board card to fire `board/note`, and **also** reads the SSR-hydrated first page from the Pinia store (`__INITIAL_STATE__.board.boardFeedsMap`), because a direct `/board/<id>` navigation renders page 1 server-side and fires no API. Both channels are deduped by note id.

A guard handles the home/explore SSR occasionally rendering a logged-in visitor as a guest by re-reading user info from the own-profile route.

## Tests

Pure mapping/parsing logic (id/board normalization, URL building, response unwrapping, board & note mapping across the snake_case API and camelCase SSR shapes, and board name/id matching) is extracted into `collect-helpers.js` and covered by `collect-helpers.test.js` (25 cases, all synthetic data).

```
npm run test:adapter   # clis/xiaohongshu suite: 88 passed
```

Browser-driving code (`func`) follows the existing `func()` adapter pattern (see `clis/twitter/following.js`, `clis/xiaohongshu/user.js`).

## Notes

- All three require being logged into `www.xiaohongshu.com` in Chrome.
- The generated `cli-manifest.json` is intentionally left out of this PR; it is a build artifact.
