### PR TITLE
fix(1point3acres): detect login via current Discuz X user-panel markup

### DIFF
--- a/clis/1point3acres/auth.js
+++ b/clis/1point3acres/auth.js
@@ -1,6 +1,31 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
+export const IDENTITY_PROBE_JS = `
+    (() => {
+      if (/auth\\.1point3acres\\.com\\/login/.test(location.href)) {
+        return { kind: 'auth', detail: '1point3acres bbs redirected to auth login' };
+      }
+      const loginLink = document.querySelector('a[href*="auth.1point3acres.com/login"], a[href*="member.php?mod=logging&action=login"]');
+      if (loginLink && /登录/.test(loginLink.innerText || '')) {
+        return { kind: 'auth', detail: '1point3acres bbs shows 登录 link — anonymous' };
+      }
+      const nameEl = document.querySelector('a[title="访问我的空间"], #um .vwmy h4 a, a.username, .vwmy a');
+      const username = (nameEl?.innerText || nameEl?.textContent || '').trim();
+      const uid = (nameEl?.getAttribute('href') || '').match(/uid[=-](\\d+)/)?.[1] || '';
+      if (!uid && !username) {
+        const hasLoggedInMenu = !!document.querySelector('#g_upmine, #extcreditmenu');
+        return {
+          kind: hasLoggedInMenu ? 'shape' : 'auth',
+          detail: hasLoggedInMenu
+            ? '1point3acres bbs rendered logged-in menus but no identity link'
+            : '1point3acres bbs rendered but no logged-in identity',
+        };
+      }
+      return { ok: true, user_id: uid, username };
+    })()
+  `;
+
 async function has1Point3AcresAuthCookie(page) {
   const host = await page.getCookies({ url: 'https://www.1point3acres.com' });
   const root = await page.getCookies({ url: 'https://.1point3acres.com' });
@@ -13,25 +38,9 @@ async function verify1Point3AcresIdentity(page) {
   }
   await page.goto('https://www.1point3acres.com/bbs/');
   await page.wait(2);
-  const probe = await page.evaluate(`
-    (() => {
-      if (/auth\\.1point3acres\\.com\\/login/.test(location.href)) {
-        return { kind: 'auth', detail: '1point3acres bbs redirected to auth login' };
-      }
-      const loginLink = document.querySelector('a[href*="auth.1point3acres.com/login"], a[href*="member.php?mod=logging&action=login"]');
-      if (loginLink && /登录/.test(loginLink.innerText || '')) {
-        return { kind: 'auth', detail: '1point3acres bbs shows 登录 link — anonymous' };
-      }
-      const nameEl = document.querySelector('#um .vwmy h4 a, a.username, .vwmy a');
-      const username = (nameEl?.innerText || '').trim();
-      const uid = (nameEl?.getAttribute('href') || '').match(/uid[=-](\\d+)/)?.[1] || '';
-      if (!uid && !username) {
-        return { kind: 'auth', detail: '1point3acres bbs rendered but no #um identity — anonymous or shape drifted' };
-      }
-      return { ok: true, user_id: uid, username };
-    })()
-  `);
+  const probe = await page.evaluate(IDENTITY_PROBE_JS);
   if (probe?.kind === 'auth') throw new AuthRequiredError('1point3acres.com', probe.detail);
+  if (probe?.kind === 'shape') throw new CommandExecutionError(probe.detail);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected 1point3acres probe: ${JSON.stringify(probe)}`);
   return { user_id: probe.user_id, username: probe.username };
 }

--- a/clis/1point3acres/auth.test.js
+++ b/clis/1point3acres/auth.test.js
@@ -1,0 +1,45 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+import { IDENTITY_PROBE_JS } from './auth.js';
+
+function runIdentityProbe(html, url = 'https://www.1point3acres.com/bbs/') {
+  const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+  return dom.window.eval(IDENTITY_PROBE_JS);
+}
+
+describe('1point3acres auth identity probe', () => {
+  it('detects the current Discuz user-panel identity link', () => {
+    const result = runIdentityProbe(`
+      <div id="um">
+        <a href="space-uid-123456.html" title="访问我的空间">test_user</a>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true, user_id: '123456', username: 'test_user' });
+  });
+
+  it('keeps legacy identity selectors as fallbacks', () => {
+    const result = runIdentityProbe(`
+      <div id="um">
+        <div class="vwmy"><h4><a href="home.php?mod=space&uid=42">legacy_user</a></h4></div>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true, user_id: '42', username: 'legacy_user' });
+  });
+
+  it('does not report a successful blank identity when only logged-in menu ids render', () => {
+    const result = runIdentityProbe('<div id="g_upmine"></div><div id="extcreditmenu"></div>');
+
+    expect(result).toMatchObject({
+      kind: 'shape',
+      detail: '1point3acres bbs rendered logged-in menus but no identity link',
+    });
+  });
+
+  it('treats an anonymous login link as auth required', () => {
+    const result = runIdentityProbe('<a href="https://auth.1point3acres.com/login">登录</a>');
+
+    expect(result).toMatchObject({ kind: 'auth' });
+  });
+});


### PR DESCRIPTION
## Problem

`opencli 1point3acres whoami` (and login-gated commands) report
`AUTH_REQUIRED` for users who are logged in. The site updated its header
markup, so the identity probe's username selector no longer matches:

```js
document.querySelector('#um .vwmy h4 a, a.username, .vwmy a')
```

The logged-in user's own link is now:

```html
<a href="space-uid-<uid>.html" title="访问我的空间">username</a>
```

## Fix

- Match the current username link, keeping the legacy selectors as fallback:

  ```diff
  - document.querySelector('#um .vwmy h4 a, a.username, .vwmy a')
  + document.querySelector('a[title="访问我的空间"], #um .vwmy h4 a, a.username, .vwmy a')
  ```

  `a[title="访问我的空间"]` matches only the current user's own space link, and
  the existing `uid[=-](\d+)` regex already handles the `space-uid-<uid>.html`
  href.

- Also treat the logged-in header menu ids (`#g_upmine`, `#extcreditmenu`) as
  a login signal, so a future wording/markup change of the username link does
  not reintroduce a false `AUTH_REQUIRED`.

## Verification

`whoami` returns the correct `user_id` / `username` for a logged-in session.
Behavior is unchanged for the current site and for legacy markup — the new
selector and guard only add fallbacks, never remove existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
