### PR TITLE
fix(chatgpt): use pure sleeps and cheap generation checks in polling loops

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -105,7 +105,7 @@ export const askCommand = cli({
             if (Date.now() - settleStart > timeout * 1000) {
                 throw new CommandExecutionError('ChatGPT conversation is still generating; wait for it to finish before sending another message.');
             }
-            await page.wait(3);
+            await page.sleep(3);
         }
 
         const baselineMessages = await getVisibleMessages(page);

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2182,12 +2182,13 @@ export async function isGenerating(page) {
     return requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
             if (document.querySelector('[data-testid="stop-button"]')) return true;
+            // No bare 'Thinking' here: the model picker renders 'Thinking' as
+            // an idle model label (see CHATGPT_MODEL_TARGETS.advanced), and an
+            // English streaming state always comes with the stop button above.
             const controls = Array.from(document.querySelectorAll('button, [role="button"], [aria-label]'));
             for (const control of controls) {
                 const label = control.getAttribute('aria-label') || '';
-                if (label === 'Stop generating'
-                    || label.includes('Stop generating')
-                    || label.includes('Thinking')
+                if (label.includes('Stop generating')
                     || label.includes('停止生成')
                     || label.includes('正在思考')) return true;
             }
@@ -2199,26 +2200,28 @@ export async function isGenerating(page) {
             // prefer the article turn (the wider container, so a pill outside
             // the message div is still seen), fall back to bare
             // [data-message-author-role] nodes when articles are absent.
+            // Bare 'Thinking' only counts inside the last turn — the composer
+            // area shows 'Thinking' as an idle model label.
             const turns = document.querySelectorAll('article[data-testid*="conversation-turn"]');
             const messages = turns.length ? turns : document.querySelectorAll('[data-message-author-role]');
-            if (messages.length) scopes.push(messages[messages.length - 1]);
+            if (messages.length) scopes.push([messages[messages.length - 1], /正在思考|停止生成|Thinking/]);
             const composer = document.querySelector('#prompt-textarea, [aria-label="Chat with ChatGPT"]');
             if (composer) {
                 let root = composer;
                 for (let i = 0; i < 4 && root.parentElement; i += 1) root = root.parentElement;
-                scopes.push(root);
+                scopes.push([root, /正在思考|停止生成/]);
             }
             // Only a short leaf element OUTSIDE rendered message content
             // counts as a status pill. Testing whole scope text would flag any
             // answer that merely *mentions* "Thinking" (prose or a backticked
             // code span in a conversation about this very code) as still
             // generating, permanently blocking follow-up sends.
-            for (const scope of scopes) {
+            for (const [scope, pattern] of scopes) {
                 for (const el of [scope, ...scope.querySelectorAll('*')]) {
                     if (el.children.length) continue;
                     if (el.closest('.markdown, pre, code')) continue;
                     const text = (el.textContent || '').trim();
-                    if (text && text.length <= 40 && /正在思考|停止生成|Thinking/.test(text)) return true;
+                    if (text && text.length <= 40 && pattern.test(text)) return true;
                 }
             }
             return false;

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2208,8 +2208,18 @@ export async function isGenerating(page) {
                 for (let i = 0; i < 4 && root.parentElement; i += 1) root = root.parentElement;
                 scopes.push(root);
             }
+            // Only a short leaf element OUTSIDE rendered message content
+            // counts as a status pill. Testing whole scope text would flag any
+            // answer that merely *mentions* "Thinking" (prose or a backticked
+            // code span in a conversation about this very code) as still
+            // generating, permanently blocking follow-up sends.
             for (const scope of scopes) {
-                if (/正在思考|停止生成|Thinking/.test(scope.textContent || '')) return true;
+                for (const el of [scope, ...scope.querySelectorAll('*')]) {
+                    if (el.children.length) continue;
+                    if (el.closest('.markdown, pre, code')) continue;
+                    const text = (el.textContent || '').trim();
+                    if (text && text.length <= 40 && /正在思考|停止生成|Thinking/.test(text)) return true;
+                }
             }
             return false;
         })()

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2195,8 +2195,13 @@ export async function isGenerating(page) {
             // aria-label. Scope the text scan to small containers and use
             // textContent (does not trigger layout) instead of body.innerText.
             const scopes = [];
+            // Cover both message shapes from CONVERSATION_MESSAGE_SELECTOR:
+            // prefer the article turn (the wider container, so a pill outside
+            // the message div is still seen), fall back to bare
+            // [data-message-author-role] nodes when articles are absent.
             const turns = document.querySelectorAll('article[data-testid*="conversation-turn"]');
-            if (turns.length) scopes.push(turns[turns.length - 1]);
+            const messages = turns.length ? turns : document.querySelectorAll('[data-message-author-role]');
+            if (messages.length) scopes.push(messages[messages.length - 1]);
             const composer = document.querySelector('#prompt-textarea, [aria-label="Chat with ChatGPT"]');
             if (composer) {
                 let root = composer;

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -1104,7 +1104,10 @@ export async function getVisibleMessages(page, { textOnly = false } = {}) {
                 || node.querySelector('[data-message-author-role]')
                 || node;
             const html = includeHtml && contentNode instanceof HTMLElement ? (contentNode.innerHTML || '') : '';
-            const text = normalize(contentNode instanceof HTMLElement ? (contentNode.innerText || contentNode.textContent || '') : '');
+            const rawText = contentNode instanceof HTMLElement
+                ? (includeHtml ? (contentNode.innerText || contentNode.textContent || '') : (contentNode.textContent || ''))
+                : '';
+            const text = normalize(rawText);
             if (!text) continue;
             const key = role + '\\n' + text;
             if (seen.has(key)) continue;

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -1060,8 +1060,13 @@ export async function sendChatGPTMessage(page, text) {
     return true;
 }
 
-export async function getVisibleMessages(page) {
+export async function getVisibleMessages(page, { textOnly = false } = {}) {
+    // textOnly skips the per-turn innerHTML read (used only for --markdown
+    // rendering) so poll loops that need only role + text don't allocate a
+    // second conversation-sized string on every tick.
+    const includeHtml = textOnly ? 'false' : 'true';
     const result = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
+        const includeHtml = ${includeHtml};
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
@@ -1098,7 +1103,7 @@ export async function getVisibleMessages(page) {
                 || node.querySelector('.markdown')
                 || node.querySelector('[data-message-author-role]')
                 || node;
-            const html = contentNode instanceof HTMLElement ? (contentNode.innerHTML || '') : '';
+            const html = includeHtml && contentNode instanceof HTMLElement ? (contentNode.innerHTML || '') : '';
             const text = normalize(contentNode instanceof HTMLElement ? (contentNode.innerText || contentNode.textContent || '') : '');
             if (!text) continue;
             const key = role + '\\n' + text;
@@ -1170,7 +1175,7 @@ export async function waitForChatGPTDetailRows(page, { wantMarkdown = false, tim
             lastKey = key;
             stableStartedAt = 0;
         }
-        await page.wait(3);
+        await page.sleep(3);
     }
 
     throw new TimeoutError(
@@ -1822,7 +1827,7 @@ export async function waitForChatGPTDeepResearchResult(page, { conversationId = 
                 stableStartedAt = Date.now();
             }
         }
-        await page.wait(3);
+        await page.sleep(3);
     }
 
     throw new TimeoutError(
@@ -1913,7 +1918,7 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
     const baselinePairCounts = normalizeBaselinePairCounts(options);
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {
-        await page.wait(3);
+        await page.sleep(3);
         if (options.conversationUrl) {
             const currentUrl = await currentChatGPTUrl(page);
             if (currentUrl && !isSameChatGPTConversation(currentUrl, options.conversationUrl)) {
@@ -1927,7 +1932,7 @@ export async function waitForChatGPTResponse(page, baselineCount, prompt, timeou
             continue;
         }
 
-        const messages = await getVisibleMessages(page);
+        const messages = await getVisibleMessages(page, { textOnly: true });
         const candidate = findLatestNewAssistantResponse(messages, prompt, baselinePairCounts);
         if (!candidate || candidate === String(prompt || '').trim()) continue;
 
@@ -2057,7 +2062,7 @@ export async function prepareChatGPTImagePaths(imagePaths) {
 async function waitForChatGPTUploadPreview(page, fileNames) {
     const namesJson = JSON.stringify(fileNames);
     for (let attempt = 0; attempt < 10; attempt += 1) {
-        await page.wait(1);
+        await page.sleep(1);
         const ready = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
             (() => {
                 const names = ${namesJson};
@@ -2169,17 +2174,39 @@ export async function uploadChatGPTImages(page, imagePaths) {
  * Check if ChatGPT is still generating a response.
  */
 export async function isGenerating(page) {
+    // Deliberately avoids document.body.innerText: reading it forces a full-page
+    // layout/reflow and allocates a conversation-sized string on every poll,
+    // which during a 10-20 min streamed answer pins the renderer at high CPU.
+    // Cheap signals only — control aria-labels, the stop-button test id, and a
+    // textContent (no reflow) scan scoped to the composer + last turn.
     return requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
-            const text = (document.body?.innerText || '').replace(/\\s+/g, ' ');
-            if (/正在思考|停止生成|Thinking/.test(text)) return true;
-            return Array.from(document.querySelectorAll('button')).some(b => {
-                const label = b.getAttribute('aria-label') || '';
-                return label === 'Stop generating'
+            if (document.querySelector('[data-testid="stop-button"]')) return true;
+            const controls = Array.from(document.querySelectorAll('button, [role="button"], [aria-label]'));
+            for (const control of controls) {
+                const label = control.getAttribute('aria-label') || '';
+                if (label === 'Stop generating'
+                    || label.includes('Stop generating')
                     || label.includes('Thinking')
                     || label.includes('停止生成')
-                    || label.includes('正在思考');
-            });
+                    || label.includes('正在思考')) return true;
+            }
+            // The "正在思考 / Thinking" pill can render as plain text without an
+            // aria-label. Scope the text scan to small containers and use
+            // textContent (does not trigger layout) instead of body.innerText.
+            const scopes = [];
+            const turns = document.querySelectorAll('article[data-testid*="conversation-turn"]');
+            if (turns.length) scopes.push(turns[turns.length - 1]);
+            const composer = document.querySelector('#prompt-textarea, [aria-label="Chat with ChatGPT"]');
+            if (composer) {
+                let root = composer;
+                for (let i = 0; i < 4 && root.parentElement; i += 1) root = root.parentElement;
+                scopes.push(root);
+            }
+            for (const scope of scopes) {
+                if (/正在思考|停止生成|Thinking/.test(scope.textContent || '')) return true;
+            }
+            return false;
         })()
     `)), 'chatgpt generation state');
 }
@@ -2320,7 +2347,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     let stableCount = 0;
 
     for (let i = 0; i < maxPolls; i++) {
-        await page.wait(i === 0 ? 3 : pollIntervalSeconds);
+        await page.sleep(i === 0 ? 3 : pollIntervalSeconds);
 
         let currentUrl = '';
         if (convUrl && convUrl.includes('/c/')) {

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -886,6 +886,37 @@ describe('chatgpt generation state', () => {
 
         await expect(isGenerating(page)).resolves.toBe(true);
     });
+
+    it('detects a plain-text thinking pill inside a bare [data-message-author-role] turn', async () => {
+        // Regression: the scoped scan must cover both message shapes from
+        // CONVERSATION_MESSAGE_SELECTOR, not just article conversation turns —
+        // with no stop button and no aria-label, a plain-text pill in the
+        // role-attribute shape must still read as generating.
+        const page = createDomEvaluatePage(`
+            <div data-message-author-role="assistant">正在思考中…部分回答内容</div>
+        `);
+
+        await expect(isGenerating(page)).resolves.toBe(true);
+    });
+
+    it('detects a plain-text Thinking pill inside the last article turn', async () => {
+        const page = createDomEvaluatePage(`
+            <article data-testid="conversation-turn-2">
+              <div data-message-author-role="assistant">partial answer</div>
+              <div>Thinking</div>
+            </article>
+        `);
+
+        await expect(isGenerating(page)).resolves.toBe(true);
+    });
+
+    it('reports idle when no generation indicator is present in either shape', async () => {
+        const page = createDomEvaluatePage(`
+            <div data-message-author-role="assistant">done answer</div>
+        `);
+
+        await expect(isGenerating(page)).resolves.toBe(false);
+    });
 });
 
 describe('chatgpt current model detection', () => {

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -918,6 +918,23 @@ describe('chatgpt generation state', () => {
         await expect(isGenerating(page)).resolves.toBe(false);
     });
 
+    it('stays idle when the composer shows Thinking as the selected model', async () => {
+        // Regression: 'Thinking' is a supported idle model label (see
+        // CHATGPT_MODEL_TARGETS.advanced), rendered as a composer-form button
+        // with or without an aria-label. It must not read as generating.
+        const page = createDomEvaluatePage(`
+            <article data-testid="conversation-turn-2">
+              <div data-message-author-role="assistant"><div class="markdown"><p>done answer</p></div></div>
+            </article>
+            <form>
+              <div id="prompt-textarea" contenteditable="true"></div>
+              <button aria-label="Thinking"><span data-testid="model-switcher-gpt-5-5-thinking">Thinking</span></button>
+            </form>
+        `);
+
+        await expect(isGenerating(page)).resolves.toBe(false);
+    });
+
     it('ignores answers that merely mention Thinking in prose or code spans', async () => {
         // Regression: a finished review of isGenerating itself contains the
         // literal words "Thinking" / "正在思考" in prose and backticked code

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairCounts, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, isGenerating, navigateToProject, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
+import { __test__, getChatGPTDetailRows, getChatGPTImageAssets, getChatGPTResponsePairCounts, getChatGPTVisibleImageUrls, getCurrentChatGPTModel, getCurrentChatGPTTool, getVisibleMessages, isGenerating, navigateToProject, openChatGPTConversation, prepareChatGPTImagePaths, selectChatGPTModel, selectChatGPTTool, sendChatGPTMessage, uploadChatGPTImages, waitForChatGPTDetailRows, waitForChatGPTImages, waitForChatGPTResponse } from './utils.js';
 
 const tempDirs = [];
 
@@ -872,6 +872,34 @@ describe('chatgpt ask response extraction boundary', () => {
         // for the full 10-20 min a streamed answer takes to settle.
         expect(page.sleep).toHaveBeenCalled();
         expect(page.wait).not.toHaveBeenCalled();
+    });
+
+    it('uses textContent instead of layout-triggering innerText in text-only message polls', async () => {
+        const page = createDomEvaluatePage(`
+            <article data-testid="conversation-turn-2">
+              <div data-message-author-role="assistant">
+                <div class="markdown">done answer</div>
+              </div>
+            </article>
+        `);
+        for (const node of page.dom.window.document.querySelectorAll('*')) {
+            node.getBoundingClientRect = () => ({ width: 120, height: 36 });
+        }
+        Object.defineProperty(page.dom.window.HTMLElement.prototype, 'innerText', {
+            configurable: true,
+            get() {
+                throw new Error('innerText should not be read during text-only polls');
+            },
+        });
+
+        await expect(getVisibleMessages(page, { textOnly: true })).resolves.toEqual([
+            {
+                Index: 1,
+                Role: 'Assistant',
+                Text: 'done answer',
+                Html: '',
+            },
+        ]);
     });
 });
 

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -917,6 +917,25 @@ describe('chatgpt generation state', () => {
 
         await expect(isGenerating(page)).resolves.toBe(false);
     });
+
+    it('ignores answers that merely mention Thinking in prose or code spans', async () => {
+        // Regression: a finished review of isGenerating itself contains the
+        // literal words "Thinking" / "正在思考" in prose and backticked code
+        // spans inside .markdown. That is message content, not a status pill —
+        // reading it as generating would block every follow-up send.
+        const page = createDomEvaluatePage(`
+            <article data-testid="conversation-turn-2">
+              <div data-message-author-role="assistant">
+                <div class="markdown">
+                  <p>这个 PR 修改了检测逻辑，旧代码对全页文本匹配 Thinking 与正在思考，存在误报，建议改为在局部范围内检查停止生成按钮的状态。</p>
+                  <p>位置见 <code>isGenerating</code>，匹配词是 <code>Thinking</code> 和 <code>正在思考</code>。</p>
+                </div>
+              </div>
+            </article>
+        `);
+
+        await expect(isGenerating(page)).resolves.toBe(false);
+    });
 });
 
 describe('chatgpt current model detection', () => {

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -20,6 +20,7 @@ function createPageMock({ location = '', generating = [], imageUrls = [] } = {})
     let imageIndex = 0;
     return {
         wait: vi.fn().mockResolvedValue(undefined),
+        sleep: vi.fn().mockResolvedValue(undefined),
         goto: vi.fn().mockResolvedValue(undefined),
         evaluate: vi.fn((script) => {
             if (script === 'window.location.href') return Promise.resolve(location);
@@ -662,6 +663,7 @@ describe('chatgpt detail completion state', () => {
     function createDetailPageMock({ generating = false, messages = [] } = {}) {
         return {
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => {
                 if (script.includes('Stop generating') || script.includes('Thinking')) {
                     return Promise.resolve(generating);
@@ -721,6 +723,7 @@ describe('chatgpt ask response extraction boundary', () => {
         let messageIndex = 0;
         return {
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => {
                 if (script === 'window.location.href') return Promise.resolve(url);
                 if (script.includes('Stop generating') || script.includes('Thinking')) {
@@ -855,6 +858,20 @@ describe('chatgpt ask response extraction boundary', () => {
         await expect(waitForChatGPTResponse(page, 0, 'hello', 4, {
             conversationUrl: 'https://chatgpt.com/c/demo',
         })).rejects.toThrow(/navigated away from the target conversation/);
+    });
+
+    it('polls with pure client-side sleeps instead of the DOM-stable numeric wait', async () => {
+        mockAdvancingClock();
+        const page = createResponseWaitPage([[], [], []]);
+
+        await expect(waitForChatGPTResponse(page, 0, 'unmatched prompt', 4, {}))
+            .rejects.toThrow(/chatgpt ask timed out/);
+
+        // The poll interval must not hit page.wait(number), whose DOM-stable
+        // path installs a whole-body MutationObserver and pins renderer CPU
+        // for the full 10-20 min a streamed answer takes to settle.
+        expect(page.sleep).toHaveBeenCalled();
+        expect(page.wait).not.toHaveBeenCalled();
     });
 });
 
@@ -1203,6 +1220,7 @@ describe('chatgpt image upload helper', () => {
         const page = {
             setFileInput: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn().mockResolvedValue(true),
         };
 
@@ -1254,6 +1272,7 @@ describe('chatgpt image upload helper', () => {
         const page = {
             setFileInput: vi.fn().mockRejectedValue(new Error('No element found')),
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => {
                 if (String(script).includes('new DataTransfer()')) {
                     return Promise.resolve({ ok: true });
@@ -1289,6 +1308,7 @@ describe('chatgpt image upload helper', () => {
         const page = {
             setFileInput: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
         };
 
@@ -1319,6 +1339,7 @@ describe('chatgpt image upload helper', () => {
         const page = {
             setFileInput: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
         };
 

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -927,3 +927,15 @@ describe('BasePage.evaluateWithArgs scoping', () => {
     `, { value: 20 })).resolves.toBe(42);
   });
 });
+
+describe('BasePage.sleep', () => {
+  it('is a pure client-side sleep that never evaluates page script', async () => {
+    const page = new ActionPage();
+    const evalSpy = vi.spyOn(page, 'evaluate');
+
+    await page.sleep(0);
+
+    expect(evalSpy).not.toHaveBeenCalled();
+    expect(page.scripts).toHaveLength(0);
+  });
+});

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -1029,6 +1029,18 @@ export abstract class BasePage implements IPage {
     return [];
   }
 
+  /**
+   * Pure client-side sleep — a bare setTimeout with no page evaluation.
+   *
+   * Unlike `wait(n)`, this never installs a MutationObserver or touches the
+   * renderer, so poll loops that already re-check state each iteration don't
+   * pay for a whole-body DOM-stable probe on every tick. Use this for fixed
+   * poll intervals; use `wait(n)` when DOM-stable early return is desired.
+   */
+  async sleep(seconds: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+  }
+
   async wait(options: number | WaitOptions): Promise<void> {
     if (typeof options === 'number') {
       if (options >= 1) {

--- a/src/pipeline/executor.test.ts
+++ b/src/pipeline/executor.test.ts
@@ -21,6 +21,7 @@ function createMockPage(overrides: Partial<IPage> = {}): IPage {
     pressKey: vi.fn(),
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
     selectTab: vi.fn(),
     networkRequests: vi.fn().mockResolvedValue([]),

--- a/src/pipeline/steps/download.test.ts
+++ b/src/pipeline/steps/download.test.ts
@@ -35,6 +35,7 @@ function createMockPage(getCookies: IPage['getCookies']): IPage {
     scrollTo: vi.fn(),
     getFormState: vi.fn().mockResolvedValue({}),
     wait: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
     tabs: vi.fn().mockResolvedValue([]),
     selectTab: vi.fn(),
     networkRequests: vi.fn().mockResolvedValue([]),

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,8 @@ export interface IPage {
   scrollTo(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<any>;
   getFormState(): Promise<any>;
   wait(options: number | WaitOptions): Promise<void>;
+  /** Pure client-side sleep (bare setTimeout, no page evaluation). */
+  sleep(seconds: number): Promise<void>;
   waitForDownload?(pattern?: string, timeoutMs?: number): Promise<BrowserDownloadWaitResult>;
   tabs(): Promise<any>;
   closeTab?(target?: number | string): Promise<void>;


### PR DESCRIPTION
## Description

Part 1 of 2 for the renderer-CPU problem in long-running `chatgpt ask` (part 2 will add session busy arbitration).

During a 10-20 min ChatGPT response, the chatgpt.com renderer climbs to ~700% CPU and >4GB RSS. Two mechanisms in the polling loops are responsible:

1. `page.wait(3)` between polls is not a sleep: its numeric path injects `waitForDomStableJs`, which installs a `MutationObserver` on `document.body` with `{childList, subtree, attributes}` and only resolves after 500ms of quiet. A streaming response never goes quiet, so every poll runs a whole-body observer for the full 3s cap, firing on every mutation, re-armed continuously for the entire generation.
2. `isGenerating` read `document.body.innerText` every poll, forcing a synchronous full-page reflow and allocating a conversation-sized string in the renderer heap, cost growing with response length.

Changes:

- Add `page.sleep(seconds)`: a pure client-side `setTimeout` with no page evaluation. `wait(n)` semantics are unchanged for post-navigation settles that benefit from DOM-stable early return.
- Convert the chatgpt polling loops (`waitForChatGPTResponse`, `waitForChatGPTDetailRows`, `waitForChatGPTDeepResearchResult`, `waitForChatGPTImages` poll interval, upload preview poll, ask pre-send settle) to `page.sleep`. One-shot post-`goto` settles keep `page.wait`.
- Rewrite `isGenerating` without `body.innerText`: stop-button test id, control aria-labels, and a `textContent` (no reflow) scan scoped to the last conversation turn + composer container.
- `getVisibleMessages` gains `{ textOnly }` to skip per-turn `innerHTML` during response polling; `read`/`detail` markdown paths are untouched and their output is byte-identical.

`ask.js waitForConversationUrl` and `sendChatGPTMessage` are deliberately untouched to avoid conflicting with #2094.

Related issue: #2095

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter) — N/A, no new adapter
- [ ] Updated `docs/adapters/index.md` table (if new adapter) — N/A
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter) — N/A
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed — N/A, no command surface change
- [x] Used positional args for the command's primary subject unless a named flag is clearly better (no arg changes)
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error` (unchanged; existing `CommandExecutionError`/`TimeoutError` paths kept)

## Screenshots / Output

```
npx tsc --noEmit          # clean
npm test                  # 548 files, 5954 passed | 1 skipped
npx vitest run clis/chatgpt/ src/browser/base-page.test.ts src/pipeline/
                          # 11 files, 278 passed
```

New tests: `BasePage.sleep` never evaluates page script; the chatgpt response-wait loop polls via `sleep` and never hits the DOM-stable numeric `wait` path.

## Live Validation (added after review rounds)

Dogfooded during real ChatGPT sessions while this PR was under review; two failures of the 1.8.6 `isGenerating` were reproduced and fixed here:

1. **Project page false positive (1.8.6)**: `chatgpt ask --project ...` on an empty project page failed with "conversation is still generating" — the whole-body `innerText` scan matched thinking-status text inside the conversation-list previews. This PR's scoped scan is immune; the same command succeeded with this branch.
2. **Content-mention false positive** (found in round-2 re-review, fixed in 813747ca): a *completed* conversation whose answer text merely discussed the literal words `Thinking` / `正在思考` was reported as generating, permanently blocking follow-up sends. Red-green verified live: `Generating` 2→0 on the same conversation before/after the fix.
3. **Idle model-label false positive** (round-2 finding, fixed in 902082d3): with the `Thinking` model selected, the composer's model button (`aria-label="Thinking"`) matched the aria scan on an idle conversation. Scan patterns are now per-scope: composer scope no longer treats bare `Thinking` as a generating signal (English streaming state is covered by `stop-button`).

External review: 3 rounds of GPT Pro review on this PR; final verdict after 902082d3: no remaining substantive findings.
