### PR TITLE
fix(adapters): update DOM selectors for Doubao, DeepSeek, ChatGPT, Kimi (2026-07)

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -32,7 +32,9 @@ async function waitForConversationUrl(page, timeoutSeconds = 30) {
             await page.wait(1);
         }
     }
-    throw new CommandExecutionError('ChatGPT did not create a conversation URL after sending the message.');
+    // ChatGPT SPA may keep the URL at / or /new during the first exchange;
+    // return empty IDs instead of throwing so the response can still be read.
+    return { conversationId: '', conversationUrl: '' };
 }
 
 export const askCommand = cli({

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -1024,9 +1024,34 @@ export async function sendChatGPTMessage(page, text) {
         if (sent?.sendBtnFound) break;
     }
 
+    let sendMethod = 'click';
     if (!sent?.sendBtnFound) {
-        return false;
-    }
+        // ChatGPT no longer ships a dedicated send-button in the DOM;
+        // the composer submits on Enter in the contenteditable / textarea.
+        const enterResult = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
+            (() => {
+                const isVisible = (el) => {
+                    if (!(el instanceof HTMLElement)) return false;
+                    const style = window.getComputedStyle(el);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    const rect = el.getBoundingClientRect();
+                    return rect.width > 0 && rect.height > 0;
+                };
+                const sels = ${JSON.stringify(COMPOSER_SELECTORS)};
+                let composer = null;
+                for (let si = 0; si < sels.length; si++) { composer = document.querySelector(sels[si]); if (composer && isVisible(composer)) break; }
+                if (!composer) return { ok: false, reason: 'composer not found for Enter fallback' };
+                composer.focus();
+                composer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true, composed: true }));
+                composer.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true, composed: true }));
+                return { ok: true };
+            })()
+        `)), 'chatgpt enter fallback');
+        if (!enterResult?.ok) {
+            return false;
+        }
+        sendMethod = 'enter';
+    } else {
 
     await page.evaluate(`
         (() => {
@@ -1057,6 +1082,7 @@ export async function sendChatGPTMessage(page, text) {
             if (sendBtn) sendBtn.click();
         })()
     `);
+    }
     return true;
 }
 

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -3,7 +3,10 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const DEEPSEEK_DOMAIN = 'chat.deepseek.com';
 export const DEEPSEEK_URL = 'https://chat.deepseek.com/';
 export const TEXTAREA_SELECTOR = 'textarea[placeholder*="DeepSeek"]';
-export const MESSAGE_SELECTOR = '.ds-message';
+// DeepSeek renders messages inside a virtualised list. The container has a
+// stable ds-virtual-list-visible-items class; individual turns are direct
+// children with hashed CSS-module class names that change per build.
+export const MESSAGE_SELECTOR = '.ds-virtual-list-visible-items > *';
 const CONVERSATION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 /**
@@ -59,12 +62,14 @@ export async function getPageState(page) {
         const url = window.location.href;
         const title = document.title;
         const textarea = document.querySelector('${TEXTAREA_SELECTOR}');
-        const avatar = document.querySelector('img[src*="user-avatar"]');
+        // If the composer textarea is visible the user is logged in;
+        // DeepSeek's login page renders a different UI without a textarea.
+        const isLoggedIn = !!textarea;
         return {
             url,
             title,
             hasTextarea: !!textarea,
-            isLoggedIn: !!avatar,
+            isLoggedIn,
         };
     })()`);
 }
@@ -108,21 +113,15 @@ export async function sendMessage(page, prompt) {
         document.execCommand('insertText', false, ${promptJson});
         await new Promise(r => setTimeout(r, 800));
 
-        // Find the send button: last non-toggle button in the textarea's container
-        var container = box.parentElement;
-        while (container && !container.querySelector('div[role="button"]')) {
-            container = container.parentElement;
-        }
-        if (container) {
-            var btns = container.querySelectorAll('div[role="button"]:not(.ds-toggle-button)');
-            var sendBtn = btns[btns.length - 1];
-            if (sendBtn && sendBtn.getAttribute('aria-disabled') === 'false'
-                && sendBtn.querySelectorAll('svg').length > 0) {
-                sendBtn.click();
-                return { ok: true };
-            }
+        // Direct selector: DeepSeek's send button is the filled-circle primary
+        // button inside the composer row (2026-07 DOM).
+        var sendBtn = document.querySelector('div[role="button"].ds-button--primary.ds-button--filled.ds-button--circle');
+        if (sendBtn && sendBtn.querySelectorAll('svg').length > 0) {
+            sendBtn.click();
+            return { ok: true, method: 'direct-click' };
         }
 
+        // Fallback: Enter key
         box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
         return { ok: true, method: 'enter' };
     })()`);
@@ -170,6 +169,15 @@ export async function waitForResponse(page, baselineCount, prompt, timeoutMs, pa
 
     while (Date.now() - startTime < timeoutMs) {
         await page.wait(3);
+
+        // Virtual list: scroll to bottom so off-screen responses become visible
+        await page.evaluate(`(() => {
+            const list = document.querySelector('.ds-virtual-list-visible-items');
+            if (list) {
+                const parent = list.parentElement;
+                if (parent) parent.scrollTop = parent.scrollHeight;
+            }
+        })()`);
 
         let result;
         try {

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -168,6 +168,17 @@ function getTurnsScript() {
         // [class*="top-item-"] and the only reliable assistant signal is the
         // .flow-markdown-body / .md-box-root content container WITHOUT any
         // send-bubble marker.
+        // 2026-07: Doubao removed ALL data-testid attributes. User turns keep
+        // bg-g-send-msg-bubble; assistant turns have neither that nor
+        // bg-g-receive-msg-bubble.  An inner-item- without a send-bubble is
+        // an assistant turn (even if flow-markdown-body hasn't rendered yet).
+        if (
+          root.matches('[class*="inner-item-"], [class*="top-item-"]')
+          && !root.matches('[class*="bg-g-send-msg-bubble"]')
+          && !root.querySelector('[class*="bg-g-send-msg-bubble"]')
+        ) {
+          return 'Assistant';
+        }
         if (
           (root.matches('[class*="inner-item-"], [class*="top-item-"]')
             || root.closest('[class*="inner-item-"], [class*="top-item-"]'))
@@ -182,6 +193,12 @@ function getTurnsScript() {
       };
 
       const messageTextSelectors = [
+        // 2026-07: Doubao removed all data-testid. Use .flow-markdown-body
+        // for assistant content and .whitespace-pre-wrap for user bubbles.
+        '.flow-markdown-body',
+        '.md-box-root',
+        '[class*="md-box-root"]',
+        '[class*="whitespace-pre-wrap"]',
         '[data-testid="message_text_content"]',
         '[data-testid="message_content"]',
         '[data-testid*="message_text"]',
@@ -189,10 +206,6 @@ function getTurnsScript() {
         '[class*="message-text"]',
         '[class*="message-content"]',
         '[class*="bg-g-send-msg-bubble"]',
-        '[class*="bg-g-receive-msg-bubble"]',
-        '.flow-markdown-body',
-        '.md-box-root',
-        '[class*="md-box-root"]',
         '[class*="bubble"]',
       ];
       const messageImageSelector = messageTextSelectors.map((s) => s + ' img').join(', ');
@@ -748,12 +761,10 @@ export async function waitForDoubaoResponse(page, beforeLines, beforeTurns, prom
         const visibleCandidate = assistantCandidate ? sanitizeCandidate(assistantCandidate.Text) : '';
         if (visibleCandidate)
             return visibleCandidate;
-        const lines = await getDoubaoTranscriptLines(page);
-        const additions = collectDoubaoTranscriptAdditions(beforeLines, lines, promptText, sanitizeCandidate)
-            .split('\n')
-            .filter(Boolean);
-        const shortCandidate = additions.find((line) => line.length <= 120);
-        return shortCandidate || additions[additions.length - 1] || '';
+        // 2026-07: transcript fallback is unreliable (returns full-page noise
+        // when the assistant bubble is still rendering).  Skip it and keep
+        // polling — the turn text will populate once generation finishes.
+        return '';
     };
     const pollIntervalSeconds = 2;
     const maxPolls = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -85,9 +85,10 @@ export function clickBySvgNameScript(svgName, opts = {}) {
       if (!parent) break;
       target = parent;
       if (target.tagName === 'BUTTON' || target.getAttribute('role') === 'button' || target.onclick || target.tagName === 'A') break;
-      // 2026-07 Kimi: send button is a plain DIV (chat-editor-action) with
-      // React event delegation — no onclick / role / button tag.
-      if (target.className && typeof target.className === 'string' && /chat-editor-action/i.test(target.className)) break;
+      // 2026-07 Kimi (Lexical editor): the actual send button is .send-button-container,
+      // a DIV with no onclick/role/button-tag. Its parent .chat-editor-action is just
+      // the toolbar wrapper — clicking it does nothing. Match both for safety.
+      if (target.className && typeof target.className === 'string' && /send-button-container|chat-editor-action/i.test(target.className)) break;
     }
     const r = target.getBoundingClientRect();
     const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -85,6 +85,9 @@ export function clickBySvgNameScript(svgName, opts = {}) {
       if (!parent) break;
       target = parent;
       if (target.tagName === 'BUTTON' || target.getAttribute('role') === 'button' || target.onclick || target.tagName === 'A') break;
+      // 2026-07 Kimi: send button is a plain DIV (chat-editor-action) with
+      // React event delegation — no onclick / role / button tag.
+      if (target.className && typeof target.className === 'string' && /chat-editor-action/i.test(target.className)) break;
     }
     const r = target.getBoundingClientRect();
     const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };

--- a/clis/kimi/chat.js
+++ b/clis/kimi/chat.js
@@ -247,9 +247,12 @@ async function sendKimiMessage(page, text) {
     const prompt = String(text || '').trim();
     if (!prompt) throw new ArgumentError('text', 'is required');
     await ensureOnKimi(page);
+    // Kimi's home page has NO .chat-content-list — it only appears after
+    // SPA-navigating into a conversation.  Use a broader selector so the
+    // before-count is meaningful on the home page too.
     const beforeUsers = await page.evaluate(`(() => {
-      return Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
-        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || ''))).length;
+      return Array.from(document.querySelectorAll('.chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|chat-content-item-user|me-/i.test(String(row.className || ''))).length;
     })()`);
     const typeRes = await page.evaluate(`(() => {
       ${IS_VISIBLE_JS}
@@ -265,14 +268,16 @@ async function sendKimiMessage(page, text) {
     const sendRes = await page.evaluate(clickBySvgNameScript('Send'));
     if (!sendRes?.ok) throw new CommandExecutionError(sendRes?.reason || 'Send button click failed', '');
 
-    const deadline = Date.now() + 3000;
+    // Kimi's SPA navigates to /chat/<id> after sending; give it 15 s to
+    // settle instead of the old 3 s which was too tight for cold loads.
+    const deadline = Date.now() + 15000;
     while (Date.now() < deadline) {
         const verified = await page.evaluate(`(() => {
       const normalize = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
       const prompt = normalize(${JSON.stringify(prompt)});
       const before = Number(${JSON.stringify(beforeUsers)}) || 0;
-      const rows = Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
-        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || '')));
+      const rows = Array.from(document.querySelectorAll('.chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|chat-content-item-user|me-/i.test(String(row.className || '')));
       return rows.slice(before).some((row) => normalize(row.innerText || row.textContent).includes(prompt));
     })()`);
         if (verified) return { prompt };


### PR DESCRIPTION
## Summary

Updates 4 adapters whose DOM selectors broke after upstream website changes in 2026-07.

### Doubao ✅ (verified working)
- All `data-testid` attributes removed by Doubao — adapter now uses class-based detection
- Assistant turns: `inner-item-` without `bg-g-send-msg-bubble` → Assistant
- Text extraction: prioritize `.md-box-root` / `.whitespace-pre-wrap`
- Removed unreliable transcript fallback (returned full-page noise)

### DeepSeek (improved)
- `.ds-message` → `.ds-virtual-list-visible-items > *` (CSS module hashes)
- Login check via textarea presence (avatar img selector removed)
- Send button: direct selector `div[role=button].ds-button--primary.ds-button--filled.ds-button--circle`
- Auto-scroll virtual list to bottom during response polling

### ChatGPT (improved)
- Enter key fallback when `data-testid=send-button` absent
- Conversation URL detection non-fatal (SPA may not update URL immediately)

### Kimi (improved)
- Broadened message selectors (no longer require `.chat-content-list` parent)
- Send verification timeout: 3s → 15s
- `clickBySvgNameScript`: detect `.chat-editor-action` (React event delegation div)