### PR TITLE
fix(observation): prune expired out-of-order events

### DIFF
--- a/src/observation/ring-buffer.test.ts
+++ b/src/observation/ring-buffer.test.ts
@@ -22,4 +22,12 @@ describe('RingBuffer', () => {
     buffer.push({ ts: 3, value: 3 });
     expect(buffer.values().map((item) => item.value)).toEqual([2, 3]);
   });
+
+  it('prunes expired items that arrive after newer events', () => {
+    const buffer = new RingBuffer<{ ts: number; value: string }>({ maxAgeMs: 5_000, now: () => 10_000 });
+    buffer.push({ ts: 9_000, value: 'new' });
+    buffer.push({ ts: 4_000, value: 'late-old' });
+
+    expect(buffer.values().map((item) => item.value)).toEqual(['new']);
+  });
 });

--- a/src/observation/ring-buffer.ts
+++ b/src/observation/ring-buffer.ts
@@ -45,9 +45,7 @@ export class RingBuffer<T extends { ts: number }> {
       this.items = this.items.slice(this.items.length - this.maxItems);
     }
     if (this.maxAgeMs > 0) {
-      const firstKept = this.items.findIndex((item) => item.ts >= minTs);
-      if (firstKept > 0) this.items = this.items.slice(firstKept);
-      else if (firstKept === -1) this.items = [];
+      this.items = this.items.filter((item) => item.ts >= minTs);
     }
   }
 }


### PR DESCRIPTION
## Description

`RingBuffer.prune()` assumed events were appended in timestamp order and sliced everything before the first unexpired event. Observation evidence can be collected asynchronously and appended later with its original timestamp, so an expired event arriving after a newer event could remain in the buffer beyond the configured window.

Filter each buffered event against the cutoff instead, preserving insertion order for retained events. A regression test covers a late-arriving expired event.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```text
src/observation: 5 files passed, 16 tests passed
TypeScript: tsc --noEmit passed
Default test gate: 553 files passed, 6062 tests passed, 1 skipped
```
