### PR TITLE
fix(zhihu): accept http pagination next urls

### DIFF
--- a/clis/zhihu/paginate.js
+++ b/clis/zhihu/paginate.js
@@ -57,7 +57,8 @@ function normalizeZhihuApiUrl(value) {
     if (typeof value !== 'string' || !value) return '';
     try {
         const url = new URL(value);
-        if (url.protocol !== 'https:') return '';
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') return '';
+        url.protocol = 'https:';
         if (url.hostname === 'api.zhihu.com' && url.pathname.startsWith('/members/')) {
             return `https://www.zhihu.com/api/v4${url.pathname}${url.search}`;
         }
@@ -106,6 +107,7 @@ export async function fetchZhihuList(page, firstUrl, limit, label) {
             items.push(item);
             if (items.length >= limit) break;
         }
+        if (items.length >= limit) break;
         if (data.paging?.is_end) break;
         const next = normalizeZhihuApiUrl(data.paging?.next);
         if (!next || !sameZhihuApiPath(next, firstUrl)) {

--- a/clis/zhihu/pins.test.js
+++ b/clis/zhihu/pins.test.js
@@ -35,6 +35,27 @@ describe('zhihu pins', () => {
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('follows Zhihu http next URLs by upgrading them to https', async () => {
+        const cmd = getRegistry().get('zhihu/pins');
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                data: [{ id: 'pin1', excerpt_title: 'first' }],
+                paging: {
+                    is_end: false,
+                    next: 'http://www.zhihu.com/api/v4/members/foo/pins?offset=1',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: 'pin2', excerpt_title: 'second' }],
+                paging: { is_end: true },
+            });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'foo', limit: 2 })).resolves.toEqual([
+            { rank: 1, excerpt: 'first', type: '', likes: 0, comments: 0, reposts: 0, created: 0, url: 'https://www.zhihu.com/pin/pin1' },
+            { rank: 2, excerpt: 'second', type: '', likes: 0, comments: 0, reposts: 0, created: 0, url: 'https://www.zhihu.com/pin/pin2' },
+        ]);
+        expect(evaluate.mock.calls[1][0]).toContain('https://www.zhihu.com/api/v4/members/foo/pins?offset=1');
+    });
+
     it('rejects invalid limits before navigation', async () => {
         const cmd = getRegistry().get('zhihu/pins');
         const page = { goto: vi.fn(), evaluate: vi.fn() };

--- a/clis/zhihu/user-answers.test.js
+++ b/clis/zhihu/user-answers.test.js
@@ -59,6 +59,42 @@ describe('zhihu user-answers', () => {
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('follows Zhihu http next URLs by upgrading them to https', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                data: [{ id: 'a1', question: { id: 'q1', title: 'Q1' } }],
+                paging: {
+                    is_end: false,
+                    next: 'http://www.zhihu.com/api/v4/members/foo/answers?offset=1',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: 'a2', question: { id: 'q2', title: 'Q2' } }],
+                paging: { is_end: true },
+            });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'foo', limit: 2 })).resolves.toEqual([
+            { rank: 1, question: 'Q1', votes: 0, comments: 0, created: 0, url: 'https://www.zhihu.com/question/q1/answer/a1' },
+            { rank: 2, question: 'Q2', votes: 0, comments: 0, created: 0, url: 'https://www.zhihu.com/question/q2/answer/a2' },
+        ]);
+        expect(evaluate.mock.calls[1][0]).toContain('https://www.zhihu.com/api/v4/members/foo/answers?offset=1');
+    });
+
+    it('does not validate paging.next after the requested limit is reached', async () => {
+        const cmd = getRegistry().get('zhihu/user-answers');
+        const evaluate = vi.fn().mockResolvedValue({
+            data: [{ id: 'a1', question: { id: 'q1', title: 'Q1' } }],
+            paging: {
+                is_end: false,
+                next: 'http://evil.example/api/v4/members/foo/answers?offset=1',
+            },
+        });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'foo', limit: 1 })).resolves.toEqual([
+            { rank: 1, question: 'Q1', votes: 0, comments: 0, created: 0, url: 'https://www.zhihu.com/question/q1/answer/a1' },
+        ]);
+        expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
     it('rejects invalid limits before navigation', async () => {
         const cmd = getRegistry().get('zhihu/user-answers');
         const page = { goto: vi.fn(), evaluate: vi.fn() };

--- a/clis/zhihu/user-articles.test.js
+++ b/clis/zhihu/user-articles.test.js
@@ -35,6 +35,27 @@ describe('zhihu user-articles', () => {
         await expect(cmd.func(page, { user: 'foo', limit: 2 })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    it('follows Zhihu http next URLs by upgrading them to https', async () => {
+        const cmd = getRegistry().get('zhihu/user-articles');
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({
+                data: [{ id: 'p1', title: 'Title 1' }],
+                paging: {
+                    is_end: false,
+                    next: 'http://www.zhihu.com/api/v4/members/foo/articles?offset=1',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: 'p2', title: 'Title 2' }],
+                paging: { is_end: true },
+            });
+        await expect(cmd.func({ goto: vi.fn().mockResolvedValue(undefined), evaluate }, { user: 'foo', limit: 2 })).resolves.toEqual([
+            { rank: 1, title: 'Title 1', votes: 0, comments: 0, created: 0, url: 'https://zhuanlan.zhihu.com/p/p1' },
+            { rank: 2, title: 'Title 2', votes: 0, comments: 0, created: 0, url: 'https://zhuanlan.zhihu.com/p/p2' },
+        ]);
+        expect(evaluate.mock.calls[1][0]).toContain('https://www.zhihu.com/api/v4/members/foo/articles?offset=1');
+    });
+
     it('rejects invalid limits before navigation', async () => {
         const cmd = getRegistry().get('zhihu/user-articles');
         const page = { goto: vi.fn(), evaluate: vi.fn() };


### PR DESCRIPTION
## Summary
- accept Zhihu pagination next URLs returned as http:// by upgrading them to https://
- stop validating paging.next once the requested limit has already been satisfied
- add regression coverage for http next URLs and limit-satisfied pagination

Fixes #2144.

## Verification
- npx vitest run --project adapter clis/zhihu/user-answers.test.js clis/zhihu/user-articles.test.js clis/zhihu/pins.test.js