### PR TITLE
fix(ths): fetch hot rank from public API

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -34192,9 +34192,9 @@
     "name": "hot-rank",
     "description": "同花顺热股榜",
     "access": "read",
-    "domain": "eq.10jqka.com.cn",
-    "strategy": "cookie",
-    "browser": true,
+    "domain": "dq.10jqka.com.cn",
+    "strategy": "public",
+    "browser": false,
     "args": [
       {
         "name": "limit",
@@ -34213,8 +34213,7 @@
     ],
     "type": "js",
     "modulePath": "ths/hot-rank.js",
-    "sourceFile": "ths/hot-rank.js",
-    "navigateBefore": true
+    "sourceFile": "ths/hot-rank.js"
   },
   {
     "site": "tieba",

--- a/clis/ths/hot-rank.js
+++ b/clis/ths/hot-rank.js
@@ -1,50 +1,62 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CliError } from '@jackwener/opencli/errors';
 
-const THS_HOT_URL = 'https://eq.10jqka.com.cn/webpage/ths-hot-list/index.html?showStatusBar=true';
+const THS_HOT_API_URL = 'https://dq.10jqka.com.cn/fuyao/hot_list_data/out/hot_list/v1/stock?stock_type=a&type=hour&list_type=normal';
+
+function tagsFromStock(stock) {
+  const tag = stock?.tag && typeof stock.tag === 'object' ? stock.tag : {};
+  return [
+    ...(Array.isArray(tag.concept_tag) ? tag.concept_tag : []),
+    ...(Array.isArray(tag.popularity_tag) ? tag.popularity_tag : []),
+  ].filter(Boolean).join(',');
+}
+
+function parseLimit(raw) {
+  const limit = Number(raw ?? 20);
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 100) {
+    throw new CliError('INVALID_ARGUMENT', '--limit must be a positive integer no greater than 100');
+  }
+  return limit;
+}
 
 cli({
   site: 'ths',
   name: 'hot-rank',
     access: 'read',
   description: '同花顺热股榜',
-  domain: 'eq.10jqka.com.cn',
-  strategy: Strategy.COOKIE,
-  navigateBefore: true,
+  domain: 'dq.10jqka.com.cn',
+  strategy: Strategy.PUBLIC,
+  browser: false,
   args: [
     { name: 'limit', type: 'int', default: 20, help: '返回数量' },
   ],
   columns: ['rank', 'name', 'changePercent', 'heat', 'tags'],
-  func: async (page, kwargs) => {
-    await page.goto(THS_HOT_URL);
-    await page.wait({ timeout: 15000 });
-    const data = await page.evaluate(`
-      (() => {
-        const cleanText = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim();
-        const cards = document.querySelectorAll('div.pt-22.pb-24.bgc-white.border');
-        const results = [];
-        const seen = new Set();
-        cards.forEach((card, idx) => {
-          const row = card.querySelector('div.flex.bgc-white');
-          if (!row) return;
-          const nameEl = row.querySelector('span.ellipsis');
-          const name = cleanText(nameEl);
-          if (!name || seen.has(name)) return;
-          seen.add(name);
-          const tagEls = card.querySelectorAll('div.tag.PFSC-R');
-          const tags = Array.from(tagEls).map(t => cleanText(t)).filter(Boolean).join(',');
-          const rankEl = row.querySelector('div.THSMF-M.bold');
-          results.push({
-            rank: cleanText(rankEl) || String(idx + 1),
-            name,
-            changePercent: cleanText(row.querySelector('div.range')),
-            heat: cleanText(row.querySelector('div.col4 > span')),
-            tags,
-          });
-        });
-        return results;
-      })()
-    `);
-    if (!Array.isArray(data)) return [];
-    return data.slice(0, kwargs.limit);
+  func: async (args) => {
+    const limit = parseLimit(args.limit);
+    const resp = await fetch(THS_HOT_API_URL, {
+      headers: {
+        'Accept': 'application/json,text/plain,*/*',
+        'User-Agent': 'Mozilla/5.0',
+        'Referer': 'https://eq.10jqka.com.cn/',
+      },
+    });
+    if (!resp.ok) throw new CliError('HTTP_ERROR', `ths hot-rank failed: HTTP ${resp.status}`);
+    const payload = await resp.json();
+    const stocks = Array.isArray(payload?.data?.stock_list) ? payload.data.stock_list : [];
+    if (stocks.length === 0) throw new CliError('NO_DATA', 'ths hot-rank API returned no stock data');
+
+    return stocks.slice(0, limit).map((stock, index) => ({
+      rank: stock.order ?? index + 1,
+      name: stock.name ?? '',
+      changePercent: stock.rise_and_fall ?? '',
+      heat: stock.rate ?? '',
+      tags: tagsFromStock(stock),
+    }));
   },
 });
+
+export const __test__ = {
+  THS_HOT_API_URL,
+  parseLimit,
+  tagsFromStock,
+};

--- a/clis/ths/hot-rank.test.js
+++ b/clis/ths/hot-rank.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CliError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
-import './hot-rank.js';
+import { __test__ } from './hot-rank.js';
 
 describe('ths hot-rank command', () => {
   it('registers the command with correct metadata', () => {
@@ -10,9 +11,10 @@ describe('ths hot-rank command', () => {
       site: 'ths',
       name: 'hot-rank',
       description: expect.stringContaining('同花顺'),
-      domain: 'eq.10jqka.com.cn',
-      navigateBefore: true,
+      domain: 'dq.10jqka.com.cn',
+      browser: false,
     });
+    expect(command.strategy).toBe('public');
     expect(command.columns).toEqual(['rank', 'name', 'changePercent', 'heat', 'tags']);
   });
 
@@ -21,44 +23,106 @@ describe('ths hot-rank command', () => {
     expect(command.columns).toContain('tags');
   });
 
-  it('returns hot stock data with tags field', async () => {
+  it('fetches the public hot list API and maps authoritative ranks', async () => {
     const command = getRegistry().get('ths/hot-rank');
-    const mockData = [
-      { rank: 1, name: '圣阳股份', changePercent: '+10.00%', heat: '28.5万', tags: '动力电池回收,钠离子电池' },
-    ];
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      wait: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue(mockData),
-    };
-    const result = await command.func(page, { limit: 20 });
-    expect(result).toHaveLength(1);
-    expect(result[0].tags).toBe('动力电池回收,钠离子电池');
-    expect(result[0].name).toBe('圣阳股份');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          stock_list: [
+            {
+              order: 21,
+              name: '圣阳股份',
+              rise_and_fall: '+10.00%',
+              rate: '28.5万',
+              tag: { concept_tag: ['动力电池回收'], popularity_tag: ['钠离子电池'] },
+            },
+          ],
+        },
+      }),
+    });
+
+    try {
+      const result = await command.func({ limit: 20 });
+      expect(fetchSpy).toHaveBeenCalledWith(__test__.THS_HOT_API_URL, expect.objectContaining({
+        headers: expect.objectContaining({ Referer: 'https://eq.10jqka.com.cn/' }),
+      }));
+      expect(result).toEqual([
+        { rank: 21, name: '圣阳股份', changePercent: '+10.00%', heat: '28.5万', tags: '动力电池回收,钠离子电池' },
+      ]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('respects the limit parameter', async () => {
     const command = getRegistry().get('ths/hot-rank');
-    const mockData = Array.from({ length: 30 }, (_, i) => ({
-      rank: i + 1, name: `stock${i}`, changePercent: '0%', heat: '0', tags: '',
-    }));
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      wait: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue(mockData),
-    };
-    const result = await command.func(page, { limit: 10 });
-    expect(result).toHaveLength(10);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          stock_list: Array.from({ length: 30 }, (_, i) => ({
+            order: i + 1,
+            name: `stock${i}`,
+            rise_and_fall: '0%',
+            rate: '0',
+            tag: {},
+          })),
+        },
+      }),
+    });
+
+    try {
+      const result = await command.func({ limit: 10 });
+      expect(result).toHaveLength(10);
+      expect(result[9].rank).toBe(10);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
-  it('returns empty array when evaluate returns non-array', async () => {
+  it('throws NO_DATA when the API shape has no stock list', async () => {
     const command = getRegistry().get('ths/hot-rank');
-    const page = {
-      goto: vi.fn().mockResolvedValue(undefined),
-      wait: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue(null),
-    };
-    const result = await command.func(page, { limit: 20 });
-    expect(result).toEqual([]);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: {} }),
+    });
+
+    try {
+      await expect(command.func({ limit: 20 })).rejects.toMatchObject({ code: 'NO_DATA' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('throws HTTP_ERROR when the API request fails', async () => {
+    const command = getRegistry().get('ths/hot-rank');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    try {
+      await expect(command.func({ limit: 20 })).rejects.toBeInstanceOf(CliError);
+      await expect(command.func({ limit: 20 })).rejects.toMatchObject({ code: 'HTTP_ERROR' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('rejects invalid limits before fetching', async () => {
+    const command = getRegistry().get('ths/hot-rank');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await expect(command.func({ limit: 0 })).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    await expect(command.func({ limit: 101 })).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    await expect(command.func({ limit: 'abc' })).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('combines concept and popularity tags', () => {
+    expect(__test__.tagsFromStock({
+      tag: { concept_tag: ['AI'], popularity_tag: ['算力'] },
+    })).toBe('AI,算力');
   });
 });


### PR DESCRIPTION
## Summary
- replace THS hot-rank DOM scraping with the page public hot_list JSON API
- use API-provided order as the authoritative rank so --limit 100 can return a dense 1..100 list
- make the command public/direct instead of requiring Browser Bridge
- update cli-manifest and adapter tests
- reject invalid --limit values explicitly instead of silently clamping

Fixes #2140.

## Verification
- npx vitest run --project adapter clis/ths/hot-rank.test.js
- npm run check:typed-error-lint
- npm run build
- node dist/src/main.js ths hot-rank --limit 3 -f json