### PR TITLE
fix(update-check): clear timers after fetch failures

### DIFF
--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  _fetchWithTimeout as fetchWithTimeout,
   _extractLatestExtensionVersionFromReleases as extractLatestExtensionVersionFromReleases,
   _buildUpdateNotices as buildUpdateNotices,
   _EXTENSION_STALE_MS as EXTENSION_STALE_MS,
 } from './update-check.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchWithTimeout', () => {
+  it('clears its abort timer when fetch rejects before the timeout', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unavailable')));
+
+    await expect(fetchWithTimeout('https://example.com', {})).rejects.toThrow(
+      'network unavailable',
+    );
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
 
 describe('extractLatestExtensionVersionFromReleases', () => {
   it('reads the extension version from a versioned asset on a normal CLI release', () => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -85,6 +85,20 @@ function isCI(): boolean {
   return !!(process.env.CI || process.env.CONTINUOUS_INTEGRATION);
 }
 
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = 3000,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 interface NoticeInputs {
   cliVersion: string;
   cache: UpdateCache | null;
@@ -162,13 +176,9 @@ function extractLatestExtensionVersionFromReleases(releases: GitHubRelease[]): s
 /** Fetch the latest extension version from GitHub Releases. */
 async function fetchLatestExtensionVersion(): Promise<string | undefined> {
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(GITHUB_RELEASES_URL, {
-      signal: controller.signal,
+    const res = await fetchWithTimeout(GITHUB_RELEASES_URL, {
       headers: { 'User-Agent': `opencli/${PKG_VERSION}`, Accept: 'application/vnd.github+json' },
     });
-    clearTimeout(timer);
     if (!res.ok) return undefined;
     const releases = await res.json() as GitHubRelease[];
     return extractLatestExtensionVersionFromReleases(releases);
@@ -187,13 +197,9 @@ export function checkForUpdateBackground(): void {
 
   void (async () => {
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 3000);
-      const res = await fetch(NPM_REGISTRY_URL, {
-        signal: controller.signal,
+      const res = await fetchWithTimeout(NPM_REGISTRY_URL, {
         headers: { 'User-Agent': `opencli/${PKG_VERSION}` },
       });
-      clearTimeout(timer);
       if (!res.ok) return;
       const data = await res.json() as { version?: string };
       if (typeof data.version === 'string') {
@@ -230,6 +236,7 @@ export function getCachedLatestExtensionVersion(): string | undefined {
 }
 
 export {
+  fetchWithTimeout as _fetchWithTimeout,
   extractLatestExtensionVersionFromReleases as _extractLatestExtensionVersionFromReleases,
   buildUpdateNotices as _buildUpdateNotices,
   EXTENSION_STALE_MS as _EXTENSION_STALE_MS,


### PR DESCRIPTION
## Description

The update checker is intended to be fully non-blocking, but both background fetch paths only cleared their three-second abort timers after a successful `fetch`. When a network request rejected early, the live timer could keep a short-lived CLI process open until the timeout elapsed.

Route both requests through one timeout helper that clears its timer in `finally`, covering successful responses and network failures. The regression test verifies that an immediately rejected fetch leaves no pending timer.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

```text
npx vitest run --project unit src/update-check.test.ts
Test Files  1 passed (1)
Tests       11 passed (11)

npm run typecheck
tsc --noEmit

npm test
Test Files  553 passed (553)
Tests       6062 passed | 1 skipped (6063)
```
