### PR TITLE
fix(boss): distinguish environment rejection from auth expiry

### DIFF
--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -5,6 +5,8 @@ const BOSS_DOMAIN = 'www.zhipin.com';
 const CHAT_URL = `https://${BOSS_DOMAIN}/web/chat/index`;
 const COOKIE_EXPIRED_CODES = new Set([7, 37]);
 const COOKIE_EXPIRED_MSG = 'Cookie 已过期！请在当前 Chrome 浏览器中重新登录 BOSS 直聘。';
+const AMBIGUOUS_AUTH_CODE = 37;
+const ENVIRONMENT_REJECTED_MARKERS = ['环境存在异常', '环境异常', 'abnormal environment'];
 const RECRUITER_ONLY_MSG = '该命令仅支持招聘端（BOSS 端）账号，请使用招聘者账号登录后重试。';
 const DEFAULT_TIMEOUT = 15_000;
 // ── Core helpers ────────────────────────────────────────────────────────────
@@ -56,6 +58,13 @@ export function checkAuth(data) {
         throw new AuthRequiredError(BOSS_DOMAIN, COOKIE_EXPIRED_MSG);
     }
 }
+function checkEnvironment(data) {
+    const message = String(data.message || '').toLowerCase();
+    if (data.code === AMBIGUOUS_AUTH_CODE &&
+        ENVIRONMENT_REJECTED_MARKERS.some((marker) => message.includes(marker.toLowerCase()))) {
+        throw new CommandExecutionError(`Boss rejected the current browser environment: ${data.message || 'Unknown error'} (code=${data.code})`, '重新登录通常无法解决此问题。请保留当前页面，稍后重试，并在问题持续时上报完整错误信息。');
+    }
+}
 /**
  * Map BOSS code=24 ("请切换身份后再试") to a typed AuthRequiredError.
  * Recruiter-only commands (recommend, joblist, stats, resume, mark,
@@ -80,6 +89,7 @@ export function assertOk(data, errorPrefix) {
     }
     if (data.code === 0)
         return;
+    checkEnvironment(data);
     checkAuth(data);
     checkRecruiterSide(data);
     const prefix = errorPrefix ? `${errorPrefix}: ` : '';

--- a/clis/boss/utils.test.js
+++ b/clis/boss/utils.test.js
@@ -12,6 +12,30 @@ describe('assertOk', () => {
         expect(() => assertOk({ code: 37, message: 'expired' })).toThrow(AuthRequiredError);
     });
 
+    it('does not misclassify code 37 environment rejection as expired login', () => {
+        let error;
+        try {
+            assertOk({ code: 37, message: '您的环境存在异常.' }, 'Boss search failed');
+        } catch (caught) {
+            error = caught;
+        }
+
+        expect(error).toBeInstanceOf(CommandExecutionError);
+        expect(error).not.toBeInstanceOf(AuthRequiredError);
+        expect(error.code).toBe('COMMAND_EXEC');
+        expect(error.message).toContain('环境存在异常');
+        expect(error.message).toContain('code=37');
+        expect(error.hint).toContain('重新登录通常无法解决');
+    });
+
+    it('keeps code 37 login-expiry responses as auth required', () => {
+        expect(() => assertOk({ code: 37, message: '登录状态已失效' })).toThrow(AuthRequiredError);
+    });
+
+    it('keeps code 7 responses as auth required', () => {
+        expect(() => assertOk({ code: 7, message: '请重新登录' })).toThrow(AuthRequiredError);
+    });
+
     it('maps code 24 (identity mismatch) to AuthRequiredError with recruiter-only hint', () => {
         try {
             assertOk({ code: 24, message: '请切换身份后再试' });


### PR DESCRIPTION
## Summary

- distinguish BOSS code 37 environment-anomaly responses from expired authentication
- keep code 7 and non-environment code 37 responses backward-compatible as auth-required
- return a structured command error that explains re-login usually does not resolve an environment rejection

## Why

BOSS can return code 37 with `您的环境存在异常.` while the user remains logged in and the search page is visibly usable. Treating every code 37 response as expired cookies sends users through a repeated, ineffective login flow.

This change only corrects error classification and guidance. It does not add browser masking or verification bypass behavior.

## Tests

- `npx vitest run --project adapter clis/boss`
- `npm run typecheck`
