### PR TITLE
fix(runtime): honor OPENCLI_CDP_ENDPOINT for web adapters

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BrowserBridge, CDPBridge } from './browser/index.js';
+import { getBrowserFactory } from './runtime.js';
+
+describe('getBrowserFactory', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses BrowserBridge for regular sites by default', () => {
+    expect(getBrowserFactory('xianyu')).toBe(BrowserBridge);
+  });
+
+  it('uses CDPBridge when OPENCLI_CDP_ENDPOINT is configured', () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'http://127.0.0.1:9333');
+
+    expect(getBrowserFactory('xianyu')).toBe(CDPBridge);
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,10 +7,12 @@ import { DEFAULT_BROWSER_COMMAND_TIMEOUT, DEFAULT_BROWSER_CONNECT_TIMEOUT } from
 export { DEFAULT_BROWSER_COMMAND_TIMEOUT, DEFAULT_BROWSER_CONNECT_TIMEOUT };
 
 /**
- * Returns the appropriate browser factory based on site type.
- * Uses CDPBridge for registered Electron apps, otherwise BrowserBridge.
+ * Returns the appropriate browser factory based on explicit configuration and site type.
+ * A manual CDP endpoint takes precedence, registered Electron apps use CDPBridge,
+ * and all other sites use BrowserBridge.
  */
 export function getBrowserFactory(site?: string): new () => IBrowserFactory {
+  if (process.env.OPENCLI_CDP_ENDPOINT) return CDPBridge;
   if (site && isElectronApp(site)) return CDPBridge;
   return BrowserBridge;
 }


### PR DESCRIPTION
## Problem

`OPENCLI_CDP_ENDPOINT` is documented as the manual CDP endpoint override, but regular website adapters ignore it. `getBrowserFactory()` selects `CDPBridge` only for registered Electron apps and always selects `BrowserBridge` for sites such as `xianyu`.

As a result, a command such as:

```bash
OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9333 opencli xianyu whoami
```

still tries to connect through the Browser Bridge daemon. In a setup with multiple connected extension profiles, it fails with `BROWSER_CONNECT: Multiple Browser Bridge profiles are connected`, even though the explicitly configured headless Chrome CDP endpoint is reachable and authenticated.

## Fix

Give an explicitly configured `OPENCLI_CDP_ENDPOINT` precedence in `getBrowserFactory()` and select `CDPBridge` for any adapter when it is present. Existing behavior is unchanged when the variable is absent: registered Electron apps still use CDP and regular sites still use Browser Bridge.

Add regression coverage for both branches:

- a regular site uses `BrowserBridge` by default
- a regular site uses `CDPBridge` when `OPENCLI_CDP_ENDPOINT` is configured

## Verification

- `npx vitest run --project unit src/runtime.test.ts` — 2 passed
- `npm run typecheck` — clean
- Live verification with a dedicated authenticated Chrome profile running under `--headless=new --remote-debugging-port=9333`: `opencli xianyu whoami -f json` returned `logged_in: true` through the manual CDP endpoint.
