### PR TITLE
fix(instagram): fetch user feed by username

### DIFF
--- a/clis/instagram/user.js
+++ b/clis/instagram/user.js
@@ -18,22 +18,14 @@ cli({
   const headers = { 'X-IG-App-ID': '936619743392459' };
   const opts = { credentials: 'include', headers };
 
-  // Get user ID first
-  const r1 = await fetch(
-    'https://www.instagram.com/api/v1/users/web_profile_info/?username=' + encodeURIComponent(username),
-    opts
-  );
-  if (!r1.ok) throw new Error('HTTP ' + r1.status + ' - make sure you are logged in to Instagram');
-  const d1 = await r1.json();
-  const userId = d1?.data?.user?.id;
-  if (!userId) throw new Error('User not found: ' + username);
-
-  // Get user feed
+  // Fetch directly by username. web_profile_info is gated for some public
+  // accounts even with a valid session, while this feed endpoint still returns
+  // the same media item shape this command maps.
   const r2 = await fetch(
-    'https://www.instagram.com/api/v1/feed/user/' + userId + '/?count=' + limit,
+    'https://www.instagram.com/api/v1/feed/user/' + encodeURIComponent(username) + '/username/?count=' + limit,
     opts
   );
-  if (!r2.ok) throw new Error('Failed to fetch user feed: HTTP ' + r2.status);
+  if (!r2.ok) throw new Error('HTTP ' + r2.status + ' - make sure you are logged in to Instagram');
   const d2 = await r2.json();
   return (d2?.items || []).slice(0, limit).map((p, i) => ({
     index: i + 1,

--- a/clis/instagram/user.test.js
+++ b/clis/instagram/user.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './user.js';
+
+function getUserEvaluateJs() {
+  const cmd = getRegistry().get('instagram/user');
+  const evalStep = cmd.pipeline.find((s) => s.evaluate);
+  return evalStep.evaluate;
+}
+
+async function runUserEvaluate(fetchFn, args = { username: 'sleepcycleapp', limit: 2 }) {
+  const js = getUserEvaluateJs()
+    .replace('${{ args.username | json }}', JSON.stringify(args.username))
+    .replace('${{ args.limit }}', String(args.limit));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchFn;
+  try {
+    return await eval(js);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe('instagram/user feed fetch', () => {
+  it('fetches recent posts directly by username', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            caption: { text: 'First post\nwith newline' },
+            like_count: 12,
+            comment_count: 3,
+            media_type: 1,
+            taken_at: 1784451600,
+          },
+          {
+            caption: { text: 'Second post' },
+            like_count: 4,
+            comment_count: 1,
+            media_type: 2,
+          },
+        ],
+      }),
+    });
+
+    const result = await runUserEvaluate(fetchFn, { username: 'sleep cycle/app', limit: 2 });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0][0]).toBe('https://www.instagram.com/api/v1/feed/user/sleep%20cycle%2Fapp/username/?count=2');
+    expect(fetchFn.mock.calls[0][1]).toMatchObject({
+      credentials: 'include',
+      headers: { 'X-IG-App-ID': '936619743392459' },
+    });
+    expect(fetchFn.mock.calls[0][0]).not.toContain('web_profile_info');
+    expect(result).toEqual([
+      { index: 1, caption: 'First post with newline', likes: 12, comments: 3, type: 'photo', date: expect.any(String) },
+      { index: 2, caption: 'Second post', likes: 4, comments: 1, type: 'video', date: '' },
+    ]);
+  });
+
+  it('keeps the login-oriented error for failed feed requests', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    await expect(runUserEvaluate(fetchFn)).rejects.toThrow('HTTP 400 - make sure you are logged in to Instagram');
+  });
+});


### PR DESCRIPTION
## Summary
- change `instagram user` to fetch `/api/v1/feed/user/<username>/username/` directly
- avoid the `web_profile_info` username-to-id preflight that returns HTTP 400 for some public accounts
- add adapter coverage proving the command no longer calls `web_profile_info`

Fixes #2147 for `instagram user`.

Note: this intentionally does not touch follow/followers/following/profile/write commands that still need profile metadata or user IDs; those need a separate first-principles fix rather than bundling into this low-risk user-feed patch.

## Verification
- npx vitest run --project adapter clis/instagram/user.test.js