### PR TITLE
feat(daemon): fail fast when a write command already holds the site session

### DIFF
--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -4,6 +4,7 @@ import {
   BrowserCommandError,
   fetchDaemonStatus,
   getDaemonHealth,
+  isUnknownOutcomeError,
   requestDaemonShutdown,
   sendCommand,
   setDaemonCommandTimeoutSeconds,
@@ -651,5 +652,25 @@ describe('daemon-client', () => {
 
     expect(ensureSpy).not.toHaveBeenCalled();
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isUnknownOutcomeError', () => {
+  it('is true for each unknown-outcome code', () => {
+    for (const code of ['command_result_unknown', 'command_lost', 'result_evicted']) {
+      expect(isUnknownOutcomeError(new BrowserCommandError('unknown', code))).toBe(true);
+    }
+  });
+
+  it('is false for an ordinary failure code and for a success (no error)', () => {
+    expect(isUnknownOutcomeError(new BrowserCommandError('boom', 'attach_failed'))).toBe(false);
+    expect(isUnknownOutcomeError(new Error('plain failure'))).toBe(false);
+    expect(isUnknownOutcomeError(undefined)).toBe(false);
+    expect(isUnknownOutcomeError(null)).toBe(false);
+  });
+
+  it('unwraps an unknown-outcome error nested in a cause chain', () => {
+    const wrapped = new Error('adapter failed', { cause: new BrowserCommandError('lost', 'command_lost') });
+    expect(isUnknownOutcomeError(wrapped)).toBe(true);
   });
 });

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -7,7 +7,9 @@ import {
   requestDaemonShutdown,
   sendCommand,
   setDaemonCommandTimeoutSeconds,
+  setDaemonRunContext,
 } from './daemon-client.js';
+import { SessionBusyError } from '../errors.js';
 import * as daemonLifecycle from './daemon-lifecycle.js';
 
 describe('daemon-client', () => {
@@ -18,6 +20,7 @@ describe('daemon-client', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+    setDaemonRunContext(null);
   });
 
   it('fetchDaemonStatus sends the shared status request and returns parsed data', async () => {
@@ -213,6 +216,56 @@ describe('daemon-client', () => {
     expect(ids[0]).toMatch(new RegExp(`^cmd_${process.pid}_1763000000000_\\d+$`));
     expect(ids[1]).toMatch(new RegExp(`^cmd_${process.pid}_1763000000000_\\d+$`));
     expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('attaches the run context (runId/command/access) to every command as a lease heartbeat', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+    setDaemonRunContext({ runId: 'run_4242_1_a', command: 'chatgpt ask', access: 'write' });
+
+    await sendCommand('exec', { code: '1 + 1', surface: 'adapter', session: 'site:chatgpt', siteSession: 'persistent' });
+    await sendCommand('exec', { code: '2 + 2', surface: 'adapter', session: 'site:chatgpt', siteSession: 'persistent' });
+
+    for (const call of vi.mocked(fetch).mock.calls) {
+      const body = JSON.parse(String(call[1]?.body)) as { runId?: string; command?: string; access?: string };
+      expect(body.runId).toBe('run_4242_1_a');
+      expect(body.command).toBe('chatgpt ask');
+      expect(body.access).toBe('write');
+    }
+  });
+
+  it('omits run-context fields when no run context is set (read/ephemeral commands)', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { runId?: string; access?: string };
+    expect(body.runId).toBeUndefined();
+    expect(body.access).toBeUndefined();
+  });
+
+  it('throws a terminal SessionBusyError on a session_busy response without retrying', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      status: 409,
+      json: () => Promise.resolve({
+        id: 'server',
+        ok: false,
+        errorCode: 'session_busy',
+        error: 'Session "site:chatgpt" is busy: chatgpt ask (pid 111) has been driving it for 42s.',
+        errorHint: 'Wait for it to finish, or stop it with `kill 111` if it is stuck. Read-only commands are not blocked.',
+      }),
+    } as Response);
+
+    await expect(
+      sendCommand('exec', { code: '1 + 1', surface: 'adapter', session: 'site:chatgpt', siteSession: 'persistent' }),
+    ).rejects.toBeInstanceOf(SessionBusyError);
+    // Terminal: no ensure-bridge / re-dispatch — exactly one request went out.
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
   });
 
   it('sendCommand forwards OPENCLI_PROFILE as a hard contextId requirement', async () => {

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   BrowserCommandError,
+  clearDaemonRunContext,
   fetchDaemonStatus,
   getDaemonHealth,
   isUnknownOutcomeError,
@@ -235,6 +236,25 @@ describe('daemon-client', () => {
       expect(body.command).toBe('chatgpt ask');
       expect(body.access).toBe('write');
     }
+  });
+
+  it('clearDaemonRunContext only clears the context that still belongs to the runId', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+    setDaemonRunContext({ runId: 'run_4242_1_a', command: 'chatgpt ask', access: 'write' });
+
+    // A stale run's deferred cleanup must not strip a different owner's context.
+    clearDaemonRunContext('run_9999_2_b');
+    await sendCommand('exec', { code: '1 + 1', surface: 'adapter', session: 'site:chatgpt', siteSession: 'persistent' });
+    const kept = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { runId?: string };
+    expect(kept.runId).toBe('run_4242_1_a');
+
+    clearDaemonRunContext('run_4242_1_a');
+    await sendCommand('exec', { code: '2 + 2', surface: 'adapter', session: 'site:chatgpt', siteSession: 'persistent' });
+    const cleared = JSON.parse(String(vi.mocked(fetch).mock.calls[1][1]?.body)) as { runId?: string };
+    expect(cleared.runId).toBeUndefined();
   });
 
   it('omits run-context fields when no run context is set (read/ephemeral commands)', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -5,7 +5,7 @@
  */
 
 import { sleep } from '../utils.js';
-import { BrowserConnectError } from '../errors.js';
+import { BrowserConnectError, SessionBusyError } from '../errors.js';
 import { COMMAND_RESULT_UNKNOWN_CODE, COMMAND_RESULT_UNKNOWN_HINT } from '../daemon-utils.js';
 import { classifyBrowserError } from './errors.js';
 import { profileRouteParams, resolveProfileSelection } from './profile.js';
@@ -26,6 +26,60 @@ let _idCounter = 0;
 
 function generateId(): string {
   return `cmd_${process.pid}_${Date.now()}_${++_idCounter}`;
+}
+
+/**
+ * Id for a whole logical CLI command run. Encodes the CLI pid so the daemon can
+ * name/kill the holder in a busy error (see parsePidFromRunId in session-lease.ts).
+ */
+export function generateRunId(): string {
+  return `run_${process.pid}_${Date.now()}_${++_idCounter}`;
+}
+
+/**
+ * Identity of the CLI command run currently driving the browser, attached to
+ * every command so the daemon can arbitrate the write lease. Module-level and
+ * one-per-invocation, matching `setDaemonCommandTimeoutSeconds`. Null for read
+ * and ephemeral commands, which are never lease-arbitrated.
+ */
+export interface DaemonRunContext {
+  runId: string;
+  command: string;
+  access: 'read' | 'write';
+}
+
+let _runContext: DaemonRunContext | null = null;
+
+export function setDaemonRunContext(ctx: DaemonRunContext | null): void {
+  _runContext = ctx;
+}
+
+/**
+ * Best-effort release of a persistent site-session lease on command completion.
+ * A direct one-shot POST (no bridge ensure / retry): if it never lands, the
+ * daemon's TTL reclaims the lease anyway, so this must never block the caller.
+ */
+export async function releaseSiteSessionLease(params: {
+  runId: string;
+  session: string;
+  surface: 'adapter';
+}): Promise<void> {
+  try {
+    await requestDaemon('/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: generateId(),
+        action: 'lease-release',
+        runId: params.runId,
+        session: params.session,
+        surface: params.surface,
+      }),
+      timeout: 2000,
+    });
+  } catch {
+    // Best-effort: TTL expiry reclaims the lease if the daemon is unreachable.
+  }
 }
 
 /**
@@ -118,7 +172,7 @@ function isPreConnectFetchError(err: unknown): boolean {
 
 export interface DaemonCommand {
   id: string;
-  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames';
+  action: 'exec' | 'navigate' | 'tabs' | 'cookies' | 'screenshot' | 'close-window' | 'set-file-input' | 'insert-text' | 'bind' | 'network-capture-start' | 'network-capture-read' | 'wait-download' | 'cdp' | 'frames' | 'lease-release';
   /** Target page identity (targetId). Cross-layer contract with the extension. */
   page?: string;
   code?: string;
@@ -177,6 +231,17 @@ export interface DaemonCommand {
    * absorbing queueing and service-worker wake latency.
    */
   deadlineAt?: number;
+  /**
+   * Stable id for the whole logical CLI command run (NOT the per-exec `id`).
+   * The daemon uses it to arbitrate a write lease on the persistent site
+   * session: the first command acquires, same-runId execs refresh it as a
+   * heartbeat, a concurrent different-runId write fails fast. See session-lease.ts.
+   */
+  runId?: string;
+  /** Human command name (e.g. `chatgpt ask`) surfaced in the busy error. */
+  command?: string;
+  /** Command access level; only 'write' commands take/hold a session lease. */
+  access?: 'read' | 'write';
 }
 
 export interface DaemonResult {
@@ -285,6 +350,14 @@ async function sendCommandRaw(
       ...(contextId && { contextId }),
       ...(preferredContextId && { preferredContextId }),
       ...(windowMode && { windowMode }),
+      // Carry the run identity so the daemon can acquire/refresh the write
+      // lease on the persistent site session. The same runId across every exec
+      // of one command is the heartbeat that keeps a long-running holder alive.
+      ...(_runContext && {
+        runId: _runContext.runId,
+        command: _runContext.command,
+        access: _runContext.access,
+      }),
     };
     try {
       const res = await requestDaemon('/command', {
@@ -297,6 +370,13 @@ async function sendCommandRaw(
       const result = (await res.json()) as DaemonResult;
 
       if (result.ok) return result;
+
+      // A second concurrent write on the same persistent site session is
+      // rejected before the daemon dispatches anything — terminal, never
+      // retried, and surfaced as a CliError so the busy message is the output.
+      if (result.errorCode === 'session_busy') {
+        throw new SessionBusyError(result.error ?? 'The site session is busy.', result.errorHint);
+      }
 
       if (result.errorCode && UNKNOWN_OUTCOME_CODES.has(result.errorCode)) {
         throw new BrowserCommandError(result.error ?? 'Browser command result is unknown', result.errorCode, result.errorHint);
@@ -333,7 +413,7 @@ async function sendCommandRaw(
 
       throw new BrowserCommandError(result.error ?? 'Daemon command failed', result.errorCode, result.errorHint);
     } catch (err) {
-      if (err instanceof BrowserCommandError || err instanceof BrowserConnectError) throw err;
+      if (err instanceof BrowserCommandError || err instanceof BrowserConnectError || err instanceof SessionBusyError) throw err;
 
       if (err instanceof Error && err.name === 'AbortError') {
         throw new BrowserCommandError(

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -137,6 +137,25 @@ function versionAtLeast(version: string | null | undefined, min: string): boolea
 /** Error codes meaning the executor's outcome is genuinely unknown — never auto-retry. */
 const UNKNOWN_OUTCOME_CODES = new Set(['command_result_unknown', 'command_lost', 'result_evicted']);
 
+/**
+ * True when a thrown error carries an unknown-outcome code — the browser-side
+ * command may still be running even though the client gave up. Callers use this
+ * to decide whether it is safe to release a persistent site-session lease: it is
+ * not, because the still-running command keeps mutating the tab. Walks the cause
+ * chain so a wrapped `BrowserCommandError` is still recognized.
+ */
+export function isUnknownOutcomeError(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && UNKNOWN_OUTCOME_CODES.has(code)) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 /** Max transport attempts for one logical command (same id throughout). */
 const TRANSPORT_MAX_ATTEMPTS = 4;
 

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -55,6 +55,16 @@ export function setDaemonRunContext(ctx: DaemonRunContext | null): void {
 }
 
 /**
+ * Clear the run context only if it still belongs to `runId`. Used by deferred
+ * cleanup (an adapter that outlived its CLI timeout settles later): by then a
+ * newer run may own the context, and unconditionally nulling it would strip
+ * that run's lease heartbeats mid-flight.
+ */
+export function clearDaemonRunContext(runId: string): void {
+  if (_runContext?.runId === runId) _runContext = null;
+}
+
+/**
  * Best-effort release of a persistent site-session lease on command completion.
  * A direct one-shot POST (no bridge ensure / retry): if it never lands, the
  * daemon's TTL reclaims the lease anyway, so this must never block the caller.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -76,17 +76,36 @@ type PendingEntry = {
    */
   settlers: PendingSettler[];
   timer: ReturnType<typeof setTimeout>;
+  /**
+   * Set for lease-eligible commands: while this entry is pending, the holder
+   * is alive even past the lease TTL (a single exec can outlast it), and
+   * settling refreshes the lease so the TTL clock restarts cleanly.
+   */
+  leaseKey?: string;
+  runId?: string;
 };
 const pending = new Map<string, PendingEntry>();
 
-// One logical write lease per (surface, persistent site session). Serializes
-// concurrent adapter write commands so a retry can't drive the same Chrome tab
-// as a still-running command. Stale leases self-expire (see session-lease.ts).
+// One logical write lease per (contextId, surface, persistent site session).
+// Serializes concurrent adapter write commands so a retry can't drive the same
+// Chrome tab as a still-running command. Stale leases self-expire (see
+// session-lease.ts).
 const sessionLeases = new SessionLeaseRegistry();
+
+/** A TTL-stale lease holder with a command still in flight is alive, not dead. */
+function runHasPendingWork(runId: string): boolean {
+  for (const entry of pending.values()) {
+    if (entry.runId === runId) return true;
+  }
+  return false;
+}
 
 function settlePending(id: string, entry: PendingEntry, outcome: { data?: unknown; error?: Error }): void {
   clearTimeout(entry.timer);
   pending.delete(id);
+  // A settling command is proof of holder liveness — restart the TTL clock so
+  // an exec that outlived the TTL hands over to normal heartbeats seamlessly.
+  if (entry.leaseKey && entry.runId) sessionLeases.heartbeat(entry.leaseKey, entry.runId, Date.now());
   for (const settler of entry.settlers) {
     if (outcome.error) settler.reject(outcome.error);
     else settler.resolve(outcome.data);
@@ -335,27 +354,50 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
-      // ─── Session write lease ──────────────────────────────────────────
-      // Explicit release on normal command completion — daemon-local, never
-      // dispatched to the extension.
+      // ─── Session write lease: explicit release ───────────────────────
+      // Daemon-local, never dispatched to the extension. Keyed by runId alone:
+      // runIds are globally unique, and re-resolving the profile route here
+      // could fail (the profile may have disconnected since acquire).
       if (body.action === 'lease-release') {
-        if (typeof body.runId === 'string' && typeof body.surface === 'string' && typeof body.session === 'string') {
-          sessionLeases.release(getSessionLeaseKey(body.surface, body.session), body.runId);
-        }
+        if (typeof body.runId === 'string') sessionLeases.releaseByRunId(body.runId);
         jsonResponse(res, 200, { id: body.id, ok: true });
         return;
       }
-      // Arbitrate write commands on a persistent site session: the first
-      // acquires, same-runId execs refresh (heartbeat), a concurrent
-      // different-runId write fails fast BEFORE any page is driven. Read and
-      // ephemeral commands are never arbitrated.
+
+      const route = resolveExtensionConnection(
+        typeof body.contextId === 'string' ? body.contextId : undefined,
+        typeof body.preferredContextId === 'string' ? body.preferredContextId : undefined,
+      );
+      if (!route.connection) {
+        jsonResponse(res, route.errorCode === 'profile_required' ? 409 : 503, {
+          id: body.id,
+          ok: false,
+          errorCode: route.errorCode,
+          error: route.error,
+          ...(route.errorHint ? { errorHint: route.errorHint } : {}),
+        });
+        return;
+      }
+
+      // ─── Session write lease: arbitration ────────────────────────────
+      // Runs AFTER profile routing (the resolved contextId is part of the
+      // lease key — the same site session in two Chrome profiles drives two
+      // different browsers) but BEFORE any dispatch to the extension. The
+      // first write acquires, same-runId execs refresh (heartbeat), and a
+      // concurrent different-runId write fails fast. Read and ephemeral
+      // commands are never arbitrated.
+      let leaseKey: string | undefined;
+      let leaseRunId: string | undefined;
       if (isSessionLeaseCommand(body)) {
         const now = Date.now();
-        const key = getSessionLeaseKey(body.surface, body.session);
+        const key = getSessionLeaseKey(route.connection.contextId, body.surface, body.session);
         const outcome = sessionLeases.touch(key, {
           runId: body.runId,
           command: typeof body.command === 'string' && body.command ? body.command : body.action,
           now,
+          // A holder past the TTL whose exec is still in flight is alive — a
+          // single slow command produces no heartbeat until it settles.
+          hasPendingWork: runHasPendingWork,
         });
         if (!outcome.granted) {
           const failure = buildSessionBusyFailure(body.session, outcome.holder, now);
@@ -372,21 +414,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
           });
           return;
         }
-      }
-
-      const route = resolveExtensionConnection(
-        typeof body.contextId === 'string' ? body.contextId : undefined,
-        typeof body.preferredContextId === 'string' ? body.preferredContextId : undefined,
-      );
-      if (!route.connection) {
-        jsonResponse(res, route.errorCode === 'profile_required' ? 409 : 503, {
-          id: body.id,
-          ok: false,
-          errorCode: route.errorCode,
-          error: route.error,
-          ...(route.errorHint ? { errorHint: route.errorHint } : {}),
-        });
-        return;
+        leaseKey = key;
+        leaseRunId = body.runId;
       }
 
       // Absolute deadline wins over the legacy duration field: all hops share
@@ -423,6 +452,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
           dispatched: false,
           settlers: [{ resolve, reject }],
           timer,
+          ...(leaseKey && leaseRunId ? { leaseKey, runId: leaseRunId } : {}),
         };
         pending.set(body.id, entry);
         const failBeforeDispatch = (err: unknown) => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -316,7 +316,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       profileDisconnected: route.errorCode === 'profile_disconnected',
       profiles,
       pending: pending.size,
-      sessionLeases: sessionLeases.list(Date.now()),
+      sessionLeases: sessionLeases.list(Date.now(), runHasPendingWork),
       commandResultUnknown: commandResultUnknownCount,
       memoryMB: Math.round(mem.rss / 1024 / 1024 * 10) / 10,
       port: PORT,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -36,6 +36,12 @@ import {
   getResponseCorsHeaders,
   resolveProfileRoute,
 } from './daemon-utils.js';
+import {
+  SessionLeaseRegistry,
+  buildSessionBusyFailure,
+  getSessionLeaseKey,
+  isSessionLeaseCommand,
+} from './session-lease.js';
 
 const PORT = DEFAULT_DAEMON_PORT;
 if (!isIgnorableDaemonPortEnv(process.env.OPENCLI_DAEMON_PORT)) {
@@ -72,6 +78,11 @@ type PendingEntry = {
   timer: ReturnType<typeof setTimeout>;
 };
 const pending = new Map<string, PendingEntry>();
+
+// One logical write lease per (surface, persistent site session). Serializes
+// concurrent adapter write commands so a retry can't drive the same Chrome tab
+// as a still-running command. Stale leases self-expire (see session-lease.ts).
+const sessionLeases = new SessionLeaseRegistry();
 
 function settlePending(id: string, entry: PendingEntry, outcome: { data?: unknown; error?: Error }): void {
   clearTimeout(entry.timer);
@@ -286,6 +297,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       profileDisconnected: route.errorCode === 'profile_disconnected',
       profiles,
       pending: pending.size,
+      sessionLeases: sessionLeases.list(Date.now()),
       commandResultUnknown: commandResultUnknownCount,
       memoryMB: Math.round(mem.rss / 1024 / 1024 * 10) / 10,
       port: PORT,
@@ -321,6 +333,45 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       if (!body.id) {
         jsonResponse(res, 400, { ok: false, error: 'Missing command id' });
         return;
+      }
+
+      // ─── Session write lease ──────────────────────────────────────────
+      // Explicit release on normal command completion — daemon-local, never
+      // dispatched to the extension.
+      if (body.action === 'lease-release') {
+        if (typeof body.runId === 'string' && typeof body.surface === 'string' && typeof body.session === 'string') {
+          sessionLeases.release(getSessionLeaseKey(body.surface, body.session), body.runId);
+        }
+        jsonResponse(res, 200, { id: body.id, ok: true });
+        return;
+      }
+      // Arbitrate write commands on a persistent site session: the first
+      // acquires, same-runId execs refresh (heartbeat), a concurrent
+      // different-runId write fails fast BEFORE any page is driven. Read and
+      // ephemeral commands are never arbitrated.
+      if (isSessionLeaseCommand(body)) {
+        const now = Date.now();
+        const key = getSessionLeaseKey(body.surface, body.session);
+        const outcome = sessionLeases.touch(key, {
+          runId: body.runId,
+          command: typeof body.command === 'string' && body.command ? body.command : body.action,
+          now,
+        });
+        if (!outcome.granted) {
+          const failure = buildSessionBusyFailure(body.session, outcome.holder, now);
+          log.warn(
+            `[daemon] Session ${key} busy — rejected ${body.command ?? body.action} ` +
+            `(runId=${body.runId}); held by ${outcome.holder.command} (runId=${outcome.holder.runId})`,
+          );
+          jsonResponse(res, failure.status, {
+            id: body.id,
+            ok: false,
+            errorCode: failure.errorCode,
+            error: failure.message,
+            errorHint: failure.errorHint,
+          });
+          return;
+        }
       }
 
       const route = resolveExtensionConnection(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -131,6 +131,17 @@ export class ArgumentError extends CliError {
   }
 }
 
+/**
+ * Thrown when a write command cannot run because another write command already
+ * holds the same persistent site session (see session-lease.ts). Uses TEMPFAIL
+ * so callers/scripts treat it as "retry later" rather than a permanent failure.
+ */
+export class SessionBusyError extends CliError {
+  constructor(message: string, hint?: string) {
+    super('SESSION_BUSY', message, hint, EXIT_CODES.TEMPFAIL);
+  }
+}
+
 export class EmptyResultError extends CliError {
   constructor(command: string, hint?: string) {
     super(

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -836,6 +836,38 @@ describe('executeCommand — persistent write lease release', () => {
     }
   });
 
+  it('skips the deferred release when a timed-out adapter ends with an unknown outcome', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+    const clearCtxSpy = vi.spyOn(daemonClient, 'clearDaemonRunContext');
+
+    try {
+      // Same rule as the immediate path: if the zombie's last browser command
+      // ends result-unknown, the browser side may still be busy — the lease
+      // must lapse via TTL, not an explicit release.
+      let failAdapter!: (err: Error) => void;
+      const adapterGate = new Promise<never>((_resolve, reject) => { failAdapter = reject; });
+      const cmd = persistentWriteCmd(async () => adapterGate);
+      const rejection = expect(executeCommand(cmd, {})).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      await rejection;
+
+      failAdapter(new BrowserCommandError('late result unknown', 'command_result_unknown'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      const runId = runCtxSpy.mock.calls[0][0]?.runId;
+      expect(clearCtxSpy).toHaveBeenCalledWith(runId);
+      expect(releaseSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+      daemonClient.setDaemonRunContext(null);
+    }
+  });
+
   it('does NOT release the lease when pre-navigation fails with an unknown outcome', async () => {
     const mockPage = {
       goto: vi.fn().mockRejectedValue(new BrowserCommandError('navigate result unknown', 'command_result_unknown')),

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -797,27 +797,42 @@ describe('executeCommand — persistent write lease release', () => {
     vi.restoreAllMocks();
   });
 
-  it('does NOT release the lease when the CLI-layer timeout fires with the adapter still running', async () => {
+  it('keeps the run identity bound through a CLI-layer timeout and cleans up when the adapter settles', async () => {
     vi.useFakeTimers();
     vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
     vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
     const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
     const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+    const clearCtxSpy = vi.spyOn(daemonClient, 'clearDaemonRunContext');
 
     try {
-      // runWithTimeout does not cancel the adapter promise: after the timeout
-      // wins, the adapter can keep driving the tab, so the lease must lapse
-      // via TTL instead of being handed to a challenger immediately.
-      const cmd = persistentWriteCmd(() => new Promise(() => {}));
+      // runWithTimeout does not cancel the adapter promise, and the process
+      // only exits when the event loop drains — the adapter can keep driving
+      // the tab well past the lease TTL. The run context must stay bound (its
+      // follow-up commands heartbeat the lease, blocking challengers) and the
+      // lease released only when the adapter actually settles.
+      let finishAdapter!: () => void;
+      const adapterGate = new Promise<void>((resolve) => { finishAdapter = resolve; });
+      const cmd = persistentWriteCmd(async () => { await adapterGate; return [{ ok: true }]; });
       const rejection = expect(executeCommand(cmd, {})).rejects.toThrow('timed out');
       await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
       await rejection;
 
       expect(releaseSpy).not.toHaveBeenCalled();
-      expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+      expect(runCtxSpy).not.toHaveBeenCalledWith(null);
+      expect(clearCtxSpy).not.toHaveBeenCalled();
+
+      finishAdapter();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const runId = runCtxSpy.mock.calls[0][0]?.runId;
+      expect(clearCtxSpy).toHaveBeenCalledWith(runId);
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+      expect(releaseSpy).toHaveBeenCalledWith(expect.objectContaining({ runId }));
     } finally {
       vi.useRealTimers();
       vi.restoreAllMocks();
+      daemonClient.setDaemonRunContext(null);
     }
   });
 

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -796,4 +796,57 @@ describe('executeCommand — persistent write lease release', () => {
     expect(runCtxSpy).toHaveBeenLastCalledWith(null);
     vi.restoreAllMocks();
   });
+
+  it('does NOT release the lease when the CLI-layer timeout fires with the adapter still running', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+
+    try {
+      // runWithTimeout does not cancel the adapter promise: after the timeout
+      // wins, the adapter can keep driving the tab, so the lease must lapse
+      // via TTL instead of being handed to a challenger immediately.
+      const cmd = persistentWriteCmd(() => new Promise(() => {}));
+      const rejection = expect(executeCommand(cmd, {})).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      await rejection;
+
+      expect(releaseSpy).not.toHaveBeenCalled();
+      expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('does NOT release the lease when pre-navigation fails with an unknown outcome', async () => {
+    const mockPage = {
+      goto: vi.fn().mockRejectedValue(new BrowserCommandError('navigate result unknown', 'command_result_unknown')),
+    } as any;
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+
+    // The pre-nav wrapper must keep the original error on the cause chain so
+    // the release decision still sees the unknown outcome.
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'lease-prenav-unknown', access: 'write',
+      description: 'test pre-nav unknown outcome keeps the lease',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      siteSession: 'persistent',
+      navigateBefore: 'https://example.com/inbox',
+      func: async () => [{ ok: true }],
+    });
+    await expect(executeCommand(cmd, {})).rejects.toThrow('Pre-navigation to https://example.com/inbox failed');
+
+    expect(mockPage.goto).toHaveBeenCalledWith('https://example.com/inbox');
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+    vi.restoreAllMocks();
+  });
 });

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -9,6 +9,8 @@ import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
 import * as runtime from './runtime.js';
 import * as capRouting from './capabilityRouting.js';
+import * as daemonClient from './browser/daemon-client.js';
+import { BrowserCommandError } from './browser/daemon-client.js';
 
 describe('executeCommand — non-browser timeout', () => {
   it('applies the user --timeout arg as the ceiling for non-browser commands', async () => {
@@ -735,5 +737,63 @@ describe('executeCommand — non-browser timeout', () => {
       fs.rmSync(baseDir, { recursive: true, force: true });
       vi.restoreAllMocks();
     }
+  });
+});
+
+describe('executeCommand — persistent write lease release', () => {
+  function persistentWriteCmd(func: () => Promise<unknown>): CliCommand {
+    return cli({
+      site: 'test-execution',
+      name: 'lease-write', access: 'write',
+      description: 'test persistent write lease release',
+      browser: true,
+      strategy: Strategy.PUBLIC,
+      siteSession: 'persistent',
+      func,
+    });
+  }
+
+  it('releases the lease after a successful persistent write', async () => {
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+
+    await executeCommand(persistentWriteCmd(async () => [{ ok: true }]), {});
+
+    expect(releaseSpy).toHaveBeenCalledTimes(1);
+    expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+    vi.restoreAllMocks();
+  });
+
+  it('releases the lease after an ordinary persistent write failure', async () => {
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+
+    const cmd = persistentWriteCmd(async () => { throw new BrowserCommandError('boom', 'attach_failed'); });
+    await expect(executeCommand(cmd, {})).rejects.toThrow('boom');
+
+    expect(releaseSpy).toHaveBeenCalledTimes(1);
+    expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT release the lease after an unknown-outcome failure but still clears the run context', async () => {
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn({} as any));
+    const releaseSpy = vi.spyOn(daemonClient, 'releaseSiteSessionLease').mockResolvedValue(undefined);
+    const runCtxSpy = vi.spyOn(daemonClient, 'setDaemonRunContext');
+
+    // The browser-side command may still be running against the persistent tab,
+    // so releasing now would let a manual rerun collide with it — the TTL must
+    // reclaim the lease instead.
+    const cmd = persistentWriteCmd(async () => { throw new BrowserCommandError('result unknown', 'command_result_unknown'); });
+    await expect(executeCommand(cmd, {})).rejects.toThrow('result unknown');
+
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(runCtxSpy).toHaveBeenLastCalledWith(null);
+    vi.restoreAllMocks();
   });
 });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -30,7 +30,7 @@ import { adapterLoadError, ArgumentError, CommandExecutionError, SessionBusyErro
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { profileRouteParams, resolveProfileSelection } from './browser/profile.js';
-import { generateRunId, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
+import { generateRunId, isUnknownOutcomeError, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -274,6 +274,8 @@ export async function executeCommand(
         ? { runId: generateRunId(), session }
         : null;
       if (leaseRun) setDaemonRunContext({ runId: leaseRun.runId, command: fullName(cmd), access: 'write' });
+      let browserRunError: unknown;
+      try {
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
           ? null
@@ -391,14 +393,28 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession }).finally(async () => {
-        // Release the lease and clear the run identity whether the command
-        // succeeded or failed. Best-effort: TTL reclaims it if release is lost.
+      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      } catch (err) {
+        browserRunError = err;
+        throw err;
+      } finally {
+        // Clear the run identity whether the command succeeded or failed, then
+        // release the lease so a retry succeeds immediately. Best-effort: TTL
+        // reclaims it if the release is lost.
+        //
+        // Exception: an unknown-outcome failure (result-unknown / command-lost /
+        // result-evicted) means the browser-side command may STILL be running
+        // against the persistent tab. Releasing now would let a manual rerun
+        // acquire the lease and collide with the stale command — the very
+        // collision this lease prevents. Skip the explicit release and let the
+        // TTL reclaim it after a bounded quiet period.
         if (leaseRun) {
           setDaemonRunContext(null);
-          await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
+          if (!isUnknownOutcomeError(browserRunError)) {
+            await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
+          }
         }
-      });
+      }
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -275,6 +275,7 @@ export async function executeCommand(
         : null;
       if (leaseRun) setDaemonRunContext({ runId: leaseRun.runId, command: fullName(cmd), access: 'write' });
       let browserRunError: unknown;
+      let adapterStillRunning = false;
       try {
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
@@ -333,6 +334,10 @@ export async function executeCommand(
               `Pre-navigation to ${preNavUrl} failed: ${err instanceof Error ? err.message : err}`,
               'Check that the site is reachable and the browser extension is running.',
             );
+            // Keep the original error reachable: the lease-release decision walks
+            // the cause chain, and a pre-nav navigate/exec can itself end with an
+            // unknown outcome while still running against the persistent tab.
+            wrapped.cause = err;
             if (observation && (traceMode === 'on' || traceMode === 'retain-on-failure')) {
               observation.record({
                 stream: 'error',
@@ -347,11 +352,18 @@ export async function executeCommand(
             throw wrapped;
           }
         }
+        const browserTimeout = userTimeoutSec !== null
+          ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
+          : DEFAULT_BROWSER_COMMAND_TIMEOUT;
+        const commandRun = runCommand(cmd, page, kwargs, debug);
+        // runWithTimeout races but never cancels: when the CLI-layer timeout
+        // wins, the adapter promise keeps driving the tab from this process.
+        // Track settledness so the lease-release decision can tell a finished
+        // adapter apart from one still running behind a timeout.
+        let commandSettled = false;
+        commandRun.then(() => { commandSettled = true; }, () => { commandSettled = true; });
         try {
-          const browserTimeout = userTimeoutSec !== null
-            ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
-            : DEFAULT_BROWSER_COMMAND_TIMEOUT;
-          const result = await runWithTimeout(runCommand(cmd, page, kwargs, debug), {
+          const result = await runWithTimeout(commandRun, {
             timeout: browserTimeout,
             label: fullName(cmd),
           });
@@ -370,6 +382,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           return result;
         } catch (err) {
+          if (!commandSettled) adapterStillRunning = true;
           if (observation) {
             observation.record({
               stream: 'action',
@@ -402,15 +415,20 @@ export async function executeCommand(
         // release the lease so a retry succeeds immediately. Best-effort: TTL
         // reclaims it if the release is lost.
         //
-        // Exception: an unknown-outcome failure (result-unknown / command-lost /
-        // result-evicted) means the browser-side command may STILL be running
-        // against the persistent tab. Releasing now would let a manual rerun
-        // acquire the lease and collide with the stale command — the very
-        // collision this lease prevents. Skip the explicit release and let the
-        // TTL reclaim it after a bounded quiet period.
+        // Exceptions — cases where the session may still be driven and the TTL
+        // must reclaim the lease instead of an explicit release:
+        // - An unknown-outcome failure (result-unknown / command-lost /
+        //   result-evicted, anywhere in the cause chain) means the browser-side
+        //   command may STILL be running against the persistent tab.
+        // - A CLI-layer timeout does not cancel the adapter promise, so the
+        //   adapter may keep issuing browser commands from this process after
+        //   the run has already failed.
+        // Releasing in either state would let a manual rerun acquire the lease
+        // and collide with the stale work — the very collision this lease
+        // prevents.
         if (leaseRun) {
           setDaemonRunContext(null);
-          if (!isUnknownOutcomeError(browserRunError)) {
+          if (!isUnknownOutcomeError(browserRunError) && !adapterStillRunning) {
             await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
           }
         }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -26,11 +26,11 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { executePipeline } from './pipeline/index.js';
-import { adapterLoadError, ArgumentError, CommandExecutionError, attachTraceReceipt, getErrorMessage } from './errors.js';
+import { adapterLoadError, ArgumentError, CommandExecutionError, SessionBusyError, attachTraceReceipt, getErrorMessage } from './errors.js';
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { profileRouteParams, resolveProfileSelection } from './browser/profile.js';
-import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
+import { generateRunId, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -265,6 +265,15 @@ export async function executeCommand(
       const session = resolveAdapterBrowserSession(cmd, siteSession);
       const keepTab = resolveKeepTab(siteSession, opts.keepTab);
       const windowMode = resolveBrowserWindowMode(cmd.defaultWindowMode ?? 'background', opts.windowMode);
+      // Persistent-session write commands take a logical lease on the site
+      // session so a concurrent retry fails fast instead of driving the same
+      // Chrome tab. The runId flows to the daemon on every command (acquire +
+      // heartbeat); we release it explicitly when the command settles. Read and
+      // ephemeral commands are never leased.
+      const leaseRun = siteSession === 'persistent' && cmd.access === 'write'
+        ? { runId: generateRunId(), session }
+        : null;
+      if (leaseRun) setDaemonRunContext({ runId: leaseRun.runId, command: fullName(cmd), access: 'write' });
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
           ? null
@@ -309,6 +318,9 @@ export async function executeCommand(
               data: { url: preNavUrl },
             });
           } catch (err) {
+            // A busy-session rejection is the whole point of the arbitration —
+            // surface it verbatim instead of burying it in a pre-nav wrapper.
+            if (err instanceof SessionBusyError) throw err;
             observation?.record({
               stream: 'action',
               name: 'pre_navigate',
@@ -379,7 +391,14 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession }).finally(async () => {
+        // Release the lease and clear the run identity whether the command
+        // succeeded or failed. Best-effort: TTL reclaims it if release is lost.
+        if (leaseRun) {
+          setDaemonRunContext(null);
+          await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
+        }
+      });
     } else {
       // Non-browser commands: enforce a timeout only when the command exposes
       // a `--timeout` arg (and the resolved value is positive). Without that

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -438,11 +438,16 @@ export async function executeCommand(
           if (adapterStillRunning && adapterRun) {
             const runId = leaseRun.runId;
             const session = leaseRun.session;
-            const settle = () => {
+            const settle = (err?: unknown) => {
               clearDaemonRunContext(runId);
-              void releaseSiteSessionLease({ runId, session, surface: 'adapter' });
+              // Same rule as the immediate path below: an unknown-outcome
+              // ending means the browser side may still be busy — skip the
+              // explicit release and leave the lease to TTL reclamation.
+              if (!isUnknownOutcomeError(err)) {
+                void releaseSiteSessionLease({ runId, session, surface: 'adapter' });
+              }
             };
-            adapterRun.then(settle, settle);
+            adapterRun.then(() => settle(), (err) => settle(err));
           } else {
             setDaemonRunContext(null);
             if (!isUnknownOutcomeError(browserRunError)) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -30,7 +30,7 @@ import { adapterLoadError, ArgumentError, CommandExecutionError, SessionBusyErro
 import { shouldUseBrowserSession } from './capabilityRouting.js';
 import { getBrowserFactory, browserSession, runWithTimeout, DEFAULT_BROWSER_COMMAND_TIMEOUT, type BrowserWindowMode } from './runtime.js';
 import { profileRouteParams, resolveProfileSelection } from './browser/profile.js';
-import { generateRunId, isUnknownOutcomeError, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
+import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
 import { isElectronApp } from './electron-apps.js';
@@ -275,7 +275,11 @@ export async function executeCommand(
         : null;
       if (leaseRun) setDaemonRunContext({ runId: leaseRun.runId, command: fullName(cmd), access: 'write' });
       let browserRunError: unknown;
-      let adapterStillRunning = false;
+      // `as` casts defeat literal narrowing: both are assigned only inside the
+      // browserSession callback, which TS's flow analysis does not see from the
+      // finally block below.
+      let adapterStillRunning = false as boolean;
+      let adapterRun = null as Promise<unknown> | null;
       try {
       result = await browserSession(BrowserFactory, async (page) => {
         const observation = traceMode === 'off'
@@ -356,6 +360,7 @@ export async function executeCommand(
           ? userTimeoutSec + RUNTIME_TIMEOUT_PADDING_SECONDS
           : DEFAULT_BROWSER_COMMAND_TIMEOUT;
         const commandRun = runCommand(cmd, page, kwargs, debug);
+        adapterRun = commandRun;
         // runWithTimeout races but never cancels: when the CLI-layer timeout
         // wins, the adapter promise keeps driving the tab from this process.
         // Track settledness so the lease-release decision can tell a finished
@@ -415,21 +420,34 @@ export async function executeCommand(
         // release the lease so a retry succeeds immediately. Best-effort: TTL
         // reclaims it if the release is lost.
         //
-        // Exceptions — cases where the session may still be driven and the TTL
-        // must reclaim the lease instead of an explicit release:
+        // Exceptions — cases where the session may still be driven, so an
+        // immediate explicit release would hand the lease to a challenger that
+        // then collides with the stale work (the very collision this lease
+        // prevents):
+        // - A CLI-layer timeout does not cancel the adapter promise, and the
+        //   process only exits when the event loop drains, so the adapter may
+        //   keep driving the tab for minutes. Keep the run identity bound: its
+        //   follow-up commands heartbeat the lease (challengers stay blocked
+        //   past the TTL), and cleanup runs when the adapter finally settles.
+        //   If the process dies first, the daemon TTL reclaims the lease.
         // - An unknown-outcome failure (result-unknown / command-lost /
         //   result-evicted, anywhere in the cause chain) means the browser-side
-        //   command may STILL be running against the persistent tab.
-        // - A CLI-layer timeout does not cancel the adapter promise, so the
-        //   adapter may keep issuing browser commands from this process after
-        //   the run has already failed.
-        // Releasing in either state would let a manual rerun acquire the lease
-        // and collide with the stale work — the very collision this lease
-        // prevents.
+        //   command may STILL be running against the persistent tab; there is
+        //   nothing to await client-side, so the TTL is the quiet period.
         if (leaseRun) {
-          setDaemonRunContext(null);
-          if (!isUnknownOutcomeError(browserRunError) && !adapterStillRunning) {
-            await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
+          if (adapterStillRunning && adapterRun) {
+            const runId = leaseRun.runId;
+            const session = leaseRun.session;
+            const settle = () => {
+              clearDaemonRunContext(runId);
+              void releaseSiteSessionLease({ runId, session, surface: 'adapter' });
+            };
+            adapterRun.then(settle, settle);
+          } else {
+            setDaemonRunContext(null);
+            if (!isUnknownOutcomeError(browserRunError)) {
+              await releaseSiteSessionLease({ runId: leaseRun.runId, session: leaseRun.session, surface: 'adapter' });
+            }
           }
         }
       }

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -24,9 +24,13 @@ function writeCommand(over: Record<string, unknown> = {}): Record<string, unknow
 }
 
 describe('getSessionLeaseKey', () => {
-  it('partitions by surface and encoded session', () => {
-    expect(getSessionLeaseKey('adapter', 'site:chatgpt')).toBe('adapter␟site%3Achatgpt');
-    expect(getSessionLeaseKey('adapter', 'site:x')).not.toBe(getSessionLeaseKey('browser', 'site:x'));
+  it('partitions by profile, surface, and encoded session', () => {
+    expect(getSessionLeaseKey('default', 'adapter', 'site:chatgpt')).toBe('default␟adapter␟site%3Achatgpt');
+    expect(getSessionLeaseKey('default', 'adapter', 'site:x')).not.toBe(getSessionLeaseKey('default', 'browser', 'site:x'));
+  });
+  it('keeps the same session in different Chrome profiles on different keys', () => {
+    expect(getSessionLeaseKey('work', 'adapter', 'site:chatgpt'))
+      .not.toBe(getSessionLeaseKey('personal', 'adapter', 'site:chatgpt'));
   });
 });
 
@@ -58,7 +62,7 @@ describe('isSessionLeaseCommand', () => {
 });
 
 describe('SessionLeaseRegistry', () => {
-  const KEY = getSessionLeaseKey('adapter', 'site:chatgpt');
+  const KEY = getSessionLeaseKey('default', 'adapter', 'site:chatgpt');
 
   it('grants the first write and rejects a concurrent write on the same key', () => {
     const reg = new SessionLeaseRegistry();
@@ -74,12 +78,30 @@ describe('SessionLeaseRegistry', () => {
   it('does not block a write on a different session key', () => {
     const reg = new SessionLeaseRegistry();
     reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
-    const other = reg.touch(getSessionLeaseKey('adapter', 'site:claude'), {
+    const other = reg.touch(getSessionLeaseKey('default', 'adapter', 'site:claude'), {
       runId: 'run_222_2_b',
       command: 'claude ask',
       now: T0,
     });
     expect(other.granted).toBe(true);
+  });
+
+  it('does not block the same session in a different Chrome profile', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(getSessionLeaseKey('work', 'adapter', 'site:chatgpt'), {
+      runId: 'run_111_1_a', command: 'chatgpt ask', now: T0,
+    });
+    // Same session name, different profile → different browser → no conflict.
+    const other = reg.touch(getSessionLeaseKey('personal', 'adapter', 'site:chatgpt'), {
+      runId: 'run_222_2_b', command: 'chatgpt ask', now: T0,
+    });
+    expect(other.granted).toBe(true);
+    // But a rival within the SAME profile is still busy.
+    const rival = reg.touch(getSessionLeaseKey('work', 'adapter', 'site:chatgpt'), {
+      runId: 'run_333_3_c', command: 'chatgpt ask', now: T0 + 1,
+    });
+    expect(rival.granted).toBe(false);
+    expect(rival.holder.runId).toBe('run_111_1_a');
   });
 
   it('treats same-runId execs as heartbeats that keep the holder alive past the TTL', () => {
@@ -109,23 +131,72 @@ describe('SessionLeaseRegistry', () => {
     expect(retry.holder.runId).toBe('run_222_2_b');
   });
 
-  it('releases the lease so a retry succeeds immediately on normal completion', () => {
+  it('releases by runId alone so a retry succeeds immediately on normal completion', () => {
     const reg = new SessionLeaseRegistry();
     reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
-    reg.release(KEY, 'run_111_1_a');
+    // No key/contextId needed — the profile may have disconnected by now.
+    reg.releaseByRunId('run_111_1_a');
 
     const retry = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + 1 });
     expect(retry.granted).toBe(true);
   });
 
-  it('ignores a release from a run that no longer owns the lease', () => {
+  it('ignores a release from a run that holds nothing', () => {
     const reg = new SessionLeaseRegistry();
     reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
     // A stale/late release from a different run must not free the live holder.
-    reg.release(KEY, 'run_999_9_z');
+    reg.releaseByRunId('run_999_9_z');
 
     const rival = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + 1 });
     expect(rival.granted).toBe(false);
+  });
+
+  it('keeps a TTL-stale holder with an in-flight command alive against a challenger', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+
+    // One slow exec (e.g. a long navigate) produces no heartbeat past the TTL,
+    // but the daemon reports it as pending work — the challenger stays blocked.
+    const rival = reg.touch(KEY, {
+      runId: 'run_222_2_b',
+      command: 'chatgpt ask',
+      now: T0 + SESSION_LEASE_TTL_MS + 10_000,
+      hasPendingWork: (runId) => runId === 'run_111_1_a',
+    });
+    expect(rival.granted).toBe(false);
+    expect(rival.holder.runId).toBe('run_111_1_a');
+  });
+
+  it('lets a challenger acquire once the pending command settled and the TTL truly lapsed', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+
+    // The slow exec settles → the daemon heartbeats the lease → TTL restarts.
+    const settledAt = T0 + SESSION_LEASE_TTL_MS + 10_000;
+    reg.heartbeat(KEY, 'run_111_1_a', settledAt);
+
+    // Just after settle the holder is fresh again.
+    const early = reg.touch(KEY, {
+      runId: 'run_222_2_b', command: 'chatgpt ask', now: settledAt + 1, hasPendingWork: () => false,
+    });
+    expect(early.granted).toBe(false);
+
+    // With no further activity and no pending work, the TTL finally expires.
+    const late = reg.touch(KEY, {
+      runId: 'run_222_2_b', command: 'chatgpt ask', now: settledAt + SESSION_LEASE_TTL_MS + 1, hasPendingWork: () => false,
+    });
+    expect(late.granted).toBe(true);
+    expect(late.holder.runId).toBe('run_222_2_b');
+  });
+
+  it('heartbeat never lets a non-owner resurrect or steal the lease', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    reg.heartbeat(KEY, 'run_999_9_z', T0 + 1);
+
+    const holder = reg.get(KEY, T0 + 2);
+    expect(holder?.runId).toBe('run_111_1_a');
+    expect(holder?.lastSeenAt).toBe(T0);
   });
 
   it('lists and evicts holders by liveness for status surfaces', () => {

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -208,6 +208,25 @@ describe('SessionLeaseRegistry', () => {
     expect(reg.get(KEY, T0 + SESSION_LEASE_TTL_MS + 1)).toBeUndefined();
     expect(reg.list(T0 + SESSION_LEASE_TTL_MS + 1)).toEqual([]);
   });
+
+  it('lists a TTL-stale holder that still has pending work (matches touch aliveness)', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    const staleNow = T0 + SESSION_LEASE_TTL_MS + 10_000;
+
+    // Without the predicate the TTL-stale holder is hidden, so /status would
+    // wrongly show no holder while a long exec still rejects challengers.
+    expect(reg.list(staleNow)).toEqual([]);
+
+    // With a pending in-flight command it stays listed, matching touch()'s
+    // aliveness rule so /status and arbitration agree.
+    expect(reg.list(staleNow, (runId) => runId === 'run_111_1_a')).toEqual([
+      expect.objectContaining({ key: KEY, runId: 'run_111_1_a' }),
+    ]);
+
+    // A predicate that reports no pending work drops the stale holder again.
+    expect(reg.list(staleNow, () => false)).toEqual([]);
+  });
 });
 
 describe('buildSessionBusyFailure', () => {

--- a/src/session-lease.test.ts
+++ b/src/session-lease.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_LEASE_TTL_MS,
+  SessionLeaseRegistry,
+  buildSessionBusyFailure,
+  getSessionLeaseKey,
+  isSessionLeaseCommand,
+  parsePidFromRunId,
+} from './session-lease.js';
+
+const T0 = 1_000_000;
+
+function writeCommand(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    surface: 'adapter',
+    siteSession: 'persistent',
+    access: 'write',
+    session: 'site:chatgpt',
+    runId: 'run_111_1_a',
+    command: 'chatgpt ask',
+    ...over,
+  };
+}
+
+describe('getSessionLeaseKey', () => {
+  it('partitions by surface and encoded session', () => {
+    expect(getSessionLeaseKey('adapter', 'site:chatgpt')).toBe('adapter␟site%3Achatgpt');
+    expect(getSessionLeaseKey('adapter', 'site:x')).not.toBe(getSessionLeaseKey('browser', 'site:x'));
+  });
+});
+
+describe('parsePidFromRunId', () => {
+  it('recovers the pid from a run id', () => {
+    expect(parsePidFromRunId('run_4242_1700000000000_7')).toBe(4242);
+  });
+  it('returns null for a malformed run id', () => {
+    expect(parsePidFromRunId('cmd_4242_1_7')).toBeNull();
+    expect(parsePidFromRunId('run_0_1_7')).toBeNull();
+  });
+});
+
+describe('isSessionLeaseCommand', () => {
+  it('matches an adapter persistent write with identity', () => {
+    expect(isSessionLeaseCommand(writeCommand())).toBe(true);
+  });
+  it('excludes read commands (a user mid-ask can still check state)', () => {
+    expect(isSessionLeaseCommand(writeCommand({ access: 'read' }))).toBe(false);
+  });
+  it('excludes ephemeral sessions and non-adapter surfaces', () => {
+    expect(isSessionLeaseCommand(writeCommand({ siteSession: 'ephemeral' }))).toBe(false);
+    expect(isSessionLeaseCommand(writeCommand({ surface: 'browser' }))).toBe(false);
+  });
+  it('excludes commands without identity or session', () => {
+    expect(isSessionLeaseCommand(writeCommand({ runId: undefined }))).toBe(false);
+    expect(isSessionLeaseCommand(writeCommand({ session: '' }))).toBe(false);
+  });
+});
+
+describe('SessionLeaseRegistry', () => {
+  const KEY = getSessionLeaseKey('adapter', 'site:chatgpt');
+
+  it('grants the first write and rejects a concurrent write on the same key', () => {
+    const reg = new SessionLeaseRegistry();
+    const first = reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    expect(first.granted).toBe(true);
+
+    const second = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + 1000 });
+    expect(second.granted).toBe(false);
+    expect(second.holder.runId).toBe('run_111_1_a');
+    expect(second.holder.pid).toBe(111);
+  });
+
+  it('does not block a write on a different session key', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    const other = reg.touch(getSessionLeaseKey('adapter', 'site:claude'), {
+      runId: 'run_222_2_b',
+      command: 'claude ask',
+      now: T0,
+    });
+    expect(other.granted).toBe(true);
+  });
+
+  it('treats same-runId execs as heartbeats that keep the holder alive past the TTL', () => {
+    const reg = new SessionLeaseRegistry();
+    const acquired = reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    expect(acquired.granted).toBe(true);
+
+    // Heartbeat just before expiry keeps startedAt but advances lastSeenAt.
+    const beat = reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 + SESSION_LEASE_TTL_MS });
+    expect(beat.granted).toBe(true);
+    expect(beat.holder.startedAt).toBe(T0);
+
+    // A rival long after the original acquire is still blocked because the
+    // holder kept refreshing.
+    const rival = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + SESSION_LEASE_TTL_MS + 1 });
+    expect(rival.granted).toBe(false);
+    expect(rival.holder.runId).toBe('run_111_1_a');
+  });
+
+  it('lets a retry re-acquire after the holder dies and the TTL lapses', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+
+    // No heartbeats — the holder was killed. Past the TTL the lease is stale.
+    const retry = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + SESSION_LEASE_TTL_MS + 1 });
+    expect(retry.granted).toBe(true);
+    expect(retry.holder.runId).toBe('run_222_2_b');
+  });
+
+  it('releases the lease so a retry succeeds immediately on normal completion', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    reg.release(KEY, 'run_111_1_a');
+
+    const retry = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + 1 });
+    expect(retry.granted).toBe(true);
+  });
+
+  it('ignores a release from a run that no longer owns the lease', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    // A stale/late release from a different run must not free the live holder.
+    reg.release(KEY, 'run_999_9_z');
+
+    const rival = reg.touch(KEY, { runId: 'run_222_2_b', command: 'chatgpt ask', now: T0 + 1 });
+    expect(rival.granted).toBe(false);
+  });
+
+  it('lists and evicts holders by liveness for status surfaces', () => {
+    const reg = new SessionLeaseRegistry();
+    reg.touch(KEY, { runId: 'run_111_1_a', command: 'chatgpt ask', now: T0 });
+    expect(reg.list(T0)).toEqual([
+      expect.objectContaining({ key: KEY, runId: 'run_111_1_a', command: 'chatgpt ask', pid: 111 }),
+    ]);
+    expect(reg.get(KEY, T0 + SESSION_LEASE_TTL_MS + 1)).toBeUndefined();
+    expect(reg.list(T0 + SESSION_LEASE_TTL_MS + 1)).toEqual([]);
+  });
+});
+
+describe('buildSessionBusyFailure', () => {
+  it('names the holder, its pid, and how long it has held the lease', () => {
+    const failure = buildSessionBusyFailure(
+      'site:chatgpt',
+      { runId: 'run_111_1_a', command: 'chatgpt ask', pid: 111, startedAt: T0, lastSeenAt: T0 + 40_000 },
+      T0 + 42_000,
+    );
+    expect(failure.status).toBe(409);
+    expect(failure.errorCode).toBe('session_busy');
+    expect(failure.message).toContain('chatgpt ask');
+    expect(failure.message).toContain('pid 111');
+    expect(failure.message).toContain('42s');
+    expect(failure.errorHint).toContain('kill 111');
+    expect(failure.errorHint).toContain('Read-only commands are not blocked');
+  });
+
+  it('degrades gracefully when the pid is unknown', () => {
+    const failure = buildSessionBusyFailure(
+      'site:chatgpt',
+      { runId: 'x', command: 'chatgpt ask', pid: null, startedAt: T0, lastSeenAt: T0 },
+      T0 + 5_000,
+    );
+    expect(failure.message).not.toContain('pid');
+    expect(failure.errorHint).not.toContain('kill');
+  });
+});

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-(surface, session) write-command arbitration for the daemon.
+ *
+ * A long adapter write command (e.g. `chatgpt ask`, 10-20 min) is hundreds of
+ * short 'exec' round-trips against ONE persistent site session. When an outer
+ * agent times out and retries while the first process is still alive, both
+ * processes drive the same Chrome tab, multiplying renderer load — there is no
+ * arbitration at the exec level because two interleaved asks rarely have an
+ * exec in flight at the same instant.
+ *
+ * This registry grants ONE logical write lease per (surface, session) that
+ * spans the whole CLI command run. A second concurrent write fails fast, and a
+ * lease whose holder died (kill -9, crash) self-expires after TTL of inactivity
+ * so a retry succeeds within a bounded time. Each exec that flows through
+ * refreshes the lease, so a live long-running holder keeps it indefinitely.
+ *
+ * The daemon is the arbiter because it is the single local process that sees
+ * every CLI client; keeping the logic here (pure, no I/O) makes it testable
+ * without Chrome.
+ */
+
+/** Inactivity window after which a lease is considered abandoned. */
+export const SESSION_LEASE_TTL_MS = 45_000;
+
+/** Machine-readable error code for the fast-fail busy response. */
+export const SESSION_BUSY_CODE = 'session_busy';
+
+export interface SessionLeaseHolder {
+  /** Stable per logical CLI command run (NOT the per-exec command id). */
+  runId: string;
+  /** Human command name, e.g. `chatgpt ask`. */
+  command: string;
+  /** CLI process pid recovered from the runId, for the "kill it" hint. */
+  pid: number | null;
+  /** When the current holder first acquired the lease. */
+  startedAt: number;
+  /** Last time an exec from the holder refreshed the lease (heartbeat). */
+  lastSeenAt: number;
+}
+
+/**
+ * Lease key = `${surface}␟${encodeURIComponent(session)}`, matching the
+ * extension's own lease-key shape so both layers partition sessions the same
+ * way. The unit separator (U+241F) cannot appear in a surface value.
+ */
+export function getSessionLeaseKey(surface: string, session: string): string {
+  return `${surface}␟${encodeURIComponent(session)}`;
+}
+
+/** CLI runIds are `run_<pid>_<ts>_<rand>`; recover the pid for the busy hint. */
+export function parsePidFromRunId(runId: string): number | null {
+  const match = /^run_(\d+)_/.exec(runId);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+export type SessionLeaseCommand = {
+  surface?: unknown;
+  siteSession?: unknown;
+  access?: unknown;
+  session?: unknown;
+  runId?: unknown;
+};
+
+/**
+ * A command is subject to lease arbitration only when it is an adapter write
+ * against a persistent site session and carries the identity needed to own a
+ * lease. Read commands, ephemeral sessions, and non-adapter surfaces are never
+ * arbitrated — a user mid-ask must still be able to check state.
+ */
+export function isSessionLeaseCommand<T extends SessionLeaseCommand>(
+  command: T,
+): command is T & { surface: 'adapter'; siteSession: 'persistent'; access: 'write'; session: string; runId: string } {
+  return (
+    command.surface === 'adapter' &&
+    command.siteSession === 'persistent' &&
+    command.access === 'write' &&
+    typeof command.session === 'string' && command.session.length > 0 &&
+    typeof command.runId === 'string' && command.runId.length > 0
+  );
+}
+
+export interface LeaseTouchResult {
+  granted: boolean;
+  holder: SessionLeaseHolder;
+}
+
+export class SessionLeaseRegistry {
+  private readonly leases = new Map<string, SessionLeaseHolder>();
+
+  constructor(private readonly ttlMs: number = SESSION_LEASE_TTL_MS) {}
+
+  /**
+   * Acquire or refresh the lease for `key`.
+   *
+   * - Free key, or the current holder's lease has gone stale (holder died
+   *   without releasing): the caller takes it — `granted: true`.
+   * - Same runId as the current holder: refresh (heartbeat) — `granted: true`.
+   * - A different runId while the holder is still alive: `granted: false`, and
+   *   `holder` describes who to wait for or kill.
+   */
+  touch(key: string, input: { runId: string; command: string; now: number }): LeaseTouchResult {
+    const current = this.leases.get(key);
+    const alive = current !== undefined && input.now - current.lastSeenAt <= this.ttlMs;
+    if (current !== undefined && alive && current.runId !== input.runId) {
+      return { granted: false, holder: current };
+    }
+    const holder: SessionLeaseHolder = current !== undefined && current.runId === input.runId
+      ? { ...current, command: input.command, lastSeenAt: input.now }
+      : {
+        runId: input.runId,
+        command: input.command,
+        pid: parsePidFromRunId(input.runId),
+        startedAt: input.now,
+        lastSeenAt: input.now,
+      };
+    this.leases.set(key, holder);
+    return { granted: true, holder };
+  }
+
+  /** Release the lease only if `runId` still owns it (idempotent otherwise). */
+  release(key: string, runId: string): void {
+    const current = this.leases.get(key);
+    if (current !== undefined && current.runId === runId) this.leases.delete(key);
+  }
+
+  /** Active (non-expired) holder for `key`, lazily evicting a stale one. */
+  get(key: string, now: number): SessionLeaseHolder | undefined {
+    const current = this.leases.get(key);
+    if (current === undefined) return undefined;
+    if (now - current.lastSeenAt > this.ttlMs) {
+      this.leases.delete(key);
+      return undefined;
+    }
+    return current;
+  }
+
+  /** Snapshot of active holders for status surfaces (who owns each session). */
+  list(now: number): Array<{ key: string } & SessionLeaseHolder> {
+    const out: Array<{ key: string } & SessionLeaseHolder> = [];
+    for (const [key, holder] of this.leases) {
+      if (now - holder.lastSeenAt <= this.ttlMs) out.push({ key, ...holder });
+    }
+    return out;
+  }
+}
+
+export interface SessionBusyFailure {
+  message: string;
+  errorCode: string;
+  errorHint: string;
+  status: number;
+}
+
+/** Build the fast-fail response naming the holder, its pid, and hold time. */
+export function buildSessionBusyFailure(
+  session: string,
+  holder: SessionLeaseHolder,
+  now: number,
+): SessionBusyFailure {
+  const heldSeconds = Math.max(0, Math.round((now - holder.startedAt) / 1000));
+  const who = holder.pid != null ? `${holder.command} (pid ${holder.pid})` : holder.command;
+  const stop = holder.pid != null
+    ? `Wait for it to finish, or stop it with \`kill ${holder.pid}\` if it is stuck.`
+    : 'Wait for it to finish, or stop that process if it is stuck.';
+  return {
+    message: `Session "${session}" is busy: ${who} has been driving it for ${heldSeconds}s.`,
+    errorCode: SESSION_BUSY_CODE,
+    errorHint: `${stop} Read-only commands are not blocked.`,
+    status: 409,
+  };
+}

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -170,11 +170,19 @@ export class SessionLeaseRegistry {
     return current;
   }
 
-  /** Snapshot of active holders for status surfaces (who owns each session). */
-  list(now: number): Array<{ key: string } & SessionLeaseHolder> {
+  /**
+   * Snapshot of active holders for status surfaces (who owns each session).
+   * Uses the same aliveness rule as `touch()`: a TTL-stale holder with a
+   * command still in flight is alive, not dead, so `hasPendingWork` keeps it
+   * listed. Without it, `/status` would show no holder while challengers are
+   * still being rejected — misleading during a single long exec. Read-only:
+   * never lazily evicts.
+   */
+  list(now: number, hasPendingWork?: (runId: string) => boolean): Array<{ key: string } & SessionLeaseHolder> {
     const out: Array<{ key: string } & SessionLeaseHolder> = [];
     for (const [key, holder] of this.leases) {
-      if (now - holder.lastSeenAt <= this.ttlMs) out.push({ key, ...holder });
+      const alive = now - holder.lastSeenAt <= this.ttlMs || hasPendingWork?.(holder.runId) === true;
+      if (alive) out.push({ key, ...holder });
     }
     return out;
   }

--- a/src/session-lease.ts
+++ b/src/session-lease.ts
@@ -1,5 +1,5 @@
 /**
- * Per-(surface, session) write-command arbitration for the daemon.
+ * Per-(contextId, surface, session) write-command arbitration for the daemon.
  *
  * A long adapter write command (e.g. `chatgpt ask`, 10-20 min) is hundreds of
  * short 'exec' round-trips against ONE persistent site session. When an outer
@@ -8,11 +8,14 @@
  * arbitration at the exec level because two interleaved asks rarely have an
  * exec in flight at the same instant.
  *
- * This registry grants ONE logical write lease per (surface, session) that
- * spans the whole CLI command run. A second concurrent write fails fast, and a
- * lease whose holder died (kill -9, crash) self-expires after TTL of inactivity
- * so a retry succeeds within a bounded time. Each exec that flows through
- * refreshes the lease, so a live long-running holder keeps it indefinitely.
+ * This registry grants ONE logical write lease per (contextId, surface,
+ * session) that spans the whole CLI command run. A second concurrent write
+ * fails fast, and a lease whose holder died (kill -9, crash) self-expires
+ * after TTL of inactivity so a retry succeeds within a bounded time. Each exec
+ * that flows through refreshes the lease, and a holder whose single exec
+ * outlives the TTL (e.g. a slow navigate) is still protected while that exec
+ * is in flight (see `hasPendingWork`), so a live long-running holder keeps the
+ * lease indefinitely.
  *
  * The daemon is the arbiter because it is the single local process that sees
  * every CLI client; keeping the logic here (pure, no I/O) makes it testable
@@ -39,12 +42,16 @@ export interface SessionLeaseHolder {
 }
 
 /**
- * Lease key = `${surface}␟${encodeURIComponent(session)}`, matching the
- * extension's own lease-key shape so both layers partition sessions the same
- * way. The unit separator (U+241F) cannot appear in a surface value.
+ * Lease key = `${contextId}␟${surface}␟${encodeURIComponent(session)}`. The
+ * Chrome profile (contextId) is part of the key because a persistent site
+ * session name like `site:chatgpt` is only unique WITHIN a profile — the same
+ * adapter running in two profiles drives two different browsers and must never
+ * self-block. The unit separator (U+241F) cannot appear in a contextId or
+ * surface value; the session segment matches the extension's own lease-key
+ * encoding so both layers partition sessions the same way.
  */
-export function getSessionLeaseKey(surface: string, session: string): string {
-  return `${surface}␟${encodeURIComponent(session)}`;
+export function getSessionLeaseKey(contextId: string, surface: string, session: string): string {
+  return `${contextId}␟${surface}␟${encodeURIComponent(session)}`;
 }
 
 /** CLI runIds are `run_<pid>_<ts>_<rand>`; recover the pid for the busy hint. */
@@ -99,10 +106,20 @@ export class SessionLeaseRegistry {
    * - Same runId as the current holder: refresh (heartbeat) — `granted: true`.
    * - A different runId while the holder is still alive: `granted: false`, and
    *   `holder` describes who to wait for or kill.
+   *
+   * Liveness is TTL-based, but a TTL-stale holder with a command still in
+   * flight is NOT dead — a single exec can legitimately outlast the TTL (e.g.
+   * a slow navigate produces no heartbeat until it settles). `hasPendingWork`
+   * lets the daemon report that, keeping the registry pure.
    */
-  touch(key: string, input: { runId: string; command: string; now: number }): LeaseTouchResult {
+  touch(
+    key: string,
+    input: { runId: string; command: string; now: number; hasPendingWork?: (runId: string) => boolean },
+  ): LeaseTouchResult {
     const current = this.leases.get(key);
-    const alive = current !== undefined && input.now - current.lastSeenAt <= this.ttlMs;
+    const alive = current !== undefined && (
+      input.now - current.lastSeenAt <= this.ttlMs || input.hasPendingWork?.(current.runId) === true
+    );
     if (current !== undefined && alive && current.runId !== input.runId) {
       return { granted: false, holder: current };
     }
@@ -119,10 +136,27 @@ export class SessionLeaseRegistry {
     return { granted: true, holder };
   }
 
-  /** Release the lease only if `runId` still owns it (idempotent otherwise). */
-  release(key: string, runId: string): void {
+  /**
+   * Refresh the holder's liveness without acquiring: called when one of the
+   * holder's in-flight commands settles, so the TTL clock restarts cleanly
+   * after an exec that outlived it. A non-owner runId never resurrects or
+   * steals a lease here.
+   */
+  heartbeat(key: string, runId: string, now: number): void {
     const current = this.leases.get(key);
-    if (current !== undefined && current.runId === runId) this.leases.delete(key);
+    if (current !== undefined && current.runId === runId) current.lastSeenAt = now;
+  }
+
+  /**
+   * Release every lease held by `runId` (idempotent). Keyless on purpose: the
+   * release path must not depend on re-resolving the profile route — the
+   * profile may have disconnected by the time the CLI releases — and runIds
+   * are globally unique, so the runId alone identifies the lease.
+   */
+  releaseByRunId(runId: string): void {
+    for (const [key, holder] of this.leases) {
+      if (holder.runId === runId) this.leases.delete(key);
+    }
   }
 
   /** Active (non-expired) holder for `key`, lazily evicting a stale one. */


### PR DESCRIPTION
## Description

Part 2 of 2 for #2095 (part 1 is #2099, which fixes the per-poll renderer cost).

A long `chatgpt ask` (10-20 min) is hundreds of short `exec` round-trips against one persistent site session. When an outer agent times out and retries while the first opencli process is still alive, both processes drive the same Chrome tab and the renderer load multiplies. There is no arbitration today: persistent sessions all resolve to the fixed `site:<site>` name, and the extension's `activeCommandCounts` is only a teardown refcount. Arbitration can't happen at the exec level either — two interleaved asks rarely have an exec in flight at the same instant, so the lock must span the whole logical CLI command run.

This PR adds a per-(surface, session) write lease in the daemon, the single local process that sees every CLI client:

- The CLI attaches a stable `runId` (`run_<pid>_<ts>_<rand>`), command name, and access level to every command (module-level run context, mirroring `setDaemonCommandTimeoutSeconds`). Set only for persistent-session write commands.
- The daemon acquires the lease on the first eligible command, refreshes it on same-runId execs (the ~3s poll is a natural heartbeat), and rejects a concurrent different-runId write **before** dispatching to the extension. The busy response names the holder command, its pid, and how long it has held the lease, plus a wait-or-kill hint; the CLI surfaces it as `SessionBusyError` (CliError, exit `EX_TEMPFAIL`) with no transport retry.
- Stale leases self-expire after 45s of inactivity, so a retry after `kill -9` / crash succeeds within a bounded time. Normal completion and error paths release explicitly via a best-effort `lease-release` (TTL is the backstop).
- `/status` now exposes current lease holders, answering "which command owns this session".

Read commands (`status`, `read`, `detail`), ephemeral sessions, non-adapter surfaces, and different sessions are never arbitrated. Arbitration logic is pure and lives in `src/session-lease.ts`; no extension change, so no extension version bump.

This implements the three mitigations requested in #2095: expose the session owner, fail fast with a busy/lease error, and provide a cleanup path for stale sessions (TTL auto-expiry).

Related issue: #2095

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter) — N/A, platform-only change
- [ ] Updated `docs/adapters/index.md` table (if new adapter) — N/A
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter) — N/A
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed — N/A, no command surface change
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better — N/A, no new commands
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error` (new `SessionBusyError` extends `CliError`)

## Screenshots / Output

```
npx tsc --noEmit          # clean
npm test                  # 549 files, 5971 passed | 1 skipped
npx vitest run src/session-lease.test.ts src/browser/daemon-client.test.ts \
               src/daemon.test.ts src/execution.test.ts
                          # 4 files, 86 passed
```

New tests cover: acquire→busy on the same key, different key not blocked, read/ephemeral/non-adapter excluded, heartbeat keeps a live holder past TTL, TTL expiry allows re-acquire, explicit release lets a retry succeed, stale-runId release ignored, busy-message content, run-context attachment, and terminal `SessionBusyError` with exactly one request (no retry).

~~Known bounded edge: a single exec lasting longer than the 45s TTL has no heartbeat until it returns.~~ Closed by 2f8f8913: in-flight pending work now counts as holder liveness, and settling refreshes the lease. The same commit also scopes lease keys by Chrome profile (contextId), so the same site session in two profiles is never falsely busy. Both were P2 findings from external review.


Round-2 external review found two more issues, closed by eab4abeb:

1. **P2 — unknown-outcome failures no longer release the lease immediately.** A daemon-side dispatch timeout returns `command_result_unknown` (or `command_lost` / `result_evicted`): the browser-side command may still be running against the persistent tab. The client now skips the explicit `lease-release` for these failures and lets the 45s TTL reclaim the lease, so an instant manual rerun gets `session_busy` instead of colliding with the stale command. Ordinary failures and successes keep the immediate release.
2. **P3 — `/status` now lists holders kept alive by in-flight work.** `list()` uses the same aliveness rule as `touch()` (TTL-stale + pending work = alive), so during a single >45s exec the status output names the holder that challengers are actually being rejected by.

+7 regression tests (`npm test`: 5983 passed | 1 skipped).


Round-3 external review found two more lease-safety gaps, closed by 2bf81d18:

1. **P2 — a CLI-layer timeout no longer releases the lease while the adapter is still running.** `runWithTimeout` races but never cancels: when the timeout wins, the adapter promise keeps driving the tab from the same process. The release decision now tracks whether the adapter promise actually settled (class-matching `TimeoutError` would be wrong — adapters throw the same class after finishing cleanly, and those runs should still release immediately). Unsettled → TTL reclamation.
2. **P2 — pre-navigation unknown outcomes are no longer masked by the wrapper.** The pre-nav `CommandExecutionError` now carries the original error as `cause`, so `isUnknownOutcomeError`'s cause-chain walk sees a `command_result_unknown`/`command_lost`/`result_evicted` navigate failure and skips the explicit release.

+2 regression tests, both red-green verified against the pre-fix code (`npm test`: 5985 passed | 1 skipped).


Round-4 external review found the remaining gap in the timeout path, closed by 50c13017:

**P2 — a timed-out adapter now keeps its run identity until it actually settles.** Round 3 stopped the explicit release, but the `finally` still cleared the global run context, so the zombie adapter's follow-up commands carried no `runId`: they neither heartbeat the lease nor participated in arbitration, and after the 45s TTL a rerun could acquire the lease while the zombie was still driving the tab. This is a real CLI-lifetime scenario — the command error path sets `process.exitCode` rather than calling `process.exit()`, so the zombie's timers keep the event loop (and the zombie) alive for minutes. Now, when the CLI-layer timeout wins the race, both cleanup steps (run-context clear + `lease-release`) are deferred to the adapter promise's own settlement: the zombie's commands keep heartbeating (challengers stay blocked past the TTL for as long as it lives), and the clear is `runId`-guarded so a stale run's deferred cleanup can never strip a newer run's context. If the process dies first, the daemon TTL reclaims the lease as before.

Regression tests: run context stays bound and no release happens while the adapter hangs past the timeout; settling the adapter triggers the guarded clear + one release; `clearDaemonRunContext` ignores a non-owner runId. Red-green verified (`npm test`: 5986 passed | 1 skipped).


Round-5 external review caught an inconsistency in the round-4 deferred cleanup, closed by deca483d:

**P2 — the deferred settle now applies the same unknown-outcome rule as the immediate path.** When a timed-out adapter finally rejects with `command_result_unknown` / `command_lost` / `result_evicted`, the browser-side command may still be running; the deferred cleanup previously released unconditionally. It now inspects the rejection reason and skips the explicit release for unknown outcomes (run context is still cleared), leaving the lease to TTL reclamation. Regression test added, red-green verified (`npm test`: 5987 passed | 1 skipped).
