### PR TITLE
fix: click hit-testing + facebook feed/search DOM drift (#2076 #2071 #2089 #2090)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -13526,7 +13526,7 @@
     "type": "js",
     "modulePath": "facebook/search.js",
     "sourceFile": "facebook/search.js",
-    "navigateBefore": "https://www.facebook.com"
+    "navigateBefore": false
   },
   {
     "site": "facebook",

--- a/clis/facebook/feed.js
+++ b/clis/facebook/feed.js
@@ -24,7 +24,26 @@ function buildFeedExtractScript(limit) {
     const limit = ${limit};
 
     function clean(value) {
-      return String(value || '').replace(/\\s+/g, ' ').trim();
+      // Strip zero-width / bidi control chars first: Facebook injects them into
+      // decoy nodes to poison scrapers. See issue #2089.
+      return String(value || '')
+        .replace(/[\\u200b-\\u200f\\u202a-\\u202e\\u2060\\ufeff]/g, '')
+        .replace(/\\s+/g, ' ')
+        .trim();
+    }
+
+    // FB anti-scrape decoys: long spaceless digit runs, spaced single-char
+    // strings ("a b c d e"), and hidden-domain .com spam. Real author/content
+    // text never looks like this.
+    function isDecoyText(text) {
+      if (!text) return true;
+      if (/^\\d{8,}$/.test(text)) return true;
+      if (/^(?:\\S ){4,}\\S$/.test(text) && text.replace(/\\s/g, '').length <= 12) return true;
+      return false;
+    }
+
+    function isReelsOrCarouselChrome(text) {
+      return /^(Reels|Reels and short videos|Reels 和短视频|快拍|短视频|People you may know)/i.test(text);
     }
 
     function textOf(el) {
@@ -116,6 +135,8 @@ function buildFeedExtractScript(limit) {
           && !isActionText(text)
           && !isMetricText(text)
           && !isTimestampText(text)
+          && !isDecoyText(text)
+          && !/^[\\d\\s.,-]+$/.test(text)   // reject all-digit decoy names, but keep "Class of 2024" (#2089)
           && !/\\/groups\\/|\\/watch\\/|\\/reel\\/|\\/events\\/|\\/friends\\//i.test(href)) {
           return text;
         }
@@ -129,6 +150,7 @@ function buildFeedExtractScript(limit) {
         if (text.length <= 10) return false;
         if (isSuggestionOrChrome(text) || isSponsored(text)) return false;
         if (isActionText(text) || isMetricText(text) || isTimestampText(text)) return false;
+        if (isDecoyText(text) || isReelsOrCarouselChrome(text)) return false;
         if (/^(See more|查看更多|更多)$/i.test(text)) return false;
         return true;
       });
@@ -168,6 +190,47 @@ function buildFeedExtractScript(limit) {
     function primaryContainers() {
       return Array.from(document.querySelectorAll('[role="article"]'))
         .filter((el) => textOf(el).length > 30);
+    }
+
+    // Modern Facebook no longer wraps posts in [role="article"] nor exposes the
+    // Like/Comment/Share aria-labels the fallback keyed on. Every post still
+    // carries one "Actions for this post" control (the ⋯ menu). Anchor on it and
+    // walk up to the HIGHEST ancestor that still contains exactly one such
+    // control — that bounds the node to a single post. See issue #2089.
+    function actionMenuAnchors() {
+      // Post menus only — NOT "Actions for this comment", so the anchor set,
+      // countMenus, and loadFeedPosts all key on the same thing (#2089).
+      return Array.from(document.querySelectorAll('[aria-label]')).filter((el) =>
+        /^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test(labelOf(el)));
+    }
+
+    function actionAnchoredContainers() {
+      const menus = actionMenuAnchors();
+      const seen = new WeakSet();
+      const containers = [];
+      const countMenus = (node) => {
+        let n = 0;
+        for (const el of node.querySelectorAll('[aria-label]')) {
+          if (/^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test(labelOf(el))) n += 1;
+        }
+        return n;
+      };
+      const LANDMARK_ROLES = new Set(['main', 'feed', 'banner', 'navigation', 'complementary', 'contentinfo', 'region']);
+      for (const menu of menus) {
+        let node = menu.parentElement;
+        let best = null;
+        for (let depth = 0; depth < 22 && node && node !== document.body && node !== document.documentElement; depth += 1, node = node.parentElement) {
+          // Never let a single-post page climb the container up to a page
+          // landmark (role=main/feed/...) and emit the whole region as a post.
+          if (LANDMARK_ROLES.has(node.getAttribute('role') || '')) break;
+          if (countMenus(node) === 1) best = node; else break;
+        }
+        if (best && !seen.has(best) && textOf(best).length > 30) {
+          seen.add(best);
+          containers.push(best);
+        }
+      }
+      return containers;
     }
 
     function fallbackContainers() {
@@ -210,7 +273,8 @@ function buildFeedExtractScript(limit) {
     if (isAuthPage()) return { status: 'auth', rows: [], diagnostics: {} };
 
     const primary = primaryContainers();
-    const combined = dedupe([...primary, ...fallbackContainers()]);
+    const actionAnchored = actionAnchoredContainers();
+    const combined = dedupe([...primary, ...actionAnchored, ...fallbackContainers()]);
     const rows = [];
     for (const container of combined) {
       const row = extractPost(container, rows.length + 1);
@@ -224,11 +288,34 @@ function buildFeedExtractScript(limit) {
       diagnostics: {
         articleCount: document.querySelectorAll('[role="article"]').length,
         primaryCount: primary.length,
+        actionMenuCount: actionMenuAnchors().length,
         fallbackActionCount: document.querySelectorAll('[role="main"] [aria-label="Like"], [role="main"] [aria-label="赞"], [role="main"] [aria-label="Comment"], [role="main"] [aria-label="评论"]').length,
         mainTextLength: textOf(document.querySelector('[role="main"]')).length,
       },
     };
   })()`;
+}
+
+// Facebook streams feed posts in lazily as you scroll, so a single extraction
+// off the initial viewport under-returns. Scroll a bounded number of times
+// until enough post action-menus are present (or we stop growing). See #2089.
+async function loadFeedPosts(page, limit) {
+  const scrollStep = `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    window.scrollTo(0, document.body.scrollHeight);
+    await sleep(800);
+    return document.querySelectorAll('[aria-label]').length
+      ? document.querySelectorAll('[role="article"]').length
+        + Array.from(document.querySelectorAll('[aria-label]')).filter((el) => /^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test((el.getAttribute('aria-label') || '').trim())).length
+      : 0;
+  })()`;
+  let prev = -1;
+  for (let i = 0; i < 8; i += 1) {
+    let count = 0;
+    try { count = Number(unwrapBrowserResult(await page.evaluate(scrollStep))) || 0; } catch { break; }
+    if (count >= limit || count === prev) break;
+    prev = count;
+  }
 }
 
 async function getFacebookFeed(page, kwargs) {
@@ -241,6 +328,8 @@ async function getFacebookFeed(page, kwargs) {
       'Check that facebook.com is reachable and the browser extension is connected.',
     );
   }
+
+  await loadFeedPosts(page, limit);
 
   let payload;
   try {
@@ -269,7 +358,7 @@ async function getFacebookFeed(page, kwargs) {
   }
 
   const diagnostics = payload.diagnostics || {};
-  if (diagnostics.articleCount || diagnostics.fallbackActionCount || diagnostics.mainTextLength > 200) {
+  if (diagnostics.articleCount || diagnostics.actionMenuCount || diagnostics.fallbackActionCount || diagnostics.mainTextLength > 200) {
     throw new CommandExecutionError(
       'facebook feed page rendered but no feed rows could be extracted',
       `Diagnostics: articles=${diagnostics.articleCount || 0}, actions=${diagnostics.fallbackActionCount || 0}, mainTextLength=${diagnostics.mainTextLength || 0}.`,

--- a/clis/facebook/feed.test.js
+++ b/clis/facebook/feed.test.js
@@ -166,4 +166,90 @@ describe('facebook feed', () => {
     await expect(__test__.command.func(createPage({ rows: null }), { limit: 1 }))
       .rejects.toBeInstanceOf(CommandExecutionError);
   });
+
+  // Modern Facebook feed (#2089): no [role="article"], no Like/Comment
+  // aria-labels — each post is bounded by its "Actions for this post" menu.
+  // NOTE: this fixture encodes the DOM shape described in the issue, not a
+  // captured live sample, so live verification is still required.
+  it('extracts modern feed posts anchored on the "Actions for this post" menu (#2089)', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/carol">Carol Poster</a></h3>
+            <div dir="auto">A modern feed post with no role=article wrapper anywhere on it.</div>
+            <a href="https://www.facebook.com/carol/posts/999">2h</a>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/dave">Dave Danger</a></h3>
+            <div dir="auto">Second streamed post body that should also be extracted fine.</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.diagnostics.actionMenuCount).toBe(2);
+    expect(payload.rows.map((r) => r.author)).toEqual(['Carol Poster', 'Dave Danger']);
+    expect(payload.rows[0].content).toContain('modern feed post');
+  });
+
+  it('keeps a legitimate author name that contains a 4-digit run (#2089)', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/class2024">Class of 2024</a></h3>
+            <div dir="auto">Reunion planning post body long enough to be extracted correctly.</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/other">Someone Else</a></h3>
+            <div dir="auto">A second post so the container walk stops before the main landmark.</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+    expect(payload.rows[0].author).toBe('Class of 2024');
+  });
+
+  it('does not emit the whole main landmark as one post on a single-post page (#2089)', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/solo">Solo Poster</a></h3>
+            <div dir="auto">The only post on the page — the container must not climb to role=main.</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].author).toBe('Solo Poster');
+  });
+
+  it('rejects a digit-bearing decoy author and hidden-char decoy text (#2089)', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/real">Real Human</a></h3>
+            <span>​​​</span>
+            <div dir="auto">Genuine post content that survives the anti-scrape decoy filtering.</div>
+            <div dir="auto">1234567890123</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].author).toBe('Real Human');
+    expect(payload.rows[0].content).not.toContain('1234567890123');
+  });
 });

--- a/clis/facebook/search.js
+++ b/clis/facebook/search.js
@@ -1,39 +1,186 @@
-import { cli } from '@jackwener/opencli/registry';
-cli({
-    site: 'facebook',
-    name: 'search',
-    access: 'read',
-    description: 'Search Facebook for people, pages, or posts',
-    domain: 'www.facebook.com',
-    args: [
-        { name: 'query', required: true, positional: true, help: 'Search query' },
-        { name: 'limit', type: 'int', default: 10, help: 'Number of results' },
-    ],
-    columns: ['index', 'title', 'text', 'url'],
-    pipeline: [
-        { navigate: 'https://www.facebook.com' },
-        { navigate: { url: 'https://www.facebook.com/search/top?q=${{ args.query | urlencode }}', settleMs: 4000 } },
-        { evaluate: `(async () => {
-  const limit = \${{ args.limit }};
-  // Search results are typically in role="article" or role="listitem"
-  let items = document.querySelectorAll('[role="article"]');
-  if (items.length === 0) {
-    items = document.querySelectorAll('[role="listitem"]');
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+const FACEBOOK_HOME = 'https://www.facebook.com';
+const MAX_LIMIT = 50;
+
+function requireLimit(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > MAX_LIMIT) {
+    throw new ArgumentError(`facebook search --limit must be an integer between 1 and ${MAX_LIMIT}`);
   }
-  return Array.from(items)
-    .filter(el => el.textContent.trim().length > 20)
-    .slice(0, limit)
-    .map((el, i) => {
-      const link = el.querySelector('a[href*="facebook.com/"]');
-      const heading = el.querySelector('h2, h3, h4, strong');
-      return {
-        index: i + 1,
-        title: heading ? heading.textContent.trim().substring(0, 80) : '',
-        text: el.textContent.trim().replace(/\\s+/g, ' ').substring(0, 150),
-        url: link ? link.href.split('?')[0] : '',
-      };
-    });
-})()
-` },
-    ],
-});
+  return n;
+}
+
+function requireQuery(value) {
+  const q = String(value ?? '').trim();
+  if (!q) throw new ArgumentError('facebook search requires a non-empty query');
+  return q;
+}
+
+function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && 'data' in value) return value.data;
+  return value;
+}
+
+// Modern facebook.com /search/top renders results inside [role="feed"] as
+// entity/content links (people, pages, groups, posts) — [role="article"] /
+// [role="listitem"] no longer wrap them — and FB seeds scrambled hidden-char
+// decoy links back to /search/top. Collect anchors inside the feed, keep only
+// real entity/content hrefs, and drop the decoys plus obfuscated text. See #2090.
+function buildSearchExtractScript(limit) {
+  return `(() => {
+    const limit = ${limit};
+
+    function clean(value) {
+      return String(value || '')
+        .replace(/[\\u200b-\\u200f\\u202a-\\u202e\\u2060\\ufeff]/g, '')
+        .replace(/\\s+/g, ' ')
+        .trim();
+    }
+
+    // FB anti-scrape obfuscation: long spaceless digit tokens and spaced
+    // single-char strings ("a b c d e"). Real titles never look like this.
+    function isObfuscated(text) {
+      if (!text) return true;
+      if (/^\\d{8,}$/.test(text)) return true;
+      if (/^(?:\\S ){4,}\\S$/.test(text) && text.replace(/\\s/g, '').length <= 12) return true;
+      return false;
+    }
+
+    function isEntityHref(href) {
+      if (!href) return false;
+      let u;
+      try { u = new URL(href, 'https://www.facebook.com'); } catch (e) { return false; }
+      // drop hidden-domain .com spam — real results stay on facebook.com
+      if (!/(^|\\.)facebook\\.com$/i.test(u.hostname)) return false;
+      const p = u.pathname;
+      if (/^\\/search(\\/|$)/i.test(p)) return false;                  // decoy links back to search (incl. bare /search)
+      // chrome / non-result destinations that the catch-all below would keep
+      if (/^\\/(login|checkpoint|help|policies|privacy|settings|bookmarks|messages|notifications|marketplace|gaming|friends|requests|saved|me)\\b/i.test(p)) return false;
+      return /^\\/(profile\\.php|groups\\/|events\\/|watch\\/|reel\\/|pages\\/|permalink\\.php|story\\.php|[^/]+\\/posts\\/|[^/]+\\/videos\\/|[A-Za-z0-9.\\-]{2,}\\/?$)/i.test(p);
+    }
+
+    function isAuthPage() {
+      const path = window.location && window.location.pathname ? window.location.pathname : '';
+      const body = clean(document.body && document.body.textContent);
+      return /^\\/(login|checkpoint)(\\/|$|\\.php)/.test(path)
+        || /^(Log in to Facebook|Facebook登录|登录 Facebook)/i.test(body)
+        || /You must log in to continue/i.test(body);
+    }
+
+    if (isAuthPage()) return { status: 'auth', rows: [], diagnostics: {} };
+
+    const feed = document.querySelector('[role="feed"]')
+      || document.querySelector('[role="main"]')
+      || document.body;
+    const anchors = Array.from(feed.querySelectorAll('a[href]'));
+    const seen = new Set();
+    const rows = [];
+    for (const a of anchors) {
+      const rawHref = a.href || a.getAttribute('href') || '';
+      if (!isEntityHref(rawHref)) continue;
+      let key;
+      try { const u = new URL(rawHref, 'https://www.facebook.com'); key = u.origin + u.pathname; }
+      catch (e) { key = rawHref.split('?')[0].split('#')[0]; }
+      if (seen.has(key)) continue;
+
+      const title = clean(a.textContent).substring(0, 80);
+      if (!title || isObfuscated(title)) continue;
+
+      // climb a few levels for the surrounding card text
+      let card = a;
+      for (let i = 0; i < 4 && card.parentElement; i += 1) {
+        card = card.parentElement;
+        if (clean(card.textContent).length > title.length + 20) break;
+      }
+      const text = clean(card.textContent).substring(0, 150);
+      if (isObfuscated(text)) continue;
+
+      seen.add(key);
+      rows.push({ index: rows.length + 1, title, text, url: key });
+      if (rows.length >= limit) break;
+    }
+
+    return {
+      status: rows.length ? 'ok' : 'no_rows',
+      rows,
+      diagnostics: {
+        feedFound: !!document.querySelector('[role="feed"]'),
+        anchorCount: anchors.length,
+        mainTextLength: clean((document.querySelector('[role="main"]') || {}).textContent).length,
+      },
+    };
+  })()`;
+}
+
+async function searchFacebook(page, kwargs) {
+  const query = requireQuery(kwargs.query);
+  const limit = requireLimit(kwargs.limit ?? 10);
+
+  // Navigate home first so the SPA is warm, then to the search results.
+  // Regression guard for #625: extraction must run *after* this navigation.
+  try {
+    await page.goto(FACEBOOK_HOME);
+    await page.goto(`https://www.facebook.com/search/top?q=${encodeURIComponent(query)}`, { settleMs: 4000 });
+  } catch (err) {
+    throw new CommandExecutionError(
+      `Failed to open facebook search: ${err instanceof Error ? err.message : err}`,
+      'Check that facebook.com is reachable and the browser extension is connected.',
+    );
+  }
+
+  let payload;
+  try {
+    payload = unwrapBrowserResult(await page.evaluate(buildSearchExtractScript(limit)));
+  } catch (err) {
+    throw new CommandExecutionError(
+      `Failed to read facebook search results: ${err instanceof Error ? err.message : err}`,
+      'Facebook may not have rendered or the search markup may have changed.',
+    );
+  }
+
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.rows)) {
+    throw new CommandExecutionError('facebook search returned malformed extraction payload');
+  }
+  if (payload.status === 'auth') {
+    throw new AuthRequiredError('www.facebook.com', 'Open Chrome and log in to Facebook before retrying.');
+  }
+  if (payload.rows.length > 0) return payload.rows;
+
+  const d = payload.diagnostics || {};
+  if (d.anchorCount || d.mainTextLength > 200) {
+    throw new CommandExecutionError(
+      'facebook search page rendered but no entity results could be extracted',
+      `Diagnostics: feed=${!!d.feedFound}, anchors=${d.anchorCount || 0}, mainTextLength=${d.mainTextLength || 0}.`,
+    );
+  }
+  throw new EmptyResultError('facebook search', `No Facebook results were visible for "${query}".`);
+}
+
+const command = {
+  site: 'facebook',
+  name: 'search',
+  access: 'read',
+  description: 'Search Facebook for people, pages, or posts',
+  domain: 'www.facebook.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'query', required: true, positional: true, help: 'Search query' },
+    { name: 'limit', type: 'int', default: 10, help: 'Number of results' },
+  ],
+  columns: ['index', 'title', 'text', 'url'],
+  func: searchFacebook,
+};
+
+cli(command);
+
+export const __test__ = {
+  buildSearchExtractScript,
+  command,
+  searchFacebook,
+  requireLimit,
+  requireQuery,
+};

--- a/clis/facebook/search.test.js
+++ b/clis/facebook/search.test.js
@@ -1,55 +1,114 @@
 /**
- * Regression test for issue #625.
- * Facebook search must navigate in the pipeline before DOM extraction.
+ * Facebook search: extraction against the modern /search/top DOM (#2090) plus
+ * the #625 regression guard that navigation runs before DOM extraction.
+ *
+ * NOTE: the fixtures encode the DOM shape described in issue #2090, not a
+ * captured live sample, so live verification is still required.
  */
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { executePipeline } from '@jackwener/opencli/pipeline';
-// Import the adapter to register it
-import './search.js';
-/**
- * Minimal browser mock for pipeline execution tests.
- * Only methods touched by this adapter path are implemented.
- */
-function createMockPage() {
-    return {
-        goto: vi.fn(),
-        evaluate: vi.fn().mockResolvedValue([]),
-        getCookies: vi.fn().mockResolvedValue([]),
-        snapshot: vi.fn().mockResolvedValue(''),
-        click: vi.fn(),
-        typeText: vi.fn(),
-        pressKey: vi.fn(),
-        scrollTo: vi.fn(),
-        getFormState: vi.fn().mockResolvedValue({}),
-        wait: vi.fn(),
-        tabs: vi.fn().mockResolvedValue([]),
-        selectTab: vi.fn(),
-        networkRequests: vi.fn().mockResolvedValue([]),
-        consoleMessages: vi.fn().mockResolvedValue(''),
-        scroll: vi.fn(),
-        autoScroll: vi.fn(),
-        installInterceptor: vi.fn(),
-        getInterceptedRequests: vi.fn().mockResolvedValue([]),
-        waitForCapture: vi.fn().mockResolvedValue(undefined),
-        screenshot: vi.fn().mockResolvedValue(''),
-    };
+import { __test__ } from './search.js';
+
+function runExtract(html, limit = 10, url = 'https://www.facebook.com/search/top?q=ai') {
+  const dom = new JSDOM(html, { url });
+  return Function('window', 'document', `return ${__test__.buildSearchExtractScript(limit)};`)(dom.window, dom.window.document);
 }
-describe('facebook search pipeline', () => {
-    it('navigates to search results before extracting DOM data', async () => {
-        const cmd = getRegistry().get('facebook/search');
-        expect(cmd).toBeDefined();
-        const pipeline = cmd.pipeline ?? [];
-        const page = createMockPage();
-        await executePipeline(page, pipeline, {
-            args: { query: 'AI agent', limit: 3 },
-        });
-        expect(page.goto).toHaveBeenNthCalledWith(1, 'https://www.facebook.com');
-        expect(page.goto).toHaveBeenNthCalledWith(2, 'https://www.facebook.com/search/top?q=AI%20agent', {
-            waitUntil: undefined,
-            settleMs: 4000,
-        });
-        expect(page.evaluate).toHaveBeenCalledTimes(1);
-        expect(String(page.evaluate.mock.calls[0]?.[0] ?? '')).not.toContain('window.location.href');
-    });
+
+function createPage(payload) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(payload),
+  };
+}
+
+describe('facebook search', () => {
+  it('registers the search command with the row contract', () => {
+    const cmd = getRegistry().get('facebook/search');
+    expect(cmd).toBeDefined();
+    expect(cmd.columns).toEqual(['index', 'title', 'text', 'url']);
+  });
+
+  it('navigates home then to search results before extracting (#625)', async () => {
+    const page = createPage({ status: 'ok', rows: [{ index: 1, title: 'X', text: 'x', url: 'https://www.facebook.com/x' }] });
+    await __test__.searchFacebook(page, { query: 'AI agent', limit: 3 });
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://www.facebook.com');
+    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://www.facebook.com/search/top?q=AI%20agent', { settleMs: 4000 });
+    // extraction script must not depend on live URL reads
+    expect(String(page.evaluate.mock.calls[0]?.[0] ?? '')).not.toContain('window.location.href');
+  });
+
+  it('extracts entity/content links from [role="feed"] and drops decoys (#2090)', () => {
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/carol.page">Carol's Page</a><span>Public figure · 12K followers</span></div>
+        <div><a role="link" href="https://www.facebook.com/groups/1234567/">AI Builders Group</a><span>Group · 3K members</span></div>
+        <div><a role="link" href="https://www.facebook.com/dave/posts/9988">Dave's post about AI agents</a></div>
+        <a role="link" href="https://www.facebook.com/search/top?q=aaaa">See more results</a>
+        <a role="link" href="https://evil-cdn.com/x">1234567890123456</a>
+        <a role="link" href="https://www.facebook.com/a.b.c">a b c d e f</a>
+      </div>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows.map((r) => r.url)).toEqual([
+      'https://www.facebook.com/carol.page',
+      'https://www.facebook.com/groups/1234567/',
+      'https://www.facebook.com/dave/posts/9988',
+    ]);
+    expect(payload.rows[0].title).toBe("Carol's Page");
+    // decoy search link and non-facebook spam excluded
+    expect(payload.rows.some((r) => /\/search\//.test(r.url))).toBe(false);
+    expect(payload.rows.some((r) => /evil-cdn/.test(r.url))).toBe(false);
+  });
+
+  it('drops bare /search decoys and facebook chrome links (#2090)', () => {
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/realpage">Real Page</a></div>
+        <a role="link" href="https://www.facebook.com/search?q=bare">Bare search decoy</a>
+        <a role="link" href="https://www.facebook.com/marketplace">Marketplace</a>
+        <a role="link" href="https://www.facebook.com/messages/t/123">Messages</a>
+        <a role="link" href="https://www.facebook.com/notifications">Notifications</a>
+      </div>
+    `);
+    expect(payload.rows.map((r) => r.url)).toEqual(['https://www.facebook.com/realpage']);
+  });
+
+  it('dedupes repeated entity links and honours the limit', () => {
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/carol.page">Carol's Page</a></div>
+        <div><a role="link" href="https://www.facebook.com/carol.page?ref=xyz">Carol's Page (again)</a></div>
+        <div><a role="link" href="https://www.facebook.com/erin">Erin</a></div>
+      </div>
+    `, 1);
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.rows[0].url).toBe('https://www.facebook.com/carol.page');
+  });
+
+  it('reports auth pages as an auth status', () => {
+    const payload = runExtract('<div role="main">Log in to Facebook</div>', 10, 'https://www.facebook.com/login/');
+    expect(payload.status).toBe('auth');
+    expect(payload.rows).toEqual([]);
+  });
+
+  it('validates query and limit before navigation', async () => {
+    const page = createPage({ status: 'ok', rows: [] });
+    await expect(__test__.searchFacebook(page, { query: '  ', limit: 3 })).rejects.toBeInstanceOf(ArgumentError);
+    await expect(__test__.searchFacebook(page, { query: 'ok', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('maps auth, empty, drift, and malformed payloads to typed errors', async () => {
+    await expect(__test__.searchFacebook(createPage({ status: 'auth', rows: [] }), { query: 'q', limit: 1 }))
+      .rejects.toBeInstanceOf(AuthRequiredError);
+    await expect(__test__.searchFacebook(createPage({ status: 'no_rows', rows: [], diagnostics: {} }), { query: 'q', limit: 1 }))
+      .rejects.toBeInstanceOf(EmptyResultError);
+    await expect(__test__.searchFacebook(createPage({ status: 'no_rows', rows: [], diagnostics: { anchorCount: 40, mainTextLength: 800 } }), { query: 'q', limit: 1 }))
+      .rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(__test__.searchFacebook(createPage({ rows: null }), { query: 'q', limit: 1 }))
+      .rejects.toBeInstanceOf(CommandExecutionError);
+  });
 });

--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -288,7 +288,7 @@ describe('BasePage native input routing', () => {
       .mockResolvedValueOnce({ root: { nodeId: 1 } })
       .mockResolvedValueOnce({ nodeId: 9 })
       .mockResolvedValueOnce({});
-    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true }];
+    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true, hit: 'target' }];
     page.withArgsResults = [{ ok: true, multiple: false, accept: 'application/pdf' }, undefined];
 
     await page.click('#save');
@@ -301,7 +301,7 @@ describe('BasePage native input routing', () => {
   it('clicks via CDP Input.dispatchMouseEvent when rect is visible', async () => {
     const page = new ActionPage();
     page.nativeClick = vi.fn().mockResolvedValue(undefined);
-    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true }];
+    page.results = [resolveOk, { x: 50, y: 100, w: 200, h: 32, visible: true, hit: 'target' }];
 
     await page.click('#category');
 
@@ -336,7 +336,7 @@ describe('BasePage native input routing', () => {
     });
 
     await expect(page.snapshot({ source: 'ax' })).resolves.toContain('[1]button "Submit"');
-    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenNthCalledWith(1, 'Accessibility.enable', {});
     expect(page.cdp).toHaveBeenNthCalledWith(2, 'Accessibility.getFullAXTree', {});
@@ -399,7 +399,7 @@ describe('BasePage native input routing', () => {
     expect(snapshot).toContain('frame "https://other.example/embed":');
     expect(snapshot).toContain('[3]button "Cross Save"');
 
-    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'exact', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target', targetUrl: 'https://other.example/embed' });
@@ -439,7 +439,7 @@ describe('BasePage native input routing', () => {
 
     const snapshot = await page.snapshot({ source: 'ax' }) as string;
     expect(snapshot).toContain('[1]button "Cross Save"');
-    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'exact', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target', targetUrl: 'https://other.example/embed' });
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target', targetUrl: 'https://other.example/embed' });
@@ -481,7 +481,7 @@ describe('BasePage native input routing', () => {
     });
 
     await page.snapshot({ source: 'ax' });
-    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', { frameId: 'cross-frame', sessionId: 'target', targetUrl: 'https://other.example/embed' });
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'cross-frame', sessionId: 'target', targetUrl: 'https://other.example/embed' });
@@ -528,7 +528,7 @@ describe('BasePage native input routing', () => {
     });
 
     await page.snapshot({ source: 'ax' });
-    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+    await expect(page.click('2')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.enable', {});
     expect(page.cdp).toHaveBeenCalledWith('Accessibility.getFullAXTree', { frameId: 'same-frame' });
@@ -559,7 +559,7 @@ describe('BasePage native input routing', () => {
     });
 
     await page.snapshot({ source: 'ax' });
-    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+    await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified', click_method: 'ax' });
 
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 10 });
     expect(page.cdp).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 42 });
@@ -592,7 +592,7 @@ describe('BasePage native input routing', () => {
     for (let i = 0; i < 10; i++) {
       staleBackendIds.add(currentBackendId);
       currentBackendId += 1;
-      await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified' });
+      await expect(page.click('1')).resolves.toEqual({ matches_n: 1, match_level: 'reidentified', click_method: 'ax' });
     }
 
     expect(page.nativeClick).toHaveBeenCalledTimes(10);
@@ -637,7 +637,7 @@ describe('BasePage native input routing', () => {
     page.nativeClick = nativeClick;
     page.results = [
       resolveOk,
-      { x: 10, y: 20, w: 100, h: 30, visible: true },
+      { x: 10, y: 20, w: 100, h: 30, visible: true, hit: 'target' },
       { status: 'js_failed', x: 10, y: 20, error: 'click intercepted' },
     ];
 
@@ -710,7 +710,7 @@ describe('BasePage native input routing', () => {
       resolveOk,
       { ok: true, checked: false, disabled: false, kind: 'checkbox' },
       resolveOk,
-      { x: 20, y: 30, w: 40, h: 20, visible: true },
+      { x: 20, y: 30, w: 40, h: 20, visible: true, hit: 'target' },
       { ok: true, checked: true, disabled: false, kind: 'checkbox' },
     ];
 

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -47,6 +47,25 @@ export interface ResolveSuccess {
    * clean `exact` match — the page changed, the action still succeeded.
    */
   match_level: TargetMatchLevel;
+  /**
+   * Which physical click path executed: `cdp` (trusted Input.dispatchMouseEvent),
+   * `js` (el.click() fallback), or `ax` (accessibility-node click). Surfaced so
+   * agents can tell a trusted synthetic click from the untrusted JS fallback.
+   */
+  click_method?: 'cdp' | 'js' | 'ax';
+  /**
+   * Result of hit-testing the click point against the resolved element:
+   * `target` (the point lands on the element or a descendant — trustworthy),
+   * `other` (an overlay/sibling covers it — the CDP click would miss), or
+   * `none` (nothing at the point). Only set on click().
+   */
+  hit?: 'target' | 'ancestor' | 'other' | 'none';
+  /**
+   * True when the click was retargeted from the resolved element to a nearby
+   * clickable ancestor (e.g. an <svg> icon whose click handler lives on the
+   * wrapping <div>), so the handler actually fires. See issue #2071.
+   */
+  retargeted?: boolean;
 }
 
 export interface FillTextResult extends ResolveSuccess {
@@ -296,29 +315,35 @@ export abstract class BasePage implements IPage {
     // Phase 2: measure first so native click can run before DOM el.click().
     // Custom dropdowns often listen to pointer/mouse down/up; DOM el.click()
     // only fires click and can silently report success without opening/selecting.
-    const rect = await this.evaluate(boundingRectResolvedJs({ skipScroll: nativeScrolled })) as
-      | { x: number; y: number; w: number; h: number; visible: boolean }
+    const rect = await this.evaluate(boundingRectResolvedJs({ skipScroll: nativeScrolled, forClick: true })) as
+      | { x: number; y: number; w: number; h: number; visible: boolean; hit?: 'target' | 'ancestor' | 'other' | 'none'; retargeted?: boolean }
       | null;
+    const meta = { hit: rect?.hit, retargeted: rect?.retargeted } as const;
 
-    if (rect?.visible === true) {
+    // Trust a CDP click when the point hit-tests onto the target, a descendant,
+    // or an ancestor (open shadow-DOM host / own wrapper — CDP still reaches the
+    // target there). Only an unrelated overlay ('other') forces the el.click()
+    // fallback, which dispatches straight on the node. See issues #2076/#2071.
+    if (rect?.visible === true && (rect.hit === 'target' || rect.hit === 'ancestor')) {
       const success = await this.tryNativeClick(rect.x, rect.y);
-      if (success) return resolved;
+      if (success) return { ...resolved, click_method: 'cdp', ...meta };
     }
 
-    // JS fallback for older backends or zero-rect targets.
+    // JS fallback: el.click() dispatches straight on __resolved, bypassing the
+    // occluding overlay (also covers older backends / zero-rect targets).
     const result = await this.evaluate(clickResolvedJs({ skipScroll: nativeScrolled })) as
       | string
       | { status: string; x?: number; y?: number; w?: number; h?: number; error?: string }
       | null;
 
-    if (typeof result === 'string' || result == null) return resolved;
+    if (typeof result === 'string' || result == null) return { ...resolved, click_method: 'js', ...meta };
 
-    if (result.status === 'clicked') return resolved;
+    if (result.status === 'clicked') return { ...resolved, click_method: 'js', ...meta };
 
     // JS click failed — try CDP native click if coordinates available
     if (result.x != null && result.y != null) {
       const success = await this.tryNativeClick(result.x, result.y);
-      if (success) return resolved;
+      if (success) return { ...resolved, click_method: 'cdp', ...meta };
     }
 
     throw new Error(`Click failed: ${result.error ?? 'JS click and CDP fallback both failed'}`);
@@ -390,7 +415,7 @@ export abstract class BasePage implements IPage {
     if (!resolved) return null;
     try {
       await nativeClick.call(this, resolved.x, resolved.y);
-      return { matches_n: 1, match_level: resolved.matchLevel };
+      return { matches_n: 1, match_level: resolved.matchLevel, click_method: 'ax' };
     } catch {
       return null;
     }

--- a/src/browser/target-resolver.test.ts
+++ b/src/browser/target-resolver.test.ts
@@ -1,5 +1,146 @@
 import { describe, expect, it } from 'vitest';
-import { resolveTargetJs } from './target-resolver.js';
+import { resolveTargetJs, boundingRectResolvedJs } from './target-resolver.js';
+
+/**
+ * Build a fake element usable by the generated boundingRectResolvedJs. Rects are
+ * {left,top,width,height}; getBoundingClientRect derives right/bottom.
+ */
+function makeEl(opts: {
+  tag: string; rect: { left: number; top: number; width: number; height: number };
+  cursor?: string; onclick?: boolean; role?: string; attrs?: Record<string, string>;
+}) {
+  const attrs = opts.attrs ?? {};
+  const el: any = {
+    nodeType: 1,
+    tagName: opts.tag.toUpperCase(),
+    _cursor: opts.cursor ?? 'auto',
+    onclick: opts.onclick ? () => {} : null,
+    parentElement: null,
+    children: [] as any[],
+    scrollIntoView() {},
+    getBoundingClientRect() {
+      const r = opts.rect;
+      return { left: r.left, top: r.top, width: r.width, height: r.height, right: r.left + r.width, bottom: r.top + r.height };
+    },
+    getAttribute(k: string) { return k === 'role' ? (opts.role ?? null) : (attrs[k] ?? null); },
+    hasAttribute(k: string) { return k === 'role' ? opts.role != null : k in attrs; },
+    contains(other: any) {
+      if (other === el) return true;
+      for (const c of el.children) { if (c === other || (c.contains && c.contains(other))) return true; }
+      return false;
+    },
+  };
+  return el;
+}
+
+/** Resolve computed cursor with CSS inheritance, so the fake DOM matches the
+ * browser: a child with no own cursor inherits its ancestors' pointer cursor. */
+function inheritedCursor(node: any): string {
+  let n = node;
+  while (n) {
+    if (n._cursor && n._cursor !== 'auto') return n._cursor;
+    n = n.parentElement;
+  }
+  return 'auto';
+}
+
+/** Run the generated boundingRectResolvedJs against a fake DOM. */
+function runRect(resolved: any, elementAt: (x: number, y: number) => any) {
+  const fakeWindow: any = { __resolved: resolved, getComputedStyle: (n: any) => ({ cursor: inheritedCursor(n) }) };
+  const fakeDoc: any = { elementFromPoint: (x: number, y: number) => elementAt(x, y) };
+  const js = boundingRectResolvedJs({ skipScroll: true, forClick: true });
+  // js is an IIFE expression `(() => {...})()`; arrow captures window/document
+  // params. Wrap in parens so ASI doesn't turn `return\n(` into `return;`.
+  return new Function('window', 'document', 'return (' + js + ')')(fakeWindow, fakeDoc);
+}
+
+describe('boundingRectResolvedJs runtime behavior', () => {
+  it('reports hit=target and no retarget when the centre lands on the element', () => {
+    const btn = makeEl({ tag: 'button', rect: { left: 0, top: 0, width: 100, height: 40 } });
+    const out = runRect(btn, () => btn);
+    expect(out.visible).toBe(true);
+    expect(out.hit).toBe('target');
+    expect(out.retargeted).toBe(false);
+    expect(out.x).toBe(50); expect(out.y).toBe(20);
+  });
+
+  it('retargets an <svg> icon to its clickable <div> ancestor (#2071)', () => {
+    const div = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 80, height: 80 }, cursor: 'pointer' });
+    const svg = makeEl({ tag: 'svg', rect: { left: 20, top: 20, width: 40, height: 40 } });
+    svg.parentElement = div; div.children = [svg];
+    // elementFromPoint at the div centre returns the svg (topmost paint), which
+    // is contained by div → hit=target on the retargeted element.
+    const out = runRect(svg, () => svg);
+    expect(out.retargeted).toBe(true);
+    expect(out.hit).toBe('target');
+    // measured rect is the div's (80x80 → centre 40,40), not the svg's
+    expect(out.w).toBe(80); expect(out.x).toBe(40); expect(out.y).toBe(40);
+  });
+
+  it('retargets to an ancestor that owns an onclick handler even without cursor:pointer (#2071)', () => {
+    const div = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 60, height: 60 }, onclick: true });
+    const svg = makeEl({ tag: 'svg', rect: { left: 10, top: 10, width: 40, height: 40 } });
+    svg.parentElement = div; div.children = [svg];
+    const out = runRect(svg, () => svg);
+    expect(out.retargeted).toBe(true);
+    expect(out.w).toBe(60);
+  });
+
+  it('does not retarget when no ancestor is clickable', () => {
+    const wrap = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 60, height: 60 } });
+    const span = makeEl({ tag: 'span', rect: { left: 10, top: 10, width: 40, height: 40 } });
+    span.parentElement = wrap; wrap.children = [span];
+    const out = runRect(span, () => span);
+    expect(out.retargeted).toBe(false);
+    expect(out.w).toBe(40);
+  });
+
+  it('treats an ancestor hit as trustworthy (open shadow-DOM host / own wrapper) and keeps the centre', () => {
+    // elementFromPoint returns a light-DOM ancestor (e.g. the shadow host) that
+    // contains the target — CDP pierces to the target, so this must NOT fall back.
+    const host = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 120, height: 60 } });
+    const btn = makeEl({ tag: 'button', rect: { left: 10, top: 10, width: 100, height: 40 } });
+    btn.parentElement = host; host.children = [btn];
+    const out = runRect(btn, () => host); // topmost at every point is the host (ancestor)
+    expect(out.hit).toBe('ancestor');
+    expect(out.retargeted).toBe(false);
+    // centre kept — no wasted probing when the hit is already trustworthy
+    expect(out.x).toBe(60); expect(out.y).toBe(30);
+  });
+
+  it('hover/dblClick mode (forClick omitted) returns the plain element centre with no hit-test', () => {
+    const div = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 80, height: 80 }, cursor: 'pointer' });
+    const svg = makeEl({ tag: 'svg', rect: { left: 20, top: 20, width: 40, height: 40 } });
+    svg.parentElement = div; div.children = [svg];
+    const js = boundingRectResolvedJs({ skipScroll: true }); // no forClick
+    const out = new Function('window', 'document', 'return (' + js + ')')(
+      { __resolved: svg, getComputedStyle: () => ({ cursor: 'pointer' }) },
+      { elementFromPoint: () => div },
+    );
+    // no retarget, no hit field — svg's own centre (40,40), unchanged behavior
+    expect(out.hit).toBeUndefined();
+    expect(out.retargeted).toBeUndefined();
+    expect(out.x).toBe(40); expect(out.y).toBe(40); expect(out.w).toBe(40);
+  });
+
+  it('reports hit=other when an overlay covers the element and no probe point lands (#2076)', () => {
+    const btn = makeEl({ tag: 'button', rect: { left: 0, top: 0, width: 100, height: 40 } });
+    const overlay = makeEl({ tag: 'div', rect: { left: 0, top: 0, width: 1000, height: 1000 } });
+    const out = runRect(btn, () => overlay); // every point hits the overlay
+    expect(out.hit).toBe('other');
+    expect(out.retargeted).toBe(false);
+  });
+
+  it('recovers a hitting point by probing when the centre is occluded but a corner is clear (#2076)', () => {
+    const btn = makeEl({ tag: 'button', rect: { left: 0, top: 0, width: 100, height: 40 } });
+    const overlay = makeEl({ tag: 'div', rect: { left: 40, top: 15, width: 20, height: 10 } });
+    // Centre (50,20) is covered by the overlay; the top-left inset (3,3) is clear.
+    const out = runRect(btn, (x, y) => (x === 50 && y === 20 ? overlay : btn));
+    expect(out.hit).toBe('target');
+    // the returned point moved off the occluded centre (50,20)
+    expect(out.x === 50 && out.y === 20).toBe(false);
+  });
+});
 
 /**
  * Tests for the target resolver JS generator.

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -301,20 +301,115 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
  * pointer/mouse chain that Radix/MUI/shadcn dropdowns rely on. Keep measurement
  * separate so the CDP-primary path does not call DOM `el.click()` first.
  */
-export function boundingRectResolvedJs(opts: { skipScroll?: boolean } = {}): string {
+export function boundingRectResolvedJs(opts: { skipScroll?: boolean; forClick?: boolean } = {}): string {
   const shouldScroll = opts.skipScroll ? 'false' : 'true';
+  const forClick = opts.forClick ? 'true' : 'false';
   return `
     (() => {
       const el = window.__resolved;
       if (!el) throw new Error('No resolved element');
       if (${shouldScroll}) el.scrollIntoView({ behavior: 'instant', block: 'center' });
-      const rect = el.getBoundingClientRect();
+
+      const FOR_CLICK = ${forClick};
+      // hover()/dblClick() want the plain element centre — the retarget + hit-test
+      // below are click-only so those actions keep their original behaviour.
+      if (!FOR_CLICK) {
+        const r0 = el.getBoundingClientRect();
+        return {
+          x: Math.round(r0.left + r0.width / 2),
+          y: Math.round(r0.top + r0.height / 2),
+          w: Math.round(r0.width),
+          h: Math.round(r0.height),
+          visible: Math.round(r0.width) > 0 && Math.round(r0.height) > 0,
+        };
+      }
+
+      // Does this node OWN a click handler? Deliberately excludes cursor:pointer,
+      // which is an *inherited* CSS property — an <svg> icon inside a clickable
+      // <div> inherits the pointer cursor but owns no handler, so cursor can't
+      // decide whether a node is the real click target. See issue #2071.
+      const ownsClickHandler = (node) => {
+        if (!node || node.nodeType !== 1) return false;
+        const tag = node.tagName.toLowerCase();
+        if (['a','button','input','select','textarea','label','summary'].includes(tag)) return true;
+        const role = node.getAttribute && node.getAttribute('role');
+        if (role && ['button','link','menuitem','menuitemcheckbox','menuitemradio','tab','option','checkbox','radio','switch'].includes(role)) return true;
+        if (typeof node.onclick === 'function') return true;
+        if (node.hasAttribute && (node.hasAttribute('onclick') || node.hasAttribute('jsaction'))) return true;
+        try {
+          for (const k in node) {
+            if (k.charCodeAt(0) === 95 && (k.indexOf('__reactProps$') === 0 || k.indexOf('__reactEventHandlers$') === 0)) {
+              const p = node[k];
+              if (p && (p.onClick || p.onMouseDown || p.onMouseUp)) return true;
+            }
+          }
+        } catch (e) {}
+        return false;
+      };
+      // A retarget destination just needs to look clickable; here cursor:pointer
+      // IS a useful signal (the ancestor is where it was set).
+      const isClickableAncestor = (node) => {
+        if (ownsClickHandler(node)) return true;
+        try { return window.getComputedStyle(node).cursor === 'pointer'; } catch (e) { return false; }
+      };
+
+      // #2071: if the resolved node owns no click handler but a nearby ancestor
+      // is clickable, aim at that ancestor so the handler fires.
+      let target = el;
+      let retargeted = false;
+      if (!ownsClickHandler(el)) {
+        let a = el.parentElement, hops = 0;
+        while (a && hops < 4) {
+          if (isClickableAncestor(a)) { target = a; retargeted = true; break; }
+          a = a.parentElement; hops++;
+        }
+      }
+
+      const rect = target.getBoundingClientRect();
       const w = Math.round(rect.width);
       const h = Math.round(rect.height);
-      const x = Math.round(rect.left + rect.width / 2);
-      const y = Math.round(rect.top + rect.height / 2);
+      let x = Math.round(rect.left + rect.width / 2);
+      let y = Math.round(rect.top + rect.height / 2);
       const visible = w > 0 && h > 0;
-      return { x, y, w, h, visible };
+
+      // #2076: verify the click point actually lands on the target. A trusted
+      // CDP click hit-tests at (x,y) and delivers the event to whatever is
+      // topmost there — an overlay/sibling can silently swallow it. Classify:
+      //   'target'   — the point is the target or a light-DOM descendant.
+      //   'ancestor' — the point is an ANCESTOR of the target. This is the
+      //                open-shadow-DOM case (elementFromPoint returns the shadow
+      //                *host*, not the shadow content) and the "point sits over
+      //                the target's own wrapper background" case. In both a CDP
+      //                click at (x,y) still reaches the target — CDP hit-testing
+      //                pierces shadow roots, and light-DOM clicks bubble up — so
+      //                it is trustworthy, unlike an unrelated overlay.
+      //   'other'    — an unrelated element covers the point (the real overlay
+      //                bug); the caller then dispatches a direct DOM click.
+      const hitClass = (px, py) => {
+        let at = null;
+        try { at = document.elementFromPoint(px, py); } catch (e) { return 'none'; }
+        if (!at) return 'none';
+        if (at === target || target.contains(at)) return 'target';
+        if (at.contains && at.contains(target)) return 'ancestor';
+        return 'other';
+      };
+      let hit = visible ? hitClass(x, y) : 'none';
+      if (visible && hit !== 'target' && hit !== 'ancestor') {
+        const cands = [
+          [rect.left + rect.width * 0.5, rect.top + rect.height * 0.25],
+          [rect.left + rect.width * 0.25, rect.top + rect.height * 0.5],
+          [rect.left + rect.width * 0.75, rect.top + rect.height * 0.5],
+          [rect.left + rect.width * 0.5, rect.top + rect.height * 0.75],
+          [rect.left + 3, rect.top + 3],
+          [rect.right - 3, rect.bottom - 3],
+        ];
+        for (const c of cands) {
+          const px = Math.round(c[0]), py = Math.round(c[1]);
+          const hc = hitClass(px, py);
+          if (hc === 'target' || hc === 'ancestor') { x = px; y = py; hit = hc; break; }
+        }
+      }
+      return { x, y, w, h, visible, hit, retargeted };
     })()
   `;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1966,8 +1966,13 @@ Examples:
         process.exitCode = EXIT_CODES.USAGE_ERROR;
         return;
       }
-      const { matches_n, match_level } = await page.click(resolvedTarget, parsed.opts);
-      console.log(JSON.stringify({ clicked: true, target: resolvedTarget, matches_n, match_level }, null, 2));
+      const { matches_n, match_level, click_method, hit, retargeted } = await page.click(resolvedTarget, parsed.opts);
+      console.log(JSON.stringify({
+        clicked: true, target: resolvedTarget, matches_n, match_level,
+        ...(click_method && { click_method }),
+        ...(hit && { hit }),
+        ...(retargeted && { retargeted }),
+      }, null, 2));
     }));
 
   addBrowserTabOption(

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface IPage {
   fetchJson(url: string, opts?: FetchJsonOptions): Promise<unknown>;
   getCookies(opts?: { domain?: string; url?: string }): Promise<BrowserCookie[]>;
   snapshot(opts?: SnapshotOptions): Promise<any>;
-  click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
+  click(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified'; click_method?: 'cdp' | 'js' | 'ax'; hit?: 'target' | 'ancestor' | 'other' | 'none'; retargeted?: boolean }>;
   dblClick?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
   hover?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;
   focus?(ref: string, opts?: { nth?: number; firstOnMulti?: boolean }): Promise<{ focused: boolean; matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' }>;


### PR DESCRIPTION
Completes the deferred batch. Three commits, four issues.

- **#2076 + #2071** `fix(browser)` — `click()` no longer reports `{clicked:true}` for a CDP mouse event that silently landed on an overlay or on a handler-less child. It hit-tests the click point (`elementFromPoint`), trusts CDP for `target`/`ancestor` (ancestor covers open shadow-DOM hosts, where CDP pierces to the target), probes inset points on a miss, and falls back to a direct DOM click only for a real overlay. Handler-less nodes (e.g. an `<svg>` icon) retarget to a nearby clickable ancestor so the handler fires. New `click_method`/`hit`/`retargeted` fields are surfaced. `hover()`/`dblClick()` keep their original behaviour (the rework is click-only).
- **#2089** `fix(facebook)` — feed anchors each post on its "Actions for this post" menu (modern FB dropped `[role="article"]` and the Like/Comment aria-labels), with scroll-to-load, all-digit decoy-author rejection, and hidden-char/Reels decoy filtering.
- **#2090** `fix(facebook)` — search collects entity/content links inside `[role="feed"]`, dropping `/search` decoys, chrome links, off-domain spam, and obfuscated text. Converted pipeline→func so the extractor is unit-testable; preserves the #625 navigate-before-extract guard.

**Verification**: full unit+adapter+extension suite green (6061 passed); `tsc`, `opencli validate`, typed-error-lint, and silent-column-drop all clean. The click generated-JS is executed against a fake DOM (cursor inheritance modelled) and the Facebook extractors against jsdom fixtures.

**Independent review incorporated**: an adversarial review flagged the click rework's real (narrow) regression surface — open shadow-DOM widgets — which this PR fixes via the `ancestor` hit class; plus hover/dblClick isolation, a bare-`/search` decoy gap, an over-broad digit-author rejection, an action-menu regex mismatch, and a single-post landmark-climb. All addressed.

**Needs live verification** (offline suite can't cover real browser hit-testing / live FB DOM): a real Radix/MUI or shadow-DOM dropdown for the click path, and logged-in Facebook feed/search for #2089/#2090. The jsdom fixtures encode the issue-described shapes, not captured live DOM.