### PR TITLE
fix(skills): quote sitemap-author description to keep frontmatter valid YAML

### DIFF
--- a/skills/opencli-sitemap-author/SKILL.md
+++ b/skills/opencli-sitemap-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opencli-sitemap-author
-description: Use when creating or maintaining OpenCLI site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo.
+description: "Use when creating or maintaining OpenCLI site sitemaps: agent-facing navigation, page-state, action, workflow, API-reference, pitfall, and fallback knowledge for a website. Use after browser exploration discovers durable site context, when a sitemap is stale, or when promoting local site knowledge into the repo."
 allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
 ---
 


### PR DESCRIPTION
## Problem

The front matter in `skills/opencli-sitemap-author/SKILL.md` has an unquoted plain scalar whose value contains `": "` (colon-space):

```yaml
description: Use when creating or maintaining OpenCLI site sitemaps: agent-facing navigation, ...
```

A strict YAML parser reads `": "` as a mapping indicator and rejects the front matter (`python3 -c "import yaml,sys; yaml.safe_load(sys.stdin)"` raises `mapping values are not allowed here`).

## Fix

Wrap the value in double quotes. The text is unchanged. This is the only `skills/*/SKILL.md` whose front matter fails to parse (verified across all of them).
