### PR TITLE
fix(chatgpt): don't require the legacy session cookie for whoami (#2087)

### DIFF
--- a/clis/chatgpt/auth.js
+++ b/clis/chatgpt/auth.js
@@ -1,20 +1,25 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
+// NextAuth chunks a large session token into `...session-token.0`, `.1`, …, so
+// match by prefix rather than the exact legacy name (which current ChatGPT
+// sessions may no longer set verbatim) — see #2087.
 async function hasChatgptSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://chatgpt.com' });
-  return cookies.some(c => c.name === '__Secure-next-auth.session-token' && c.value);
+  return cookies.some(c => c.name.startsWith('__Secure-next-auth.session-token') && c.value);
 }
 
-async function verifyChatgptIdentity(page) {
-  if (!await hasChatgptSessionCookie(page)) {
-    throw new AuthRequiredError('chatgpt.com', 'ChatGPT __Secure-next-auth.session-token cookie missing');
+function unwrapEvaluateResult(payload) {
+  if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+    return payload.data;
   }
-  await page.goto('https://chatgpt.com/');
-  await page.wait(2);
-  const result = await page.evaluate(`(async () => {
+  return payload;
+}
+
+function buildChatgptIdentityProbe() {
+  return `(async () => {
     try {
-      const res = await fetch('/api/auth/session', { credentials: 'include' });
+      const res = await fetch('/api/auth/session', { credentials: 'include', headers: { 'Accept': 'application/json' } });
       if (res.status === 401 || res.status === 403) {
         return { kind: 'auth', detail: 'ChatGPT /api/auth/session HTTP ' + res.status };
       }
@@ -28,7 +33,17 @@ async function verifyChatgptIdentity(page) {
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
-  })()`);
+  })()`;
+}
+
+async function verifyChatgptIdentity(page) {
+  // /api/auth/session is the authoritative login check, so don't pre-gate on a
+  // specific cookie name: current sessions can be authenticated without the
+  // legacy __Secure-next-auth.session-token, and chunked tokens use a different
+  // name. Gating here caused false AUTH_REQUIRED for logged-in users (#2087).
+  await page.goto('https://chatgpt.com/');
+  await page.wait(2);
+  const result = unwrapEvaluateResult(await page.evaluate(buildChatgptIdentityProbe()));
   if (result?.kind === 'auth') throw new AuthRequiredError('chatgpt.com', result.detail);
   if (result?.kind === 'http') throw new CommandExecutionError(`HTTP ${result.httpStatus} from /api/auth/session`);
   if (result?.kind === 'exception') throw new CommandExecutionError(`ChatGPT whoami failed: ${result.detail}`);
@@ -50,3 +65,5 @@ registerSiteAuthCommands({
     return verifyChatgptIdentity(page);
   },
 });
+
+export const __test__ = { buildChatgptIdentityProbe, verifyChatgptIdentity, hasChatgptSessionCookie, unwrapEvaluateResult };

--- a/clis/chatgpt/auth.test.js
+++ b/clis/chatgpt/auth.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { __test__ } from './auth.js';
+
+function makePage({ cookies = [], evalResults = [] } = {}) {
+    let i = 0;
+    return {
+        getCookies: vi.fn().mockResolvedValue(cookies),
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(() => Promise.resolve(evalResults[i++])),
+    };
+}
+
+describe('chatgpt auth', () => {
+    it('recognizes chunked NextAuth session cookies (.0 / .1)', async () => {
+        const page = makePage({ cookies: [{ name: '__Secure-next-auth.session-token.0', value: 'x' }] });
+        expect(await __test__.hasChatgptSessionCookie(page)).toBe(true);
+    });
+
+    it('still recognizes the legacy unchunked cookie', async () => {
+        const page = makePage({ cookies: [{ name: '__Secure-next-auth.session-token', value: 'x' }] });
+        expect(await __test__.hasChatgptSessionCookie(page)).toBe(true);
+    });
+
+    it('does not treat a non-session cookie as logged in', async () => {
+        const page = makePage({ cookies: [{ name: 'oai-did', value: 'x' }] });
+        expect(await __test__.hasChatgptSessionCookie(page)).toBe(false);
+    });
+
+    it('probes the authoritative /api/auth/session endpoint', () => {
+        expect(__test__.buildChatgptIdentityProbe()).toContain('/api/auth/session');
+    });
+
+    it('verifies identity via the session endpoint without gating on the legacy cookie', async () => {
+        // No session cookie at all, yet the endpoint reports a logged-in user:
+        // the fix must NOT pre-reject with AUTH_REQUIRED (#2087).
+        const page = makePage({ cookies: [], evalResults: [{ ok: true, user_id: 'u-123', name: 'Ada' }] });
+        const result = await __test__.verifyChatgptIdentity(page);
+        expect(result).toEqual({ user_id: 'u-123', name: 'Ada' });
+        expect(page.goto).toHaveBeenCalledWith('https://chatgpt.com/');
+    });
+
+    it('maps an anonymous session to AuthRequiredError', async () => {
+        const page = makePage({ evalResults: [{ kind: 'auth', detail: 'anonymous' }] });
+        await expect(__test__.verifyChatgptIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps a non-ok probe response to CommandExecutionError', async () => {
+        const page = makePage({ evalResults: [{ kind: 'http', httpStatus: 500 }] });
+        await expect(__test__.verifyChatgptIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps an exception-kind probe response to CommandExecutionError', async () => {
+        const page = makePage({ evalResults: [{ kind: 'exception', detail: 'boom' }] });
+        await expect(__test__.verifyChatgptIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('unwraps Browser Bridge evaluate envelopes', () => {
+        const payload = { ok: true, user_id: 'u', name: 'n' };
+        expect(__test__.unwrapEvaluateResult({ session: 'site:chatgpt', data: payload })).toBe(payload);
+    });
+});


### PR DESCRIPTION
## What
`opencli chatgpt whoami` returns `AUTH_REQUIRED` even for logged-in users — `chatgpt status` says Login: Yes and `/api/auth/session` returns 200 with a user in the same session. Closes #2087.

## Root cause (`clis/chatgpt/auth.js`)
- `hasChatgptSessionCookie` matched only the **exact** legacy name `__Secure-next-auth.session-token`. NextAuth chunks large tokens into `…session-token.0`, `.1`, so a valid session is missed.
- `verifyChatgptIdentity` **hard-threw** `AuthRequiredError` when that cookie was absent — *before* the authoritative `/api/auth/session` check. Current sessions can authenticate without the verbatim cookie.

## Fix (mirrors the merged weibo #2047 / #2055 approach)
- Match the session cookie by **prefix** (`startsWith('__Secure-next-auth.session-token')`) so chunked tokens count — used by `quickCheck` and `poll`.
- `verify` no longer pre-gates on a cookie name: it navigates and reads `/api/auth/session` as the source of truth (no user / 401 / 403 → AuthRequiredError; non-ok → CommandExecutionError; exception → CommandExecutionError).
- Unwrap the Browser Bridge `{session,data}` evaluate envelope (parity with the hardening added when weixin #2055 merged).
- Extract `buildChatgptIdentityProbe()` for testability.

## Test
New `clis/chatgpt/auth.test.js` (9): chunked + legacy cookie recognition, non-session-cookie rejection, probe hits `/api/auth/session`, **verify succeeds via the endpoint with no session cookie present** (the #2087 regression), anonymous → AuthRequiredError, non-ok / exception → CommandExecutionError, envelope unwrap.

## Verification
- `vitest run clis/chatgpt/auth.test.js` → 9 passed
- `check:typed-error-lint` / `check:silent-column-drop` → no new violations