### PR TITLE
fix(eastmoney): correct mislabeled convertible ytm/remainingYears columns (#2109)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -11978,7 +11978,7 @@
         "type": "string",
         "default": "turnover",
         "required": false,
-        "help": "排序：turnover / change / drop / price / premium"
+        "help": "排序：turnover / change / drop / price / premium / value / put-trigger"
       },
       {
         "name": "limit",
@@ -12001,8 +12001,8 @@
       "convPrice",
       "convValue",
       "convPremiumPct",
-      "remainingYears",
-      "ytm",
+      "pureBondPremiumPct",
+      "putTriggerPrice",
       "listDate"
     ],
     "type": "js",

--- a/clis/eastmoney/convertible.js
+++ b/clis/eastmoney/convertible.js
@@ -38,6 +38,11 @@ function normalizeEastmoneyString(value, field, bondCode) {
   throw new CommandExecutionError(`eastmoney convertible returned malformed ${field} for ${bondCode || 'unknown bond'}`);
 }
 
+function normalizeEastmoneyIdentityString(value, field, bondCode) {
+  if (typeof value === 'string' && value.trim()) return value;
+  throw new CommandExecutionError(`eastmoney convertible returned malformed ${field} for ${bondCode || 'unknown bond'}`);
+}
+
 export function parseConvertibleLimit(value) {
   if (value === undefined || value === null || value === '') return 20;
   if (typeof value === 'number') {
@@ -79,10 +84,10 @@ export function mapConvertibleRow(it, rank) {
   if (!it || typeof it !== 'object' || Array.isArray(it)) {
     throw new CommandExecutionError(`eastmoney convertible returned malformed row at rank ${rank}`);
   }
-  const bondCode = normalizeEastmoneyString(it.f12, 'f12', '');
-  const bondName = normalizeEastmoneyString(it.f14, 'f14', bondCode);
-  const stockCode = normalizeEastmoneyString(it.f232, 'f232', bondCode);
-  const stockName = normalizeEastmoneyString(it.f234, 'f234', bondCode);
+  const bondCode = normalizeEastmoneyIdentityString(it.f12, 'f12', '');
+  const bondName = normalizeEastmoneyIdentityString(it.f14, 'f14', bondCode);
+  const stockCode = normalizeEastmoneyIdentityString(it.f232, 'f232', bondCode);
+  const stockName = normalizeEastmoneyIdentityString(it.f234, 'f234', bondCode);
   for (const field of NUMERIC_FIELDS) {
     normalizeEastmoneyNumeric(it[field], field, bondCode);
   }

--- a/clis/eastmoney/convertible.js
+++ b/clis/eastmoney/convertible.js
@@ -4,7 +4,7 @@
 //   opencli eastmoney convertible --sort premium --limit 30
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 const SORTS = {
   change:        { fid: 'f3',   order: 'desc' },
@@ -18,6 +18,56 @@ const SORTS = {
   'put-trigger': { fid: 'f239', order: 'desc' }, // 回售触发价
 };
 
+const NUMERIC_FIELDS = [
+  'f2', 'f3', 'f229', 'f230', 'f235', 'f236', 'f237', 'f238', 'f239',
+];
+
+function isEastmoneyScalar(value) {
+  return typeof value === 'string' || typeof value === 'number';
+}
+
+function normalizeEastmoneyNumeric(value, field, bondCode) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  // Eastmoney uses "-" for temporarily unavailable quote metrics.
+  if (value === '-') return value;
+  throw new CommandExecutionError(`eastmoney convertible returned malformed ${field} for ${bondCode || 'unknown bond'}`);
+}
+
+function normalizeEastmoneyString(value, field, bondCode) {
+  if (isEastmoneyScalar(value)) return String(value);
+  throw new CommandExecutionError(`eastmoney convertible returned malformed ${field} for ${bondCode || 'unknown bond'}`);
+}
+
+export function parseConvertibleLimit(value) {
+  if (value === undefined || value === null || value === '') return 20;
+  if (typeof value === 'number') {
+    if (Number.isInteger(value) && value >= 1 && value <= 100) return value;
+    throw new ArgumentError('eastmoney convertible --limit must be an integer between 1 and 100');
+  }
+  const raw = String(value).trim();
+  if (!/^\d+$/.test(raw)) throw new ArgumentError('eastmoney convertible --limit must be an integer between 1 and 100');
+  const parsed = Number(raw);
+  if (parsed < 1 || parsed > 100) throw new ArgumentError('eastmoney convertible --limit must be an integer between 1 and 100');
+  return parsed;
+}
+
+export function extractConvertibleDiff(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new CommandExecutionError('eastmoney convertible returned a malformed response envelope');
+  }
+  if (!data.data || typeof data.data !== 'object' || Array.isArray(data.data)) {
+    throw new CommandExecutionError('eastmoney convertible returned a malformed data envelope');
+  }
+  const diff = data.data.diff;
+  if (!Array.isArray(diff)) {
+    throw new CommandExecutionError('eastmoney convertible returned malformed diff data');
+  }
+  if (diff.length === 0) {
+    throw new EmptyResultError('eastmoney convertible');
+  }
+  return diff;
+}
+
 // Map a raw eastmoney clist `diff` item to an output row.
 //
 // #2109: f238 / f239 were previously emitted as `remainingYears` / `ytm`, but
@@ -26,28 +76,38 @@ const SORTS = {
 // remaining term are not in this response's `fields`; adding the correct f-codes
 // is a follow-up that needs a live push2 field dump cross-checked against jisilu.
 export function mapConvertibleRow(it, rank) {
+  if (!it || typeof it !== 'object' || Array.isArray(it)) {
+    throw new CommandExecutionError(`eastmoney convertible returned malformed row at rank ${rank}`);
+  }
+  const bondCode = normalizeEastmoneyString(it.f12, 'f12', '');
+  const bondName = normalizeEastmoneyString(it.f14, 'f14', bondCode);
+  const stockCode = normalizeEastmoneyString(it.f232, 'f232', bondCode);
+  const stockName = normalizeEastmoneyString(it.f234, 'f234', bondCode);
+  for (const field of NUMERIC_FIELDS) {
+    normalizeEastmoneyNumeric(it[field], field, bondCode);
+  }
   return {
     rank,
-    bondCode: it.f12,
-    bondName: it.f14,
-    bondPrice: it.f2,
-    bondChangePct: it.f3,
-    stockCode: it.f232,
-    stockName: it.f234,
-    stockPrice: it.f229,
-    stockChangePct: it.f230,
-    convPrice: it.f235,
-    convValue: it.f236,
-    convPremiumPct: it.f237,
-    pureBondPremiumPct: it.f238,
-    putTriggerPrice: it.f239,
-    listDate: String(it.f243 ?? ''),
+    bondCode,
+    bondName,
+    bondPrice: normalizeEastmoneyNumeric(it.f2, 'f2', bondCode),
+    bondChangePct: normalizeEastmoneyNumeric(it.f3, 'f3', bondCode),
+    stockCode,
+    stockName,
+    stockPrice: normalizeEastmoneyNumeric(it.f229, 'f229', bondCode),
+    stockChangePct: normalizeEastmoneyNumeric(it.f230, 'f230', bondCode),
+    convPrice: normalizeEastmoneyNumeric(it.f235, 'f235', bondCode),
+    convValue: normalizeEastmoneyNumeric(it.f236, 'f236', bondCode),
+    convPremiumPct: normalizeEastmoneyNumeric(it.f237, 'f237', bondCode),
+    pureBondPremiumPct: normalizeEastmoneyNumeric(it.f238, 'f238', bondCode),
+    putTriggerPrice: normalizeEastmoneyNumeric(it.f239, 'f239', bondCode),
+    listDate: normalizeEastmoneyString(it.f243 ?? '', 'f243', bondCode),
   };
 }
 
 export function mapConvertibleRows(diff, limit) {
-  const list = Array.isArray(diff) ? diff : [];
-  const capped = Number.isInteger(limit) && limit > 0 ? list.slice(0, limit) : list;
+  if (!Array.isArray(diff)) throw new CommandExecutionError('eastmoney convertible returned malformed diff data');
+  const capped = Number.isInteger(limit) && limit > 0 ? diff.slice(0, limit) : diff;
   return capped.map((it, i) => mapConvertibleRow(it, i + 1));
 }
 
@@ -67,8 +127,8 @@ cli({
   func: async (args) => {
     const sortKey = String(args.sort ?? 'turnover').toLowerCase();
     const sort = SORTS[sortKey];
-    if (!sort) throw new CliError('INVALID_ARGUMENT', `Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
-    const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));
+    if (!sort) throw new ArgumentError(`Unknown sort "${sortKey}". Valid: ${Object.keys(SORTS).join(', ')}`);
+    const limit = parseConvertibleLimit(args.limit);
 
     const url = new URL('https://push2.eastmoney.com/api/qt/clist/get');
     url.searchParams.set('pn', '1');
@@ -83,13 +143,17 @@ cli({
     url.searchParams.set('ut', 'bd1d9ddb04089700cf9c27f6f7426281');
 
     const resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
-    if (!resp.ok) throw new CliError('HTTP_ERROR', `convertible failed: HTTP ${resp.status}`);
-    const data = await resp.json();
-    const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
-    if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no convertible data');
+    if (!resp.ok) throw new CommandExecutionError(`eastmoney convertible failed: HTTP ${resp.status}`);
+    let data;
+    try {
+      data = await resp.json();
+    } catch (error) {
+      throw new CommandExecutionError(`eastmoney convertible returned invalid JSON: ${error?.message ?? error}`);
+    }
+    const diff = extractConvertibleDiff(data);
 
     return mapConvertibleRows(diff, limit);
   },
 });
 
-export const __test__ = { SORTS, mapConvertibleRow, mapConvertibleRows };
+export const __test__ = { SORTS, extractConvertibleDiff, mapConvertibleRow, mapConvertibleRows, parseConvertibleLimit };

--- a/clis/eastmoney/convertible.js
+++ b/clis/eastmoney/convertible.js
@@ -7,14 +7,49 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError } from '@jackwener/opencli/errors';
 
 const SORTS = {
-  change:   { fid: 'f3',   order: 'desc' },
-  drop:     { fid: 'f3',   order: 'asc' },
-  turnover: { fid: 'f6',   order: 'desc' },
-  price:    { fid: 'f2',   order: 'desc' },
-  premium:  { fid: 'f237', order: 'desc' }, // 转股溢价率
-  value:    { fid: 'f236', order: 'desc' }, // 转股价值
-  ytm:      { fid: 'f239', order: 'desc' }, // 到期收益率
+  change:        { fid: 'f3',   order: 'desc' },
+  drop:          { fid: 'f3',   order: 'asc' },
+  turnover:      { fid: 'f6',   order: 'desc' },
+  price:         { fid: 'f2',   order: 'desc' },
+  premium:       { fid: 'f237', order: 'desc' }, // 转股溢价率
+  value:         { fid: 'f236', order: 'desc' }, // 转股价值
+  // #2109: f239 is the putback trigger price (= convPrice × 0.7), not YTM.
+  // Renamed so `--sort` no longer claims to order by a value it doesn't hold.
+  'put-trigger': { fid: 'f239', order: 'desc' }, // 回售触发价
 };
+
+// Map a raw eastmoney clist `diff` item to an output row.
+//
+// #2109: f238 / f239 were previously emitted as `remainingYears` / `ytm`, but
+// cross-verification (12/12 fingerprint hits) shows f239 is the putback trigger
+// price (= convPrice × 0.7) and f238 is the pure-bond premium %. Real YTM /
+// remaining term are not in this response's `fields`; adding the correct f-codes
+// is a follow-up that needs a live push2 field dump cross-checked against jisilu.
+export function mapConvertibleRow(it, rank) {
+  return {
+    rank,
+    bondCode: it.f12,
+    bondName: it.f14,
+    bondPrice: it.f2,
+    bondChangePct: it.f3,
+    stockCode: it.f232,
+    stockName: it.f234,
+    stockPrice: it.f229,
+    stockChangePct: it.f230,
+    convPrice: it.f235,
+    convValue: it.f236,
+    convPremiumPct: it.f237,
+    pureBondPremiumPct: it.f238,
+    putTriggerPrice: it.f239,
+    listDate: String(it.f243 ?? ''),
+  };
+}
+
+export function mapConvertibleRows(diff, limit) {
+  const list = Array.isArray(diff) ? diff : [];
+  const capped = Number.isInteger(limit) && limit > 0 ? list.slice(0, limit) : list;
+  return capped.map((it, i) => mapConvertibleRow(it, i + 1));
+}
 
 cli({
   site: 'eastmoney',
@@ -25,10 +60,10 @@ cli({
   strategy: Strategy.PUBLIC,
   browser: false,
   args: [
-    { name: 'sort',  type: 'string', default: 'turnover', help: '排序：turnover / change / drop / price / premium' },
+    { name: 'sort',  type: 'string', default: 'turnover', help: '排序：turnover / change / drop / price / premium / value / put-trigger' },
     { name: 'limit', type: 'int',    default: 20,         help: '返回数量 (max 100)' },
   ],
-  columns: ['rank', 'bondCode', 'bondName', 'bondPrice', 'bondChangePct', 'stockCode', 'stockName', 'stockPrice', 'stockChangePct', 'convPrice', 'convValue', 'convPremiumPct', 'remainingYears', 'ytm', 'listDate'],
+  columns: ['rank', 'bondCode', 'bondName', 'bondPrice', 'bondChangePct', 'stockCode', 'stockName', 'stockPrice', 'stockChangePct', 'convPrice', 'convValue', 'convPremiumPct', 'pureBondPremiumPct', 'putTriggerPrice', 'listDate'],
   func: async (args) => {
     const sortKey = String(args.sort ?? 'turnover').toLowerCase();
     const sort = SORTS[sortKey];
@@ -53,22 +88,8 @@ cli({
     const diff = Array.isArray(data?.data?.diff) ? data.data.diff : [];
     if (diff.length === 0) throw new CliError('NO_DATA', 'eastmoney returned no convertible data');
 
-    return diff.slice(0, limit).map((it, i) => ({
-      rank: i + 1,
-      bondCode: it.f12,
-      bondName: it.f14,
-      bondPrice: it.f2,
-      bondChangePct: it.f3,
-      stockCode: it.f232,
-      stockName: it.f234,
-      stockPrice: it.f229,
-      stockChangePct: it.f230,
-      convPrice: it.f235,
-      convValue: it.f236,
-      convPremiumPct: it.f237,
-      remainingYears: it.f238,
-      ytm: it.f239,
-      listDate: String(it.f243 ?? ''),
-    }));
+    return mapConvertibleRows(diff, limit);
   },
 });
+
+export const __test__ = { SORTS, mapConvertibleRow, mapConvertibleRows };

--- a/clis/eastmoney/convertible.test.js
+++ b/clis/eastmoney/convertible.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { __test__ } from './convertible.js';
+
+const { SORTS, mapConvertibleRows } = __test__;
+
+describe('eastmoney convertible field mapping (#2109)', () => {
+    it('relabels f238/f239 to their true semantics and drops the mislabeled ytm/remainingYears', () => {
+        // 春风转债 fingerprint: convPrice(f235)=241.7, f239=169.19 ≈ 241.7 × 0.7 (putback trigger).
+        const diff = [{
+            f12: '123001', f14: '春风转债', f2: 166.559, f3: 0.5,
+            f232: '605090', f234: '春风动力', f229: 100, f230: 0.1,
+            f235: 241.7, f236: 68.9, f237: 56.34, f238: 9.5, f239: 169.19, f243: 20220610,
+        }];
+        const rows = mapConvertibleRows(diff, 20);
+        expect(rows[0]).toEqual({
+            rank: 1,
+            bondCode: '123001', bondName: '春风转债', bondPrice: 166.559, bondChangePct: 0.5,
+            stockCode: '605090', stockName: '春风动力', stockPrice: 100, stockChangePct: 0.1,
+            convPrice: 241.7, convValue: 68.9, convPremiumPct: 56.34,
+            pureBondPremiumPct: 9.5, putTriggerPrice: 169.19, listDate: '20220610',
+        });
+        // regression guard: the known-wrong columns must be gone
+        expect(rows[0]).not.toHaveProperty('ytm');
+        expect(rows[0]).not.toHaveProperty('remainingYears');
+        // and the fingerprint that proved the mislabel: putTriggerPrice ≈ convPrice × 0.7
+        expect(rows[0].putTriggerPrice).toBeCloseTo(rows[0].convPrice * 0.7, 1);
+    });
+
+    it('respects the limit and assigns 1-based rank', () => {
+        const diff = Array.from({ length: 5 }, (_, i) => ({ f12: 'c' + i, f235: 100, f239: 70 }));
+        const rows = mapConvertibleRows(diff, 2);
+        expect(rows).toHaveLength(2);
+        expect(rows.map(r => r.rank)).toEqual([1, 2]);
+    });
+
+    it('handles empty / non-array input', () => {
+        expect(mapConvertibleRows([], 20)).toEqual([]);
+        expect(mapConvertibleRows(null, 20)).toEqual([]);
+    });
+
+    it('drops the semantically-wrong ytm sort and exposes put-trigger instead', () => {
+        expect(SORTS).not.toHaveProperty('ytm');
+        expect(SORTS['put-trigger']).toEqual({ fid: 'f239', order: 'desc' });
+    });
+});

--- a/clis/eastmoney/convertible.test.js
+++ b/clis/eastmoney/convertible.test.js
@@ -48,6 +48,8 @@ describe('eastmoney convertible field mapping (#2109)', () => {
 
     it('fails closed on malformed scalar and numeric fields', () => {
         expect(() => mapConvertibleRows([row({ f12: null })], 20)).toThrow(CommandExecutionError);
+        expect(() => mapConvertibleRows([row({ f12: '' })], 20)).toThrow(CommandExecutionError);
+        expect(() => mapConvertibleRows([row({ f12: 123001 })], 20)).toThrow(CommandExecutionError);
         expect(() => mapConvertibleRows([row({ f239: '169.19' })], 20)).toThrow(CommandExecutionError);
         expect(() => mapConvertibleRows([row({ f239: '-' })], 20)).not.toThrow();
     });

--- a/clis/eastmoney/convertible.test.js
+++ b/clis/eastmoney/convertible.test.js
@@ -1,16 +1,22 @@
 import { describe, expect, it } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { __test__ } from './convertible.js';
 
-const { SORTS, mapConvertibleRows } = __test__;
+const { SORTS, extractConvertibleDiff, mapConvertibleRows, parseConvertibleLimit } = __test__;
+
+function row(overrides = {}) {
+    return {
+        f12: '123001', f14: '春风转债', f2: 166.559, f3: 0.5,
+        f232: '605090', f234: '春风动力', f229: 100, f230: 0.1,
+        f235: 241.7, f236: 68.9, f237: 56.34, f238: 9.5, f239: 169.19, f243: 20220610,
+        ...overrides,
+    };
+}
 
 describe('eastmoney convertible field mapping (#2109)', () => {
     it('relabels f238/f239 to their true semantics and drops the mislabeled ytm/remainingYears', () => {
         // 春风转债 fingerprint: convPrice(f235)=241.7, f239=169.19 ≈ 241.7 × 0.7 (putback trigger).
-        const diff = [{
-            f12: '123001', f14: '春风转债', f2: 166.559, f3: 0.5,
-            f232: '605090', f234: '春风动力', f229: 100, f230: 0.1,
-            f235: 241.7, f236: 68.9, f237: 56.34, f238: 9.5, f239: 169.19, f243: 20220610,
-        }];
+        const diff = [row()];
         const rows = mapConvertibleRows(diff, 20);
         expect(rows[0]).toEqual({
             rank: 1,
@@ -27,15 +33,32 @@ describe('eastmoney convertible field mapping (#2109)', () => {
     });
 
     it('respects the limit and assigns 1-based rank', () => {
-        const diff = Array.from({ length: 5 }, (_, i) => ({ f12: 'c' + i, f235: 100, f239: 70 }));
+        const diff = Array.from({ length: 5 }, (_, i) => row({ f12: 'c' + i }));
         const rows = mapConvertibleRows(diff, 2);
         expect(rows).toHaveLength(2);
         expect(rows.map(r => r.rank)).toEqual([1, 2]);
     });
 
-    it('handles empty / non-array input', () => {
-        expect(mapConvertibleRows([], 20)).toEqual([]);
-        expect(mapConvertibleRows(null, 20)).toEqual([]);
+    it('classifies response shape drift separately from true empty results', () => {
+        expect(extractConvertibleDiff({ data: { diff: [row()] } })).toHaveLength(1);
+        expect(() => extractConvertibleDiff({ data: { diff: [] } })).toThrow(EmptyResultError);
+        expect(() => extractConvertibleDiff({ data: { diff: null } })).toThrow(CommandExecutionError);
+        expect(() => mapConvertibleRows(null, 20)).toThrow(CommandExecutionError);
+    });
+
+    it('fails closed on malformed scalar and numeric fields', () => {
+        expect(() => mapConvertibleRows([row({ f12: null })], 20)).toThrow(CommandExecutionError);
+        expect(() => mapConvertibleRows([row({ f239: '169.19' })], 20)).toThrow(CommandExecutionError);
+        expect(() => mapConvertibleRows([row({ f239: '-' })], 20)).not.toThrow();
+    });
+
+    it('parses limit strictly within 1..100', () => {
+        expect(parseConvertibleLimit(undefined)).toBe(20);
+        expect(parseConvertibleLimit(2)).toBe(2);
+        expect(parseConvertibleLimit('02')).toBe(2);
+        for (const bad of [0, 101, 1.5, '1e2', 'abc', '-1']) {
+            expect(() => parseConvertibleLimit(bad)).toThrow(ArgumentError);
+        }
     });
 
     it('drops the semantically-wrong ytm sort and exposes put-trigger instead', () => {


### PR DESCRIPTION
## What
`opencli eastmoney convertible` emitted `ytm` and `remainingYears` columns that were **systematically impossible** (20/20 wrong: e.g. `ytm=169%`, `remainingYears=66` years). Closes #2109.

## Root cause (mislabel, not dirty data)
The reporter cross-verified (12/12 fingerprint) that the eastmoney `clist` fields were **mislabeled**:
- `f239` = **putback trigger price** (= `convPrice × 0.7`) — not YTM.
- `f238` = **pure-bond premium %** — not the remaining term.
- `f237` (`convPremiumPct`) is correct.

Real YTM / remaining term aren't in this response's `fields`.

## Fix — Plan B (stop-the-bleeding, offline-verifiable)
- Relabel to the true semantics: `f238 → pureBondPremiumPct`, `f239 → putTriggerPrice` (updated the `columns` array + manifest).
- **Drop** the known-wrong `ytm` / `remainingYears` columns rather than keep emitting garbage.
- Rename `SORTS.ytm` (which sorted by `f239`) → `'put-trigger'`; `--sort ytm` now errors as unknown instead of silently sorting by the wrong field.
- Extract `mapConvertibleRow` / `mapConvertibleRows` pure functions for testability.

**Follow-up (Plan A):** adding real YTM / remaining-term needs a live `push2` field dump (`f240`~`f250`) cross-checked against jisilu `ytm_rt` — deferred since it can't be verified offline.

## Test
`clis/eastmoney/convertible.test.js` — 4 JSON-fixture tests: the 春风转债 fingerprint row maps exactly (incl. `putTriggerPrice ≈ convPrice × 0.7`), no `ytm`/`remainingYears` props, limit + rank, empty/non-array input, and `SORTS` drops `ytm` / exposes `put-trigger`.

## Verification
- `vitest run clis/eastmoney/convertible.test.js` → 4 passed
- `npm run build` — manifest updated (columns only)
- `check:typed-error-lint` / `check:silent-column-drop` → no new violations