### PR TITLE
fix(skills): quote sitemap author frontmatter

### DIFF
--- a/skills/opencli-sitemap-author/SKILL.md
+++ b/skills/opencli-sitemap-author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opencli-sitemap-author
-description: Use when creating or maintaining OpenCLI site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo.
-allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
+description: "Use when creating or maintaining OpenCLI site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo."
+allowed-tools: "Bash(opencli:*), Read, Edit, Write, Grep"
 ---
 
 # opencli-sitemap-author


### PR DESCRIPTION
## Why
`opencli-sitemap-author` has invalid YAML frontmatter: unquoted colons in both `description` and `allowed-tools` make strict YAML parsers fail. Hermes currently falls back to a line parser, but other consumers can reject the skill.

## Change
Quote both scalar values without changing their content.

## Verification
Parsed the complete frontmatter with PyYAML and asserted the preserved `name`, `description`, and `allowed-tools` values.