### PR TITLE
fix(webai adapters): refresh chat platform selectors

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -32,7 +32,9 @@ async function waitForConversationUrl(page, timeoutSeconds = 30) {
             await page.wait(1);
         }
     }
-    throw new CommandExecutionError('ChatGPT did not create a conversation URL after sending the message.');
+    // ChatGPT SPA may keep the URL at / or /new during the first exchange;
+    // return empty IDs instead of throwing so the response can still be read.
+    return { conversationId: '', conversationUrl: '' };
 }
 
 export const askCommand = cli({

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -1024,9 +1024,34 @@ export async function sendChatGPTMessage(page, text) {
         if (sent?.sendBtnFound) break;
     }
 
+    let sendMethod = 'click';
     if (!sent?.sendBtnFound) {
-        return false;
-    }
+        // ChatGPT no longer ships a dedicated send-button in the DOM;
+        // the composer submits on Enter in the contenteditable / textarea.
+        const enterResult = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
+            (() => {
+                const isVisible = (el) => {
+                    if (!(el instanceof HTMLElement)) return false;
+                    const style = window.getComputedStyle(el);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    const rect = el.getBoundingClientRect();
+                    return rect.width > 0 && rect.height > 0;
+                };
+                const sels = ${JSON.stringify(COMPOSER_SELECTORS)};
+                let composer = null;
+                for (let si = 0; si < sels.length; si++) { composer = document.querySelector(sels[si]); if (composer && isVisible(composer)) break; }
+                if (!composer) return { ok: false, reason: 'composer not found for Enter fallback' };
+                composer.focus();
+                composer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true, composed: true }));
+                composer.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true, composed: true }));
+                return { ok: true };
+            })()
+        `)), 'chatgpt enter fallback');
+        if (!enterResult?.ok) {
+            return false;
+        }
+        sendMethod = 'enter';
+    } else {
 
     await page.evaluate(`
         (() => {
@@ -1057,6 +1082,7 @@ export async function sendChatGPTMessage(page, text) {
             if (sendBtn) sendBtn.click();
         })()
     `);
+    }
     return true;
 }
 

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -3,10 +3,11 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const DEEPSEEK_DOMAIN = 'chat.deepseek.com';
 export const DEEPSEEK_URL = 'https://chat.deepseek.com/';
 export const TEXTAREA_SELECTOR = 'textarea[placeholder*="DeepSeek"]';
-// DeepSeek renders messages inside a virtualised list. The container has a
-// stable ds-virtual-list-visible-items class; individual turns are direct
-// children with hashed CSS-module class names that change per build.
-export const MESSAGE_SELECTOR = '.ds-virtual-list-visible-items > *';
+// DeepSeek renders messages inside a virtualised list.  Each turn is a
+// .ds-message element — these are stable and never duplicated, unlike the
+// outer virtual-list-item wrappers whose CSS-module class names vary per build.
+// Assistant turns carry .ds-assistant-message-main-content as a reliable role marker.
+export const MESSAGE_SELECTOR = '.ds-message';
 const CONVERSATION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 /**
@@ -108,22 +109,24 @@ export async function sendMessage(page, prompt) {
         if (!box) return { ok: false, reason: 'textarea not found' };
 
         box.focus();
-        box.value = '';
-        document.execCommand('selectAll');
+        // execCommand('insertText') works reliably on DeepSeek's native
+        // <textarea> — unlike Kimi's Lexical editor, React-controlled
+        // textareas pick up this DOM mutation and fire onChange.
+        document.execCommand('selectAll', false);
         document.execCommand('insertText', false, ${promptJson});
-        await new Promise(r => setTimeout(r, 800));
+        // Let React reconcile the controlled component.
+        await new Promise(r => setTimeout(r, 500));
 
-        // Direct selector: DeepSeek's send button is the filled-circle primary
-        // button inside the composer row (2026-07 DOM).
+        // Send button: ds-button--primary + ds-button--filled + ds-button--circle.
         var sendBtn = document.querySelector('div[role="button"].ds-button--primary.ds-button--filled.ds-button--circle');
-        if (sendBtn && sendBtn.querySelectorAll('svg').length > 0) {
+        if (sendBtn && !sendBtn.classList.contains('ds-button--disabled')) {
             sendBtn.click();
             return { ok: true, method: 'direct-click' };
         }
 
-        // Fallback: Enter key
+        // Fallback: Enter key in the textarea.
         box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
-        return { ok: true, method: 'enter' };
+        return { ok: true, method: 'enter-fallback' };
     })()`);
 }
 
@@ -272,10 +275,12 @@ export async function getVisibleMessages(page) {
     const result = await page.evaluate(`(() => {
         const msgs = document.querySelectorAll('${MESSAGE_SELECTOR}');
         return Array.from(msgs).map(m => {
-            // User messages carry an extra hash-class alongside ds-message
-            const isUser = m.className.split(/\\s+/).length > 2;
+            // Reliable role detection: assistant turns carry
+            // .ds-assistant-message-main-content inside the .ds-message wrapper.
+            // Class-name counting is fragile across builds.
+            const isAssistant = !!m.querySelector('.ds-assistant-message-main-content');
             return {
-                Role: isUser ? 'user' : 'assistant',
+                Role: isAssistant ? 'assistant' : 'user',
                 Text: (m.innerText || '').trim(),
             };
         }).filter(m => m.Text);

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -3,7 +3,10 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 export const DEEPSEEK_DOMAIN = 'chat.deepseek.com';
 export const DEEPSEEK_URL = 'https://chat.deepseek.com/';
 export const TEXTAREA_SELECTOR = 'textarea[placeholder*="DeepSeek"]';
-export const MESSAGE_SELECTOR = '.ds-message';
+// DeepSeek renders messages inside a virtualised list. The container has a
+// stable ds-virtual-list-visible-items class; individual turns are direct
+// children with hashed CSS-module class names that change per build.
+export const MESSAGE_SELECTOR = '.ds-virtual-list-visible-items > *';
 const CONVERSATION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 /**
@@ -59,12 +62,14 @@ export async function getPageState(page) {
         const url = window.location.href;
         const title = document.title;
         const textarea = document.querySelector('${TEXTAREA_SELECTOR}');
-        const avatar = document.querySelector('img[src*="user-avatar"]');
+        // If the composer textarea is visible the user is logged in;
+        // DeepSeek's login page renders a different UI without a textarea.
+        const isLoggedIn = !!textarea;
         return {
             url,
             title,
             hasTextarea: !!textarea,
-            isLoggedIn: !!avatar,
+            isLoggedIn,
         };
     })()`);
 }
@@ -108,21 +113,15 @@ export async function sendMessage(page, prompt) {
         document.execCommand('insertText', false, ${promptJson});
         await new Promise(r => setTimeout(r, 800));
 
-        // Find the send button: last non-toggle button in the textarea's container
-        var container = box.parentElement;
-        while (container && !container.querySelector('div[role="button"]')) {
-            container = container.parentElement;
-        }
-        if (container) {
-            var btns = container.querySelectorAll('div[role="button"]:not(.ds-toggle-button)');
-            var sendBtn = btns[btns.length - 1];
-            if (sendBtn && sendBtn.getAttribute('aria-disabled') === 'false'
-                && sendBtn.querySelectorAll('svg').length > 0) {
-                sendBtn.click();
-                return { ok: true };
-            }
+        // Direct selector: DeepSeek's send button is the filled-circle primary
+        // button inside the composer row (2026-07 DOM).
+        var sendBtn = document.querySelector('div[role="button"].ds-button--primary.ds-button--filled.ds-button--circle');
+        if (sendBtn && sendBtn.querySelectorAll('svg').length > 0) {
+            sendBtn.click();
+            return { ok: true, method: 'direct-click' };
         }
 
+        // Fallback: Enter key
         box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
         return { ok: true, method: 'enter' };
     })()`);
@@ -170,6 +169,15 @@ export async function waitForResponse(page, baselineCount, prompt, timeoutMs, pa
 
     while (Date.now() - startTime < timeoutMs) {
         await page.wait(3);
+
+        // Virtual list: scroll to bottom so off-screen responses become visible
+        await page.evaluate(`(() => {
+            const list = document.querySelector('.ds-virtual-list-visible-items');
+            if (list) {
+                const parent = list.parentElement;
+                if (parent) parent.scrollTop = parent.scrollHeight;
+            }
+        })()`);
 
         let result;
         try {

--- a/clis/doubao/utils.js
+++ b/clis/doubao/utils.js
@@ -168,6 +168,17 @@ function getTurnsScript() {
         // [class*="top-item-"] and the only reliable assistant signal is the
         // .flow-markdown-body / .md-box-root content container WITHOUT any
         // send-bubble marker.
+        // 2026-07: Doubao removed ALL data-testid attributes. User turns keep
+        // bg-g-send-msg-bubble; assistant turns have neither that nor
+        // bg-g-receive-msg-bubble.  An inner-item- without a send-bubble is
+        // an assistant turn (even if flow-markdown-body hasn't rendered yet).
+        if (
+          root.matches('[class*="inner-item-"], [class*="top-item-"]')
+          && !root.matches('[class*="bg-g-send-msg-bubble"]')
+          && !root.querySelector('[class*="bg-g-send-msg-bubble"]')
+        ) {
+          return 'Assistant';
+        }
         if (
           (root.matches('[class*="inner-item-"], [class*="top-item-"]')
             || root.closest('[class*="inner-item-"], [class*="top-item-"]'))
@@ -182,6 +193,12 @@ function getTurnsScript() {
       };
 
       const messageTextSelectors = [
+        // 2026-07: Doubao removed all data-testid. Use .flow-markdown-body
+        // for assistant content and .whitespace-pre-wrap for user bubbles.
+        '.flow-markdown-body',
+        '.md-box-root',
+        '[class*="md-box-root"]',
+        '[class*="whitespace-pre-wrap"]',
         '[data-testid="message_text_content"]',
         '[data-testid="message_content"]',
         '[data-testid*="message_text"]',
@@ -189,10 +206,6 @@ function getTurnsScript() {
         '[class*="message-text"]',
         '[class*="message-content"]',
         '[class*="bg-g-send-msg-bubble"]',
-        '[class*="bg-g-receive-msg-bubble"]',
-        '.flow-markdown-body',
-        '.md-box-root',
-        '[class*="md-box-root"]',
         '[class*="bubble"]',
       ];
       const messageImageSelector = messageTextSelectors.map((s) => s + ' img').join(', ');
@@ -748,12 +761,10 @@ export async function waitForDoubaoResponse(page, beforeLines, beforeTurns, prom
         const visibleCandidate = assistantCandidate ? sanitizeCandidate(assistantCandidate.Text) : '';
         if (visibleCandidate)
             return visibleCandidate;
-        const lines = await getDoubaoTranscriptLines(page);
-        const additions = collectDoubaoTranscriptAdditions(beforeLines, lines, promptText, sanitizeCandidate)
-            .split('\n')
-            .filter(Boolean);
-        const shortCandidate = additions.find((line) => line.length <= 120);
-        return shortCandidate || additions[additions.length - 1] || '';
+        // 2026-07: transcript fallback is unreliable (returns full-page noise
+        // when the assistant bubble is still rendering).  Skip it and keep
+        // polling — the turn text will populate once generation finishes.
+        return '';
     };
     const pollIntervalSeconds = 2;
     const maxPolls = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -85,9 +85,10 @@ export function clickBySvgNameScript(svgName, opts = {}) {
       if (!parent) break;
       target = parent;
       if (target.tagName === 'BUTTON' || target.getAttribute('role') === 'button' || target.onclick || target.tagName === 'A') break;
-      // 2026-07 Kimi: send button is a plain DIV (chat-editor-action) with
-      // React event delegation — no onclick / role / button tag.
-      if (target.className && typeof target.className === 'string' && /chat-editor-action/i.test(target.className)) break;
+      // 2026-07 Kimi (Lexical editor): the actual send button is .send-button-container,
+      // a DIV with no onclick/role/button-tag. Its parent .chat-editor-action is just
+      // the toolbar wrapper — clicking it does nothing. Match both for safety.
+      if (target.className && typeof target.className === 'string' && /send-button-container|chat-editor-action/i.test(target.className)) break;
     }
     const r = target.getBoundingClientRect();
     const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };

--- a/clis/kimi/_utils.js
+++ b/clis/kimi/_utils.js
@@ -85,6 +85,9 @@ export function clickBySvgNameScript(svgName, opts = {}) {
       if (!parent) break;
       target = parent;
       if (target.tagName === 'BUTTON' || target.getAttribute('role') === 'button' || target.onclick || target.tagName === 'A') break;
+      // 2026-07 Kimi: send button is a plain DIV (chat-editor-action) with
+      // React event delegation — no onclick / role / button tag.
+      if (target.className && typeof target.className === 'string' && /chat-editor-action/i.test(target.className)) break;
     }
     const r = target.getBoundingClientRect();
     const opts = { bubbles: true, cancelable: true, clientX: r.x + r.width/2, clientY: r.y + r.height/2 };

--- a/clis/kimi/chat.js
+++ b/clis/kimi/chat.js
@@ -247,9 +247,12 @@ async function sendKimiMessage(page, text) {
     const prompt = String(text || '').trim();
     if (!prompt) throw new ArgumentError('text', 'is required');
     await ensureOnKimi(page);
+    // Kimi's home page has NO .chat-content-list — it only appears after
+    // SPA-navigating into a conversation.  Use a broader selector so the
+    // before-count is meaningful on the home page too.
     const beforeUsers = await page.evaluate(`(() => {
-      return Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
-        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || ''))).length;
+      return Array.from(document.querySelectorAll('.chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|chat-content-item-user|me-/i.test(String(row.className || ''))).length;
     })()`);
     const typeRes = await page.evaluate(`(() => {
       ${IS_VISIBLE_JS}
@@ -265,14 +268,16 @@ async function sendKimiMessage(page, text) {
     const sendRes = await page.evaluate(clickBySvgNameScript('Send'));
     if (!sendRes?.ok) throw new CommandExecutionError(sendRes?.reason || 'Send button click failed', '');
 
-    const deadline = Date.now() + 3000;
+    // Kimi's SPA navigates to /chat/<id> after sending; give it 15 s to
+    // settle instead of the old 3 s which was too tight for cold loads.
+    const deadline = Date.now() + 15000;
     while (Date.now() < deadline) {
         const verified = await page.evaluate(`(() => {
       const normalize = (value) => String(value || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
       const prompt = normalize(${JSON.stringify(prompt)});
       const before = Number(${JSON.stringify(beforeUsers)}) || 0;
-      const rows = Array.from(document.querySelectorAll('.chat-content-list .chat-content-item, .message-list > *, .segment'))
-        .filter((row) => /user|sent-by-user|me-/i.test(String(row.className || '')));
+      const rows = Array.from(document.querySelectorAll('.chat-content-item, .message-list > *, .segment'))
+        .filter((row) => /user|sent-by-user|chat-content-item-user|me-/i.test(String(row.className || '')));
       return rows.slice(before).some((row) => normalize(row.innerText || row.textContent).includes(prompt));
     })()`);
         if (verified) return { prompt };

--- a/clis/qwen/detail.js
+++ b/clis/qwen/detail.js
@@ -5,6 +5,7 @@ import {
     bubbleHtmlToMarkdown,
     dismissLoginModal,
     getMessageBubbles,
+    getSessionMessagesFromApi,
     normalizeBooleanFlag,
     parseQianwenSessionId,
 } from './utils.js';
@@ -44,6 +45,14 @@ cli({
             bubbles = await getMessageBubbles(page);
             if (bubbles.length > 0) break;
             await page.wait(POLL_INTERVAL_S);
+        }
+
+        // The current Qianwen history UI can hydrate the question while leaving
+        // the answer wrapper empty even though the complete response is stored.
+        // Recover from the same read-only history API used by the web app.
+        if (!bubbles.some((bubble) => bubble.role === 'Assistant' && String(bubble.text || '').trim())) {
+            const apiBubbles = await getSessionMessagesFromApi(page, sessionId);
+            if (apiBubbles.length) bubbles = apiBubbles;
         }
 
         if (!bubbles.length) {

--- a/clis/qwen/utils.js
+++ b/clis/qwen/utils.js
@@ -268,6 +268,67 @@ export async function getMessageBubbles(page) {
         .filter((item) => item.id && item.text);
 }
 
+export function parseSessionMessageRecords(records) {
+    if (!Array.isArray(records)) return [];
+    const out = [];
+    for (let index = 0; index < records.length; index += 1) {
+        const record = records[index] || {};
+        const reqId = String(record.req_id || `api-${index}`);
+        const userParts = Array.isArray(record.request_messages)
+            ? record.request_messages.map((message) => String(message?.content || '').trim()).filter(Boolean)
+            : [];
+        if (userParts.length) {
+            out.push({ id: `${reqId}-question`, role: 'User', text: userParts.join('\n'), html: '' });
+        }
+
+        // Qianwen stores progress cards, citations, and the final rendered answer
+        // together in response_messages. The final answer is normally the longest
+        // non-signal textual payload (often mime_type=multi_load/iframe).
+        const assistantCandidates = Array.isArray(record.response_messages)
+            ? record.response_messages
+                .filter((message) => !String(message?.mime_type || '').startsWith('signal/'))
+                .map((message) => String(message?.content || '').trim())
+                .filter(Boolean)
+            : [];
+        const assistantText = assistantCandidates.sort((a, b) => b.length - a.length)[0] || '';
+        if (assistantText) {
+            out.push({ id: `${reqId}-answer`, role: 'Assistant', text: assistantText, html: '' });
+        }
+    }
+    return out;
+}
+
+export async function getSessionMessagesFromApi(page, sessionId, pageSize = 20) {
+    const result = await page.evaluate(`(async () => {
+      try {
+        const utdid = (document.cookie.match(/(?:^|;\\s*)b-user-id=([^;]+)/)?.[1])
+          || (document.cookie.match(/(?:^|;\\s*)utdid=([^;]+)/)?.[1])
+          || '';
+        const query = new URLSearchParams({
+          biz_id: 'ai_qwen', chat_client: 'h5', device: 'pc', fr: 'pc', pr: 'qwen',
+          ut: utdid, la: 'zh-CN', tz: 'Asia/Shanghai', wv: '3.8.6', ve: '3.8.6',
+          session_id: ${JSON.stringify(sessionId)}, page_size: ${JSON.stringify(String(pageSize))},
+          page: '1', return_response_messages: 'true', event_filter: 'all',
+        }).toString();
+        const response = await fetch('https://${QIANWEN_API_DOMAIN}/api/v1/session/msg/list?' + query, {
+          method: 'GET', credentials: 'include',
+        });
+        const text = await response.text();
+        let body = null;
+        try { body = text ? JSON.parse(text) : null; } catch { body = null; }
+        return { ok: response.ok, status: response.status, body };
+      } catch (error) {
+        return { ok: false, status: 0, error: String(error?.message || error) };
+      }
+    })()`);
+    if (!result?.ok) return [];
+    const data = result.body?.data || {};
+    const records = Array.isArray(data.list) ? data.list
+        : Array.isArray(data.record_list) ? data.record_list
+            : [];
+    return parseSessionMessageRecords(records);
+}
+
 export function bubbleHtmlToMarkdown(html) {
     try {
         return htmlToMarkdown(html).trim();

--- a/clis/qwen/utils.test.js
+++ b/clis/qwen/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
-import { parseQianwenSessionId, waitForAnswer } from './utils.js';
+import { parseQianwenSessionId, parseSessionMessageRecords, waitForAnswer } from './utils.js';
 
 describe('qwen waitForAnswer baseline anchoring', () => {
     // page.evaluate serves both getMessageBubbles (data-chat-question-wrap) and
@@ -82,6 +82,26 @@ describe('qwen waitForAnswer baseline anchoring', () => {
         );
         expect(result.status).toBe('partial');
         expect(result.assistant).toEqual(bubbles[1]);
+    });
+});
+
+describe('qwen history API record parsing', () => {
+    it('recovers the stored answer when the history DOM answer wrapper is empty', () => {
+        const records = [{
+            req_id: 'req-1',
+            request_messages: [{ content: 'compare models' }],
+            response_messages: [
+                { mime_type: 'signal/post', content: 'internal progress' },
+                { mime_type: 'bar/progress', content: '' },
+                { mime_type: 'multi_load/iframe', content: 'Default: Terra high. Escalation: Sol max.' },
+                { mime_type: 'text/plain', content: 'short footer' },
+            ],
+        }];
+
+        expect(parseSessionMessageRecords(records)).toEqual([
+            { id: 'req-1-question', role: 'User', text: 'compare models', html: '' },
+            { id: 'req-1-answer', role: 'Assistant', text: 'Default: Terra high. Escalation: Sol max.', html: '' },
+        ]);
     });
 });
 


### PR DESCRIPTION
## Summary
- Fix ChatGPT response handling when conversation URLs are delayed and send button selectors changed
- Fix Doubao, DeepSeek, and Kimi DOM selectors for current web UIs
- Fix Qwen history detail when the hydrated DOM has an empty assistant wrapper: recover the complete stored response through Qwen's read-only session message API
- Keep web AI adapters concise and aligned with current OpenCLI command behavior

## Test Plan
- `npm run typecheck`
- `npm run build`
- `npx vitest run clis/qwen/utils.test.js` — 11/11 passed
- Live read-only smoke test: `qwen detail fe3412bcec1f4174815500555e59be31` recovered 2 turns including the complete assistant answer
- `opencli validate chatgpt`
- `opencli validate deepseek`
- `opencli validate doubao`
- `opencli validate kimi`
- `opencli validate qwen`

Note: ChatGLM changes are intentionally excluded because testing it triggers access verification.