### PR TITLE
fix(huodongxing): handle temporary busy event pages

### DIFF
--- a/clis/huodongxing/events.js
+++ b/clis/huodongxing/events.js
@@ -3,6 +3,7 @@ import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwen
 
 const BASE_URL = 'https://www.huodongxing.com/events';
 const MAX_LIMIT = 50;
+const RESULT_CARD_SELECTOR = '.search-tab-content-item-mesh';
 export const EVENTS_COLUMNS = [
   'rank',
   'id',
@@ -241,6 +242,14 @@ export function extractEventRowsPayload(limit = 20) {
         hint: 'Wait a few minutes and retry from a real browser session.',
       };
     }
+    if (/系统加载中|当前访问人数过多|请休息片刻重试|不要频繁刷新|系统繁忙|系统忙|系统异常|服务异常|服务繁忙|访问失败|访问异常|页面出错|系统维护|error\s*code/i.test(pageText)) {
+      return {
+        ok: false,
+        code: 'TRANSIENT_ACCESS',
+        message: 'huodongxing events page returned a temporary busy/access page',
+        hint: 'Huodongxing returned a temporary busy/access page instead of event cards. Wait and retry from the same browser session.',
+      };
+    }
     if (cards.length > 0) {
       return {
         ok: false,
@@ -259,6 +268,10 @@ export function extractEventRowsPayload(limit = 20) {
   return { ok: true, rows };
 }
 
+function isTransientAccessPayload(result) {
+  return unwrapEvaluateResult(result)?.code === 'TRANSIENT_ACCESS';
+}
+
 function requireExtractionRows(result) {
   const payload = unwrapEvaluateResult(result);
   if (payload?.ok === true && Array.isArray(payload.rows)) return payload.rows;
@@ -272,6 +285,12 @@ function requireExtractionRows(result) {
     throw new CommandExecutionError(
       payload.message || 'huodongxing events was rate limited by www.huodongxing.com',
       payload.hint || 'Wait a few minutes and retry from a real browser session.',
+    );
+  }
+  if (payload?.code === 'TRANSIENT_ACCESS') {
+    throw new CommandExecutionError(
+      payload.message || 'huodongxing events page returned a temporary busy/access page',
+      payload.hint || 'Wait and retry from the same browser session.',
     );
   }
   if (payload?.code === 'INVALID_LIMIT') {
@@ -291,6 +310,22 @@ function requireExtractionRows(result) {
 
 export function extractEventRows(limit = 20) {
   return requireExtractionRows(extractEventRowsPayload(limit));
+}
+
+async function extractEventRowsFromPage(page, limit) {
+  return page.evaluate(`(${extractEventRowsPayload.toString()})(${limit})`);
+}
+
+async function waitForEventCards(page) {
+  await page.wait({ selector: RESULT_CARD_SELECTOR, timeout: 10 }).catch(async () => {
+    await page.wait({ time: 1 });
+  });
+}
+
+async function navigateAndExtractEventRowsPayload(page, url, limit) {
+  await page.goto(url, { settleMs: 5000 });
+  await waitForEventCards(page);
+  return extractEventRowsFromPage(page, limit);
 }
 
 cli({
@@ -314,9 +349,11 @@ cli({
   func: async (page, args) => {
     const limit = requireLimit(args.limit);
     const url = buildEventsUrl(args);
-    await page.goto(url);
-    await page.wait(2);
-    const result = await page.evaluate(`(${extractEventRowsPayload.toString()})(${limit})`);
+    let result = await navigateAndExtractEventRowsPayload(page, url, limit);
+    if (isTransientAccessPayload(result)) {
+      await waitForEventCards(page);
+      result = await extractEventRowsFromPage(page, limit);
+    }
     return filterRowsByDateRange(requireExtractionRows(result), args);
   },
 });

--- a/clis/huodongxing/events.test.js
+++ b/clis/huodongxing/events.test.js
@@ -216,6 +216,11 @@ describe('huodongxing events adapter', () => {
       .toThrow(EmptyResultError);
   });
 
+  it('keeps generic empty-state copy with later-follow-up wording as empty results', () => {
+    expect(() => withDocument('<html><body>暂无活动，敬请稍后关注</body></html>', () => extractEventRows(10)))
+      .toThrow(EmptyResultError);
+  });
+
   it('throws CommandExecutionError when event cards cannot produce stable rows', () => {
     expect(() => withDocument(MALFORMED_CARD_HTML, () => extractEventRows(10)))
       .toThrow(CommandExecutionError);
@@ -224,6 +229,47 @@ describe('huodongxing events adapter', () => {
   it('classifies Huodongxing rate-limit pages separately from empty results', () => {
     expect(() => withDocument('<html><head><title>操作过于频繁</title></head><body>操作过于频繁</body></html>', () => extractEventRows(10)))
       .toThrow(CommandExecutionError);
+  });
+
+  it('classifies transient Huodongxing access errors separately from empty results', () => {
+    expect(() => withDocument('<html><head><title>系统加载中</title></head><body>系统加载中 当前访问人数过多 请休息片刻重试 不要频繁刷新 ERROR CODE</body></html>', () => extractEventRows(10)))
+      .toThrow(CommandExecutionError);
+  });
+
+  it('waits for event cards and extracts again after a transient access page', async () => {
+    const command = getRegistry().get('huodongxing/events');
+    const row = {
+      rank: 1,
+      id: '7864377535500',
+      title: 'AI Meetup',
+      time: '06/24 周三 14:00',
+      eventType: 'offline',
+      city: '浙江杭州',
+      location: '浙江杭州',
+      organizer: 'Org',
+      url: 'https://www.huodongxing.com/event/7864377535500',
+    };
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          code: 'TRANSIENT_ACCESS',
+          message: 'huodongxing events page returned a temporary busy/access page',
+        })
+        .mockResolvedValueOnce({ ok: true, rows: [row] }),
+    };
+
+    await expect(command.func(page, { limit: 5, city: '全部' })).resolves.toEqual([row]);
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://www.huodongxing.com/events?orderby=o&d=ts&city=%E5%85%A8%E9%83%A8',
+      { settleMs: 5000 },
+    );
+    expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '.search-tab-content-item-mesh', timeout: 10 });
+    expect(page.wait).toHaveBeenNthCalledWith(2, { selector: '.search-tab-content-item-mesh', timeout: 10 });
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
   });
 
   it('throws typed errors from structured browser extraction failures', async () => {


### PR DESCRIPTION
## Summary
- Wait for the Huodongxing event-card selector before extracting rows instead of relying on a fixed 2-second settle.
- Classify Huodongxing temporary busy/access pages as command errors instead of `EMPTY_RESULT`, using the text shown in #2027 (`系统加载中`, `当前访问人数过多`, `不要频繁刷新`, `ERROR CODE`).
- Re-extract once from the same browser page after a temporary busy/access payload, while preserving legitimate empty-state pages as `EMPTY_RESULT`.

Fixes #2027

## Test Plan
- `npm run build`
- `npx vitest run --project adapter clis/huodongxing/events.test.js`
- `node dist/src/main.js validate huodongxing`
- `git diff --check`
