### PR TITLE
fix(twitter): harden article API response handling

### DIFF
--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -97,9 +97,14 @@ cli({
 
         const resp = await fetch(url, {headers, credentials: 'include'});
         if (!resp.ok) return {httpStatus: resp.status};
-        const d = await resp.json();
+        let d;
+        try {
+          d = await resp.json();
+        } catch {
+          return {error: 'Twitter API response was not valid JSON', hint: 'You may be logged out or the request was blocked'};
+        }
 
-        const result = d.data?.tweetResult?.result;
+        const result = d?.data?.tweetResult?.result;
         if (!result) return {error: 'Article not found'};
 
         // Unwrap TweetWithVisibilityResults

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -1,8 +1,13 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { resolveTwitterQueryId, describeTwitterApiError } from './shared.js';
+import { resolveTwitterQueryId, describeTwitterApiError, unwrapBrowserResult } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 const TWEET_RESULT_BY_REST_ID_QUERY_ID = '7xflPyRiUxGVbJd4uWmbfg';
+
+function isPlainObject(value) {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
 cli({
     site: 'twitter',
     name: 'article',
@@ -57,7 +62,7 @@ cli({
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
         const queryId = await resolveTwitterQueryId(page, 'TweetResultByRestId', TWEET_RESULT_BY_REST_ID_QUERY_ID);
-        const result = await page.evaluate(`
+        const rawResult = unwrapBrowserResult(await page.evaluate(`
       async () => {
         const tweetId = "${tweetId}";
         const ct0 = ${JSON.stringify(ct0)};
@@ -95,7 +100,12 @@ cli({
           + '&features=' + encodeURIComponent(features)
           + '&fieldToggles=' + encodeURIComponent(fieldToggles);
 
-        const resp = await fetch(url, {headers, credentials: 'include'});
+        let resp;
+        try {
+          resp = await fetch(url, {headers, credentials: 'include'});
+        } catch (error) {
+          return {error: 'Twitter article request failed: ' + String(error && error.message || error)};
+        }
         if (!resp.ok) return {httpStatus: resp.status};
         let d;
         try {
@@ -103,15 +113,30 @@ cli({
         } catch {
           return {error: 'Twitter API response was not valid JSON', hint: 'You may be logged out or the request was blocked'};
         }
+        if (!d || typeof d !== 'object' || Array.isArray(d)) {
+          return {error: 'Twitter API response payload was malformed'};
+        }
 
         const result = d?.data?.tweetResult?.result;
-        if (!result) return {error: 'Article not found'};
+        if (!result) {
+          if (Array.isArray(d.errors) && d.errors.length > 0) {
+            return {error: 'Twitter TweetResultByRestId returned GraphQL errors: ' + JSON.stringify(d.errors).slice(0, 200)};
+          }
+          return {error: 'Article not found'};
+        }
 
         // Unwrap TweetWithVisibilityResults
         const tw = result.tweet || result;
         const legacy = tw.legacy || {};
         const user = tw.core?.user_results?.result;
-        const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';
+        const returnedTweetId = tw.rest_id || legacy.id_str;
+        if (typeof returnedTweetId !== 'string' || returnedTweetId !== tweetId) {
+          return {error: 'Twitter API response did not match requested tweet ' + tweetId};
+        }
+        const screenName = user?.legacy?.screen_name || user?.core?.screen_name || '';
+        if (typeof screenName !== 'string' || !/^[A-Za-z0-9_]{1,15}$/.test(screenName)) {
+          return {error: 'Twitter API response did not include a valid author screen name for tweet ' + tweetId};
+        }
 
         // Extract article content
         const articleResults = tw.article?.article_results?.result;
@@ -163,13 +188,23 @@ cli({
           url: 'https://x.com/' + screenName + '/status/' + tweetId,
         }];
       }
-    `);
-        if (result?.httpStatus) {
-            throw new CommandExecutionError(describeTwitterApiError('TweetResultByRestId', result.httpStatus));
+    `));
+        if (!Array.isArray(rawResult) && !isPlainObject(rawResult)) {
+            throw new CommandExecutionError('Twitter article response payload is malformed');
         }
-        if (result?.error) {
-            throw new CommandExecutionError(result.error + (result.hint ? ` (${result.hint})` : ''));
+        if (rawResult?.httpStatus) {
+            const message = describeTwitterApiError('TweetResultByRestId', rawResult.httpStatus);
+            if (rawResult.httpStatus === 401 || rawResult.httpStatus === 403) {
+                throw new AuthRequiredError('x.com', message);
+            }
+            throw new CommandExecutionError(message);
         }
-        return result || [];
+        if (rawResult?.error) {
+            throw new CommandExecutionError(rawResult.error + (rawResult.hint ? ` (${rawResult.hint})` : ''));
+        }
+        if (!Array.isArray(rawResult)) {
+            throw new CommandExecutionError('Twitter article response payload is malformed');
+        }
+        return rawResult;
     }
 });

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -48,10 +48,11 @@ cli({
           return null;
         })()
       `);
-            if (!resolvedId || typeof resolvedId !== 'string') {
+            const resolvedTweetId = unwrapBrowserResult(resolvedId);
+            if (!resolvedTweetId || typeof resolvedTweetId !== 'string') {
                 throw new CommandExecutionError(`Could not resolve article ${tweetId} to a tweet ID. The article page may not contain a linked tweet.`);
             }
-            tweetId = resolvedId;
+            tweetId = resolvedTweetId;
         }
         // Navigate to the tweet page for cookie context
         await page.goto(`https://x.com/i/status/${tweetId}`);
@@ -126,7 +127,13 @@ cli({
         }
 
         // Unwrap TweetWithVisibilityResults
+        if (!result || typeof result !== 'object' || Array.isArray(result)) {
+          return {error: 'Twitter API response tweet result was malformed'};
+        }
         const tw = result.tweet || result;
+        if (!tw || typeof tw !== 'object' || Array.isArray(tw)) {
+          return {error: 'Twitter API response tweet result was malformed'};
+        }
         const legacy = tw.legacy || {};
         const user = tw.core?.user_results?.result;
         const returnedTweetId = tw.rest_id || legacy.id_str;
@@ -153,15 +160,25 @@ cli({
           }
           return {error: 'Tweet ' + tweetId + ' has no article content'};
         }
+        if (!articleResults || typeof articleResults !== 'object' || Array.isArray(articleResults)) {
+          return {error: 'Twitter API response article result was malformed'};
+        }
 
         const title = articleResults.title || '(Untitled)';
         const contentState = articleResults.content_state || {};
+        if (!contentState || typeof contentState !== 'object' || Array.isArray(contentState)) {
+          return {error: 'Twitter API response article content was malformed'};
+        }
         const blocks = contentState.blocks || [];
+        if (!Array.isArray(blocks)) {
+          return {error: 'Twitter API response article blocks were malformed'};
+        }
 
         // Convert draft.js blocks to Markdown
         const parts = [];
         let orderedCounter = 0;
         for (const block of blocks) {
+          if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
           const blockType = block.type || 'unstyled';
           if (blockType === 'atomic') continue;
           const text = block.text || '';

--- a/clis/twitter/article.test.js
+++ b/clis/twitter/article.test.js
@@ -14,6 +14,63 @@ function createPage(articleResult) {
     };
 }
 
+function createPageWithEvaluateResults(evaluateResults) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf-token' }]),
+        evaluate: vi.fn()
+            .mockImplementation(() => Promise.resolve(evaluateResults.shift())),
+    };
+}
+
+function validArticlePayload(overrides = {}) {
+    return {
+        data: {
+            tweetResult: {
+                result: {
+                    tweet: {
+                        rest_id: '1234567890',
+                        legacy: { full_text: 'fallback text' },
+                        core: {
+                            user_results: {
+                                result: {
+                                    legacy: { screen_name: 'alice' },
+                                },
+                            },
+                        },
+                        article: {
+                            article_results: {
+                                result: {
+                                    title: 'Long article',
+                                    content_state: {
+                                        blocks: [{ type: 'unstyled', text: 'body' }],
+                                    },
+                                },
+                            },
+                        },
+                        ...overrides.tweet,
+                    },
+                },
+            },
+        },
+    };
+}
+
+async function evaluateArticleFetchScript(script, payload) {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(payload),
+    });
+    try {
+        // The adapter passes Browser Bridge an `async () => { ... }` source string.
+        return await eval(`(${script})`)();
+    } finally {
+        globalThis.fetch = previousFetch;
+    }
+}
+
 describe('twitter article command', () => {
     it('unwraps Browser Bridge envelopes around article rows', async () => {
         const command = getRegistry().get('twitter/article');
@@ -52,5 +109,59 @@ describe('twitter article command', () => {
         await expect(command.func(createPage({
             error: 'Twitter TweetResultByRestId returned GraphQL errors: [{"message":"rate limited"}]',
         }), { 'tweet-id': '1234567890' })).rejects.toThrow(/GraphQL errors/);
+    });
+
+    it('unwraps Browser Bridge envelopes when resolving /i/article URLs to parent tweet ids', async () => {
+        const command = getRegistry().get('twitter/article');
+        const rows = [{
+            title: 'Long article',
+            author: 'alice',
+            content: 'body',
+            url: 'https://x.com/alice/status/1234567890',
+        }];
+        const page = createPageWithEvaluateResults([
+            { session: 'browser:default', data: '1234567890' },
+            null,
+            rows,
+        ]);
+
+        await expect(command.func(page, { 'tweet-id': 'https://x.com/i/article/987654321' }))
+            .resolves.toEqual(rows);
+        expect(page.goto).toHaveBeenNthCalledWith(1, 'https://x.com/i/article/987654321');
+        expect(page.goto).toHaveBeenNthCalledWith(2, 'https://x.com/i/status/1234567890');
+    });
+
+    it('fails closed when article API nested result shapes are malformed', async () => {
+        const command = getRegistry().get('twitter/article');
+        const page = createPageWithEvaluateResults([
+            null,
+            undefined,
+        ]);
+        page.evaluate.mockImplementationOnce(() => Promise.resolve(null));
+        page.evaluate.mockImplementationOnce(async (script) => evaluateArticleFetchScript(script, validArticlePayload({
+            tweet: {
+                article: { article_results: { result: 'not-an-object' } },
+            },
+        })));
+
+        await expect(command.func(page, { 'tweet-id': '1234567890' }))
+            .rejects.toThrow(/article result was malformed/);
+    });
+
+    it('fails closed when article API content blocks are malformed', async () => {
+        const command = getRegistry().get('twitter/article');
+        const page = createPageWithEvaluateResults([
+            null,
+            undefined,
+        ]);
+        page.evaluate.mockImplementationOnce(() => Promise.resolve(null));
+        page.evaluate.mockImplementationOnce(async (script) => evaluateArticleFetchScript(script, validArticlePayload({
+            tweet: {
+                article: { article_results: { result: { title: 'Bad', content_state: { blocks: {} } } } },
+            },
+        })));
+
+        await expect(command.func(page, { 'tweet-id': '1234567890' }))
+            .rejects.toThrow(/article blocks were malformed/);
     });
 });

--- a/clis/twitter/article.test.js
+++ b/clis/twitter/article.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './article.js';
+
+function createPage(articleResult) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue([{ name: 'ct0', value: 'csrf-token' }]),
+        evaluate: vi.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(articleResult),
+    };
+}
+
+describe('twitter article command', () => {
+    it('unwraps Browser Bridge envelopes around article rows', async () => {
+        const command = getRegistry().get('twitter/article');
+        const rows = [{
+            title: 'Long article',
+            author: 'alice',
+            content: 'body',
+            url: 'https://x.com/alice/status/1234567890',
+        }];
+
+        await expect(command.func(createPage({ session: 'browser:default', data: rows }), { 'tweet-id': '1234567890' }))
+            .resolves.toEqual(rows);
+    });
+
+    it('maps HTTP auth failures to AuthRequiredError', async () => {
+        const command = getRegistry().get('twitter/article');
+
+        await expect(command.func(createPage({ httpStatus: 401 }), { 'tweet-id': '1234567890' }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('fails closed for malformed article response envelopes', async () => {
+        const command = getRegistry().get('twitter/article');
+
+        await expect(command.func(createPage({}), { 'tweet-id': '1234567890' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(createPage({ session: 'browser:default', data: {} }), { 'tweet-id': '1234567890' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command.func(createPage(null), { 'tweet-id': '1234567890' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('surfaces GraphQL error payloads instead of returning a success-shaped fallback', async () => {
+        const command = getRegistry().get('twitter/article');
+
+        await expect(command.func(createPage({
+            error: 'Twitter TweetResultByRestId returned GraphQL errors: [{"message":"rate limited"}]',
+        }), { 'tweet-id': '1234567890' })).rejects.toThrow(/GraphQL errors/);
+    });
+});


### PR DESCRIPTION
## Problem

Two failure modes on the `article` command's GraphQL response were unhandled and surfaced as opaque `page.evaluate` crashes:

1. A 2xx response with a **non-JSON body** (logged-out HTML page, block/challenge page) made `await resp.json()` throw. `clis/twitter/profile.js` already guards this; `article.js` did not.
2. A valid JSON `null` body made `d.data?.` throw a `TypeError` — optional chaining protects `.data?.` but not the root `d` — bypassing the structured-error path.

## Fix

- Wrap `resp.json()` in try/catch and return a structured `{error, hint}`, which the existing outer handler turns into a clear `CommandExecutionError`. The raw parser message is **not** surfaced — V8's JSON `SyntaxError` echoes a fragment of the response body.
- Guard the response root with `d?.data?.tweetResult?.result`.

## Verification

`npm run build`, `npm run typecheck`, `npm run check:typed-error-lint` (new=0), and the twitter adapter test suite (105 passing) all pass.
