### PR TITLE
fix(extension): stop SW wake events from wiping the lease registry, add owned-group ledger

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -944,29 +944,7 @@ const ownedContainers = {
   interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
   automation: { windowId: null, groupId: null, promise: null, groupPromise: null }
 };
-const INTERACTIVE_GROUP_LEDGER_KEY = "opencli_interactive_group_ledger_v1";
 const interactiveGroupLedger = /* @__PURE__ */ new Set();
-async function restoreInteractiveGroupLedger() {
-  try {
-    const session = chrome.storage?.session;
-    if (!session) return;
-    const raw = await session.get(INTERACTIVE_GROUP_LEDGER_KEY);
-    const stored = raw[INTERACTIVE_GROUP_LEDGER_KEY];
-    interactiveGroupLedger.clear();
-    if (Array.isArray(stored)) {
-      for (const id of stored) {
-        if (typeof id === "number") interactiveGroupLedger.add(id);
-      }
-    }
-  } catch {
-  }
-}
-async function persistInteractiveGroupLedger() {
-  try {
-    await chrome.storage?.session?.set({ [INTERACTIVE_GROUP_LEDGER_KEY]: [...interactiveGroupLedger] });
-  } catch {
-  }
-}
 class CommandFailure extends Error {
   constructor(code, message, hint) {
     super(message);
@@ -1063,7 +1041,10 @@ function emptyRegistry() {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: { windowId: ownedContainers.interactive.windowId },
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupIds: [...interactiveGroupLedger]
+      },
       automation: { windowId: ownedContainers.automation.windowId }
     },
     leases: {}
@@ -1082,7 +1063,8 @@ async function readRegistry() {
       contextId: currentContextId,
       ownedContainers: {
         interactive: {
-          windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null
+          windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null,
+          groupIds: Array.isArray(storedContainers.interactive?.groupIds) ? storedContainers.interactive.groupIds.filter((id) => typeof id === "number") : []
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null
@@ -1122,7 +1104,10 @@ async function persistRuntimeState() {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: { windowId: ownedContainers.interactive.windowId },
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupIds: [...interactiveGroupLedger]
+      },
       automation: { windowId: ownedContainers.automation.windowId }
     },
     leases
@@ -1233,7 +1218,7 @@ async function collectOwnedGroupCandidates(role) {
       ledgerPruned = true;
     }
   }
-  if (ledgerPruned) await persistInteractiveGroupLedger();
+  if (ledgerPruned) await persistRuntimeState();
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
     for (const group of groups) groupsById.set(group.id, group);
@@ -1330,10 +1315,7 @@ async function createOwnedGroup(role, windowId, ids) {
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
-  if (role === "interactive") {
-    interactiveGroupLedger.add(groupId);
-    await persistInteractiveGroupLedger();
-  }
+  if (role === "interactive") interactiveGroupLedger.add(groupId);
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -1372,7 +1354,7 @@ async function ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids) {
       ownedContainers[role].groupId = canonical.id;
       if (!interactiveGroupLedger.has(canonical.id)) {
         interactiveGroupLedger.add(canonical.id);
-        await persistInteractiveGroupLedger();
+        await persistRuntimeState();
       }
     } else {
       ownedContainers[role].groupId = null;
@@ -2338,7 +2320,8 @@ async function releaseLease(leaseKey, reason = "released") {
 }
 async function reconcileTargetLeaseRegistry() {
   const registry = await readRegistry();
-  await restoreInteractiveGroupLedger();
+  interactiveGroupLedger.clear();
+  for (const id of registry.ownedContainers.interactive.groupIds) interactiveGroupLedger.add(id);
   for (const role of Object.keys(ownedContainers)) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
     const windowId = ownedContainers[role].windowId;

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -742,6 +742,8 @@ const CONTEXT_ID_KEY = "opencli_context_id_v1";
 let currentContextId = "default";
 let contextIdPromise = null;
 let connectInFlight = null;
+let workerReady = Promise.resolve();
+let workerRecovered = true;
 async function getCurrentContextId() {
   if (contextIdPromise) return contextIdPromise;
   contextIdPromise = (async () => {
@@ -820,7 +822,8 @@ function isDaemonSocketActive(socket = ws) {
 function connect() {
   if (isDaemonSocketActive()) return Promise.resolve();
   if (connectInFlight) return connectInFlight;
-  connectInFlight = connectAttempt().finally(() => {
+  const attempt = workerRecovered ? connectAttempt() : workerReady.then(() => connectAttempt());
+  connectInFlight = attempt.finally(() => {
     connectInFlight = null;
   });
   return connectInFlight;
@@ -938,8 +941,8 @@ const CONTAINER_TAB_GROUP_TITLE = {
 const OWNED_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();
 const ownedContainers = {
-  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
-  automation: { windowId: null, groupId: null, promise: null, groupPromise: null }
+  interactive: { windowId: null, groupId: null, groupIds: /* @__PURE__ */ new Set(), promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, groupIds: /* @__PURE__ */ new Set(), promise: null, groupPromise: null }
 };
 class CommandFailure extends Error {
   constructor(code, message, hint) {
@@ -1039,7 +1042,8 @@ function emptyRegistry() {
     ownedContainers: {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId
+        groupId: ownedContainers.interactive.groupId,
+        groupIds: [...ownedContainers.interactive.groupIds]
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -1063,7 +1067,8 @@ async function readRegistry() {
       ownedContainers: {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null,
-          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null
+          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null,
+          groupIds: Array.isArray(storedContainers.interactive?.groupIds) ? storedContainers.interactive.groupIds.filter((id) => typeof id === "number") : []
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null,
@@ -1106,7 +1111,8 @@ async function persistRuntimeState() {
     ownedContainers: {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId
+        groupId: ownedContainers.interactive.groupId,
+        groupIds: [...ownedContainers.interactive.groupIds]
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -1210,6 +1216,15 @@ async function collectOwnedGroupCandidates(role) {
       container.groupId = null;
     }
   }
+  for (const groupId of [...container.groupIds]) {
+    if (groupsById.has(groupId)) continue;
+    try {
+      const group = await chrome.tabGroups.get(groupId);
+      groupsById.set(group.id, group);
+    } catch {
+      container.groupIds.delete(groupId);
+    }
+  }
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
     for (const group of groups) groupsById.set(group.id, group);
@@ -1306,6 +1321,7 @@ async function createOwnedGroup(role, windowId, ids) {
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
+  ownedContainers[role].groupIds.add(groupId);
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -1342,6 +1358,7 @@ async function ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids) {
     if (canonical) {
       ownedContainers[role].windowId = canonical.windowId;
       ownedContainers[role].groupId = canonical.id;
+      ownedContainers[role].groupIds.add(canonical.id);
     } else {
       ownedContainers[role].groupId = null;
       if (fallbackWindowId === null) ownedContainers[role].windowId = null;
@@ -1515,6 +1532,7 @@ async function getAutomationWindow(leaseKey, initialUrl) {
   return (await ensureOwnedContainerWindow(role, initialUrl, getWindowMode(leaseKey))).windowId;
 }
 chrome.windows.onRemoved.addListener(async (windowId) => {
+  await workerReady;
   for (const container of Object.values(ownedContainers)) {
     if (container.windowId === windowId) {
       container.windowId = null;
@@ -1533,6 +1551,7 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
   await persistRuntimeState();
 });
 chrome.tabs.onRemoved.addListener(async (tabId) => {
+  await workerReady;
   evictTab(tabId);
   for (const [leaseKey, session] of automationSessions.entries()) {
     if (session.preferredTabId === tabId) {
@@ -1556,11 +1575,16 @@ function initialize() {
     registerFrameTracking$1?.();
   } catch {
   }
-  void (async () => {
+  workerRecovered = false;
+  workerReady = (async () => {
     await getCurrentContextId();
     await reconcileTargetLeaseRegistry();
-    await connect();
-  })();
+  })().catch((err) => {
+    console.warn(`[opencli] Startup recovery failed: ${err instanceof Error ? err.message : String(err)}`);
+  }).finally(() => {
+    workerRecovered = true;
+  });
+  void workerReady.then(() => connect());
   console.log("[opencli] OpenCLI extension initialized");
 }
 chrome.runtime.onInstalled.addListener(() => {
@@ -1571,6 +1595,7 @@ chrome.runtime.onStartup.addListener(() => {
 });
 initialize();
 chrome.alarms.onAlarm.addListener(async (alarm) => {
+  await workerReady;
   if (alarm.name === "keepalive") void connect();
   const leaseKey = leaseKeyFromAlarmName(alarm.name);
   if (!leaseKey) return;
@@ -2296,6 +2321,9 @@ async function reconcileTargetLeaseRegistry() {
   for (const role of Object.keys(ownedContainers)) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
     ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
+    if (role === "interactive") {
+      ownedContainers.interactive.groupIds = new Set(registry.ownedContainers.interactive?.groupIds ?? []);
+    }
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {
@@ -2349,6 +2377,11 @@ async function reconcileTargetLeaseRegistry() {
       }
     } catch {
     }
+  }
+  try {
+    await ensureOwnedContainerGroup("interactive", null, []);
+  } catch (err) {
+    console.warn(`[opencli] Startup interactive group convergence failed: ${err instanceof Error ? err.message : String(err)}`);
   }
   await persistRuntimeState();
 }

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -941,9 +941,32 @@ const CONTAINER_TAB_GROUP_TITLE = {
 const OWNED_TAB_GROUP_COLOR = "orange";
 let leaseMutationQueue = Promise.resolve();
 const ownedContainers = {
-  interactive: { windowId: null, groupId: null, groupIds: /* @__PURE__ */ new Set(), promise: null, groupPromise: null },
-  automation: { windowId: null, groupId: null, groupIds: /* @__PURE__ */ new Set(), promise: null, groupPromise: null }
+  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, promise: null, groupPromise: null }
 };
+const INTERACTIVE_GROUP_LEDGER_KEY = "opencli_interactive_group_ledger_v1";
+const interactiveGroupLedger = /* @__PURE__ */ new Set();
+async function restoreInteractiveGroupLedger() {
+  try {
+    const session = chrome.storage?.session;
+    if (!session) return;
+    const raw = await session.get(INTERACTIVE_GROUP_LEDGER_KEY);
+    const stored = raw[INTERACTIVE_GROUP_LEDGER_KEY];
+    interactiveGroupLedger.clear();
+    if (Array.isArray(stored)) {
+      for (const id of stored) {
+        if (typeof id === "number") interactiveGroupLedger.add(id);
+      }
+    }
+  } catch {
+  }
+}
+async function persistInteractiveGroupLedger() {
+  try {
+    await chrome.storage?.session?.set({ [INTERACTIVE_GROUP_LEDGER_KEY]: [...interactiveGroupLedger] });
+  } catch {
+  }
+}
 class CommandFailure extends Error {
   constructor(code, message, hint) {
     super(message);
@@ -1042,8 +1065,7 @@ function emptyRegistry() {
     ownedContainers: {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId,
-        groupIds: [...ownedContainers.interactive.groupIds]
+        groupId: ownedContainers.interactive.groupId
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -1067,8 +1089,7 @@ async function readRegistry() {
       ownedContainers: {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null,
-          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null,
-          groupIds: Array.isArray(storedContainers.interactive?.groupIds) ? storedContainers.interactive.groupIds.filter((id) => typeof id === "number") : []
+          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null,
@@ -1111,8 +1132,7 @@ async function persistRuntimeState() {
     ownedContainers: {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId,
-        groupIds: [...ownedContainers.interactive.groupIds]
+        groupId: ownedContainers.interactive.groupId
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -1216,15 +1236,18 @@ async function collectOwnedGroupCandidates(role) {
       container.groupId = null;
     }
   }
-  for (const groupId of [...container.groupIds]) {
+  let ledgerPruned = false;
+  for (const groupId of [...interactiveGroupLedger]) {
     if (groupsById.has(groupId)) continue;
     try {
       const group = await chrome.tabGroups.get(groupId);
       groupsById.set(group.id, group);
     } catch {
-      container.groupIds.delete(groupId);
+      interactiveGroupLedger.delete(groupId);
+      ledgerPruned = true;
     }
   }
+  if (ledgerPruned) await persistInteractiveGroupLedger();
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
     for (const group of groups) groupsById.set(group.id, group);
@@ -1321,7 +1344,10 @@ async function createOwnedGroup(role, windowId, ids) {
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
-  ownedContainers[role].groupIds.add(groupId);
+  if (role === "interactive") {
+    interactiveGroupLedger.add(groupId);
+    await persistInteractiveGroupLedger();
+  }
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -1358,7 +1384,10 @@ async function ensureOwnedContainerGroupUnlocked(role, fallbackWindowId, ids) {
     if (canonical) {
       ownedContainers[role].windowId = canonical.windowId;
       ownedContainers[role].groupId = canonical.id;
-      ownedContainers[role].groupIds.add(canonical.id);
+      if (!interactiveGroupLedger.has(canonical.id)) {
+        interactiveGroupLedger.add(canonical.id);
+        await persistInteractiveGroupLedger();
+      }
     } else {
       ownedContainers[role].groupId = null;
       if (fallbackWindowId === null) ownedContainers[role].windowId = null;
@@ -2318,12 +2347,10 @@ async function releaseLease(leaseKey, reason = "released") {
 }
 async function reconcileTargetLeaseRegistry() {
   const registry = await readRegistry();
+  await restoreInteractiveGroupLedger();
   for (const role of Object.keys(ownedContainers)) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
     ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
-    if (role === "interactive") {
-      ownedContainers.interactive.groupIds = new Set(registry.ownedContainers.interactive?.groupIds ?? []);
-    }
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1071,9 +1071,9 @@ function emptyRegistry() {
 }
 async function readRegistry() {
   try {
-    const local = chrome.storage?.local;
-    if (!local) return emptyRegistry();
-    const raw = await local.get(REGISTRY_KEY);
+    const session = chrome.storage?.session;
+    if (!session) return emptyRegistry();
+    const raw = await session.get(REGISTRY_KEY);
     const stored = raw[REGISTRY_KEY];
     if (!stored || stored.version !== 2 || typeof stored.leases !== "object") return emptyRegistry();
     const storedContainers = stored.ownedContainers && typeof stored.ownedContainers === "object" ? stored.ownedContainers : emptyRegistry().ownedContainers;
@@ -1096,7 +1096,7 @@ async function readRegistry() {
 }
 async function writeRegistry(registry) {
   try {
-    await chrome.storage?.local?.set({ [REGISTRY_KEY]: registry });
+    await chrome.storage?.session?.set({ [REGISTRY_KEY]: registry });
   } catch {
   }
 }
@@ -1588,6 +1588,11 @@ function initialize() {
   try {
     const registerFrameTracking$1 = registerFrameTracking;
     registerFrameTracking$1?.();
+  } catch {
+  }
+  try {
+    void chrome.storage?.local?.remove?.(REGISTRY_KEY)?.catch?.(() => {
+    });
   } catch {
   }
   workerRecovered = false;

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1063,14 +1063,8 @@ function emptyRegistry() {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: {
-        windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId
-      },
-      automation: {
-        windowId: ownedContainers.automation.windowId,
-        groupId: null
-      }
+      interactive: { windowId: ownedContainers.interactive.windowId },
+      automation: { windowId: ownedContainers.automation.windowId }
     },
     leases: {}
   };
@@ -1088,12 +1082,10 @@ async function readRegistry() {
       contextId: currentContextId,
       ownedContainers: {
         interactive: {
-          windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null,
-          groupId: typeof storedContainers.interactive?.groupId === "number" ? storedContainers.interactive.groupId : null
+          windowId: typeof storedContainers.interactive?.windowId === "number" ? storedContainers.interactive.windowId : null
         },
         automation: {
-          windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null,
-          groupId: null
+          windowId: typeof storedContainers.automation?.windowId === "number" ? storedContainers.automation.windowId : null
         }
       },
       leases: stored.leases
@@ -1130,14 +1122,8 @@ async function persistRuntimeState() {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: {
-        windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId
-      },
-      automation: {
-        windowId: ownedContainers.automation.windowId,
-        groupId: null
-      }
+      interactive: { windowId: ownedContainers.interactive.windowId },
+      automation: { windowId: ownedContainers.automation.windowId }
     },
     leases
   });
@@ -2350,14 +2336,12 @@ async function reconcileTargetLeaseRegistry() {
   await restoreInteractiveGroupLedger();
   for (const role of Object.keys(ownedContainers)) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
-    ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {
         await chrome.windows.get(windowId);
       } catch {
         ownedContainers[role].windowId = null;
-        ownedContainers[role].groupId = null;
       }
     }
   }

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -66,6 +66,7 @@ function createChromeMock() {
   let nextTabId = 10;
   let nextGroupId = 100;
   const storageState: Record<string, unknown> = {};
+  const sessionStorageState: Record<string, unknown> = {};
   const tabs: MockTab[] = [
     { id: 1, windowId: 1, url: 'https://automation.example', title: 'automation', active: true, status: 'complete', groupId: -1 },
     { id: 2, windowId: 2, url: 'https://user.example', title: 'user', active: true, status: 'complete', groupId: -1 },
@@ -213,6 +214,12 @@ function createChromeMock() {
         get: vi.fn(async (key: string) => ({ [key]: storageState[key] })),
         set: vi.fn(async (items: Record<string, unknown>) => {
           Object.assign(storageState, items);
+        }),
+      },
+      session: {
+        get: vi.fn(async (key: string) => ({ [key]: sessionStorageState[key] })),
+        set: vi.fn(async (items: Record<string, unknown>) => {
+          Object.assign(sessionStorageState, items);
         }),
       },
     },
@@ -1905,6 +1912,7 @@ describe('background tab isolation', () => {
   });
 
   const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
+  const LEDGER_KEY = 'opencli_interactive_group_ledger_v1';
 
   // Gate the registry read so the startup recovery chain (workerReady) stays
   // pending on demand. Every other storage read (context id) resolves normally.
@@ -1933,7 +1941,7 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: 200, groupIds: [200] },
+          interactive: { windowId: null, groupId: 200 },
           automation: { windowId: 1, groupId: null },
         },
         leases: {
@@ -1988,7 +1996,7 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: 200, groupIds: [200] },
+          interactive: { windowId: null, groupId: 200 },
           automation: { windowId: 1, groupId: null },
         },
         leases: {
@@ -2028,7 +2036,7 @@ describe('background tab isolation', () => {
     expect(finalRegistry.leases[adapterKey('twitter')]).toBeDefined();
   });
 
-  it('adopts an untitled orphan group through the ledger instead of creating a new one', async () => {
+  it('adopts an untitled orphan group through the session ledger instead of creating a new one', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     tabs.push({ id: 50, windowId: 5, url: 'about:blank', title: 'blank', active: true, status: 'complete', groupId: 200 });
     groups.push({ id: 200, windowId: 5, title: '', collapsed: false });
@@ -2038,12 +2046,13 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: null, groupIds: [200] },
+          interactive: { windowId: null, groupId: null },
           automation: { windowId: null, groupId: null },
         },
         leases: {},
       },
     });
+    await chrome.storage.session.set({ [LEDGER_KEY]: [200] });
 
     const mod = await import('./background');
     await mod.__test__.reconcileTargetLeaseRegistry();
@@ -2058,7 +2067,7 @@ describe('background tab isolation', () => {
     expect(container.groupIds).toContain(200);
   });
 
-  it('prunes a vanished group id from the ledger on convergence', async () => {
+  it('prunes a vanished group id from the session ledger on convergence', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
     await chrome.storage.local.set({
@@ -2066,7 +2075,42 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: null, groupIds: [300] },
+          interactive: { windowId: null, groupId: null },
+          automation: { windowId: null, groupId: null },
+        },
+        leases: {},
+      },
+    });
+    await chrome.storage.session.set({ [LEDGER_KEY]: [300] });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    const createGroupCalls = chrome.tabs.group.mock.calls.filter((call: any[]) => call[0]?.createProperties);
+    expect(createGroupCalls).toHaveLength(0);
+    expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(300);
+    const finalLedger = (await chrome.storage.session.get(LEDGER_KEY) as any)[LEDGER_KEY];
+    expect(finalLedger).toEqual([]);
+    // The v2 registry stays free of ledger data — group ids never persist
+    // beyond the browser session.
+    const finalRegistry = (await chrome.storage.local.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
+    expect(finalRegistry.ownedContainers.interactive.groupIds).toBeUndefined();
+  });
+
+  it('ignores legacy groupIds persisted in the local registry so a recycled id cannot hijack a user group', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    // A user-created group from THIS browser session whose id happens to match
+    // a ledger entry a previous OpenCLI version persisted across restarts.
+    tabs.push({ id: 70, windowId: 7, url: 'https://vacation.example', title: 'trip', active: true, status: 'complete', groupId: 400 });
+    groups.push({ id: 400, windowId: 7, title: 'Vacation', color: 'blue', collapsed: false });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: null, groupIds: [400] },
           automation: { windowId: null, groupId: null },
         },
         leases: {},
@@ -2076,11 +2120,12 @@ describe('background tab isolation', () => {
     const mod = await import('./background');
     await mod.__test__.reconcileTargetLeaseRegistry();
 
-    expect(chrome.windows.create).not.toHaveBeenCalled();
-    const createGroupCalls = chrome.tabs.group.mock.calls.filter((call: any[]) => call[0]?.createProperties);
-    expect(createGroupCalls).toHaveLength(0);
-    expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(300);
-    const finalRegistry = (await chrome.storage.local.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
-    expect(finalRegistry.ownedContainers.interactive.groupIds).toEqual([]);
+    // The user group is untouched: no retitle, no merge, no group mutation.
+    expect(groups.find((group) => group.id === 400)?.title).toBe('Vacation');
+    expect(tabs.find((tab) => tab.id === 70)?.groupId).toBe(400);
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    // And the stale id never entered the in-memory ledger.
+    expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(400);
   });
 });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1915,12 +1915,11 @@ describe('background tab isolation', () => {
   });
 
   const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
-  const LEDGER_KEY = 'opencli_interactive_group_ledger_v1';
 
-  // Gate the registry read (now in storage.session) so the startup recovery
+  // Gate the registry read (in storage.session) so the startup recovery
   // chain (workerReady) stays pending on demand. Every other storage read
-  // (context id, ledger) resolves normally. `readDirect` bypasses the gate so
-  // a test can inspect stored state without blocking on (or releasing) it.
+  // (context id) resolves normally. `readDirect` bypasses the gate so a test
+  // can inspect stored state without blocking on (or releasing) it.
   function gateRegistryRead(chrome: any) {
     const gate = deferred<void>();
     const originalGet = chrome.storage.session.get;
@@ -2053,13 +2052,12 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: null },
-          automation: { windowId: null, groupId: null },
+          interactive: { windowId: null, groupIds: [200] },
+          automation: { windowId: null },
         },
         leases: {},
       },
     });
-    await chrome.storage.session.set({ [LEDGER_KEY]: [200] });
 
     const mod = await import('./background');
     await mod.__test__.reconcileTargetLeaseRegistry();
@@ -2082,13 +2080,12 @@ describe('background tab isolation', () => {
         version: 2,
         contextId: 'user-default',
         ownedContainers: {
-          interactive: { windowId: null, groupId: null },
-          automation: { windowId: null, groupId: null },
+          interactive: { windowId: null, groupIds: [300] },
+          automation: { windowId: null },
         },
         leases: {},
       },
     });
-    await chrome.storage.session.set({ [LEDGER_KEY]: [300] });
 
     const mod = await import('./background');
     await mod.__test__.reconcileTargetLeaseRegistry();
@@ -2097,12 +2094,9 @@ describe('background tab isolation', () => {
     const createGroupCalls = chrome.tabs.group.mock.calls.filter((call: any[]) => call[0]?.createProperties);
     expect(createGroupCalls).toHaveLength(0);
     expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(300);
-    const finalLedger = (await chrome.storage.session.get(LEDGER_KEY) as any)[LEDGER_KEY];
-    expect(finalLedger).toEqual([]);
-    // The v2 registry stays free of ledger data — group ids never persist
-    // beyond the browser session.
+    // The pruned id is gone from the persisted session registry too.
     const finalRegistry = (await chrome.storage.session.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
-    expect(finalRegistry.ownedContainers.interactive.groupIds).toBeUndefined();
+    expect(finalRegistry.ownedContainers.interactive.groupIds).toEqual([]);
   });
 
   it('ignores legacy groupIds persisted in the local registry so a recycled id cannot hijack a user group', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1979,8 +1979,10 @@ describe('background tab isolation', () => {
     await alarmDone;
 
     const finalRegistry = await readDirect(REGISTRY_KEY);
-    // groupId self-heal pointer survived recovery instead of being nulled.
-    expect(finalRegistry.ownedContainers.interactive.groupId).toBe(200);
+    // Group ids never re-enter the durable registry (browser-session scoped);
+    // the canonical group is re-found in memory via the title layer instead.
+    expect(finalRegistry.ownedContainers.interactive.groupId).toBeUndefined();
+    expect(mod.__test__.getInteractiveContainer().groupId).toBe(200);
     // The lease was released down the proper owned-placeholder path, not wiped.
     expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
     expect(mod.__test__.getSession(adapterKey('twitter'))).toBeNull();
@@ -2016,7 +2018,7 @@ describe('background tab isolation', () => {
     });
     const { gate, readDirect } = gateRegistryRead(chrome);
 
-    await import('./background');
+    const mod = await import('./background');
 
     // Wake the worker via an unrelated tab-close before recovery.
     const onRemovedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
@@ -2031,7 +2033,9 @@ describe('background tab isolation', () => {
     await removedDone;
 
     const finalRegistry = await readDirect(REGISTRY_KEY);
-    expect(finalRegistry.ownedContainers.interactive.groupId).toBe(200);
+    // Group ids never re-enter the durable registry (browser-session scoped).
+    expect(finalRegistry.ownedContainers.interactive.groupId).toBeUndefined();
+    expect(mod.__test__.getInteractiveContainer().groupId).toBe(200);
     // The unrelated lease survived the unrelated tab-close.
     expect(finalRegistry.leases[adapterKey('twitter')]).toBeDefined();
   });
@@ -2127,5 +2131,37 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).not.toHaveBeenCalled();
     // And the stale id never entered the in-memory ledger.
     expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(400);
+  });
+
+  it('ignores a legacy interactive groupId persisted in the local registry so a recycled id cannot hijack a user group', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    // Same hazard as the plural groupIds ledger, through the singular cached
+    // pointer: group ids are browser-session scoped, so a groupId persisted by
+    // a previous browser session can collide with a user-created group here.
+    tabs.push({ id: 70, windowId: 7, url: 'https://vacation.example', title: 'trip', active: true, status: 'complete', groupId: 400 });
+    groups.push({ id: 400, windowId: 7, title: 'Vacation', color: 'blue', collapsed: false });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: 400 },
+          automation: { windowId: null, groupId: null },
+        },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    // The user group is untouched: no retitle, no merge, no group mutation.
+    expect(groups.find((group) => group.id === 400)?.title).toBe('Vacation');
+    expect(tabs.find((tab) => tab.id === 70)?.groupId).toBe(400);
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    // And the stale pointer was never adopted into memory.
+    expect(mod.__test__.getInteractiveContainer().groupId).toBeNull();
   });
 });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -215,6 +215,9 @@ function createChromeMock() {
         set: vi.fn(async (items: Record<string, unknown>) => {
           Object.assign(storageState, items);
         }),
+        remove: vi.fn(async (key: string) => {
+          delete storageState[key];
+        }),
       },
       session: {
         get: vi.fn(async (key: string) => ({ [key]: sessionStorageState[key] })),
@@ -1041,7 +1044,7 @@ describe('background tab isolation', () => {
   it('reconciles an owned adapter container with no stored leases without closing it or grouping new tabs', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1072,7 +1075,7 @@ describe('background tab isolation', () => {
     const { chrome } = createChromeMock();
     const deadline = Date.now() + 30_000;
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1136,7 +1139,7 @@ describe('background tab isolation', () => {
     // 5s left of a 30s adapter idle timeout when the service worker restarts.
     const deadline = now + 5_000;
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1331,7 +1334,7 @@ describe('background tab isolation', () => {
   it('reuses a persisted adapter window after worker restart without recreating an adapter group', async () => {
     const { chrome, tabs, groups } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1359,7 +1362,7 @@ describe('background tab isolation', () => {
     const { chrome, tabs, groups } = createChromeMock();
     const deadline = Date.now() + 30_000;
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1428,7 +1431,7 @@ describe('background tab isolation', () => {
   it('does not reuse a user http tab from an adapter-owned window without an owned lease signal', async () => {
     const { chrome, tabs } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       opencli_target_lease_registry_v2: {
         version: 2,
         contextId: 'user-default',
@@ -1914,14 +1917,14 @@ describe('background tab isolation', () => {
   const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
   const LEDGER_KEY = 'opencli_interactive_group_ledger_v1';
 
-  // Gate the registry read so the startup recovery chain (workerReady) stays
-  // pending on demand. Every other storage read (context id) resolves normally.
-  // `readDirect` bypasses the gate so a test can inspect stored state without
-  // blocking on (or releasing) the gate.
+  // Gate the registry read (now in storage.session) so the startup recovery
+  // chain (workerReady) stays pending on demand. Every other storage read
+  // (context id, ledger) resolves normally. `readDirect` bypasses the gate so
+  // a test can inspect stored state without blocking on (or releasing) it.
   function gateRegistryRead(chrome: any) {
     const gate = deferred<void>();
-    const originalGet = chrome.storage.local.get;
-    chrome.storage.local.get = vi.fn(async (key: string) => {
+    const originalGet = chrome.storage.session.get;
+    chrome.storage.session.get = vi.fn(async (key: string) => {
       if (key === REGISTRY_KEY) await gate.promise;
       return originalGet(key);
     });
@@ -1936,7 +1939,7 @@ describe('background tab isolation', () => {
     const deadline = Date.now() + 30_000;
     groups.push({ id: 200, windowId: 5, title: 'OpenCLI Browser', color: 'orange', collapsed: false });
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       [REGISTRY_KEY]: {
         version: 2,
         contextId: 'user-default',
@@ -1993,7 +1996,7 @@ describe('background tab isolation', () => {
     const deadline = Date.now() + 30_000;
     groups.push({ id: 200, windowId: 5, title: 'OpenCLI Browser', color: 'orange', collapsed: false });
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       [REGISTRY_KEY]: {
         version: 2,
         contextId: 'user-default',
@@ -2045,7 +2048,7 @@ describe('background tab isolation', () => {
     tabs.push({ id: 50, windowId: 5, url: 'about:blank', title: 'blank', active: true, status: 'complete', groupId: 200 });
     groups.push({ id: 200, windowId: 5, title: '', collapsed: false });
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       [REGISTRY_KEY]: {
         version: 2,
         contextId: 'user-default',
@@ -2074,7 +2077,7 @@ describe('background tab isolation', () => {
   it('prunes a vanished group id from the session ledger on convergence', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);
-    await chrome.storage.local.set({
+    await chrome.storage.session.set({
       [REGISTRY_KEY]: {
         version: 2,
         contextId: 'user-default',
@@ -2098,7 +2101,7 @@ describe('background tab isolation', () => {
     expect(finalLedger).toEqual([]);
     // The v2 registry stays free of ledger data — group ids never persist
     // beyond the browser session.
-    const finalRegistry = (await chrome.storage.local.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
+    const finalRegistry = (await chrome.storage.session.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
     expect(finalRegistry.ownedContainers.interactive.groupIds).toBeUndefined();
   });
 
@@ -2163,5 +2166,106 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.group).not.toHaveBeenCalled();
     // And the stale pointer was never adopted into memory.
     expect(mod.__test__.getInteractiveContainer().groupId).toBeNull();
+  });
+
+  it('ignores legacy container windowIds persisted in the local registry so recycled ids cannot claim user windows', async () => {
+    const { chrome, tabs } = createChromeMock();
+    // Window 7 belongs to the user in THIS browser session; a registry left in
+    // storage.local by a previous browser session claims it as both OpenCLI
+    // containers (window ids are browser-session scoped, just like group ids).
+    tabs.push({ id: 70, windowId: 7, url: 'https://vacation.example', title: 'trip', active: true, status: 'complete', groupId: -1 });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: 7 },
+          automation: { windowId: 7 },
+        },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    // The user window was never claimed as an owned container.
+    expect(mod.__test__.getInteractiveContainer().windowId).not.toBe(7);
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    expect(chrome.tabGroups.update).not.toHaveBeenCalled();
+
+    // The next adapter lease opens its own container window instead of
+    // dropping automation tabs into the user's window 7.
+    const leaseTabId = await mod.__test__.resolveTabId(undefined, adapterKey('twitter'), 'https://work.example');
+    expect(chrome.windows.create).toHaveBeenCalled();
+    expect(tabs.find((tab) => tab.id === leaseTabId)?.windowId).not.toBe(7);
+    expect(tabs.find((tab) => tab.id === 70)?.groupId).toBe(-1);
+  });
+
+  it('ignores a legacy lease persisted in the local registry so a recycled tab id cannot capture a user tab', async () => {
+    const { chrome, tabs } = createChromeMock();
+    // Tab 70 is the user's page in THIS browser session; a stale lease from a
+    // previous browser session points at the same (recycled) tab id.
+    tabs.push({ id: 70, windowId: 7, url: 'https://vacation.example', title: 'trip', active: true, status: 'complete', groupId: -1 });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null },
+          automation: { windowId: null },
+        },
+        leases: {
+          [browserKey('work')]: {
+            session: 'work',
+            surface: 'browser',
+            kind: 'owned',
+            windowId: 7,
+            owned: true,
+            preferredTabId: 70,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'persistent',
+            windowRole: 'interactive',
+            idleDeadlineAt: Date.now() + 600_000,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    // The stale lease was not resurrected onto the user's tab, and the tab was
+    // never grouped, navigated, or closed.
+    expect(mod.__test__.getSession(browserKey('work'))).toBeNull();
+    expect(tabs.find((tab) => tab.id === 70)?.groupId).toBe(-1);
+    expect(tabs.find((tab) => tab.id === 70)?.url).toBe('https://vacation.example');
+    expect(chrome.tabs.group).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+    expect(chrome.tabs.remove).not.toHaveBeenCalled();
+  });
+
+  it('removes the legacy storage.local registry key on startup reconcile', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: { interactive: { windowId: 7 }, automation: { windowId: 1 } },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith(REGISTRY_KEY);
+    const leftover = (await chrome.storage.local.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
+    expect(leftover).toBeUndefined();
   });
 });

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -249,7 +249,14 @@ describe('background tab isolation', () => {
     vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    vi.useRealTimers();
+    // Let each module's fire-and-forget startup recovery + connect() settle
+    // under THIS test's fetch stub. Otherwise a slow recovery can spill its
+    // connect into the next test and open a stray socket against that test's
+    // stub, corrupting the shared MockWebSocket.instances count.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.clearAllTimers();
     vi.useRealTimers();
     vi.unstubAllGlobals();
@@ -1808,7 +1815,7 @@ describe('background tab isolation', () => {
     mod.__test__.setSession(browserKey('default'), { windowId: 2, owned: false, preferredTabId: 2 });
 
     const onRemovedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
-    onRemovedListener(2);
+    await onRemovedListener(2);
 
     expect(mod.__test__.getSession(browserKey('default'))).toBeNull();
     expect(chrome.windows.remove).not.toHaveBeenCalled();
@@ -1895,5 +1902,185 @@ describe('background tab isolation', () => {
     }));
     expect(chrome.tabs.update).toHaveBeenCalledWith(2, expect.objectContaining({ url: 'https://other.example' }));
     expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  const REGISTRY_KEY = 'opencli_target_lease_registry_v2';
+
+  // Gate the registry read so the startup recovery chain (workerReady) stays
+  // pending on demand. Every other storage read (context id) resolves normally.
+  // `readDirect` bypasses the gate so a test can inspect stored state without
+  // blocking on (or releasing) the gate.
+  function gateRegistryRead(chrome: any) {
+    const gate = deferred<void>();
+    const originalGet = chrome.storage.local.get;
+    chrome.storage.local.get = vi.fn(async (key: string) => {
+      if (key === REGISTRY_KEY) await gate.promise;
+      return originalGet(key);
+    });
+    return {
+      gate,
+      readDirect: async (key: string) => (await originalGet(key))[key],
+    };
+  }
+
+  it('does not wipe the persisted registry when a lease idle alarm fires before recovery', async () => {
+    const { chrome, groups } = createChromeMock();
+    const deadline = Date.now() + 30_000;
+    groups.push({ id: 200, windowId: 5, title: 'OpenCLI Browser', color: 'orange', collapsed: false });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: 200, groupIds: [200] },
+          automation: { windowId: 1, groupId: null },
+        },
+        leases: {
+          [adapterKey('twitter')]: {
+            windowId: 1,
+            owned: true,
+            preferredTabId: 1,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'ephemeral',
+            windowRole: 'automation',
+            idleDeadlineAt: deadline,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+    const { gate, readDirect } = gateRegistryRead(chrome);
+
+    const mod = await import('./background');
+
+    // Wake the worker via the idle alarm before recovery has restored state.
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    const alarmDone = onAlarmListener({ name: `opencli:lease-idle:${encodeURIComponent(adapterKey('twitter'))}` });
+
+    // Drain runnable tasks while recovery stays gated. A pre-fix worker would
+    // have persisted its empty snapshot by now, wiping the registry; the gated
+    // worker must leave storage untouched.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const midFlight = await readDirect(REGISTRY_KEY);
+    expect(midFlight.ownedContainers.interactive.groupId).toBe(200);
+    expect(midFlight.leases[adapterKey('twitter')]).toBeDefined();
+
+    gate.resolve();
+    await alarmDone;
+
+    const finalRegistry = await readDirect(REGISTRY_KEY);
+    // groupId self-heal pointer survived recovery instead of being nulled.
+    expect(finalRegistry.ownedContainers.interactive.groupId).toBe(200);
+    // The lease was released down the proper owned-placeholder path, not wiped.
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(mod.__test__.getSession(adapterKey('twitter'))).toBeNull();
+  });
+
+  it('does not wipe the persisted registry when tabs.onRemoved fires before recovery', async () => {
+    const { chrome, groups } = createChromeMock();
+    const deadline = Date.now() + 30_000;
+    groups.push({ id: 200, windowId: 5, title: 'OpenCLI Browser', color: 'orange', collapsed: false });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: 200, groupIds: [200] },
+          automation: { windowId: 1, groupId: null },
+        },
+        leases: {
+          [adapterKey('twitter')]: {
+            windowId: 1,
+            owned: true,
+            preferredTabId: 1,
+            contextId: 'user-default',
+            ownership: 'owned',
+            lifecycle: 'ephemeral',
+            windowRole: 'automation',
+            idleDeadlineAt: deadline,
+            updatedAt: Date.now(),
+          },
+        },
+      },
+    });
+    const { gate, readDirect } = gateRegistryRead(chrome);
+
+    await import('./background');
+
+    // Wake the worker via an unrelated tab-close before recovery.
+    const onRemovedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
+    const removedDone = onRemovedListener(999);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const midFlight = await readDirect(REGISTRY_KEY);
+    expect(midFlight.ownedContainers.interactive.groupId).toBe(200);
+    expect(midFlight.leases[adapterKey('twitter')]).toBeDefined();
+
+    gate.resolve();
+    await removedDone;
+
+    const finalRegistry = await readDirect(REGISTRY_KEY);
+    expect(finalRegistry.ownedContainers.interactive.groupId).toBe(200);
+    // The unrelated lease survived the unrelated tab-close.
+    expect(finalRegistry.leases[adapterKey('twitter')]).toBeDefined();
+  });
+
+  it('adopts an untitled orphan group through the ledger instead of creating a new one', async () => {
+    const { chrome, tabs, groups } = createChromeMock();
+    tabs.push({ id: 50, windowId: 5, url: 'about:blank', title: 'blank', active: true, status: 'complete', groupId: 200 });
+    groups.push({ id: 200, windowId: 5, title: '', collapsed: false });
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: null, groupIds: [200] },
+          automation: { windowId: null, groupId: null },
+        },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    // The orphan was adopted and titled — no second "OpenCLI Browser" spawned.
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe('OpenCLI Browser');
+    const createGroupCalls = chrome.tabs.group.mock.calls.filter((call: any[]) => call[0]?.createProperties);
+    expect(createGroupCalls).toHaveLength(0);
+    const container = mod.__test__.getInteractiveContainer();
+    expect(container.groupId).toBe(200);
+    expect(container.groupIds).toContain(200);
+  });
+
+  it('prunes a vanished group id from the ledger on convergence', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    await chrome.storage.local.set({
+      [REGISTRY_KEY]: {
+        version: 2,
+        contextId: 'user-default',
+        ownedContainers: {
+          interactive: { windowId: null, groupId: null, groupIds: [300] },
+          automation: { windowId: null, groupId: null },
+        },
+        leases: {},
+      },
+    });
+
+    const mod = await import('./background');
+    await mod.__test__.reconcileTargetLeaseRegistry();
+
+    expect(chrome.windows.create).not.toHaveBeenCalled();
+    const createGroupCalls = chrome.tabs.group.mock.calls.filter((call: any[]) => call[0]?.createProperties);
+    expect(createGroupCalls).toHaveLength(0);
+    expect(mod.__test__.getInteractiveContainer().groupIds).not.toContain(300);
+    const finalRegistry = (await chrome.storage.local.get(REGISTRY_KEY) as any)[REGISTRY_KEY];
+    expect(finalRegistry.ownedContainers.interactive.groupIds).toEqual([]);
   });
 });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -311,18 +311,49 @@ let leaseMutationQueue: Promise<void> = Promise.resolve();
 const ownedContainers: Record<OwnedWindowRole, {
   windowId: number | null;
   groupId: number | null;
-  // Ledger of every group id we have ever owned for this role, kept so an
-  // orphan group (created by `chrome.tabs.group` but never titled because the
-  // worker died before the `tabGroups.update`) stays discoverable even when the
-  // cached `groupId` and lease/title layers can't see it. Only used for
-  // 'interactive'; 'automation' owns no visible group and leaves it empty.
-  groupIds: Set<number>;
   promise: Promise<{ windowId: number; initialTabId?: number }> | null;
   groupPromise: Promise<OwnedContainerGroup | null> | null;
 }> = {
-  interactive: { windowId: null, groupId: null, groupIds: new Set(), promise: null, groupPromise: null },
-  automation: { windowId: null, groupId: null, groupIds: new Set(), promise: null, groupPromise: null },
+  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, promise: null, groupPromise: null },
 };
+
+// Ledger of every interactive group id we have created or adopted in the
+// CURRENT browser session, kept so an orphan group (created by
+// `chrome.tabs.group` but never titled because the worker died before the
+// `tabGroups.update`) stays discoverable even when the cached `groupId` and
+// lease/title layers can't see it. Interactive-only: adapter automation never
+// creates a visible group. Backed by chrome.storage.session, NOT the local
+// registry — tab group ids are only valid within one browser session, and a
+// stale id persisted across a browser restart could collide with a recycled
+// id on a user-created group and let the ledger hijack it.
+const INTERACTIVE_GROUP_LEDGER_KEY = 'opencli_interactive_group_ledger_v1';
+const interactiveGroupLedger = new Set<number>();
+
+async function restoreInteractiveGroupLedger(): Promise<void> {
+  try {
+    const session = chrome.storage?.session;
+    if (!session) return; // no session storage — degrade to memory-only
+    const raw = await session.get(INTERACTIVE_GROUP_LEDGER_KEY) as Record<string, unknown>;
+    const stored = raw[INTERACTIVE_GROUP_LEDGER_KEY];
+    interactiveGroupLedger.clear();
+    if (Array.isArray(stored)) {
+      for (const id of stored) {
+        if (typeof id === 'number') interactiveGroupLedger.add(id);
+      }
+    }
+  } catch {
+    // Ledger restore is a recovery aid; never fail the caller on storage errors.
+  }
+}
+
+async function persistInteractiveGroupLedger(): Promise<void> {
+  try {
+    await chrome.storage?.session?.set({ [INTERACTIVE_GROUP_LEDGER_KEY]: [...interactiveGroupLedger] });
+  } catch {
+    // Best-effort — the in-memory ledger still covers the live worker.
+  }
+}
 
 type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
   idleDeadlineAt: number;
@@ -332,7 +363,7 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
 type StoredRegistry = {
   version: 2;
   contextId: BrowserContextId;
-  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null; groupIds?: number[] }>;
+  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null }>;
   leases: Record<string, StoredLease>;
 };
 
@@ -467,7 +498,6 @@ function emptyRegistry(): StoredRegistry {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
         groupId: ownedContainers.interactive.groupId,
-        groupIds: [...ownedContainers.interactive.groupIds],
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -495,9 +525,6 @@ async function readRegistry(): Promise<StoredRegistry> {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === 'number' ? storedContainers.interactive.windowId : null,
           groupId: typeof storedContainers.interactive?.groupId === 'number' ? storedContainers.interactive.groupId : null,
-          groupIds: Array.isArray(storedContainers.interactive?.groupIds)
-            ? storedContainers.interactive.groupIds.filter((id): id is number => typeof id === 'number')
-            : [],
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === 'number' ? storedContainers.automation.windowId : null,
@@ -544,7 +571,6 @@ async function persistRuntimeState(): Promise<void> {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
         groupId: ownedContainers.interactive.groupId,
-        groupIds: [...ownedContainers.interactive.groupIds],
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -681,19 +707,23 @@ async function collectOwnedGroupCandidates(role: OwnedWindowRole): Promise<Owned
     }
   }
 
-  // Ledger layer: every group id we ever created for this role. Catches the
-  // untitled orphan that all title/lease/color layers miss. A missing id means
-  // the group has been closed or converged away — drop it so the ledger stays
-  // bounded and never resurrects a dead id.
-  for (const groupId of [...container.groupIds]) {
+  // Ledger layer: every interactive group id created/adopted this browser
+  // session (role is guaranteed 'interactive' past the early return above).
+  // Catches the untitled orphan that all title/lease/color layers miss. A
+  // missing id means the group has been closed or converged away — drop it so
+  // the ledger stays bounded and never resurrects a dead id.
+  let ledgerPruned = false;
+  for (const groupId of [...interactiveGroupLedger]) {
     if (groupsById.has(groupId)) continue;
     try {
       const group = await chrome.tabGroups.get(groupId);
       groupsById.set(group.id, group);
     } catch {
-      container.groupIds.delete(groupId);
+      interactiveGroupLedger.delete(groupId);
+      ledgerPruned = true;
     }
   }
+  if (ledgerPruned) await persistInteractiveGroupLedger();
 
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
@@ -831,9 +861,13 @@ async function createOwnedGroup(
   // we must not `tabs.ungroup` on failure or the persisted id dangles.
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
-  // Record in the ledger before the (only) persist here so a crash between
-  // `tabs.group` and the title update still leaves the orphan discoverable.
-  ownedContainers[role].groupIds.add(groupId);
+  // Record in the session ledger before the title update lands so a crash
+  // between `tabs.group` and `tabGroups.update` still leaves the orphan
+  // discoverable on the next worker start.
+  if (role === 'interactive') {
+    interactiveGroupLedger.add(groupId);
+    await persistInteractiveGroupLedger();
+  }
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -891,9 +925,13 @@ async function ensureOwnedContainerGroupUnlocked(
     if (canonical) {
       ownedContainers[role].windowId = canonical.windowId;
       ownedContainers[role].groupId = canonical.id;
-      // Adopt into the ledger — covers canonicals we found via the title/lease
-      // layers (e.g. a legacy group) that createOwnedGroup never recorded.
-      ownedContainers[role].groupIds.add(canonical.id);
+      // Adopt into the session ledger — covers canonicals found via the
+      // title/lease layers (e.g. a legacy group) that createOwnedGroup never
+      // recorded (role is 'interactive' whenever a canonical exists).
+      if (!interactiveGroupLedger.has(canonical.id)) {
+        interactiveGroupLedger.add(canonical.id);
+        await persistInteractiveGroupLedger();
+      }
     } else {
       ownedContainers[role].groupId = null;
       if (fallbackWindowId === null) ownedContainers[role].windowId = null;
@@ -2095,15 +2133,13 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
 
 async function reconcileTargetLeaseRegistry(): Promise<void> {
   const registry = await readRegistry();
+  // Restore the orphan-group ledger from session storage (browser-session
+  // scoped by design — see the ledger declaration). Deliberately NOT from the
+  // local registry: group ids from a previous browser session are stale.
+  await restoreInteractiveGroupLedger();
   for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
     ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
-    // Restore the orphan-group ledger independent of window staleness: a stored
-    // orphan may live in a window other than the persisted container window, so
-    // clearing it on a stale windowId would lose the self-heal pointer.
-    if (role === 'interactive') {
-      ownedContainers.interactive.groupIds = new Set(registry.ownedContainers.interactive?.groupIds ?? []);
-    }
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {
@@ -2238,7 +2274,7 @@ export const __test__ = {
   getInteractiveContainer: () => ({
     windowId: ownedContainers.interactive.windowId,
     groupId: ownedContainers.interactive.groupId,
-    groupIds: [...ownedContainers.interactive.groupIds],
+    groupIds: [...interactiveGroupLedger],
   }),
   connectForTest: connect,
   scheduleReconnectForTest: () => scheduleReconnect(),

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -363,7 +363,11 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
 type StoredRegistry = {
   version: 2;
   contextId: BrowserContextId;
-  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null }>;
+  // Deliberately windowId-only: tab group ids are browser-session scoped, so
+  // the durable registry must never store or trust one (a recycled id could
+  // hijack a user-created group after a browser restart). Within one browser
+  // session, group recovery is covered by the session ledger + title layer.
+  ownedContainers: Record<OwnedWindowRole, { windowId: number | null }>;
   leases: Record<string, StoredLease>;
 };
 
@@ -495,14 +499,8 @@ function emptyRegistry(): StoredRegistry {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: {
-        windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId,
-      },
-      automation: {
-        windowId: ownedContainers.automation.windowId,
-        groupId: null,
-      },
+      interactive: { windowId: ownedContainers.interactive.windowId },
+      automation: { windowId: ownedContainers.automation.windowId },
     },
     leases: {},
   };
@@ -524,11 +522,9 @@ async function readRegistry(): Promise<StoredRegistry> {
       ownedContainers: {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === 'number' ? storedContainers.interactive.windowId : null,
-          groupId: typeof storedContainers.interactive?.groupId === 'number' ? storedContainers.interactive.groupId : null,
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === 'number' ? storedContainers.automation.windowId : null,
-          groupId: null,
         },
       },
       leases: stored.leases as Record<string, StoredLease>,
@@ -568,14 +564,8 @@ async function persistRuntimeState(): Promise<void> {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: {
-        windowId: ownedContainers.interactive.windowId,
-        groupId: ownedContainers.interactive.groupId,
-      },
-      automation: {
-        windowId: ownedContainers.automation.windowId,
-        groupId: null,
-      },
+      interactive: { windowId: ownedContainers.interactive.windowId },
+      automation: { windowId: ownedContainers.automation.windowId },
     },
     leases,
   });
@@ -855,15 +845,13 @@ async function createOwnedGroup(
   if (ids.length === 0) throw new Error(`Cannot create ${role} tab group without tabs`);
   await ensureTabsInWindow(ids, windowId);
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
-  // Persist groupId before the title/color update so a worker crash between
-  // the two API calls can self-heal on resume. `ensureCanonicalGroupTitle`
-  // will repair the title on the next ensure cycle if the update never lands;
-  // we must not `tabs.ungroup` on failure or the persisted id dangles.
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
-  // Record in the session ledger before the title update lands so a crash
-  // between `tabs.group` and `tabGroups.update` still leaves the orphan
-  // discoverable on the next worker start.
+  // Record in the session ledger before the title/color update lands so a
+  // worker crash between the two API calls can self-heal on resume:
+  // `ensureCanonicalGroupTitle` repairs the title on the next ensure cycle
+  // once the ledger surfaces the untitled orphan. We must not `tabs.ungroup`
+  // on failure or the recorded id dangles.
   if (role === 'interactive') {
     interactiveGroupLedger.add(groupId);
     await persistInteractiveGroupLedger();
@@ -2137,16 +2125,17 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
   // scoped by design — see the ledger declaration). Deliberately NOT from the
   // local registry: group ids from a previous browser session are stale.
   await restoreInteractiveGroupLedger();
+  // Only windowId is restored from the durable registry; the in-memory groupId
+  // cache stays null (a fresh worker) and repopulates via the session ledger,
+  // title, and lease layers during the convergence below.
   for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
-    ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {
         await chrome.windows.get(windowId);
       } catch {
         ownedContainers[role].windowId = null;
-        ownedContainers[role].groupId = null;
       }
     }
   }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -323,37 +323,9 @@ const ownedContainers: Record<OwnedWindowRole, {
 // `chrome.tabs.group` but never titled because the worker died before the
 // `tabGroups.update`) stays discoverable even when the cached `groupId` and
 // lease/title layers can't see it. Interactive-only: adapter automation never
-// creates a visible group. Backed by chrome.storage.session, NOT the local
-// registry — tab group ids are only valid within one browser session, and a
-// stale id persisted across a browser restart could collide with a recycled
-// id on a user-created group and let the ledger hijack it.
-const INTERACTIVE_GROUP_LEDGER_KEY = 'opencli_interactive_group_ledger_v1';
+// creates a visible group. Persisted as part of the session registry (see
+// StoredRegistry) and restored by reconcileTargetLeaseRegistry().
 const interactiveGroupLedger = new Set<number>();
-
-async function restoreInteractiveGroupLedger(): Promise<void> {
-  try {
-    const session = chrome.storage?.session;
-    if (!session) return; // no session storage — degrade to memory-only
-    const raw = await session.get(INTERACTIVE_GROUP_LEDGER_KEY) as Record<string, unknown>;
-    const stored = raw[INTERACTIVE_GROUP_LEDGER_KEY];
-    interactiveGroupLedger.clear();
-    if (Array.isArray(stored)) {
-      for (const id of stored) {
-        if (typeof id === 'number') interactiveGroupLedger.add(id);
-      }
-    }
-  } catch {
-    // Ledger restore is a recovery aid; never fail the caller on storage errors.
-  }
-}
-
-async function persistInteractiveGroupLedger(): Promise<void> {
-  try {
-    await chrome.storage?.session?.set({ [INTERACTIVE_GROUP_LEDGER_KEY]: [...interactiveGroupLedger] });
-  } catch {
-    // Best-effort — the in-memory ledger still covers the live worker.
-  }
-}
 
 type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
   idleDeadlineAt: number;
@@ -368,10 +340,17 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
 // storage.session survives MV3 service-worker restarts (the case recovery
 // exists for) and is cleared exactly when the ids die. initialize() also
 // best-effort removes the legacy storage.local copy older versions wrote.
+// Boundary: storage.session is also cleared on extension disable/reload/update
+// and on browser restart — recovery is only promised across service-worker
+// restarts within one browser session. Old leases are NOT recovered after an
+// extension reload/update, and no durable-id logic should be added for that.
 type StoredRegistry = {
   version: 2;
   contextId: BrowserContextId;
-  ownedContainers: Record<OwnedWindowRole, { windowId: number | null }>;
+  ownedContainers: {
+    interactive: { windowId: number | null; groupIds: number[] };
+    automation: { windowId: number | null };
+  };
   leases: Record<string, StoredLease>;
 };
 
@@ -503,7 +482,10 @@ function emptyRegistry(): StoredRegistry {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: { windowId: ownedContainers.interactive.windowId },
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupIds: [...interactiveGroupLedger],
+      },
       automation: { windowId: ownedContainers.automation.windowId },
     },
     leases: {},
@@ -526,6 +508,9 @@ async function readRegistry(): Promise<StoredRegistry> {
       ownedContainers: {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === 'number' ? storedContainers.interactive.windowId : null,
+          groupIds: Array.isArray(storedContainers.interactive?.groupIds)
+            ? storedContainers.interactive.groupIds.filter((id): id is number => typeof id === 'number')
+            : [],
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === 'number' ? storedContainers.automation.windowId : null,
@@ -568,7 +553,10 @@ async function persistRuntimeState(): Promise<void> {
     version: 2,
     contextId: currentContextId,
     ownedContainers: {
-      interactive: { windowId: ownedContainers.interactive.windowId },
+      interactive: {
+        windowId: ownedContainers.interactive.windowId,
+        groupIds: [...interactiveGroupLedger],
+      },
       automation: { windowId: ownedContainers.automation.windowId },
     },
     leases,
@@ -717,7 +705,7 @@ async function collectOwnedGroupCandidates(role: OwnedWindowRole): Promise<Owned
       ledgerPruned = true;
     }
   }
-  if (ledgerPruned) await persistInteractiveGroupLedger();
+  if (ledgerPruned) await persistRuntimeState();
 
   for (const title of getOwnedContainerGroupTitles(role)) {
     const groups = await chrome.tabGroups.query({ title });
@@ -851,15 +839,12 @@ async function createOwnedGroup(
   const groupId = await chrome.tabs.group({ tabIds: ids, createProperties: { windowId } });
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
-  // Record in the session ledger before the title/color update lands so a
+  // Record in the ledger and persist BEFORE the title/color update lands so a
   // worker crash between the two API calls can self-heal on resume:
   // `ensureCanonicalGroupTitle` repairs the title on the next ensure cycle
   // once the ledger surfaces the untitled orphan. We must not `tabs.ungroup`
   // on failure or the recorded id dangles.
-  if (role === 'interactive') {
-    interactiveGroupLedger.add(groupId);
-    await persistInteractiveGroupLedger();
-  }
+  if (role === 'interactive') interactiveGroupLedger.add(groupId);
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -922,7 +907,7 @@ async function ensureOwnedContainerGroupUnlocked(
       // recorded (role is 'interactive' whenever a canonical exists).
       if (!interactiveGroupLedger.has(canonical.id)) {
         interactiveGroupLedger.add(canonical.id);
-        await persistInteractiveGroupLedger();
+        await persistRuntimeState();
       }
     } else {
       ownedContainers[role].groupId = null;
@@ -2135,10 +2120,11 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
 
 async function reconcileTargetLeaseRegistry(): Promise<void> {
   const registry = await readRegistry();
-  // Restore the orphan-group ledger (session-scoped by design — see the
-  // ledger declaration).
-  await restoreInteractiveGroupLedger();
-  // Only windowId is restored from the registry; the in-memory groupId cache
+  // Restore the orphan-group ledger (readRegistry already coerced it to a
+  // clean number[]).
+  interactiveGroupLedger.clear();
+  for (const id of registry.ownedContainers.interactive.groupIds) interactiveGroupLedger.add(id);
+  // Only windowId is restored to the container cache; the in-memory groupId
   // stays null (a fresh worker) and repopulates via the session ledger,
   // title, and lease layers during the convergence below.
   for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -20,6 +20,19 @@ const CONTEXT_ID_KEY = 'opencli_context_id_v1';
 let currentContextId = 'default';
 let contextIdPromise: Promise<string> | null = null;
 let connectInFlight: Promise<void> | null = null;
+// Startup readiness gate. A MV3 service worker can be woken by an event
+// (alarm, window/tab removal) before initialize()'s recovery chain has
+// rehydrated in-memory lease/container state from storage. Event handlers that
+// persist state must `await workerReady` first, or an empty snapshot overwrites
+// the persisted registry (wiping self-heal pointers and lease records).
+// initialize() replaces this with the real recovery promise; it always
+// resolves (never rejects) so gated handlers can never wedge permanently.
+let workerReady: Promise<void> = Promise.resolve();
+// Synchronous mirror of workerReady's settled state. Lets connect() skip the
+// `await workerReady` microtask hop once recovery is done, so the steady-state
+// (post-recovery) connect path is byte-for-byte the original — only the
+// pre-recovery wake is gated.
+let workerRecovered = true;
 
 async function getCurrentContextId(): Promise<string> {
   if (contextIdPromise) return contextIdPromise;
@@ -108,7 +121,14 @@ function isDaemonSocketActive(socket: WebSocket | null | undefined = ws): boolea
 function connect(): Promise<void> {
   if (isDaemonSocketActive()) return Promise.resolve();
   if (connectInFlight) return connectInFlight;
-  connectInFlight = connectAttempt().finally(() => {
+  // Gate on startup recovery so a keepalive/reconnect wake never opens the
+  // socket into an un-rehydrated worker (daemon commands would then run against
+  // empty lease state). Once recovered, skip straight to connectAttempt so the
+  // steady-state path adds no extra tick. connectInFlight is set synchronously
+  // either way, so concurrent callers still coalesce; workerReady excludes
+  // connect itself, so no deadlock.
+  const attempt = workerRecovered ? connectAttempt() : workerReady.then(() => connectAttempt());
+  connectInFlight = attempt.finally(() => {
     connectInFlight = null;
   });
   return connectInFlight;
@@ -291,11 +311,17 @@ let leaseMutationQueue: Promise<void> = Promise.resolve();
 const ownedContainers: Record<OwnedWindowRole, {
   windowId: number | null;
   groupId: number | null;
+  // Ledger of every group id we have ever owned for this role, kept so an
+  // orphan group (created by `chrome.tabs.group` but never titled because the
+  // worker died before the `tabGroups.update`) stays discoverable even when the
+  // cached `groupId` and lease/title layers can't see it. Only used for
+  // 'interactive'; 'automation' owns no visible group and leaves it empty.
+  groupIds: Set<number>;
   promise: Promise<{ windowId: number; initialTabId?: number }> | null;
   groupPromise: Promise<OwnedContainerGroup | null> | null;
 }> = {
-  interactive: { windowId: null, groupId: null, promise: null, groupPromise: null },
-  automation: { windowId: null, groupId: null, promise: null, groupPromise: null },
+  interactive: { windowId: null, groupId: null, groupIds: new Set(), promise: null, groupPromise: null },
+  automation: { windowId: null, groupId: null, groupIds: new Set(), promise: null, groupPromise: null },
 };
 
 type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
@@ -306,7 +332,7 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
 type StoredRegistry = {
   version: 2;
   contextId: BrowserContextId;
-  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null }>;
+  ownedContainers: Record<OwnedWindowRole, { windowId: number | null; groupId?: number | null; groupIds?: number[] }>;
   leases: Record<string, StoredLease>;
 };
 
@@ -441,6 +467,7 @@ function emptyRegistry(): StoredRegistry {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
         groupId: ownedContainers.interactive.groupId,
+        groupIds: [...ownedContainers.interactive.groupIds],
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -468,6 +495,9 @@ async function readRegistry(): Promise<StoredRegistry> {
         interactive: {
           windowId: typeof storedContainers.interactive?.windowId === 'number' ? storedContainers.interactive.windowId : null,
           groupId: typeof storedContainers.interactive?.groupId === 'number' ? storedContainers.interactive.groupId : null,
+          groupIds: Array.isArray(storedContainers.interactive?.groupIds)
+            ? storedContainers.interactive.groupIds.filter((id): id is number => typeof id === 'number')
+            : [],
         },
         automation: {
           windowId: typeof storedContainers.automation?.windowId === 'number' ? storedContainers.automation.windowId : null,
@@ -514,6 +544,7 @@ async function persistRuntimeState(): Promise<void> {
       interactive: {
         windowId: ownedContainers.interactive.windowId,
         groupId: ownedContainers.interactive.groupId,
+        groupIds: [...ownedContainers.interactive.groupIds],
       },
       automation: {
         windowId: ownedContainers.automation.windowId,
@@ -647,6 +678,20 @@ async function collectOwnedGroupCandidates(role: OwnedWindowRole): Promise<Owned
       groupsById.set(group.id, group);
     } catch {
       container.groupId = null;
+    }
+  }
+
+  // Ledger layer: every group id we ever created for this role. Catches the
+  // untitled orphan that all title/lease/color layers miss. A missing id means
+  // the group has been closed or converged away — drop it so the ledger stays
+  // bounded and never resurrects a dead id.
+  for (const groupId of [...container.groupIds]) {
+    if (groupsById.has(groupId)) continue;
+    try {
+      const group = await chrome.tabGroups.get(groupId);
+      groupsById.set(group.id, group);
+    } catch {
+      container.groupIds.delete(groupId);
     }
   }
 
@@ -786,6 +831,9 @@ async function createOwnedGroup(
   // we must not `tabs.ungroup` on failure or the persisted id dangles.
   ownedContainers[role].groupId = groupId;
   ownedContainers[role].windowId = windowId;
+  // Record in the ledger before the (only) persist here so a crash between
+  // `tabs.group` and the title update still leaves the orphan discoverable.
+  ownedContainers[role].groupIds.add(groupId);
   await persistRuntimeState();
   const group = await chrome.tabGroups.update(groupId, {
     color: OWNED_TAB_GROUP_COLOR,
@@ -843,6 +891,9 @@ async function ensureOwnedContainerGroupUnlocked(
     if (canonical) {
       ownedContainers[role].windowId = canonical.windowId;
       ownedContainers[role].groupId = canonical.id;
+      // Adopt into the ledger — covers canonicals we found via the title/lease
+      // layers (e.g. a legacy group) that createOwnedGroup never recorded.
+      ownedContainers[role].groupIds.add(canonical.id);
     } else {
       ownedContainers[role].groupId = null;
       if (fallbackWindowId === null) ownedContainers[role].windowId = null;
@@ -1076,6 +1127,9 @@ async function getAutomationWindow(leaseKey: string, initialUrl?: string): Promi
 
 // Clean up when an owned container window is closed
 chrome.windows.onRemoved.addListener(async (windowId) => {
+  // A window-close event can wake the worker before recovery; persisting the
+  // empty pre-recovery snapshot here would wipe the registry.
+  await workerReady;
   for (const container of Object.values(ownedContainers)) {
     if (container.windowId === windowId) {
       container.windowId = null;
@@ -1096,6 +1150,8 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
 
 // Evict identity mappings when tabs are closed
 chrome.tabs.onRemoved.addListener(async (tabId) => {
+  // Same wake-before-recovery hazard as windows.onRemoved.
+  await workerReady;
   identity.evictTab(tabId);
   for (const [leaseKey, session] of automationSessions.entries()) {
     if (session.preferredTabId === tabId) {
@@ -1124,11 +1180,22 @@ function initialize(): void {
   } catch {
     // Some focused tests mock only the cdp functions they exercise.
   }
-  void (async () => {
+  // Rehydrate context + lease/container state before any event handler that
+  // persists is allowed to run (see workerReady). connect() is deliberately
+  // outside this promise — it awaits workerReady on its own, so keeping it out
+  // avoids a self-wait while still ordering the socket after recovery.
+  workerRecovered = false;
+  workerReady = (async () => {
     await getCurrentContextId();
     await reconcileTargetLeaseRegistry();
-    await connect();
-  })();
+  })().catch((err) => {
+    // Never leave workerReady rejected/pending: a wedged gate would freeze
+    // every gated handler for the life of the worker.
+    console.warn(`[opencli] Startup recovery failed: ${err instanceof Error ? err.message : String(err)}`);
+  }).finally(() => {
+    workerRecovered = true;
+  });
+  void workerReady.then(() => connect());
   console.log('[opencli] OpenCLI extension initialized');
 }
 
@@ -1146,6 +1213,9 @@ chrome.runtime.onStartup.addListener(() => {
 initialize();
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
+  // Idle-lease alarms and keepalive can both fire in a freshly woken worker;
+  // gate on recovery so releaseLease never persists an empty snapshot.
+  await workerReady;
   if (alarm.name === 'keepalive') void connect();
   const leaseKey = leaseKeyFromAlarmName(alarm.name);
   if (!leaseKey) return;
@@ -2028,6 +2098,12 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
   for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;
     ownedContainers[role].groupId = registry.ownedContainers[role]?.groupId ?? null;
+    // Restore the orphan-group ledger independent of window staleness: a stored
+    // orphan may live in a window other than the persisted container window, so
+    // clearing it on a stale windowId would lose the self-heal pointer.
+    if (role === 'interactive') {
+      ownedContainers.interactive.groupIds = new Set(registry.ownedContainers.interactive?.groupIds ?? []);
+    }
     const windowId = ownedContainers[role].windowId;
     if (windowId !== null) {
       try {
@@ -2086,6 +2162,17 @@ async function reconcileTargetLeaseRegistry(): Promise<void> {
       // Registry is semantic state, not truth. If Chrome no longer has the tab,
       // drop the lease record and never close unrelated user resources.
     }
+  }
+
+  // Converge the interactive owned group on startup: adopt/title an orphan the
+  // ledger surfaces, or clear a dangling groupId when none survives. Runs even
+  // with no leases so orphans left by a mid-create crash get repaired instead
+  // of accumulating as untitled "OpenCLI Browser" duplicates (#2097). Best
+  // effort — reconcile must still persist restored leases if this fails.
+  try {
+    await ensureOwnedContainerGroup('interactive', null, []);
+  } catch (err) {
+    console.warn(`[opencli] Startup interactive group convergence failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   await persistRuntimeState();
@@ -2148,6 +2235,11 @@ export const __test__ = {
   sessionOverrides,
   reconcileTargetLeaseRegistry,
   ensureOwnedContainerGroup,
+  getInteractiveContainer: () => ({
+    windowId: ownedContainers.interactive.windowId,
+    groupId: ownedContainers.interactive.groupId,
+    groupIds: [...ownedContainers.interactive.groupIds],
+  }),
   connectForTest: connect,
   scheduleReconnectForTest: () => scheduleReconnect(),
   getReconnectAttempts: () => reconnectAttempts,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -360,13 +360,17 @@ type StoredLease = Omit<TargetLease, 'idleTimer' | 'idleDeadlineAt'> & {
   updatedAt: number;
 };
 
+// The registry lives in chrome.storage.session, never chrome.storage.local:
+// every id it carries (window, tab, group) is a Chrome runtime number that is
+// only valid within one browser session. Persisting them across a browser
+// restart never enabled real recovery — a recycled id could instead collide
+// with a user-created window/tab/group and let the restore path claim it.
+// storage.session survives MV3 service-worker restarts (the case recovery
+// exists for) and is cleared exactly when the ids die. initialize() also
+// best-effort removes the legacy storage.local copy older versions wrote.
 type StoredRegistry = {
   version: 2;
   contextId: BrowserContextId;
-  // Deliberately windowId-only: tab group ids are browser-session scoped, so
-  // the durable registry must never store or trust one (a recycled id could
-  // hijack a user-created group after a browser restart). Within one browser
-  // session, group recovery is covered by the session ledger + title layer.
   ownedContainers: Record<OwnedWindowRole, { windowId: number | null }>;
   leases: Record<string, StoredLease>;
 };
@@ -508,9 +512,9 @@ function emptyRegistry(): StoredRegistry {
 
 async function readRegistry(): Promise<StoredRegistry> {
   try {
-    const local = chrome.storage?.local;
-    if (!local) return emptyRegistry();
-    const raw = await local.get(REGISTRY_KEY) as Record<string, unknown>;
+    const session = chrome.storage?.session;
+    if (!session) return emptyRegistry(); // no session storage — degrade to memory-only
+    const raw = await session.get(REGISTRY_KEY) as Record<string, unknown>;
     const stored = raw[REGISTRY_KEY] as Partial<StoredRegistry> | undefined;
     if (!stored || stored.version !== 2 || typeof stored.leases !== 'object') return emptyRegistry();
     const storedContainers = stored.ownedContainers && typeof stored.ownedContainers === 'object'
@@ -536,7 +540,7 @@ async function readRegistry(): Promise<StoredRegistry> {
 
 async function writeRegistry(registry: StoredRegistry): Promise<void> {
   try {
-    await chrome.storage?.local?.set({ [REGISTRY_KEY]: registry });
+    await chrome.storage?.session?.set({ [REGISTRY_KEY]: registry });
   } catch {
     // Registry persistence is a recovery aid; command execution should not fail on storage errors.
   }
@@ -1205,6 +1209,16 @@ function initialize(): void {
     registerFrameTracking?.();
   } catch {
     // Some focused tests mock only the cdp functions they exercise.
+  }
+  // Migration cleanup: older versions persisted the registry in
+  // chrome.storage.local, where its browser-session-scoped ids go stale after
+  // a browser restart (see StoredRegistry). Remove that one legacy key —
+  // nothing else in local — so it can never be trusted again. Fire-and-forget:
+  // nothing reads the local copy anymore, so ordering does not matter.
+  try {
+    void chrome.storage?.local?.remove?.(REGISTRY_KEY)?.catch?.(() => {});
+  } catch {
+    // Best-effort cleanup.
   }
   // Rehydrate context + lease/container state before any event handler that
   // persists is allowed to run (see workerReady). connect() is deliberately
@@ -2121,12 +2135,11 @@ async function releaseLease(leaseKey: string, reason: string = 'released'): Prom
 
 async function reconcileTargetLeaseRegistry(): Promise<void> {
   const registry = await readRegistry();
-  // Restore the orphan-group ledger from session storage (browser-session
-  // scoped by design — see the ledger declaration). Deliberately NOT from the
-  // local registry: group ids from a previous browser session are stale.
+  // Restore the orphan-group ledger (session-scoped by design — see the
+  // ledger declaration).
   await restoreInteractiveGroupLedger();
-  // Only windowId is restored from the durable registry; the in-memory groupId
-  // cache stays null (a fresh worker) and repopulates via the session ledger,
+  // Only windowId is restored from the registry; the in-memory groupId cache
+  // stays null (a fresh worker) and repopulates via the session ledger,
   // title, and lease layers during the convergence below.
   for (const role of Object.keys(ownedContainers) as OwnedWindowRole[]) {
     ownedContainers[role].windowId = registry.ownedContainers[role]?.windowId ?? null;


### PR DESCRIPTION
## Description

Chrome accumulates multiple `OpenCLI Browser` tab groups instead of reusing one (#2097).

**Root cause** — two defects chain together:

1. **SW wake events wipe the persisted registry.** An MV3 service worker woken by an event can run `windows.onRemoved` / `tabs.onRemoved` / the lease idle alarm before `initialize()`'s recovery chain has rehydrated in-memory state from storage. Each of those handlers ends in `persistRuntimeState()`, so the empty pre-recovery snapshot overwrites the registry — destroying the `groupId` self-heal pointer (#1862) and every lease record. `tabs.onRemoved` fires for every tab the user closes anywhere in the profile, so this happens routinely.
2. **Untitled orphans then become unrecoverable.** A worker crash between `chrome.tabs.group` and the `tabGroups.update` that sets the title leaves an untitled group whose recovery depends entirely on the persisted pointer or a registered lease tab — exactly the two signals the wipe destroys. Invisible to all discovery layers, the orphan lingers while the next command creates a fresh titled group. Concurrent agents amplify wake and ensure frequency, matching the report.

**Fix:**

- **Startup readiness gate** — `workerReady` resolves once contextId + registry recovery complete. The three event entry points and `connect()` gate on it, so an empty snapshot can never overwrite the registry and daemon commands can't run against un-rehydrated state. The gate always resolves, and `connect()` keeps synchronous `connectInFlight` coalescing via a settled-state mirror, leaving the steady-state path unchanged.
- **Owned-group ledger** — every interactive group id created or adopted in the current browser session is recorded (as `groupIds` on the registry's interactive container) and used as an extra discovery layer in `collectOwnedGroupCandidates`, so an untitled orphan stays findable with no lease and no title across MV3 worker restarts. Ids whose `chrome.tabGroups.get` fails are pruned. The id is persisted between `chrome.tabs.group` and the `tabGroups.update` title call, so a crash in that window self-heals.
- **Session-scoped registry** — the lease registry lives in `chrome.storage.session`, not `chrome.storage.local`. Every meaningful field in it (window ids, tab ids, group ids) is a Chrome runtime number valid only within one browser session; persisting them across a browser restart never enabled real recovery, but a recycled id could collide with a user-created window/tab/group and let the restore path claim, group, navigate, or close it (regression-tested for all three id kinds). `storage.session` survives MV3 worker restarts — the case recovery exists for — and is cleared exactly when the ids die. `initialize()` best-effort removes the legacy `storage.local` key so old data can never be trusted again. Documented boundary: `storage.session` is also cleared on extension disable/reload/update, so recovery is only promised across service-worker restarts within one browser session.
- **Startup convergence** — `reconcileTargetLeaseRegistry` runs one interactive group ensure at the end, so existing orphans (including ones left by older versions) are adopted, retitled, and merged on wake.

Related issue: fixes #2097

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR (`tsc --noEmit`; full unit suite: 548 files / 5961 tests pass; `npm run test:e2e`: fixed-port transport suites pass — 3 remaining failures are live-site content assertions (hackernews/tieba/ruanyifeng) that vary between runs and are unrelated)
- [x] I updated tests or docs if needed (9 regression tests, each fails on pre-fix code)
- [x] I included output or screenshots when useful (live end-to-end verification below)

### Documentation (if adding/modifying an adapter)

Not an adapter PR — extension-only change; `extension/dist/background.js` rebuilt and committed per repo convention.

## Screenshots / Output

Live verification against a real browser (Chrome for Testing 148, fresh profile, this branch's unpacked extension + built CLI, driving the extension SW over CDP):

**1. Four concurrent agent sessions → exactly one group:**

```
$ for s in agent1..agent4: opencli --profile <test> browser $s open https://example.com   (parallel)
chrome.tabGroups.query({}) →
[{"id":1895863660,"title":"OpenCLI Browser","color":"orange","windowId":149875950}]
```

**2. Kill the SW, wake it via `tabs.onRemoved` (the pre-fix wipe path) → registry survives:**

```
before: {"groupId":1946898140,"groupIds":[1946898140]}
SW stopped; victim tab closed (wake event fired)
after:  {"groupId":1946898140,"groupIds":[1946898140]}   // pre-fix: groupId wiped to null
```

**3. Inject the #2097 crash artifact (untitled group + ledger entry), kill + wake the SW → orphan adopted, not duplicated:**

```
injected: [{"id":1946898140,"title":"OpenCLI Browser"},{"id":227016254,"title":""}]  // 2 groups, 1 window
after wake:
[{"id":227016254,"title":"OpenCLI Browser","color":"orange"}]                        // converged to 1
```

**4. Two more concurrent sessions → still one group, dead ledger id pruned:**

```
[{"id":227016254,"title":"OpenCLI Browser"}]
ledger: {"groupId":227016254,"groupIds":[227016254]}
```

**5. Seed a legacy registry whose persisted `groupId` collides with a live user group, kill + wake the SW → user group untouched:**

```
seeded: local registry ownedContainers.interactive = {"windowId":null,"groupId":1766190816}   // id 1766190816 = user "Vacation" group
after wake: [{"id":1766190816,"title":"Vacation","color":"blue"}]                             // no retitle, no merge, tab kept
```

**6. Simulate post-browser-restart state (stale `storage.local` registry claiming a live user tab + window, `storage.session` empty), kill + wake the SW → user tab untouched, legacy key removed:**

```
seeded: local registry with ownedContainers.*.windowId and a lease preferredTabId all pointing at a real user tab (https://example.com)
after wake: userTab {"url":"https://example.com/","groupId":-1}   // not grouped, not navigated, not closed
            localRegistryAfter: null                              // legacy storage.local key removed
            sessionRegistry: {"leases":[],"containers":{...windowId:null}}   // live registry now in storage.session, no false leases
```

**7. Same-session SW kill with a lease in the session registry → lease survives the `tabs.onRemoved` wake:**

```
after wake: leaseSurvived {"preferredTabId":215961409,"windowId":215961404}, leaseCount 1
```

Note: `tests/e2e/browser-ax-chrome.test.ts` soft-passes on macOS when the bridge is unavailable (branded Chrome ≥137 ignores `--load-extension`), so the live run above was done with Chrome for Testing to exercise the real MV3 service worker.

