### PR TITLE
feat(xiaohongshu): 评论输出 images 字段 + 滚动加载健壮性改进

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -30131,7 +30131,8 @@
       "likes",
       "time",
       "is_reply",
-      "reply_to"
+      "reply_to",
+      "images"
     ],
     "type": "js",
     "modulePath": "rednote/comments.js",
@@ -41485,7 +41486,8 @@
       "likes",
       "time",
       "is_reply",
-      "reply_to"
+      "reply_to",
+      "images"
     ],
     "type": "js",
     "modulePath": "xiaohongshu/comments.js",

--- a/clis/rednote/comments.js
+++ b/clis/rednote/comments.js
@@ -4,7 +4,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { buildCommentsExtractJs } from '../xiaohongshu/comments.js';
+import { buildCommentsExtractJs, normalizeCommentRows } from '../xiaohongshu/comments.js';
 import { buildNoteUrl, parseNoteId } from '../xiaohongshu/note-helpers.js';
 
 const REDNOTE_SIGNED_URL_HINT = 'Pass a full rednote.com note URL with xsec_token from search results or user/profile context.';
@@ -58,7 +58,7 @@ cli({
             throw new AuthRequiredError('www.rednote.com', 'Note comments require login');
         }
         void noteId;
-        const all = data.results ?? [];
+        const all = normalizeCommentRows(data.results, 'rednote/comments');
         const toRow = (c, i) => ({
             rank: i + 1,
             author: c.author,

--- a/clis/rednote/comments.js
+++ b/clis/rednote/comments.js
@@ -33,7 +33,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of top-level comments (max 50)' },
         { name: 'with-replies', type: 'boolean', default: false, help: 'Include nested replies (楼中楼)' },
     ],
-    columns: ['rank', 'author', 'text', 'likes', 'time', 'is_reply', 'reply_to'],
+    columns: ['rank', 'author', 'text', 'likes', 'time', 'is_reply', 'reply_to', 'images'],
     func: async (page, kwargs) => {
         const limit = parseCommentLimit(kwargs.limit);
         const withReplies = Boolean(kwargs['with-replies']);
@@ -45,7 +45,7 @@ cli({
             signedUrlHint: REDNOTE_SIGNED_URL_HINT,
         }));
         await page.wait({ time: 2 + Math.random() * 3 });
-        const data = await page.evaluate(buildCommentsExtractJs(withReplies));
+        const data = await page.evaluate(buildCommentsExtractJs(withReplies, limit));
         if (!data || typeof data !== 'object') {
             throw new EmptyResultError('rednote/comments', 'Unexpected evaluate response');
         }
@@ -67,6 +67,7 @@ cli({
             time: c.time,
             is_reply: c.is_reply,
             reply_to: c.reply_to,
+            images: c.images ?? [],
         });
         if (withReplies) {
             const limited = [];

--- a/clis/rednote/rednote.test.js
+++ b/clis/rednote/rednote.test.js
@@ -90,7 +90,7 @@ describe('rednote note URL identity', () => {
         });
 
         expect(rows).toEqual([
-            { rank: 1, author: 'Alice', text: 'Nice', likes: 1, time: 'today', is_reply: false, reply_to: '' },
+            { rank: 1, author: 'Alice', text: 'Nice', likes: 1, time: 'today', is_reply: false, reply_to: '', images: [] },
         ]);
         expect(rows[0]).not.toHaveProperty('authorHrefRaw');
     });

--- a/clis/rednote/rednote.test.js
+++ b/clis/rednote/rednote.test.js
@@ -95,6 +95,22 @@ describe('rednote note URL identity', () => {
         expect(rows[0]).not.toHaveProperty('authorHrefRaw');
     });
 
+    it('fails typed for malformed comment images instead of leaking success rows', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', authorHrefRaw: '/user/profile/alice1', text: 'Nice', likes: 1, time: 'today', is_reply: false, reply_to: '', images: ['blob:https://www.rednote.com/not-stable'] },
+            ],
+        });
+        await expect(comments.func(page, {
+            'note-id': 'https://www.rednote.com/search_result/69aadbcb000000002202f131?xsec_token=abc',
+            limit: 20,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed comment row image URL'),
+        });
+    });
+
     it('uses URL-scoped rednote cookies when downloading media', async () => {
         const page = createPageMock({
             noteId: '69bc166f000000001a02069a',

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -69,12 +69,13 @@ export function parseXhsLikeCountText(value) {
  * top-level comments (and optionally nested 楼中楼 replies). Exported so
  * the rednote adapter can reuse the exact same selector chain.
  */
-export function buildCommentsExtractJs(withReplies) {
+export function buildCommentsExtractJs(withReplies, limit = 20) {
     const parseLikeCountText = parseXhsLikeCountText.toString();
     return `
       (async () => {
         const wait = (ms) => new Promise(r => setTimeout(r, ms))
         const withReplies = ${withReplies}
+        const targetCount = ${Number(limit) || 20}
 
         // Check login state
         const bodyText = document.body?.innerText || ''
@@ -82,15 +83,40 @@ export function buildCommentsExtractJs(withReplies) {
         const securityBlock = /安全限制|访问链接异常/.test(bodyText)
           || /website-login\\/error|error_code=300017|error_code=300031/.test(location.href)
 
-        // Scroll the note container to trigger comment loading
+        // Scroll to trigger comment loading. Xiaohongshu loads comments in
+        // small async batches via IntersectionObserver, and depending on the
+        // page layout / viewport the actual scrollable ancestor can be
+        // .note-scroller, .container, or the document itself — so each round
+        // drives all of them plus scrollIntoView on the last loaded comment,
+        // which works regardless of which element actually owns the scrollbar.
+        // A single stalled round doesn't mean the list is exhausted — keep
+        // going until growth stalls for several consecutive rounds, we've
+        // loaded enough top-level comments to satisfy --limit, or we hit the
+        // hard round cap.
         const scroller = document.querySelector('.note-scroller') || document.querySelector('.container')
-        if (scroller) {
-          for (let i = 0; i < 3; i++) {
-            const beforeCount = scroller.querySelectorAll('.parent-comment').length
-            scroller.scrollTo(0, scroller.scrollHeight)
-            await wait(800 + Math.random() * 1200)
-            const afterCount = scroller.querySelectorAll('.parent-comment').length
-            if (afterCount <= beforeCount) break
+        const driveScroll = () => {
+          if (scroller) scroller.scrollTo(0, scroller.scrollHeight)
+          const comments = document.querySelectorAll('.parent-comment')
+          const last = comments[comments.length - 1]
+          if (last && typeof last.scrollIntoView === 'function') last.scrollIntoView({ block: 'end' })
+          if (typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
+            window.scrollTo(0, document.body.scrollHeight)
+          }
+        }
+        {
+          let stall = 0
+          for (let i = 0; i < 60; i++) {
+            const beforeCount = document.querySelectorAll('.parent-comment').length
+            if (beforeCount >= targetCount) break
+            driveScroll()
+            await wait(1000 + Math.random() * 1200)
+            const afterCount = document.querySelectorAll('.parent-comment').length
+            if (afterCount <= beforeCount) {
+              stall++
+              if (stall >= 6) break
+            } else {
+              stall = 0
+            }
           }
         }
 
@@ -104,6 +130,19 @@ export function buildCommentsExtractJs(withReplies) {
           if (!el) return ''
           const anchor = el.querySelector(HREF_SELECTOR)
           return anchor ? (anchor.getAttribute('href') || '') : ''
+        }
+        // Attached comment photos, excluding the author avatar and inline
+        // note-content-emoji stickers rendered inside the comment text.
+        const extractImages = (el) => {
+          if (!el) return []
+          const urls = []
+          el.querySelectorAll('img').forEach(img => {
+            if (img.classList.contains('avatar-item')) return
+            if (img.closest('.content, .note-text')) return
+            const src = img.currentSrc || img.src || img.getAttribute('data-src') || ''
+            if (src && !urls.includes(src)) urls.push(src)
+          })
+          return urls
         }
         const expandReplyThreads = async (root) => {
           if (!withReplies || !root) return
@@ -138,9 +177,10 @@ export function buildCommentsExtractJs(withReplies) {
           const text = clean(item.querySelector('.content, .note-text'))
           const likes = parseLikes(item.querySelector('.count'))
           const time = clean(item.querySelector('.date, .time'))
+          const images = extractImages(item)
 
           if (!text) continue
-          results.push({ author, authorHrefRaw, text, likes, time, is_reply: false, reply_to: '' })
+          results.push({ author, authorHrefRaw, text, likes, time, is_reply: false, reply_to: '', images })
 
           // Extract nested replies (楼中楼)
           if (withReplies) {
@@ -151,8 +191,9 @@ export function buildCommentsExtractJs(withReplies) {
               const sText = clean(sub.querySelector('.content, .note-text'))
               const sLikes = parseLikes(sub.querySelector('.count'))
               const sTime = clean(sub.querySelector('.date, .time'))
+              const sImages = extractImages(sub)
               if (!sText) return
-              results.push({ author: sAuthor, authorHrefRaw: sAuthorHrefRaw, text: sText, likes: sLikes, time: sTime, is_reply: true, reply_to: author })
+              results.push({ author: sAuthor, authorHrefRaw: sAuthorHrefRaw, text: sText, likes: sLikes, time: sTime, is_reply: true, reply_to: author, images: sImages })
             })
           }
         }
@@ -174,7 +215,7 @@ export const command = cli({
         { name: 'limit', type: 'int', default: 20, help: 'Number of top-level comments (max 50)' },
         { name: 'with-replies', type: 'boolean', default: false, help: 'Include nested replies (楼中楼)' },
     ],
-    columns: ['rank', 'author', 'userId', 'profileUrl', 'text', 'likes', 'time', 'is_reply', 'reply_to'],
+    columns: ['rank', 'author', 'userId', 'profileUrl', 'text', 'likes', 'time', 'is_reply', 'reply_to', 'images'],
     func: async (page, kwargs) => {
         const limit = parseCommentLimit(kwargs.limit);
         const withReplies = Boolean(kwargs['with-replies']);
@@ -182,7 +223,7 @@ export const command = cli({
         const noteId = parseNoteId(raw);
         await page.goto(buildNoteUrl(raw, { commandName: 'xiaohongshu comments' }));
         await page.wait({ time: 2 + Math.random() * 3 });
-        const data = await page.evaluate(buildCommentsExtractJs(withReplies));
+        const data = await page.evaluate(buildCommentsExtractJs(withReplies, limit));
         if (!data || typeof data !== 'object') {
             throw new EmptyResultError('xiaohongshu/comments', 'Unexpected evaluate response');
         }
@@ -209,6 +250,7 @@ export const command = cli({
             time: c.time,
             is_reply: c.is_reply,
             reply_to: c.reply_to,
+            images: c.images ?? [],
         });
         // When limiting, count only top-level comments; their replies are included for free
         if (withReplies) {

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -203,14 +203,16 @@ export function buildCommentsExtractJs(withReplies, limit = 20) {
           const anchor = el.querySelector(HREF_SELECTOR)
           return anchor ? (anchor.getAttribute('href') || '') : ''
         }
-        // Attached comment photos, excluding the author avatar and inline
-        // note-content-emoji stickers rendered inside the comment text.
+        // Attached comment photos, excluding avatars, inline emoji, badges, and
+        // other UI images. Only images inside comment/reply media containers are
+        // projected as media evidence.
         const extractImages = (el) => {
           if (!el) return []
           const urls = []
           el.querySelectorAll('img').forEach(img => {
             if (img.classList.contains('avatar-item')) return
             if (img.closest('.content, .note-text')) return
+            if (!img.closest('.comment-pic, .reply-pic, .comment-image, .reply-image, .comment-img, .reply-img, [class*="comment-pic"], [class*="reply-pic"], [class*="comment-image"], [class*="reply-image"]')) return
             const src = img.currentSrc || img.src || img.getAttribute('data-src') || ''
             if (src && !urls.includes(src)) urls.push(src)
           })

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -6,7 +6,7 @@
  * the --with-replies flag.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CliError, EmptyResultError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
 
 const XHS_PROFILE_HREF_SELECTOR = '.author-wrapper a[href*="/user/profile/"], a.name[href*="/user/profile/"], a.user-name[href*="/user/profile/"], a[href*="/user/profile/"]';
@@ -62,6 +62,78 @@ export function parseXhsLikeCountText(value) {
     const unit = short[2].toLowerCase();
     const multiplier = unit === 'w' || unit === '万' ? 10000 : 1000;
     return Math.round(numeric * multiplier);
+}
+
+function normalizeOptionalString(value, field, commandName) {
+    if (value == null)
+        return '';
+    if (typeof value !== 'string') {
+        throw new CommandExecutionError(`${commandName}: malformed comment row ${field}`);
+    }
+    return value;
+}
+
+export function normalizeCommentImages(value, commandName) {
+    if (value == null)
+        return [];
+    if (!Array.isArray(value)) {
+        throw new CommandExecutionError(`${commandName}: malformed comment row images`);
+    }
+    const urls = [];
+    for (const raw of value) {
+        if (typeof raw !== 'string') {
+            throw new CommandExecutionError(`${commandName}: malformed comment row image URL`);
+        }
+        const trimmed = raw.trim();
+        let parsed;
+        try {
+            parsed = new URL(trimmed);
+        }
+        catch {
+            throw new CommandExecutionError(`${commandName}: malformed comment row image URL`);
+        }
+        if ((parsed.protocol !== 'https:' && parsed.protocol !== 'http:') || parsed.username || parsed.password) {
+            throw new CommandExecutionError(`${commandName}: malformed comment row image URL`);
+        }
+        const href = parsed.toString();
+        if (!urls.includes(href))
+            urls.push(href);
+    }
+    return urls;
+}
+
+export function normalizeCommentRows(value, commandName = 'xiaohongshu/comments') {
+    if (value == null)
+        return [];
+    if (!Array.isArray(value)) {
+        throw new CommandExecutionError(`${commandName}: malformed comments payload`);
+    }
+    return value.map((row, index) => {
+        if (!row || typeof row !== 'object' || Array.isArray(row)) {
+            throw new CommandExecutionError(`${commandName}: malformed comment row at index ${index}`);
+        }
+        const text = normalizeOptionalString(row.text, 'text', commandName);
+        if (!text) {
+            throw new CommandExecutionError(`${commandName}: malformed comment row text`);
+        }
+        const likes = Number(row.likes);
+        if (!Number.isInteger(likes) || likes < 0) {
+            throw new CommandExecutionError(`${commandName}: malformed comment row likes`);
+        }
+        if (typeof row.is_reply !== 'boolean') {
+            throw new CommandExecutionError(`${commandName}: malformed comment row is_reply`);
+        }
+        return {
+            author: normalizeOptionalString(row.author, 'author', commandName),
+            authorHrefRaw: normalizeOptionalString(row.authorHrefRaw, 'authorHrefRaw', commandName),
+            text,
+            likes,
+            time: normalizeOptionalString(row.time, 'time', commandName),
+            is_reply: row.is_reply,
+            reply_to: normalizeOptionalString(row.reply_to, 'reply_to', commandName),
+            images: normalizeCommentImages(row.images, commandName),
+        };
+    });
 }
 
 /**
@@ -237,7 +309,7 @@ export const command = cli({
         }
         // noteId currently unused after parsing — kept for symmetry with the note command
         void noteId;
-        const all = data.results ?? [];
+        const all = normalizeCommentRows(data.results, 'xiaohongshu/comments');
         // authorHrefRaw is a raw transport field from the extractor; it is consumed
         // here into userId / profileUrl and intentionally not part of the row shape.
         const enrich = (c, i) => ({

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -290,6 +290,24 @@ describe('xiaohongshu comments', () => {
 
         expect(data.results[0]).toMatchObject({ author: 'Alice', text: 'Great note', images: ['https://sns-img-qc.xhscdn.com/comment-photo.jpg'] });
     });
+    it('does not project author badges or action icons as comment images', async () => {
+        const data = await runCommentsExtract(`
+          <main>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <div class="author-wrapper">
+                  <span class="name">Alice</span>
+                  <img class="author-badge" src="https://sns-img-qc.xhscdn.com/badge.png" />
+                </div>
+                <div class="content">No attached photo</div>
+                <button class="like-action"><img src="https://sns-img-qc.xhscdn.com/like-icon.png" /></button>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(data.results[0]).toMatchObject({ author: 'Alice', text: 'No attached photo', images: [] });
+    });
     it('extracts authorHrefRaw from /user/profile/ anchor wrapping the name', async () => {
         const data = await runCommentsExtract(`
           <main>

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -148,6 +148,59 @@ describe('xiaohongshu comments', () => {
             limit: 5,
         })).resolves.toEqual([]);
     });
+    it('fails typed for malformed comments payloads instead of returning success-shaped output', async () => {
+        const page = createPageMock({ loginWall: false, results: { rows: [] } });
+        await expect(command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed comments payload'),
+        });
+    });
+    it('fails typed for malformed comment image payloads', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', text: 'Great note!', likes: 10, time: '2024-01-01', is_reply: false, reply_to: '', images: 'https://sns-img-qc.xhscdn.com/comment.jpg' },
+            ],
+        });
+        await expect(command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed comment row images'),
+        });
+    });
+    it('fails typed for non-stable comment image URLs', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', text: 'Great note!', likes: 10, time: '2024-01-01', is_reply: false, reply_to: '', images: ['data:image/png;base64,AAAA'] },
+            ],
+        });
+        await expect(command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('malformed comment row image URL'),
+        });
+    });
+    it('preserves normalized valid comment image URLs in output rows', async () => {
+        const page = createPageMock({
+            loginWall: false,
+            results: [
+                { author: 'Alice', text: 'Great note!', likes: 10, time: '2024-01-01', is_reply: false, reply_to: '', images: [' https://sns-img-qc.xhscdn.com/comment.jpg '] },
+            ],
+        });
+        const rows = await command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        });
+        expect(rows[0]).toMatchObject({ images: ['https://sns-img-qc.xhscdn.com/comment.jpg'] });
+    });
     it('uses condition-based comment scrolling instead of a fixed blind loop', async () => {
         const page = createPageMock({ loginWall: false, results: [] });
         await command.func(page, {

--- a/clis/xiaohongshu/comments.test.js
+++ b/clis/xiaohongshu/comments.test.js
@@ -34,7 +34,10 @@ async function runCommentsExtract(html) {
     globalThis.document = dom.window.document;
     globalThis.location = dom.window.location;
     try {
-        return await eval(buildCommentsExtractJs(false));
+        // limit=1 so the scroll-loading loop's initial "already have enough"
+        // check short-circuits instead of burning through stall retries — the
+        // JSDOM fixtures below are fully static, there's nothing more to load.
+        return await eval(buildCommentsExtractJs(false, 1));
     } finally {
         globalThis.document = previousDocument;
         globalThis.location = previousLocation;
@@ -152,9 +155,33 @@ describe('xiaohongshu comments', () => {
             limit: 5,
         });
         const script = page.evaluate.mock.calls[0][0];
-        expect(script).toContain("const beforeCount = scroller.querySelectorAll('.parent-comment').length");
-        expect(script).toContain("const afterCount = scroller.querySelectorAll('.parent-comment').length");
-        expect(script).toContain('if (afterCount <= beforeCount) break');
+        expect(script).toContain("const beforeCount = document.querySelectorAll('.parent-comment').length");
+        expect(script).toContain("const afterCount = document.querySelectorAll('.parent-comment').length");
+        expect(script).toContain('if (beforeCount >= targetCount) break');
+        expect(script).toContain('if (stall >= 6) break');
+    });
+
+    it('drives scroll growth through the scroller, scrollIntoView, and window.scrollTo together', async () => {
+        const page = createPageMock({ loginWall: false, results: [] });
+        await command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 5,
+        });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('scroller.scrollTo(0, scroller.scrollHeight)');
+        expect(script).toContain("last.scrollIntoView({ block: 'end' })");
+        expect(script).toContain('window.scrollTo(0, document.body.scrollHeight)');
+    });
+
+    it('scrolls toward the requested --limit instead of stopping after one stalled round', async () => {
+        const page = createPageMock({ loginWall: false, results: [] });
+        await command.func(page, {
+            'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
+            limit: 50,
+        });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('const targetCount = 50');
+        expect(script).toContain('for (let i = 0; i < 60; i++)');
     });
     it('extracts shortform like counts from the shared xiaohongshu/rednote DOM script', async () => {
         const data = await runCommentsExtract(`
@@ -178,9 +205,37 @@ describe('xiaohongshu comments', () => {
         `);
 
         expect(data.results).toEqual([
-            { author: 'Alice', authorHrefRaw: '', text: 'Great note', likes: 21000, time: 'today', is_reply: false, reply_to: '' },
-            { author: 'Bob', authorHrefRaw: '', text: 'Malformed count', likes: 0, time: '', is_reply: false, reply_to: '' },
+            { author: 'Alice', authorHrefRaw: '', text: 'Great note', likes: 21000, time: 'today', is_reply: false, reply_to: '', images: [] },
+            { author: 'Bob', authorHrefRaw: '', text: 'Malformed count', likes: 0, time: '', is_reply: false, reply_to: '', images: [] },
         ]);
+    });
+
+    it('extracts attached comment photos while excluding avatars and inline emoji', async () => {
+        const data = await runCommentsExtract(`
+          <main>
+            <section class="parent-comment">
+              <div class="comment-item">
+                <div class="author-wrapper">
+                  <img class="avatar-item" src="https://sns-avatar-qc.xhscdn.com/avatar/abc.jpg" />
+                  <span class="name">Alice</span>
+                </div>
+                <div class="content">Great note <img class="note-content-emoji" src="https://picasso-static.xiaohongshu.com/fe-platform/emoji.png" /></div>
+                <div class="comment-pic"><img src="https://sns-img-qc.xhscdn.com/comment-photo.jpg" /></div>
+                <span class="count">1</span>
+                <span class="date">today</span>
+              </div>
+              <div class="reply-container">
+                <div class="comment-item-sub">
+                  <span class="name">Bob</span>
+                  <div class="content">Nice</div>
+                  <div class="reply-pic"><img src="https://sns-img-qc.xhscdn.com/reply-photo.jpg" /></div>
+                </div>
+              </div>
+            </section>
+          </main>
+        `);
+
+        expect(data.results[0]).toMatchObject({ author: 'Alice', text: 'Great note', images: ['https://sns-img-qc.xhscdn.com/comment-photo.jpg'] });
     });
     it('extracts authorHrefRaw from /user/profile/ anchor wrapping the name', async () => {
         const data = await runCommentsExtract(`


### PR DESCRIPTION
## 动机

小红书笔记评论里经常带图（晒单、追评、表情包截图），目前 `comments` 命令只输出文本，图片信息完全丢失。下游做舆情/内容分析时拿不到这部分数据。

## 改动

1. **评论 images 字段**：顶层评论和嵌套回复都增加 `images` 数组，从 `.comment-picture` 图集抓取，并排除头像和 `note-content-emoji` 内联表情贴纸（这两类不是用户上传的评论配图）。`rednote`（国际版）复用同一实现。

2. **滚动加载健壮性**：
   - 加载循环从「停滞一轮就退出」改为「达到 --limit 或连续多轮无增长才退出」，避免网络慢时提前截断；
   - 滚动同时通过 scroller 元素、`scrollIntoView`、`window.scrollTo` 三路驱动——实际可滚动的祖先元素随页面布局变化，单一方式经常失效。

## 测试

- `clis/xiaohongshu/comments.test.js` 新增图片提取用例（含头像/表情排除、嵌套回复）
- `clis/xiaohongshu` + `clis/rednote` 适配器测试 38/38 通过
- `cli-manifest.json` 已重新生成，与 build-manifest 输出一致