### PR TITLE
feat(tiktok-symphony): add Symphony Creative Studio image and video adapters

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -35016,6 +35016,146 @@
     "siteSession": "persistent"
   },
   {
+    "site": "tiktok-symphony",
+    "name": "credits",
+    "description": "Symphony Creative Studio credit balance and plan",
+    "access": "read",
+    "example": "opencli tiktok-symphony credits",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "credits",
+      "plan",
+      "account"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/credits.js",
+    "sourceFile": "tiktok-symphony/credits.js",
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/image-to-video?subApp=CreativeStudio/ImageGeneration/I2VImageGeneration"
+  },
+  {
+    "site": "tiktok-symphony",
+    "name": "download",
+    "description": "Download a generated Symphony asset by assetId (see: generations)",
+    "access": "read",
+    "example": "opencli tiktok-symphony download 202607195d0d7ea36ed139b74eccb1e4 --out ./downloads",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "asset",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "assetId from `generations`, or a full asset URL"
+      },
+      {
+        "name": "out",
+        "type": "string",
+        "default": ".",
+        "required": false,
+        "help": "Directory to write the file into"
+      }
+    ],
+    "columns": [
+      "assetId",
+      "file",
+      "bytes",
+      "contentType"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/download.js",
+    "sourceFile": "tiktok-symphony/download.js",
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history"
+  },
+  {
+    "site": "tiktok-symphony",
+    "name": "generate",
+    "description": "Generate images from a prompt and up to 4 reference images (spends Symphony credits)",
+    "access": "write",
+    "example": "opencli tiktok-symphony generate \"turn this into 3D chibi style\" --refs ./cat.png",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "What to generate"
+      },
+      {
+        "name": "refs",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Comma-separated reference image paths (max 4)"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "default": "Nano Banana",
+        "required": false,
+        "help": "Model: Nano Banana / Flux Kontext Max"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Seconds to wait for rendering"
+      }
+    ],
+    "columns": [
+      "index",
+      "assetId",
+      "url",
+      "model",
+      "prompt"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/generate.js",
+    "sourceFile": "tiktok-symphony/generate.js",
+    "navigateBefore": false,
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "tiktok-symphony",
+    "name": "generations",
+    "aliases": [
+      "library"
+    ],
+    "description": "List generated assets in the Symphony Creative Studio Library",
+    "access": "read",
+    "example": "opencli tiktok-symphony generations --limit 10",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of assets to return (max 200)"
+      }
+    ],
+    "columns": [
+      "index",
+      "assetId",
+      "type",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/generations.js",
+    "sourceFile": "tiktok-symphony/generations.js",
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history"
+  },
+  {
     "site": "toutiao",
     "name": "articles",
     "description": "获取头条号创作者后台文章列表及数据",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -35037,6 +35037,46 @@
   },
   {
     "site": "tiktok-symphony",
+    "name": "delete",
+    "aliases": [
+      "rm"
+    ],
+    "description": "Permanently delete a generation from the Library (irreversible; requires --yes)",
+    "access": "write",
+    "example": "opencli tiktok-symphony delete 202607205d0d326f7499347f469b9861 --yes",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "asset",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "assetId from `generations`"
+      },
+      {
+        "name": "yes",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Actually delete. Without it the asset is only located and reported (status: dry-run)"
+      }
+    ],
+    "columns": [
+      "assetId",
+      "status",
+      "type",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/delete.js",
+    "sourceFile": "tiktok-symphony/delete.js",
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "tiktok-symphony",
     "name": "download",
     "description": "Download a generated Symphony asset by assetId (see: generations)",
     "access": "read",
@@ -35069,7 +35109,8 @@
     "type": "js",
     "modulePath": "tiktok-symphony/download.js",
     "sourceFile": "tiktok-symphony/download.js",
-    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history"
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "tiktok-symphony",
@@ -35125,6 +35166,92 @@
   },
   {
     "site": "tiktok-symphony",
+    "name": "generate-video",
+    "aliases": [
+      "video"
+    ],
+    "description": "Generate a video clip from a prompt and optional reference images (spends Symphony credits)",
+    "access": "write",
+    "example": "opencli tiktok-symphony generate-video \"a duck floating on a pool, slow zoom out\" --duration 5",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "What to generate"
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "default": "auto",
+        "required": false,
+        "help": "Sub-app: text / image / reference. \"auto\" picks text with no refs, image with 1, reference with 2+"
+      },
+      {
+        "name": "refs",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Comma-separated reference image paths (image: 1-2, reference: 1-4)"
+      },
+      {
+        "name": "frames",
+        "type": "string",
+        "default": "first",
+        "required": false,
+        "help": "Image mode only: first / first-last"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "default": "Video 1.5 Pro",
+        "required": false,
+        "help": "Model: Video 1.5 Pro"
+      },
+      {
+        "name": "duration",
+        "type": "string",
+        "default": "5",
+        "required": false,
+        "help": "Clip length: 5s / 10s / 12s"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 5400,
+        "required": false,
+        "help": "Seconds to wait when --wait true (rendering has been observed to exceed an hour)"
+      },
+      {
+        "name": "wait",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Block until the clip renders. Off by default: rendering runs for tens of minutes, so the job is submitted and `generations` picks it up later"
+      }
+    ],
+    "columns": [
+      "index",
+      "status",
+      "assetId",
+      "url",
+      "mode",
+      "model",
+      "duration",
+      "prompt"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/generate-video.js",
+    "sourceFile": "tiktok-symphony/generate-video.js",
+    "navigateBefore": false,
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "tiktok-symphony",
     "name": "generations",
     "aliases": [
       "library"
@@ -35153,7 +35280,51 @@
     "type": "js",
     "modulePath": "tiktok-symphony/generations.js",
     "sourceFile": "tiktok-symphony/generations.js",
-    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history"
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/create/history",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "tiktok-symphony",
+    "name": "jobs",
+    "aliases": [
+      "queue"
+    ],
+    "description": "Show generations in the Create feed with their render progress",
+    "access": "read",
+    "example": "opencli tiktok-symphony jobs",
+    "domain": "ads.tiktok.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of cards to return (max 50)"
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Only cards that have not produced an output yet (generating or finishing)"
+      }
+    ],
+    "columns": [
+      "index",
+      "status",
+      "progress",
+      "taskId",
+      "model",
+      "prompt",
+      "error"
+    ],
+    "type": "js",
+    "modulePath": "tiktok-symphony/jobs.js",
+    "sourceFile": "tiktok-symphony/jobs.js",
+    "navigateBefore": "https://ads.tiktok.com/creative/creativestudio/image-to-video?subApp=CreativeStudio/MiniApp/TextToVideo",
+    "defaultWindowMode": "foreground"
   },
   {
     "site": "toutiao",

--- a/clis/tiktok-symphony/credits.js
+++ b/clis/tiktok-symphony/credits.js
@@ -1,0 +1,71 @@
+// tiktok-symphony credits — Symphony credit balance and current plan.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { CREATE_URL, DEEP_QUERY_SRC, HOST, waitForValue } from './utils.js';
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'credits',
+    description: 'Symphony Creative Studio credit balance and plan',
+    access: 'read',
+    example: 'opencli tiktok-symphony credits',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: CREATE_URL,
+    args: [],
+    columns: ['credits', 'plan', 'account'],
+    func: async (page) => {
+        // Field names here deliberately avoid the `columns` vocabulary: this is
+        // a scratch parse object, not a row, and reusing column names would let
+        // a future edit mistake it for one.
+        const header = await waitForValue(page, `(() => {
+            ${DEEP_QUERY_SRC}
+            const coin = __deepAll(document, (el) => __ksTag(el, 'ks-icon') && el.getAttribute('name') === 'coin')[0];
+            const balanceText = coin && coin.parentElement ? coin.parentElement.textContent.trim() : null;
+
+            // "Basic plan" / "Plus plan" lives in the credit popover, which is
+            // rendered into the DOM without having to open it.
+            const planEl = __deepAll(document, (el) => /^[A-Z][a-z]+ plan$/.test(__ownText(el)))[0];
+
+            const nameEl = __deepAll(document, (el) => el.tagName === 'P' && __ownText(el).length > 0
+                && !!(el.closest && el.closest('nav')))[0];
+
+            const signedOut = /\\bLog in\\b|\\bSign up\\b/i.test(document.body.innerText || '');
+
+            // Keep polling while the header is still hydrating; settle as soon
+            // as we can tell "signed out" from "balance visible".
+            if (balanceText === null && !signedOut) return null;
+
+            return {
+                balanceText,
+                planLabel: planEl ? __ownText(planEl) : null,
+                accountLabel: nameEl ? __ownText(nameEl) : null,
+                signedOut,
+            };
+        })()`, { label: 'Symphony header', timeoutMs: 30000 });
+
+        if (!header) {
+            throw new CommandExecutionError('Page evaluation returned nothing — the tab may have navigated away');
+        }
+        if (header.balanceText === null && header.signedOut) {
+            throw new AuthRequiredError(HOST, 'Log in to Symphony Creative Studio in this browser first');
+        }
+        if (header.balanceText === null) {
+            throw new CommandExecutionError(
+                'Could not find the credit indicator (ks-icon[name="coin"]) — the header layout may have changed',
+            );
+        }
+
+        const digits = String(header.balanceText).replace(/[^\d]/g, '');
+        if (digits === '') {
+            throw new CommandExecutionError(`Credit indicator was not numeric: "${header.balanceText}"`);
+        }
+
+        return [{
+            credits: Number(digits),
+            plan: header.planLabel,
+            account: header.accountLabel,
+        }];
+    },
+});

--- a/clis/tiktok-symphony/delete.js
+++ b/clis/tiktok-symphony/delete.js
@@ -1,0 +1,197 @@
+// tiktok-symphony delete — permanently remove a generation from the Library.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    DEEP_QUERY_SRC,
+    HOST,
+    LIBRARY_SCROLL_SRC,
+    LIBRARY_URL,
+    waitForValue,
+} from './utils.js';
+
+/**
+ * Page-context source for the tile holding one asset, plus the state we need
+ * from it. Images and clips are matched the same way `generations` reports
+ * them: path segment for an image, `vid` query parameter for a clip.
+ */
+function tileStateSrc(assetId) {
+    return `(() => {
+        ${DEEP_QUERY_SRC}
+        const want = ${JSON.stringify(assetId)};
+        const media = __deepAll(document, (el) =>
+            (el.tagName === 'IMG' && (el.src || '').includes('/ad-creative-sg/' + want + '~'))
+            || (el.tagName === 'VIDEO' && (el.src || el.currentSrc || '').includes(want)))[0];
+        if (!media) return null;
+        return {
+            mediaType: media.tagName === 'VIDEO' ? 'Video' : 'Image',
+            mediaUrl: media.src || media.currentSrc || null,
+        };
+    })()`;
+}
+
+/**
+ * Open the tile's overflow menu and click its Delete row.
+ *
+ * Both hops are keyed on the icon name (`more-horizontal`, then `delete`)
+ * rather than on the label: the menu is localized, and its entries differ by
+ * asset kind (an image offers Share/Generate video/Edit, a clip does not).
+ * Everything is scoped to the tile, so a menu left open on another tile cannot
+ * be the one we click.
+ */
+function openTileMenuSrc(assetId) {
+    return `(() => {
+        ${DEEP_QUERY_SRC}
+        const want = ${JSON.stringify(assetId)};
+        const media = __deepAll(document, (el) =>
+            (el.tagName === 'IMG' && (el.src || '').includes('/ad-creative-sg/' + want + '~'))
+            || (el.tagName === 'VIDEO' && (el.src || el.currentSrc || '').includes(want)))[0];
+        if (!media) return null;
+        media.scrollIntoView({ block: 'center' });
+
+        let tile = media;
+        for (let i = 0; i < 8 && tile; i++) {
+            if (__deepAll(tile, (el) => __ksTag(el, 'ks-icon-more')).length) break;
+            tile = tile.parentElement;
+        }
+        if (!tile) return null;
+        const more = __deepAll(tile, (el) => __ksTag(el, 'ks-icon-more'))[0];
+        if (!more) return null;
+
+        let button = more;
+        for (let i = 0; i < 4 && button; i++) {
+            if (button.tagName === 'BUTTON') break;
+            button = button.parentElement;
+        }
+        (button || more).click();
+        window.__ocDeleteTile = tile;
+        return true;
+    })()`;
+}
+
+const CLICK_DELETE_ROW_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const tile = window.__ocDeleteTile;
+    if (!tile) return null;
+    const icon = __deepAll(tile, (el) => __ksTag(el, 'ks-icon') && el.getAttribute('name') === 'delete')[0];
+    if (!icon) return null;
+    // The row is the icon's parent; the label span next to it is what a user
+    // clicks, and either bubbles to the same handler.
+    (icon.parentElement || icon).click();
+    return true;
+})()`;
+
+/** True once at least one asset tile has rendered anywhere in the grid. */
+const ANY_ASSET_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const hit = __deepAll(document, (el) =>
+        (el.tagName === 'IMG' && /ad-creative-sg/.test(el.src || ''))
+        || (el.tagName === 'VIDEO' && !/lf-creative-factory/.test(el.src || el.currentSrc || '')
+            && (el.src || el.currentSrc)))[0];
+    return hit ? true : null;
+})()`;
+
+/** The confirm dialog, found by its shadow parts rather than its wording. */
+const CONFIRM_SRC = `(() => {
+    const modal = [...document.querySelectorAll('*')].filter((el) =>
+        el.tagName.toLowerCase().startsWith('ks-modal') && el.shadowRoot
+        && el.shadowRoot.querySelector('[part=confirmButton]'))
+        .filter((el) => el.shadowRoot.querySelector('[part=confirmButton]').getBoundingClientRect().height > 0)[0];
+    if (!modal) return null;
+    const confirm = modal.shadowRoot.querySelector('[part=confirmButton]');
+    const real = (confirm.shadowRoot && confirm.shadowRoot.querySelector('button')) || confirm;
+    real.click();
+    return true;
+})()`;
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'delete',
+    aliases: ['rm'],
+    description: 'Permanently delete a generation from the Library (irreversible; requires --yes)',
+    access: 'write',
+    example: 'opencli tiktok-symphony delete 202607205d0d326f7499347f469b9861 --yes',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: LIBRARY_URL,
+    // Library tiles mount lazily via IntersectionObserver. A background tab is
+    // never rendered, so nothing intersects and the grid stays empty.
+    defaultWindowMode: 'foreground',
+    args: [
+        { name: 'asset', type: 'string', required: true, positional: true, help: 'assetId from `generations`' },
+        {
+            name: 'yes',
+            type: 'boolean',
+            default: false,
+            help: 'Actually delete. Without it the asset is only located and reported (status: dry-run)',
+        },
+    ],
+    columns: ['assetId', 'status', 'type', 'url'],
+    func: async (page, args) => {
+        const assetId = String(args.asset ?? '').trim();
+        if (!assetId) throw new ArgumentError('asset is required: pass an assetId from `generations`');
+        if (!/^[A-Za-z0-9]+$/.test(assetId)) {
+            throw new ArgumentError(`"${assetId}" is not a valid assetId (expected alphanumeric)`);
+        }
+
+        const stateSrc = tileStateSrc(assetId);
+
+        // Let the grid mount something first. Searching a still-empty grid and
+        // then scrolling past it would report "not found" for an asset that is
+        // simply late.
+        await waitForValue(page, ANY_ASSET_SRC, { label: 'Symphony Library grid', timeoutMs: 30000 });
+
+        // Scroll the asset into the grid before doing anything destructive: a
+        // tile that was never located must not be reported as deleted.
+        let tile = await page.evaluate(stateSrc);
+        for (let attempt = 0; !tile && attempt < 40; attempt++) {
+            const scrolled = await page.evaluate(LIBRARY_SCROLL_SRC);
+            await new Promise((r) => setTimeout(r, 1200));
+            tile = await page.evaluate(stateSrc);
+            if (!tile && scrolled?.atEnd) break;
+        }
+        if (!tile) {
+            throw new EmptyResultError(
+                'tiktok-symphony delete',
+                `assetId ${assetId} was not found in the Library — check \`opencli tiktok-symphony generations\``,
+            );
+        }
+
+        const row = { assetId, status: 'dry-run', type: tile.mediaType, url: tile.mediaUrl };
+        if (!args.yes) return [row];
+
+        if (!(await page.evaluate(openTileMenuSrc(assetId)))) {
+            throw new CommandExecutionError(`could not open the overflow menu for ${assetId}`);
+        }
+
+        const opened = await waitForValue(page, CLICK_DELETE_ROW_SRC, {
+            label: `Delete entry in the menu for ${assetId}`,
+            timeoutMs: 10000,
+            intervalMs: 500,
+        }).catch(() => null);
+        if (!opened) throw new CommandExecutionError(`the overflow menu for ${assetId} has no Delete entry`);
+
+        const confirmed = await waitForValue(page, CONFIRM_SRC, {
+            label: 'delete confirmation dialog',
+            timeoutMs: 15000,
+            intervalMs: 500,
+        }).catch(() => null);
+        if (!confirmed) {
+            throw new CommandExecutionError('the delete confirmation dialog never appeared — nothing was deleted');
+        }
+
+        // Proof of deletion is the tile leaving the grid. Without this check the
+        // command would report success for a click the site quietly ignored.
+        const gone = await waitForValue(page, `(() => {
+            const t = ${stateSrc};
+            return t === null ? true : null;
+        })()`, { label: `${assetId} to disappear`, timeoutMs: 20000, intervalMs: 1000 }).catch(() => null);
+        if (!gone) {
+            throw new CommandExecutionError(
+                `${assetId} is still in the Library after confirming — the delete did not go through`,
+            );
+        }
+
+        return [{ ...row, status: 'deleted' }];
+    },
+});

--- a/clis/tiktok-symphony/download.js
+++ b/clis/tiktok-symphony/download.js
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { DEEP_QUERY_SRC, HOST, LIBRARY_URL, waitForValue } from './utils.js';
+import { DEEP_QUERY_SRC, HOST, LIBRARY_SCROLL_SRC, LIBRARY_URL, waitForValue } from './utils.js';
 
 const EXT_BY_TYPE = {
     'image/jpeg': 'jpg',
@@ -15,14 +15,23 @@ const EXT_BY_TYPE = {
     'video/quicktime': 'mov',
 };
 
-/** Page-context lookup: the signed CDN URL for one assetId, if it is rendered. */
+/**
+ * Page-context lookup: the signed CDN URL for one assetId, if it is rendered.
+ *
+ * Images and clips live on different hosts with different identity schemes, so
+ * both are searched: an image assetId is a path segment, a clip assetId is the
+ * `vid` query parameter (see `generations`).
+ */
 function findUrlSrc(assetId) {
     return `(() => {
         ${DEEP_QUERY_SRC}
         const want = ${JSON.stringify(assetId)};
         const img = __deepAll(document, (el) => el.tagName === 'IMG'
             && (el.src || '').includes('/ad-creative-sg/' + want + '~'))[0];
-        return img ? img.src : null;
+        if (img) return img.src;
+        const video = __deepAll(document, (el) => el.tagName === 'VIDEO'
+            && (el.src || el.currentSrc || '').includes(want))[0];
+        return video ? (video.src || video.currentSrc) : null;
     })()`;
 }
 
@@ -36,6 +45,10 @@ cli({
     strategy: Strategy.UI,
     browser: true,
     navigateBefore: LIBRARY_URL,
+    // The Library/feed tiles mount lazily via IntersectionObserver. A
+    // background tab is never rendered, so nothing ever intersects and the
+    // grid stays empty — this command is only correct in the foreground.
+    defaultWindowMode: 'foreground',
     args: [
         { name: 'asset', type: 'string', required: true, positional: true, help: 'assetId from `generations`, or a full asset URL' },
         { name: 'out', type: 'string', default: '.', help: 'Directory to write the file into' },
@@ -51,8 +64,9 @@ cli({
         let url;
         if (/^https?:\/\//i.test(asset)) {
             url = asset;
-            const m = /\/ad-creative-sg\/([A-Za-z0-9]+)~/.exec(asset);
-            assetId = m ? m[1] : basename(new URL(asset).pathname);
+            const image = /\/ad-creative-sg\/([A-Za-z0-9]+)~/.exec(asset);
+            const clip = /[?&]vid=([A-Za-z0-9]+)/.exec(asset);
+            assetId = image?.[1] || clip?.[1] || basename(new URL(asset).pathname);
         } else {
             if (!/^[A-Za-z0-9]+$/.test(asset)) {
                 throw new ArgumentError(`"${asset}" is not a valid assetId (expected alphanumeric) or URL`);
@@ -62,10 +76,11 @@ cli({
             // Asset URLs are signed and short-lived, so they have to be read
             // from the live Library rather than reconstructed.
             url = await page.evaluate(findUrlSrc(assetId));
-            for (let attempt = 0; !url && attempt < 12; attempt++) {
-                await page.scroll('down', 3);
+            for (let attempt = 0; !url && attempt < 30; attempt++) {
+                const scrolled = await page.evaluate(LIBRARY_SCROLL_SRC);
                 await new Promise((r) => setTimeout(r, 1200));
                 url = await page.evaluate(findUrlSrc(assetId));
+                if (!url && scrolled?.atEnd) break;
             }
             if (!url) {
                 // Give the grid one slow chance in case it was still hydrating.

--- a/clis/tiktok-symphony/download.js
+++ b/clis/tiktok-symphony/download.js
@@ -1,0 +1,115 @@
+// tiktok-symphony download — save a generated asset to a local file.
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, isAbsolute, join, resolve } from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DEEP_QUERY_SRC, HOST, LIBRARY_URL, waitForValue } from './utils.js';
+
+const EXT_BY_TYPE = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+    'image/avif': 'avif',
+    'image/gif': 'gif',
+    'video/mp4': 'mp4',
+    'video/quicktime': 'mov',
+};
+
+/** Page-context lookup: the signed CDN URL for one assetId, if it is rendered. */
+function findUrlSrc(assetId) {
+    return `(() => {
+        ${DEEP_QUERY_SRC}
+        const want = ${JSON.stringify(assetId)};
+        const img = __deepAll(document, (el) => el.tagName === 'IMG'
+            && (el.src || '').includes('/ad-creative-sg/' + want + '~'))[0];
+        return img ? img.src : null;
+    })()`;
+}
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'download',
+    description: 'Download a generated Symphony asset by assetId (see: generations)',
+    access: 'read',
+    example: 'opencli tiktok-symphony download 202607195d0d7ea36ed139b74eccb1e4 --out ./downloads',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: LIBRARY_URL,
+    args: [
+        { name: 'asset', type: 'string', required: true, positional: true, help: 'assetId from `generations`, or a full asset URL' },
+        { name: 'out', type: 'string', default: '.', help: 'Directory to write the file into' },
+    ],
+    columns: ['assetId', 'file', 'bytes', 'contentType'],
+    func: async (page, args) => {
+        const asset = String(args.asset ?? '').trim();
+        if (!asset) throw new ArgumentError('asset is required: pass an assetId or a full asset URL');
+
+        const outDir = String(args.out ?? '.');
+
+        let assetId;
+        let url;
+        if (/^https?:\/\//i.test(asset)) {
+            url = asset;
+            const m = /\/ad-creative-sg\/([A-Za-z0-9]+)~/.exec(asset);
+            assetId = m ? m[1] : basename(new URL(asset).pathname);
+        } else {
+            if (!/^[A-Za-z0-9]+$/.test(asset)) {
+                throw new ArgumentError(`"${asset}" is not a valid assetId (expected alphanumeric) or URL`);
+            }
+            assetId = asset;
+
+            // Asset URLs are signed and short-lived, so they have to be read
+            // from the live Library rather than reconstructed.
+            url = await page.evaluate(findUrlSrc(assetId));
+            for (let attempt = 0; !url && attempt < 12; attempt++) {
+                await page.scroll('down', 3);
+                await new Promise((r) => setTimeout(r, 1200));
+                url = await page.evaluate(findUrlSrc(assetId));
+            }
+            if (!url) {
+                // Give the grid one slow chance in case it was still hydrating.
+                try {
+                    url = await waitForValue(page, findUrlSrc(assetId), {
+                        label: `asset ${assetId} in Library`,
+                        timeoutMs: 8000,
+                    });
+                } catch {
+                    throw new EmptyResultError(
+                        'tiktok-symphony download',
+                        `assetId ${assetId} was not found in the Library — check \`opencli tiktok-symphony generations\``,
+                    );
+                }
+            }
+        }
+
+        let resp;
+        try {
+            resp = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', Referer: `https://${HOST}/` } });
+        } catch (error) {
+            throw new CommandExecutionError(`asset download failed: ${error?.message || error}`);
+        }
+        if (!resp.ok) throw new CommandExecutionError(`asset download failed: HTTP ${resp.status}`);
+
+        const contentType = (resp.headers.get('content-type') || '').split(';')[0].trim() || null;
+        const bytes = Buffer.from(await resp.arrayBuffer());
+        if (bytes.length === 0) throw new CommandExecutionError(`asset ${assetId} returned an empty body`);
+
+        const ext = EXT_BY_TYPE[contentType] || 'bin';
+        const dir = isAbsolute(outDir) ? outDir : resolve(process.cwd(), outDir);
+        try {
+            await mkdir(dir, { recursive: true });
+        } catch (error) {
+            throw new CommandExecutionError(`could not create output directory "${dir}": ${error?.message || error}`);
+        }
+
+        const file = join(dir, `${assetId}.${ext}`);
+        try {
+            await writeFile(file, bytes);
+        } catch (error) {
+            throw new CommandExecutionError(`could not write "${file}": ${error?.message || error}`);
+        }
+
+        return [{ assetId, file, bytes: bytes.length, contentType }];
+    },
+});

--- a/clis/tiktok-symphony/generate-video.js
+++ b/clis/tiktok-symphony/generate-video.js
@@ -1,0 +1,234 @@
+// tiktok-symphony generate-video — render a clip with the Video composer.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import {
+    CARD_QUERY_SRC,
+    COMPOSER_URL,
+    DROP_ZONE_SELECTOR,
+    HOST,
+    REF_COUNT_SRC,
+    VIDEO_DURATIONS,
+    VIDEO_FRAME_MODES,
+    VIDEO_MODELS,
+    VIDEO_MODES,
+    attachReference,
+    normalizePositiveInteger,
+    readReferenceImages,
+    resolveVideoDuration,
+    resolveVideoFrameMode,
+    resolveVideoMode,
+    resolveVideoModel,
+    selectFooterOption,
+    submitComposer,
+    typePrompt,
+    waitForValue,
+} from './utils.js';
+
+const DURATION_LABELS = VIDEO_DURATIONS.map((d) => `${d}s`);
+const FRAME_LABELS = VIDEO_FRAME_MODES.map((f) => f.label);
+
+/**
+ * The clip rendered by one generation card.
+ *
+ * A finished card swaps its progress readout for a <video>. Note the playback
+ * URL is NOT on the `ad-creative-sg` host that images use — it is served from
+ * `v16-ad-creative.tiktokcdn-row.com/video/tos/...` and carries no assetId at
+ * all. The only thing to exclude is the page's static demo clip, which sits
+ * outside any card but is cheap to rule out by host.
+ */
+function cardStateSrc(prompt) {
+    return `(() => {
+        ${CARD_QUERY_SRC}
+        const card = __cardFor(${JSON.stringify(prompt)});
+        if (!card) return null;
+        const state = __cardState(card);
+        state.clip = null;
+        for (const v of __deepAll(card, (el) => el.tagName === 'VIDEO')) {
+            const src = v.src || v.currentSrc || '';
+            if (src && !/lf-creative-factory/.test(src)) { state.clip = src; break; }
+        }
+        return state;
+    })()`;
+}
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'generate-video',
+    aliases: ['video'],
+    description: 'Generate a video clip from a prompt and optional reference images (spends Symphony credits)',
+    access: 'write',
+    example: 'opencli tiktok-symphony generate-video "a duck floating on a pool, slow zoom out" --duration 5',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: false,
+    defaultWindowMode: 'foreground',
+    args: [
+        { name: 'prompt', type: 'string', required: true, positional: true, help: 'What to generate' },
+        {
+            name: 'mode',
+            type: 'string',
+            default: 'auto',
+            help: `Sub-app: ${VIDEO_MODES.map((m) => m.key).join(' / ')}. "auto" picks text with no refs, image with 1, reference with 2+`,
+        },
+        { name: 'refs', type: 'string', default: '', help: 'Comma-separated reference image paths (image: 1-2, reference: 1-4)' },
+        { name: 'frames', type: 'string', default: 'first', help: `Image mode only: ${VIDEO_FRAME_MODES.map((f) => f.key).join(' / ')}` },
+        { name: 'model', type: 'string', default: VIDEO_MODELS[0], help: `Model: ${VIDEO_MODELS.join(' / ')}` },
+        { name: 'duration', type: 'string', default: '5', help: `Clip length: ${DURATION_LABELS.join(' / ')}` },
+        { name: 'timeout', type: 'int', default: 5400, help: 'Seconds to wait when --wait true (rendering has been observed to exceed an hour)' },
+        {
+            name: 'wait',
+            type: 'boolean',
+            default: false,
+            help: 'Block until the clip renders. Off by default: rendering runs for tens of minutes, so the job is submitted and `generations` picks it up later',
+        },
+    ],
+    columns: ['index', 'status', 'assetId', 'url', 'mode', 'model', 'duration', 'prompt'],
+    func: async (page, args) => {
+        const prompt = String(args.prompt ?? '').trim();
+        if (!prompt) throw new ArgumentError('prompt is required and cannot be blank');
+
+        const model = resolveVideoModel(args.model);
+        const duration = resolveVideoDuration(args.duration);
+        const timeoutSec = normalizePositiveInteger(args.timeout, 5400, 'timeout', { min: 60 });
+
+        const refPaths = String(args.refs ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+        const mode = String(args.mode ?? 'auto').trim().toLowerCase() === 'auto'
+            ? autoMode(refPaths.length)
+            : resolveVideoMode(args.mode);
+
+        const frameMode = resolveVideoFrameMode(args.frames);
+        const maxRefs = mode.key === 'image' ? frameMode.refs : mode.maxRefs;
+
+        if (refPaths.length < mode.minRefs) {
+            throw new ArgumentError(`mode "${mode.key}" needs at least ${mode.minRefs} reference image(s) — pass --refs`);
+        }
+        if (mode.key === 'text' && refPaths.length > 0) {
+            throw new ArgumentError('mode "text" takes no reference images — use --mode image or --mode reference');
+        }
+        if (mode.key !== 'image' && frameMode.key !== VIDEO_FRAME_MODES[0].key) {
+            // Only the Image sub-app renders this dropdown; accepting the flag
+            // elsewhere would silently drop it.
+            throw new ArgumentError(`--frames only applies to --mode image, not "${mode.key}"`);
+        }
+        if (mode.key === 'image' && frameMode.key === 'first-last' && refPaths.length !== 2) {
+            throw new ArgumentError('--frames first-last needs exactly 2 reference images (start and end frame)');
+        }
+
+        const references = await readReferenceImages(args.refs, maxRefs);
+
+        // Land on the sub-app URL directly: each Video mode is its own `subApp`,
+        // so navigating there beats clicking the mode dropdown, and a fresh load
+        // is required anyway because submitting never clears the composer.
+        await page.goto(`${COMPOSER_URL}?subApp=${mode.subApp}`, { waitUntil: 'load' });
+        await waitForValue(page, `(() => !!document.querySelector('${DROP_ZONE_SELECTOR}') || null)()`, {
+            label: 'Symphony composer',
+            timeoutMs: 30000,
+        });
+
+        // The model dropdown only carries these names on the Video tab, so its
+        // presence doubles as proof the right sub-app hydrated.
+        await selectFooterOption(page, { allowed: VIDEO_MODELS, target: model, label: 'model' });
+
+        const staleRefs = await page.evaluate(REF_COUNT_SRC);
+        if (staleRefs) {
+            throw new CommandExecutionError(
+                `composer still holds ${staleRefs} reference image(s) after reload — refusing to generate with unknown inputs`,
+            );
+        }
+
+        if (mode.key === 'image') {
+            await selectFooterOption(page, { allowed: FRAME_LABELS, target: frameMode.label, label: 'frames' });
+        }
+
+        for (const [i, ref] of references.entries()) {
+            await attachReference(page, ref, i);
+        }
+
+        await selectFooterOption(page, { allowed: DURATION_LABELS, target: duration.label, label: 'duration' });
+        await typePrompt(page, prompt);
+        await submitComposer(page);
+
+        const stateSrc = cardStateSrc(prompt);
+
+        // A card carrying a progress readout is the site acknowledging the job;
+        // without it we would report success for a request that never started.
+        const started = await waitForValue(page, `(() => {
+            const s = ${stateSrc};
+            return s && (s.cardProgress !== null || s.cardErrorCode || s.clip) ? s : null;
+        })()`, { label: 'generation to start', timeoutMs: 120000, intervalMs: 2000 });
+        rejectIfFailed(started);
+
+        const row = {
+            index: 1,
+            status: 'generating',
+            assetId: null,
+            url: null,
+            mode: mode.key,
+            model,
+            duration: duration.label,
+            prompt,
+        };
+
+        if (!args.wait) return [row];
+
+        const url = await waitForClip(page, stateSrc, timeoutSec);
+        return [{ ...row, status: 'ready', assetId: assetIdFromVideoUrl(url), url }];
+    },
+});
+
+/** Pick the sub-app that matches how many references the caller supplied. */
+function autoMode(refCount) {
+    if (refCount === 0) return resolveVideoMode('text');
+    if (refCount === 1) return resolveVideoMode('image');
+    return resolveVideoMode('reference');
+}
+
+/**
+ * Wait for the clip to finish.
+ *
+ * Rendering is slow (tens of minutes) and the card exposes a percentage that
+ * stalls near the end, so the only trustworthy completion signal is a new
+ * <video> mounting in the feed.
+ */
+async function waitForClip(page, stateSrc, timeoutSec) {
+    const deadline = Date.now() + timeoutSec * 1000;
+
+    for (;;) {
+        const state = await page.evaluate(stateSrc);
+
+        // The feed keeps only a handful of cards: a burst of other generations
+        // can push ours out while we wait, and silently polling a card that no
+        // longer exists would look identical to "still rendering".
+        if (!state) {
+            throw new CommandExecutionError(
+                'the generation card left the Create feed before the clip appeared — check `opencli tiktok-symphony jobs`',
+            );
+        }
+        rejectIfFailed(state);
+        if (state.clip) return state.clip;
+
+        if (Date.now() >= deadline) throw new TimeoutError('video generation', timeoutSec);
+        await new Promise((r) => setTimeout(r, 10000));
+    }
+}
+
+/**
+ * Surface a rejected render as a failure.
+ *
+ * Moderation refusals arrive as ordinary card text, not a dialog or an HTTP
+ * error, so nothing else stops the command from reporting a clip that will
+ * never exist. The credits are spent either way.
+ */
+function rejectIfFailed(state) {
+    if (!state?.errorCode) return;
+    const detail = state.cardErrorText || 'the site rejected this generation';
+    const task = state.cardTaskId ? ` (task ${state.cardTaskId})` : '';
+    throw new CommandExecutionError(`generation rejected [${state.cardErrorCode}]${task}: ${detail}`);
+}
+
+/** Clip URLs carry the same `/ad-creative-sg/<assetId>~...` handle as images. */
+function assetIdFromVideoUrl(url) {
+    const m = /\/ad-creative-sg\/([A-Za-z0-9]+)[~/?]/.exec(String(url || ''));
+    return m ? m[1] : null;
+}

--- a/clis/tiktok-symphony/generate.js
+++ b/clis/tiktok-symphony/generate.js
@@ -1,74 +1,54 @@
 // tiktok-symphony generate — create images from a prompt plus reference images.
-import { readFile } from 'node:fs/promises';
-import { basename, extname } from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import {
-    ArgumentError,
-    CommandExecutionError,
-    TimeoutError,
-} from '@jackwener/opencli/errors';
-import {
+    CARD_QUERY_SRC,
     CREATE_URL,
     DEEP_QUERY_SRC,
+    DROP_ZONE_SELECTOR,
     HOST,
     IMAGE_MODELS,
     MAX_REFERENCE_IMAGES,
     OUTPUTS_PER_GENERATION,
+    REF_COUNT_SRC,
+    attachReference,
     normalizePositiveInteger,
+    readReferenceImages,
+    readStable,
     resolveModel,
+    selectFooterOption,
+    submitComposer,
+    typePrompt,
     waitForValue,
 } from './utils.js';
 
-const PROMPT_SELECTOR = '[data-chatbox-part=textarea] .ProseMirror';
-const DROP_ZONE_SELECTOR = 'fieldset[aria-label="File drop zone"]';
-const MAX_REFERENCE_BYTES = 10 * 1024 * 1024;
-
-const MIME_BY_EXT = {
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.webp': 'image/webp',
-    '.gif': 'image/gif',
-    '.avif': 'image/avif',
-};
-
-/** Count reference thumbnails currently attached to the composer. */
-const REF_COUNT_SRC = `(() => {
-    ${DEEP_QUERY_SRC}
-    const header = document.querySelector('[data-chatbox-part=header]');
-    if (!header) return null;
-    // Static chrome (logo, page art) also lives here; uploaded references are
-    // object URLs or land on the creative-tool upload host.
-    return [...header.querySelectorAll('img')].filter((img) => {
-        const s = img.src || '';
-        return s.startsWith('blob:') || s.startsWith('data:')
-            || /ibyteimg\\.com|creative-tool/.test(s);
-    }).length;
-})()`;
-
-/** Every finished output asset id currently rendered in the Create feed. */
-const FEED_ASSETS_SRC = `(() => {
+/** Every rendered output asset id anywhere on the page. */
+const PAGE_ASSETS_SRC = `(() => {
     ${DEEP_QUERY_SRC}
     const ids = [];
     for (const img of __deepAll(document, (el) => el.tagName === 'IMG')) {
         const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
-        if (m && img.naturalWidth > 0 && !ids.includes(m[1])) ids.push(m[1]);
+        if (m && !ids.includes(m[1])) ids.push(m[1]);
     }
-    return ids;
+    return ids.sort();
 })()`;
 
-/** Current model shown on the footer dropdown button. */
-const CURRENT_MODEL_SRC = `(() => {
-    ${DEEP_QUERY_SRC}
-    const footer = document.querySelector('[data-chatbox-part=footer]');
-    if (!footer) return null;
-    const dd = __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))[0];
-    if (!dd) return null;
-    const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
-    // Read the button's own text: the menu is kept in the DOM, so the
-    // dropdown's textContent would contain every model name at once.
-    return btn ? __ownText(btn) : null;
-})()`;
+/** The finished outputs of one generation card, newest card first. */
+function cardAssetsSrc(prompt) {
+    return `(() => {
+        ${CARD_QUERY_SRC}
+        const card = __cardFor(${JSON.stringify(prompt)});
+        if (!card) return null;
+        const out = [];
+        for (const img of __deepAll(card, (el) => el.tagName === 'IMG')) {
+            const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
+            if (m && img.naturalWidth > 0 && !out.some((a) => a.assetId === m[1])) {
+                out.push({ assetId: m[1], url: img.src });
+            }
+        }
+        return out;
+    })()`;
+}
 
 cli({
     site: 'tiktok-symphony',
@@ -94,35 +74,7 @@ cli({
 
         const model = resolveModel(args.model);
         const timeoutSec = normalizePositiveInteger(args.timeout, 300, 'timeout', { min: 30 });
-
-        const refPaths = String(args.refs ?? '')
-            .split(',')
-            .map((s) => s.trim())
-            .filter(Boolean);
-        if (refPaths.length > MAX_REFERENCE_IMAGES) {
-            throw new ArgumentError(`refs accepts at most ${MAX_REFERENCE_IMAGES} images, got ${refPaths.length}`);
-        }
-
-        // Read every reference up front so a bad path fails before we touch the UI.
-        const references = [];
-        for (const path of refPaths) {
-            let buf;
-            try {
-                buf = await readFile(path);
-            } catch (error) {
-                throw new ArgumentError(`cannot read reference image "${path}": ${error?.message || error}`);
-            }
-            if (buf.length === 0) throw new ArgumentError(`reference image "${path}" is empty`);
-            if (buf.length > MAX_REFERENCE_BYTES) {
-                throw new ArgumentError(`reference image "${path}" is larger than ${MAX_REFERENCE_BYTES} bytes`);
-            }
-            const ext = extname(path).toLowerCase();
-            const type = MIME_BY_EXT[ext];
-            if (!type) {
-                throw new ArgumentError(`unsupported reference image type "${ext || path}" (use ${Object.keys(MIME_BY_EXT).join(' / ')})`);
-            }
-            references.push({ name: basename(path), type, b64: buf.toString('base64') });
-        }
+        const references = await readReferenceImages(args.refs, MAX_REFERENCE_IMAGES);
 
         // Always land on a freshly loaded composer: submitting does not clear
         // the prompt or references, so a reused tab would silently resend them.
@@ -145,23 +97,17 @@ cli({
             await attachReference(page, ref, i);
         }
 
-        await selectModel(page, model);
+        await selectFooterOption(page, { allowed: IMAGE_MODELS, target: model, label: 'model' });
+        await typePrompt(page, prompt);
 
-        await page.typeText(PROMPT_SELECTOR, prompt);
-        const typed = await page.evaluate(`(() => {
-            const pm = document.querySelector('${PROMPT_SELECTOR}');
-            return pm ? pm.textContent : null;
-        })()`);
-        if (!typed || !typed.includes(prompt.slice(0, 20))) {
-            throw new CommandExecutionError('prompt did not register in the composer editor');
-        }
-
-        const before = await page.evaluate(FEED_ASSETS_SRC);
+        // Let the feed finish streaming in before snapshotting: assets that
+        // arrive late would otherwise look like they came from this run.
+        const before = await readStable(page, PAGE_ASSETS_SRC);
         const known = new Set(Array.isArray(before) ? before : []);
 
-        await submit(page);
+        await submitComposer(page);
 
-        const fresh = await waitForOutputs(page, known, timeoutSec);
+        const fresh = await waitForOutputs(page, prompt, known, timeoutSec);
 
         return fresh.slice(0, OUTPUTS_PER_GENERATION).map((asset, i) => ({
             index: i + 1,
@@ -190,7 +136,18 @@ async function selectImageTab(page) {
     })()`);
 
     // The Image tab is the only one offering these models — use that as proof.
-    const model = await waitForValue(page, CURRENT_MODEL_SRC, { label: 'Image tab model selector', timeoutMs: 20000 });
+    const model = await waitForValue(page, `(() => {
+        ${DEEP_QUERY_SRC}
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        if (!footer) return null;
+        for (const dd of __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))) {
+            const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
+            const label = btn ? __ownText(btn) : '';
+            if (label) return label;
+        }
+        return null;
+    })()`, { label: 'Image tab model selector', timeoutMs: 20000 });
+
     if (!IMAGE_MODELS.includes(model)) {
         throw new CommandExecutionError(
             `composer is not on the Image tab (model selector reads "${model}") — the tab layout may have changed`,
@@ -199,135 +156,31 @@ async function selectImageTab(page) {
 }
 
 /**
- * Attach one reference image.
- *
- * The page exposes no file input and CDP file injection is refused, so the
- * supported path is the composer's own drop zone: build the File inside the
- * page and dispatch a real drop.
- */
-async function attachReference(page, ref, index) {
-    const dropped = await page.evaluate((b64, name, type, selector) => {
-        const bin = atob(b64);
-        const bytes = new Uint8Array(bin.length);
-        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-        const file = new File([bytes], name, { type });
-        const dt = new DataTransfer();
-        dt.items.add(file);
-        const zone = document.querySelector(selector);
-        if (!zone) return false;
-        for (const kind of ['dragenter', 'dragover', 'drop']) {
-            zone.dispatchEvent(new DragEvent(kind, { bubbles: true, cancelable: true, dataTransfer: dt }));
-        }
-        return true;
-    }, ref.b64, ref.name, ref.type, DROP_ZONE_SELECTOR);
-
-    if (!dropped) throw new CommandExecutionError(`could not find the composer drop zone for "${ref.name}"`);
-
-    const want = index + 1;
-    try {
-        await waitForValue(page, `(() => {
-            const n = ${REF_COUNT_SRC};
-            return n >= ${want} ? n : null;
-        })()`, { label: `reference upload "${ref.name}"`, timeoutMs: 60000, intervalMs: 700 });
-    } catch (error) {
-        if (error instanceof TimeoutError) {
-            throw new CommandExecutionError(`reference image "${ref.name}" did not attach to the composer`);
-        }
-        throw error;
-    }
-}
-
-/** Pick a model from the footer dropdown and confirm the button label changed. */
-async function selectModel(page, model) {
-    const current = await page.evaluate(CURRENT_MODEL_SRC);
-    if (current === model) return;
-
-    await page.evaluate(`(() => {
-        ${DEEP_QUERY_SRC}
-        const footer = document.querySelector('[data-chatbox-part=footer]');
-        const dd = __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))[0];
-        if (!dd) return null;
-        const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
-        if (!btn) return null;
-        const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
-        real.click();
-        return true;
-    })()`);
-
-    await page.evaluate(`(() => {
-        ${DEEP_QUERY_SRC}
-        // Options render as ks-text; the dropdown button is a ks-button, so
-        // matching on tag keeps us from clicking the trigger again.
-        const opt = __deepAll(document, (el) => __ksTag(el, 'ks-text') && __ownText(el) === ${JSON.stringify(model)})[0];
-        if (!opt) return null;
-        opt.click();
-        return true;
-    })()`);
-
-    const now = await waitForValue(page, `(() => {
-        const m = ${CURRENT_MODEL_SRC};
-        return m === ${JSON.stringify(model)} ? m : null;
-    })()`, { label: `model switch to ${model}`, timeoutMs: 15000 }).catch(() => null);
-
-    if (now !== model) {
-        throw new CommandExecutionError(`could not switch the model to "${model}"`);
-    }
-}
-
-/** Click the composer's send button once it is enabled. */
-async function submit(page) {
-    const clicked = await waitForValue(page, `(() => {
-        ${DEEP_QUERY_SRC}
-        const footer = document.querySelector('[data-chatbox-part=footer]');
-        if (!footer) return null;
-        const btn = __deepAll(footer, (el) => __ksTag(el, 'ks-icon-button')
-            && __deepAll(el, (x) => __ksTag(x, 'ks-icon-arrow-up')).length > 0)[0];
-        if (!btn) return null;
-        const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
-        if (real.disabled || btn.hasAttribute('disabled')) return null;
-        real.click();
-        return true;
-    })()`, { label: 'send button', timeoutMs: 20000 }).catch(() => null);
-
-    if (!clicked) {
-        throw new CommandExecutionError('the send button never became enabled — the composer may have rejected the input');
-    }
-}
-
-/**
  * Wait for the generation to finish.
  *
- * There is no spinner or status class to bind to: outputs simply appear in the
- * feed one at a time, so completion means "N new rendered assets".
+ * There is no spinner or status class to bind to: outputs simply appear inside
+ * the card one at a time, so completion means "the card holds N rendered
+ * assets".
  */
-async function waitForOutputs(page, known, timeoutSec) {
+async function waitForOutputs(page, prompt, known, timeoutSec) {
     const deadline = Date.now() + timeoutSec * 1000;
+    const src = cardAssetsSrc(prompt);
     let best = [];
 
     for (;;) {
-        const ids = await page.evaluate(FEED_ASSETS_SRC);
-        const fresh = (Array.isArray(ids) ? ids : []).filter((id) => !known.has(id));
+        const assets = await page.evaluate(src);
+        const fresh = (Array.isArray(assets) ? assets : []).filter((a) => !known.has(a.assetId));
         if (fresh.length > best.length) best = fresh;
         if (best.length >= OUTPUTS_PER_GENERATION) break;
         if (Date.now() >= deadline) {
-            if (best.length === 0) {
-                throw new TimeoutError('image generation', timeoutSec);
-            }
+            if (best.length === 0) throw new TimeoutError('image generation', timeoutSec);
             break; // partial render — return what actually finished
         }
         await new Promise((r) => setTimeout(r, 3000));
     }
 
-    const urls = await page.evaluate(`(() => {
-        ${DEEP_QUERY_SRC}
-        const want = ${JSON.stringify(best)};
-        const out = {};
-        for (const img of __deepAll(document, (el) => el.tagName === 'IMG')) {
-            const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
-            if (m && want.includes(m[1]) && !out[m[1]]) out[m[1]] = img.src;
-        }
-        return out;
-    })()`);
-
-    return best.map((assetId) => ({ assetId, url: (urls && urls[assetId]) || null }));
+    // One settling read: a card caught mid-swap can briefly show a recycled src.
+    const settled = await readStable(page, src, { tries: 4, intervalMs: 1500 });
+    const confirmed = (Array.isArray(settled) ? settled : []).filter((a) => !known.has(a.assetId));
+    return confirmed.length >= best.length ? confirmed : best;
 }

--- a/clis/tiktok-symphony/generate.js
+++ b/clis/tiktok-symphony/generate.js
@@ -1,0 +1,333 @@
+// tiktok-symphony generate — create images from a prompt plus reference images.
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import {
+    CREATE_URL,
+    DEEP_QUERY_SRC,
+    HOST,
+    IMAGE_MODELS,
+    MAX_REFERENCE_IMAGES,
+    OUTPUTS_PER_GENERATION,
+    normalizePositiveInteger,
+    resolveModel,
+    waitForValue,
+} from './utils.js';
+
+const PROMPT_SELECTOR = '[data-chatbox-part=textarea] .ProseMirror';
+const DROP_ZONE_SELECTOR = 'fieldset[aria-label="File drop zone"]';
+const MAX_REFERENCE_BYTES = 10 * 1024 * 1024;
+
+const MIME_BY_EXT = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.webp': 'image/webp',
+    '.gif': 'image/gif',
+    '.avif': 'image/avif',
+};
+
+/** Count reference thumbnails currently attached to the composer. */
+const REF_COUNT_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const header = document.querySelector('[data-chatbox-part=header]');
+    if (!header) return null;
+    // Static chrome (logo, page art) also lives here; uploaded references are
+    // object URLs or land on the creative-tool upload host.
+    return [...header.querySelectorAll('img')].filter((img) => {
+        const s = img.src || '';
+        return s.startsWith('blob:') || s.startsWith('data:')
+            || /ibyteimg\\.com|creative-tool/.test(s);
+    }).length;
+})()`;
+
+/** Every finished output asset id currently rendered in the Create feed. */
+const FEED_ASSETS_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const ids = [];
+    for (const img of __deepAll(document, (el) => el.tagName === 'IMG')) {
+        const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
+        if (m && img.naturalWidth > 0 && !ids.includes(m[1])) ids.push(m[1]);
+    }
+    return ids;
+})()`;
+
+/** Current model shown on the footer dropdown button. */
+const CURRENT_MODEL_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const footer = document.querySelector('[data-chatbox-part=footer]');
+    if (!footer) return null;
+    const dd = __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))[0];
+    if (!dd) return null;
+    const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
+    // Read the button's own text: the menu is kept in the DOM, so the
+    // dropdown's textContent would contain every model name at once.
+    return btn ? __ownText(btn) : null;
+})()`;
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'generate',
+    description: 'Generate images from a prompt and up to 4 reference images (spends Symphony credits)',
+    access: 'write',
+    example: 'opencli tiktok-symphony generate "turn this into 3D chibi style" --refs ./cat.png',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: false,
+    defaultWindowMode: 'foreground',
+    args: [
+        { name: 'prompt', type: 'string', required: true, positional: true, help: 'What to generate' },
+        { name: 'refs', type: 'string', default: '', help: `Comma-separated reference image paths (max ${MAX_REFERENCE_IMAGES})` },
+        { name: 'model', type: 'string', default: IMAGE_MODELS[0], help: `Model: ${IMAGE_MODELS.join(' / ')}` },
+        { name: 'timeout', type: 'int', default: 300, help: 'Seconds to wait for rendering' },
+    ],
+    columns: ['index', 'assetId', 'url', 'model', 'prompt'],
+    func: async (page, args) => {
+        const prompt = String(args.prompt ?? '').trim();
+        if (!prompt) throw new ArgumentError('prompt is required and cannot be blank');
+
+        const model = resolveModel(args.model);
+        const timeoutSec = normalizePositiveInteger(args.timeout, 300, 'timeout', { min: 30 });
+
+        const refPaths = String(args.refs ?? '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        if (refPaths.length > MAX_REFERENCE_IMAGES) {
+            throw new ArgumentError(`refs accepts at most ${MAX_REFERENCE_IMAGES} images, got ${refPaths.length}`);
+        }
+
+        // Read every reference up front so a bad path fails before we touch the UI.
+        const references = [];
+        for (const path of refPaths) {
+            let buf;
+            try {
+                buf = await readFile(path);
+            } catch (error) {
+                throw new ArgumentError(`cannot read reference image "${path}": ${error?.message || error}`);
+            }
+            if (buf.length === 0) throw new ArgumentError(`reference image "${path}" is empty`);
+            if (buf.length > MAX_REFERENCE_BYTES) {
+                throw new ArgumentError(`reference image "${path}" is larger than ${MAX_REFERENCE_BYTES} bytes`);
+            }
+            const ext = extname(path).toLowerCase();
+            const type = MIME_BY_EXT[ext];
+            if (!type) {
+                throw new ArgumentError(`unsupported reference image type "${ext || path}" (use ${Object.keys(MIME_BY_EXT).join(' / ')})`);
+            }
+            references.push({ name: basename(path), type, b64: buf.toString('base64') });
+        }
+
+        // Always land on a freshly loaded composer: submitting does not clear
+        // the prompt or references, so a reused tab would silently resend them.
+        await page.goto(CREATE_URL, { waitUntil: 'load' });
+        await waitForValue(page, `(() => !!document.querySelector('${DROP_ZONE_SELECTOR}') || null)()`, {
+            label: 'Symphony composer',
+            timeoutMs: 30000,
+        });
+
+        await selectImageTab(page);
+
+        const staleRefs = await page.evaluate(REF_COUNT_SRC);
+        if (staleRefs) {
+            throw new CommandExecutionError(
+                `composer still holds ${staleRefs} reference image(s) after reload — refusing to generate with unknown inputs`,
+            );
+        }
+
+        for (const [i, ref] of references.entries()) {
+            await attachReference(page, ref, i);
+        }
+
+        await selectModel(page, model);
+
+        await page.typeText(PROMPT_SELECTOR, prompt);
+        const typed = await page.evaluate(`(() => {
+            const pm = document.querySelector('${PROMPT_SELECTOR}');
+            return pm ? pm.textContent : null;
+        })()`);
+        if (!typed || !typed.includes(prompt.slice(0, 20))) {
+            throw new CommandExecutionError('prompt did not register in the composer editor');
+        }
+
+        const before = await page.evaluate(FEED_ASSETS_SRC);
+        const known = new Set(Array.isArray(before) ? before : []);
+
+        await submit(page);
+
+        const fresh = await waitForOutputs(page, known, timeoutSec);
+
+        return fresh.slice(0, OUTPUTS_PER_GENERATION).map((asset, i) => ({
+            index: i + 1,
+            assetId: asset.assetId,
+            url: asset.url,
+            model,
+            prompt,
+        }));
+    },
+});
+
+/** Switch the composer to the Image tab, then prove we landed there. */
+async function selectImageTab(page) {
+    await page.evaluate(`(() => {
+        ${DEEP_QUERY_SRC}
+        const topbar = document.querySelector('[data-chatbox-part=topbar]');
+        if (!topbar) return null;
+        const tabs = __deepAll(topbar, (el) => el.getAttribute('role') === 'tab');
+        if (!tabs.length) return null;
+        // Prefer the labelled tab; fall back to position so a translated UI
+        // still works (Video is first, Image second).
+        const byText = tabs.find((t) => /image|hình|图片|画像/i.test(t.textContent || ''));
+        const target = byText || tabs[1] || tabs[0];
+        if (target && target.getAttribute('aria-selected') !== 'true') target.click();
+        return true;
+    })()`);
+
+    // The Image tab is the only one offering these models — use that as proof.
+    const model = await waitForValue(page, CURRENT_MODEL_SRC, { label: 'Image tab model selector', timeoutMs: 20000 });
+    if (!IMAGE_MODELS.includes(model)) {
+        throw new CommandExecutionError(
+            `composer is not on the Image tab (model selector reads "${model}") — the tab layout may have changed`,
+        );
+    }
+}
+
+/**
+ * Attach one reference image.
+ *
+ * The page exposes no file input and CDP file injection is refused, so the
+ * supported path is the composer's own drop zone: build the File inside the
+ * page and dispatch a real drop.
+ */
+async function attachReference(page, ref, index) {
+    const dropped = await page.evaluate((b64, name, type, selector) => {
+        const bin = atob(b64);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        const file = new File([bytes], name, { type });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        const zone = document.querySelector(selector);
+        if (!zone) return false;
+        for (const kind of ['dragenter', 'dragover', 'drop']) {
+            zone.dispatchEvent(new DragEvent(kind, { bubbles: true, cancelable: true, dataTransfer: dt }));
+        }
+        return true;
+    }, ref.b64, ref.name, ref.type, DROP_ZONE_SELECTOR);
+
+    if (!dropped) throw new CommandExecutionError(`could not find the composer drop zone for "${ref.name}"`);
+
+    const want = index + 1;
+    try {
+        await waitForValue(page, `(() => {
+            const n = ${REF_COUNT_SRC};
+            return n >= ${want} ? n : null;
+        })()`, { label: `reference upload "${ref.name}"`, timeoutMs: 60000, intervalMs: 700 });
+    } catch (error) {
+        if (error instanceof TimeoutError) {
+            throw new CommandExecutionError(`reference image "${ref.name}" did not attach to the composer`);
+        }
+        throw error;
+    }
+}
+
+/** Pick a model from the footer dropdown and confirm the button label changed. */
+async function selectModel(page, model) {
+    const current = await page.evaluate(CURRENT_MODEL_SRC);
+    if (current === model) return;
+
+    await page.evaluate(`(() => {
+        ${DEEP_QUERY_SRC}
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        const dd = __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))[0];
+        if (!dd) return null;
+        const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
+        if (!btn) return null;
+        const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
+        real.click();
+        return true;
+    })()`);
+
+    await page.evaluate(`(() => {
+        ${DEEP_QUERY_SRC}
+        // Options render as ks-text; the dropdown button is a ks-button, so
+        // matching on tag keeps us from clicking the trigger again.
+        const opt = __deepAll(document, (el) => __ksTag(el, 'ks-text') && __ownText(el) === ${JSON.stringify(model)})[0];
+        if (!opt) return null;
+        opt.click();
+        return true;
+    })()`);
+
+    const now = await waitForValue(page, `(() => {
+        const m = ${CURRENT_MODEL_SRC};
+        return m === ${JSON.stringify(model)} ? m : null;
+    })()`, { label: `model switch to ${model}`, timeoutMs: 15000 }).catch(() => null);
+
+    if (now !== model) {
+        throw new CommandExecutionError(`could not switch the model to "${model}"`);
+    }
+}
+
+/** Click the composer's send button once it is enabled. */
+async function submit(page) {
+    const clicked = await waitForValue(page, `(() => {
+        ${DEEP_QUERY_SRC}
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        if (!footer) return null;
+        const btn = __deepAll(footer, (el) => __ksTag(el, 'ks-icon-button')
+            && __deepAll(el, (x) => __ksTag(x, 'ks-icon-arrow-up')).length > 0)[0];
+        if (!btn) return null;
+        const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
+        if (real.disabled || btn.hasAttribute('disabled')) return null;
+        real.click();
+        return true;
+    })()`, { label: 'send button', timeoutMs: 20000 }).catch(() => null);
+
+    if (!clicked) {
+        throw new CommandExecutionError('the send button never became enabled — the composer may have rejected the input');
+    }
+}
+
+/**
+ * Wait for the generation to finish.
+ *
+ * There is no spinner or status class to bind to: outputs simply appear in the
+ * feed one at a time, so completion means "N new rendered assets".
+ */
+async function waitForOutputs(page, known, timeoutSec) {
+    const deadline = Date.now() + timeoutSec * 1000;
+    let best = [];
+
+    for (;;) {
+        const ids = await page.evaluate(FEED_ASSETS_SRC);
+        const fresh = (Array.isArray(ids) ? ids : []).filter((id) => !known.has(id));
+        if (fresh.length > best.length) best = fresh;
+        if (best.length >= OUTPUTS_PER_GENERATION) break;
+        if (Date.now() >= deadline) {
+            if (best.length === 0) {
+                throw new TimeoutError('image generation', timeoutSec);
+            }
+            break; // partial render — return what actually finished
+        }
+        await new Promise((r) => setTimeout(r, 3000));
+    }
+
+    const urls = await page.evaluate(`(() => {
+        ${DEEP_QUERY_SRC}
+        const want = ${JSON.stringify(best)};
+        const out = {};
+        for (const img of __deepAll(document, (el) => el.tagName === 'IMG')) {
+            const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
+            if (m && want.includes(m[1]) && !out[m[1]]) out[m[1]] = img.src;
+        }
+        return out;
+    })()`);
+
+    return best.map((assetId) => ({ assetId, url: (urls && urls[assetId]) || null }));
+}

--- a/clis/tiktok-symphony/generations.js
+++ b/clis/tiktok-symphony/generations.js
@@ -1,43 +1,52 @@
 // tiktok-symphony generations — assets in the Symphony Creative Studio Library.
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { DEEP_QUERY_SRC, HOST, LIBRARY_URL, normalizeLimit, waitForValue } from './utils.js';
+import {
+    DEEP_QUERY_SRC,
+    HOST,
+    LIBRARY_SCROLL_SRC,
+    LIBRARY_URL,
+    normalizeLimit,
+    readStable,
+    waitForValue,
+} from './utils.js';
 
 /**
  * Collect every rendered Library tile. Runs in page context.
  *
- * The Library grid has no generation id anywhere in the DOM — the only
- * per-asset identity is the path segment of the signed CDN URL, so that is
- * what we surface and what `download` consumes.
+ * Images and clips are two different worlds here:
+ *   image → <img> on ad-site-sign-sg/ad-creative-sg, identity = path segment
+ *   clip  → <video> on v16-ad-creative.tiktokcdn-row.com, identity = `vid` param
+ * Neither carries a generation id, and the URLs are signed and short-lived, so
+ * these handles are all `download` has to work with.
+ *
+ * The type comes from the element kind rather than the tile's badge text: the
+ * badge is localized, and clip tiles are labelled with the tool name
+ * ("Reference to video") instead of a "Video" badge at all.
  */
 const SCRAPE_SRC = `(() => {
     ${DEEP_QUERY_SRC}
-    const imgs = __deepAll(document, (el) => el.tagName === 'IMG'
-        && /ad-site-sign-sg\\.tiktokcdn\\.com\\/ad-creative-sg\\//.test(el.src || ''));
-    if (!imgs.length) return null;
-
     const seen = new Set();
     const rows = [];
-    for (const img of imgs) {
-        const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src);
-        if (!m) continue;
-        const assetId = m[1];
-        if (seen.has(assetId)) continue;
-        seen.add(assetId);
 
-        // The tile badge reads "Image" or "Video"; walk up until we meet it.
-        let kind = null;
-        let node = img;
-        for (let i = 0; i < 6 && node; i++) {
-            const t = (node.textContent || '').trim();
-            // Tile text reads e.g. "ImageDownload" — no word boundary after the badge.
-            const hit = /^(Image|Video)/.exec(t);
-            if (hit) { kind = hit[1]; break; }
-            node = node.parentElement;
-        }
-
-        rows.push({ assetId, type: kind, url: img.src });
+    for (const img of __deepAll(document, (el) => el.tagName === 'IMG')) {
+        const m = /ad-site-sign-sg\\.tiktokcdn\\.com\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src || '');
+        if (!m || seen.has(m[1])) continue;
+        seen.add(m[1]);
+        rows.push({ assetId: m[1], type: 'Image', url: img.src });
     }
+
+    for (const v of __deepAll(document, (el) => el.tagName === 'VIDEO')) {
+        const src = v.src || v.currentSrc || '';
+        if (!src || /lf-creative-factory/.test(src)) continue; // static demo clip
+        const vid = /[?&]vid=([A-Za-z0-9]+)/.exec(src);
+        const tos = /\\/video\\/tos\\/[^/]+\\/[^/]+\\/([A-Za-z0-9]+)\\//.exec(src);
+        const assetId = (vid && vid[1]) || (tos && tos[1]);
+        if (!assetId || seen.has(assetId)) continue;
+        seen.add(assetId);
+        rows.push({ assetId, type: 'Video', url: src });
+    }
+
     return rows.length ? rows : null;
 })()`;
 
@@ -52,6 +61,10 @@ cli({
     strategy: Strategy.UI,
     browser: true,
     navigateBefore: LIBRARY_URL,
+    // The Library/feed tiles mount lazily via IntersectionObserver. A
+    // background tab is never rendered, so nothing ever intersects and the
+    // grid stays empty — this command is only correct in the foreground.
+    defaultWindowMode: 'foreground',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of assets to return (max 200)' },
     ],
@@ -59,22 +72,40 @@ cli({
     func: async (page, args) => {
         const limit = normalizeLimit(args.limit, 20, 200, 'limit');
 
-        let rows = await waitForValue(page, SCRAPE_SRC, { label: 'Symphony Library grid', timeoutMs: 30000 });
+        await waitForValue(page, SCRAPE_SRC, { label: 'Symphony Library grid', timeoutMs: 30000 });
 
-        // The grid pages in on scroll. Keep scrolling while it still grows and
-        // we are short of `limit`, with a hard stop so a stuck grid cannot spin.
-        for (let attempt = 0; rows.length < limit && attempt < 12; attempt++) {
-            const before = rows.length;
-            await page.scroll('down', 3);
-            await new Promise((resolve) => setTimeout(resolve, 1200));
-            const next = await page.evaluate(SCRAPE_SRC);
-            if (!Array.isArray(next) || next.length <= before) break;
-            rows = next;
+        // Tiles are accumulated across reads rather than replaced: the grid
+        // mounts them lazily on scroll, and nothing guarantees an earlier tile
+        // is still mounted by the time we reach the bottom.
+        const found = new Map();
+        const collect = async (src, opts) => {
+            const batch = opts ? await readStable(page, src, opts) : await page.evaluate(src);
+            if (!Array.isArray(batch)) {
+                if (batch !== null) throw new CommandExecutionError('Library scrape returned an unexpected shape');
+                return;
+            }
+            for (const row of batch) if (!found.has(row.assetId)) found.set(row.assetId, row);
+        };
+
+        await collect(SCRAPE_SRC, { tries: 8, intervalMs: 1200 });
+
+        // Thumbnails have been observed taking the better part of a minute to
+        // decode, so reaching the bottom of the grid is not a reason to stop —
+        // only a stretch with nothing new arriving is. Bounded by a deadline so
+        // a genuinely empty tail cannot spin.
+        const deadline = Date.now() + 60000;
+        let stalls = 0;
+        while (found.size < limit && Date.now() < deadline && stalls < 6) {
+            const before = found.size;
+            await page.evaluate(LIBRARY_SCROLL_SRC);
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+            await collect(SCRAPE_SRC);
+            stalls = found.size > before ? 0 : stalls + 1;
         }
 
-        if (!Array.isArray(rows)) {
-            throw new CommandExecutionError('Library scrape returned an unexpected shape');
-        }
+        await collect(SCRAPE_SRC, { tries: 6, intervalMs: 1200 });
+
+        const rows = [...found.values()];
         if (rows.length === 0) {
             throw new EmptyResultError('tiktok-symphony generations', 'The Library has no generated assets yet');
         }

--- a/clis/tiktok-symphony/generations.js
+++ b/clis/tiktok-symphony/generations.js
@@ -1,0 +1,89 @@
+// tiktok-symphony generations — assets in the Symphony Creative Studio Library.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DEEP_QUERY_SRC, HOST, LIBRARY_URL, normalizeLimit, waitForValue } from './utils.js';
+
+/**
+ * Collect every rendered Library tile. Runs in page context.
+ *
+ * The Library grid has no generation id anywhere in the DOM — the only
+ * per-asset identity is the path segment of the signed CDN URL, so that is
+ * what we surface and what `download` consumes.
+ */
+const SCRAPE_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const imgs = __deepAll(document, (el) => el.tagName === 'IMG'
+        && /ad-site-sign-sg\\.tiktokcdn\\.com\\/ad-creative-sg\\//.test(el.src || ''));
+    if (!imgs.length) return null;
+
+    const seen = new Set();
+    const rows = [];
+    for (const img of imgs) {
+        const m = /\\/ad-creative-sg\\/([A-Za-z0-9]+)~/.exec(img.src);
+        if (!m) continue;
+        const assetId = m[1];
+        if (seen.has(assetId)) continue;
+        seen.add(assetId);
+
+        // The tile badge reads "Image" or "Video"; walk up until we meet it.
+        let kind = null;
+        let node = img;
+        for (let i = 0; i < 6 && node; i++) {
+            const t = (node.textContent || '').trim();
+            // Tile text reads e.g. "ImageDownload" — no word boundary after the badge.
+            const hit = /^(Image|Video)/.exec(t);
+            if (hit) { kind = hit[1]; break; }
+            node = node.parentElement;
+        }
+
+        rows.push({ assetId, type: kind, url: img.src });
+    }
+    return rows.length ? rows : null;
+})()`;
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'generations',
+    aliases: ['library'],
+    description: 'List generated assets in the Symphony Creative Studio Library',
+    access: 'read',
+    example: 'opencli tiktok-symphony generations --limit 10',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: LIBRARY_URL,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Number of assets to return (max 200)' },
+    ],
+    columns: ['index', 'assetId', 'type', 'url'],
+    func: async (page, args) => {
+        const limit = normalizeLimit(args.limit, 20, 200, 'limit');
+
+        let rows = await waitForValue(page, SCRAPE_SRC, { label: 'Symphony Library grid', timeoutMs: 30000 });
+
+        // The grid pages in on scroll. Keep scrolling while it still grows and
+        // we are short of `limit`, with a hard stop so a stuck grid cannot spin.
+        for (let attempt = 0; rows.length < limit && attempt < 12; attempt++) {
+            const before = rows.length;
+            await page.scroll('down', 3);
+            await new Promise((resolve) => setTimeout(resolve, 1200));
+            const next = await page.evaluate(SCRAPE_SRC);
+            if (!Array.isArray(next) || next.length <= before) break;
+            rows = next;
+        }
+
+        if (!Array.isArray(rows)) {
+            throw new CommandExecutionError('Library scrape returned an unexpected shape');
+        }
+        if (rows.length === 0) {
+            throw new EmptyResultError('tiktok-symphony generations', 'The Library has no generated assets yet');
+        }
+
+        return rows.slice(0, limit).map((row, i) => ({
+            index: i + 1,
+            assetId: row.assetId,
+            type: row.type,
+            url: row.url,
+        }));
+    },
+});

--- a/clis/tiktok-symphony/jobs.js
+++ b/clis/tiktok-symphony/jobs.js
@@ -1,0 +1,98 @@
+// tiktok-symphony jobs — generations currently in the Create feed.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    CARD_QUERY_SRC,
+    COMPOSER_URL,
+    HOST,
+    VIDEO_MODES,
+    normalizeLimit,
+    waitForValue,
+} from './utils.js';
+
+const FEED_URL = `${COMPOSER_URL}?subApp=${VIDEO_MODES[0].subApp}`;
+
+/**
+ * Read every generation card in the feed. Runs in page context.
+ *
+ * A card leads with its prompt, then the model tag, then either a percentage
+ * (still rendering) or its finished outputs. There is no status attribute to
+ * read, so the presence of a percentage is the signal.
+ */
+const SCRAPE_SRC = `(() => {
+    ${CARD_QUERY_SRC}
+    const cards = __cards();
+    if (!cards.length) return null;
+
+    // Deliberately no asset count here: cards below the fold have not loaded
+    // their <img> src yet, so any number would read as a confident 0.
+    return cards.map(__cardState);
+})()`;
+
+cli({
+    site: 'tiktok-symphony',
+    name: 'jobs',
+    aliases: ['queue'],
+    description: 'Show generations in the Create feed with their render progress',
+    access: 'read',
+    example: 'opencli tiktok-symphony jobs',
+    domain: HOST,
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: FEED_URL,
+    // The Library/feed tiles mount lazily via IntersectionObserver. A
+    // background tab is never rendered, so nothing ever intersects and the
+    // grid stays empty — this command is only correct in the foreground.
+    defaultWindowMode: 'foreground',
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Number of cards to return (max 50)' },
+        { name: 'pending', type: 'boolean', default: false, help: 'Only cards that have not produced an output yet (generating or finishing)' },
+    ],
+    columns: ['index', 'status', 'progress', 'taskId', 'model', 'prompt', 'error'],
+    func: async (page, args) => {
+        const limit = normalizeLimit(args.limit, 20, 50, 'limit');
+
+        const cards = await waitForValue(page, SCRAPE_SRC, {
+            label: 'Symphony Create feed',
+            timeoutMs: 30000,
+        });
+
+        const rows = cards
+            .map((card) => ({
+                status: cardStatus(card),
+                progress: card.cardProgress,
+                taskId: card.cardTaskId,
+                model: card.cardModel,
+                prompt: card.cardPrompt,
+                error: card.cardErrorCode ? `${card.cardErrorCode}: ${card.cardErrorText || 'rejected'}` : null,
+            }))
+            .filter((row) => (args.pending ? row.status === 'generating' || row.status === 'finishing' : true));
+
+        if (rows.length === 0) {
+            throw new EmptyResultError(
+                'tiktok-symphony jobs',
+                args.pending
+                    ? 'Nothing is rendering right now'
+                    : 'The Create feed is empty — it only keeps the last 3 days',
+            );
+        }
+
+        return rows.slice(0, limit).map((row, i) => ({ index: i + 1, ...row }));
+    },
+});
+
+/**
+ * Classify a card without reading any prose.
+ *
+ * `ready` is claimed only when an output is actually mounted. Losing the
+ * percentage is NOT completion — the site sits on "Almost there…" with no
+ * readout for a long stretch, and a finished card that is scrolled out of view
+ * has not loaded its outputs either. Both land in `finishing`, which says
+ * "cannot confirm" instead of guessing.
+ */
+function cardStatus(card) {
+    if (card.cardErrorCode) return 'failed';
+    if (card.cardClip || card.cardStills > 0) return 'ready';
+    if (card.cardProgress !== null) return 'generating';
+    return 'finishing';
+}

--- a/clis/tiktok-symphony/utils.js
+++ b/clis/tiktok-symphony/utils.js
@@ -1,0 +1,121 @@
+// Shared helpers for the tiktok-symphony adapters (Symphony Creative Studio).
+import { ArgumentError, TimeoutError } from '@jackwener/opencli/errors';
+
+export const HOST = 'ads.tiktok.com';
+
+export const CREATE_URL =
+    'https://ads.tiktok.com/creative/creativestudio/image-to-video?subApp=CreativeStudio/ImageGeneration/I2VImageGeneration';
+
+export const LIBRARY_URL = 'https://ads.tiktok.com/creative/creativestudio/create/history';
+
+/** The two image models the Image tab exposes. Order matters for help text. */
+export const IMAGE_MODELS = ['Nano Banana', 'Flux Kontext Max'];
+
+/** Number of output images one Image generation produces. */
+export const OUTPUTS_PER_GENERATION = 4;
+
+/** Reference images the composer accepts. Enforced by the site, mirrored here. */
+export const MAX_REFERENCE_IMAGES = 4;
+
+/**
+ * Validate a positive integer arg without silently flooring or clamping it.
+ * Out-of-range input is a caller mistake, not something to quietly fix up.
+ */
+export function normalizePositiveInteger(value, defaultValue, label = 'value', { min = 1 } = {}) {
+    const raw = value ?? defaultValue;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n <= 0) throw new ArgumentError(`${label} must be a positive integer`);
+    if (n < min) throw new ArgumentError(`${label} must be >= ${min}`);
+    return n;
+}
+
+/** Positive integer with an explicit ceiling. */
+export function normalizeLimit(value, defaultValue, maxValue, label = 'limit') {
+    const n = normalizePositiveInteger(value, defaultValue, label);
+    if (n > maxValue) throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    return n;
+}
+
+/**
+ * Map user input onto a canonical model name, case- and spacing-insensitively.
+ * Rejects anything else rather than falling back to the default, so a typo
+ * cannot silently bill a generation to the wrong model.
+ */
+export function resolveModel(value, defaultValue = IMAGE_MODELS[0]) {
+    const raw = String(value ?? defaultValue).trim();
+    const key = raw.toLowerCase().replace(/[\s_-]+/g, '');
+    const hit = IMAGE_MODELS.find((m) => m.toLowerCase().replace(/[\s_-]+/g, '') === key);
+    if (!hit) throw new ArgumentError(`Unknown model "${raw}". Valid: ${IMAGE_MODELS.join(' / ')}`);
+    return hit;
+}
+
+/**
+ * Generated assets live at .../ad-creative-sg/<assetId>~tplv-<template>.<ext>.
+ * The DOM carries no real generation id, so this path segment is the only
+ * stable handle we can hand back to the user for `download`.
+ */
+export function assetIdFromUrl(url) {
+    const m = /\/ad-creative-sg\/([A-Za-z0-9]+)~/.exec(String(url || ''));
+    return m ? m[1] : null;
+}
+
+/** True for a CDN URL that is a finished generation output (not a reference thumb). */
+export function isOutputAssetUrl(url) {
+    return /ad-site-sign-sg\.tiktokcdn\.com\/ad-creative-sg\//.test(String(url || ''));
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll a page-context expression until it returns something non-null.
+ *
+ * The Symphony UI is a client-rendered SPA: `navigateBefore` resolves as soon
+ * as the document loads, well before the `ks-*` header and composer hydrate.
+ * Every read here has to tolerate that gap rather than assume the DOM is ready.
+ *
+ * @returns the first non-null value the expression produced
+ * @throws {TimeoutError} when the deadline passes without one
+ */
+export async function waitForValue(page, js, { timeoutMs = 20000, intervalMs = 500, label = 'page state' } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    let last = null;
+    for (;;) {
+        last = await page.evaluate(js);
+        if (last !== null && last !== undefined && last !== false) return last;
+        if (Date.now() >= deadline) throw new TimeoutError(label, Math.round(timeoutMs / 1000));
+        await sleep(intervalMs);
+    }
+}
+
+/**
+ * Page-context source for a deep querySelectorAll that descends into shadow
+ * roots. The Symphony UI is built from `ks-*` web components, so nearly every
+ * control we need is behind at least one shadow boundary.
+ *
+ * Shipped as a string because `page.evaluate` callbacks cannot close over
+ * Node-side scope; each evaluate injects this and calls it.
+ */
+export const DEEP_QUERY_SRC = `
+function __deepAll(root, test) {
+    const out = [];
+    const walk = (node) => {
+        for (const el of node.querySelectorAll('*')) {
+            if (test(el)) out.push(el);
+            if (el.shadowRoot) walk(el.shadowRoot);
+        }
+    };
+    walk(root || document);
+    return out;
+}
+function __ksTag(el, prefix) {
+    // ks-* elements carry a version suffix (ks-button-1-1-1m). Match the
+    // prefix only, or a version bump silently breaks every selector.
+    return el.tagName.toLowerCase().startsWith(prefix);
+}
+function __ownText(el) {
+    return [...el.childNodes]
+        .filter((n) => n.nodeType === 3)
+        .map((n) => n.textContent.trim())
+        .join('');
+}
+`;

--- a/clis/tiktok-symphony/utils.js
+++ b/clis/tiktok-symphony/utils.js
@@ -1,10 +1,14 @@
 // Shared helpers for the tiktok-symphony adapters (Symphony Creative Studio).
-import { ArgumentError, TimeoutError } from '@jackwener/opencli/errors';
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 
 export const HOST = 'ads.tiktok.com';
 
-export const CREATE_URL =
-    'https://ads.tiktok.com/creative/creativestudio/image-to-video?subApp=CreativeStudio/ImageGeneration/I2VImageGeneration';
+/** Every composer sub-app hangs off this page; `subApp` picks the tool. */
+export const COMPOSER_URL = 'https://ads.tiktok.com/creative/creativestudio/image-to-video';
+
+export const CREATE_URL = `${COMPOSER_URL}?subApp=CreativeStudio/ImageGeneration/I2VImageGeneration`;
 
 export const LIBRARY_URL = 'https://ads.tiktok.com/creative/creativestudio/create/history';
 
@@ -16,6 +20,52 @@ export const OUTPUTS_PER_GENERATION = 4;
 
 /** Reference images the composer accepts. Enforced by the site, mirrored here. */
 export const MAX_REFERENCE_IMAGES = 4;
+
+/**
+ * The three Video sub-apps.
+ *
+ * Each is a distinct `subApp` URL, so we navigate straight to the mode instead
+ * of clicking through the footer dropdown — one less fragile interaction, and
+ * it makes the composer state unambiguous from the first paint.
+ */
+export const VIDEO_MODES = [
+    {
+        key: 'text',
+        label: 'Text to video',
+        subApp: 'CreativeStudio/MiniApp/TextToVideo',
+        minRefs: 0,
+        maxRefs: 0,
+    },
+    {
+        key: 'image',
+        label: 'Image to video',
+        subApp: 'CreativeStudio/MiniApp/ImageToVideo',
+        minRefs: 1,
+        maxRefs: 2, // second image is the last frame, and only with --frames first-last
+    },
+    {
+        key: 'reference',
+        label: 'Reference to video',
+        subApp: 'CreativeStudio/ReferenceToVideo/ReferenceToVideo',
+        minRefs: 1,
+        maxRefs: 4,
+    },
+];
+
+/** The only model the Video tab exposes today. */
+export const VIDEO_MODELS = ['Video 1.5 Pro'];
+
+/** Clip lengths the duration dropdown offers, in seconds. */
+export const VIDEO_DURATIONS = [5, 10, 12];
+
+/** Frame modes offered by the Image-to-video sub-app. */
+export const VIDEO_FRAME_MODES = [
+    { key: 'first', label: 'First frame only', refs: 1 },
+    { key: 'first-last', label: 'First and last frame', refs: 2 },
+];
+
+/** One Video generation renders a single clip. */
+export const VIDEO_OUTPUTS_PER_GENERATION = 1;
 
 /**
  * Validate a positive integer arg without silently flooring or clamping it.
@@ -46,6 +96,47 @@ export function resolveModel(value, defaultValue = IMAGE_MODELS[0]) {
     const key = raw.toLowerCase().replace(/[\s_-]+/g, '');
     const hit = IMAGE_MODELS.find((m) => m.toLowerCase().replace(/[\s_-]+/g, '') === key);
     if (!hit) throw new ArgumentError(`Unknown model "${raw}". Valid: ${IMAGE_MODELS.join(' / ')}`);
+    return hit;
+}
+
+/** Case- and spacing-insensitive key used by every "resolve a label" helper. */
+const foldKey = (value) => String(value ?? '').trim().toLowerCase().replace(/[\s_-]+/g, '');
+
+/** Resolve `--mode` onto one of the three VIDEO_MODES entries. */
+export function resolveVideoMode(value, defaultValue = 'text') {
+    const key = foldKey(value ?? defaultValue);
+    const hit = VIDEO_MODES.find((m) => foldKey(m.key) === key || foldKey(m.label) === key);
+    if (!hit) {
+        throw new ArgumentError(`Unknown mode "${value}". Valid: ${VIDEO_MODES.map((m) => m.key).join(' / ')}`);
+    }
+    return hit;
+}
+
+/** Resolve `--model` for the Video tab. Rejects unknown names rather than defaulting. */
+export function resolveVideoModel(value, defaultValue = VIDEO_MODELS[0]) {
+    const key = foldKey(value ?? defaultValue);
+    const hit = VIDEO_MODELS.find((m) => foldKey(m) === key);
+    if (!hit) throw new ArgumentError(`Unknown model "${value}". Valid: ${VIDEO_MODELS.join(' / ')}`);
+    return hit;
+}
+
+/** Resolve `--duration`; accepts `10` or `10s`. Returns the dropdown's label. */
+export function resolveVideoDuration(value, defaultValue = VIDEO_DURATIONS[0]) {
+    const raw = String(value ?? defaultValue).trim().replace(/s$/i, '');
+    const n = Number(raw);
+    if (!VIDEO_DURATIONS.includes(n)) {
+        throw new ArgumentError(`Unknown duration "${value}". Valid: ${VIDEO_DURATIONS.map((d) => `${d}s`).join(' / ')}`);
+    }
+    return { seconds: n, label: `${n}s` };
+}
+
+/** Resolve `--frames` for the Image-to-video sub-app. */
+export function resolveVideoFrameMode(value, defaultValue = 'first') {
+    const key = foldKey(value ?? defaultValue);
+    const hit = VIDEO_FRAME_MODES.find((f) => foldKey(f.key) === key || foldKey(f.label) === key);
+    if (!hit) {
+        throw new ArgumentError(`Unknown frames "${value}". Valid: ${VIDEO_FRAME_MODES.map((f) => f.key).join(' / ')}`);
+    }
     return hit;
 }
 
@@ -104,7 +195,12 @@ function __deepAll(root, test) {
             if (el.shadowRoot) walk(el.shadowRoot);
         }
     };
-    walk(root || document);
+    const start = root || document;
+    walk(start);
+    // The root's OWN shadow root has to be walked explicitly. A ks-modal keeps
+    // its title and buttons there while its light DOM holds only the body text,
+    // so skipping this makes the dialog look like it has no controls at all.
+    if (start.shadowRoot) walk(start.shadowRoot);
     return out;
 }
 function __ksTag(el, prefix) {
@@ -119,3 +215,333 @@ function __ownText(el) {
         .join('');
 }
 `;
+
+/**
+ * Scroll the Library grid one screen further; reports whether it moved.
+ *
+ * The window itself never scrolls on that page — the grid lives in its own
+ * `overflow-auto` container, so `page.scroll` leaves it exactly where it was
+ * and every tile below the fold stays a placeholder. The container is found by
+ * shape rather than class name, which survives a restyle.
+ */
+export const LIBRARY_SCROLL_SRC = `(() => {
+    let best = null;
+    for (const el of document.querySelectorAll('*')) {
+        if (el.clientHeight < 200 || el.scrollHeight - el.clientHeight < 100) continue;
+        if (!best || el.scrollHeight > best.scrollHeight) best = el;
+    }
+    const target = best || document.scrollingElement;
+    if (!target) return { moved: false, atEnd: true };
+    const before = target.scrollTop;
+    target.scrollTop = before + Math.max(200, target.clientHeight * 0.9);
+    return {
+        moved: target.scrollTop > before,
+        atEnd: target.scrollTop >= target.scrollHeight - target.clientHeight - 4,
+    };
+})()`;
+
+/**
+ * Read a page-context expression until two consecutive reads agree.
+ *
+ * The Create feed lazy-loads and recycles <img> nodes, so a single read can
+ * catch a card mid-swap and report a neighbour's asset as one of ours. Waiting
+ * for the value to stop moving is what makes the reading trustworthy.
+ */
+export async function readStable(page, js, { tries = 10, intervalMs = 1500 } = {}) {
+    let previous = null;
+    let value = null;
+    for (let i = 0; i < tries; i++) {
+        value = await page.evaluate(js);
+        const key = JSON.stringify(value);
+        if (key === previous) return value;
+        previous = key;
+        await sleep(intervalMs);
+    }
+    return value;
+}
+
+/**
+ * Page-context source for locating one generation card in the Create feed.
+ *
+ * Diffing "all assets on the page" against a pre-submit snapshot is not safe:
+ * the feed lazy-loads, so assets from an *earlier* generation can stream in
+ * after the snapshot and look brand new. Scoping to the card that leads with
+ * our own prompt is the only reading that cannot pick up a neighbour's output.
+ */
+export const CARD_QUERY_SRC = `
+${DEEP_QUERY_SRC}
+function __cards() {
+    // Cards are the rounded feed containers; the CSSTransition class marks them
+    // once mounted, with the class-name match as a fallback if that changes.
+    const mounted = [...document.querySelectorAll('div.gen-item-enter-done')];
+    if (mounted.length) return mounted;
+    return [...document.querySelectorAll('div')].filter((d) =>
+        /rounded-\\[var\\(--ks-border-radius-container\\)\\]/.test(d.className || ''));
+}
+function __cardFor(prompt) {
+    // Newest card is first. Compare on a prefix: long prompts render truncated.
+    const head = String(prompt).slice(0, 40);
+    return __cards().find((c) => (c.innerText || '').trim().startsWith(head)) || null;
+}
+function __cardState(card) {
+    // A card ends one of three ways: still counting up, rejected with an error
+    // code, or holding its outputs. Rejection is the one that must never be
+    // mistaken for success — moderation refusals land here, not in a dialog.
+    const text = (card.innerText || '').trim();
+    const lines = text.split('\\n').map((s) => s.trim()).filter(Boolean);
+    const pct = /(\\d+)%/.exec(text);
+    const code = /Error code:\\s*([0-9]+)/.exec(text);
+    const task = /Task ID:\\s*([0-9]+)/.exec(text);
+    // A mounted output is the only positive proof of completion: the site drops
+    // the percentage before the clip appears ("Almost there…"), so "no %" on its
+    // own means nothing.
+    const clip = __deepAll(card, (el) => el.tagName === 'VIDEO')
+        .map((v) => v.src || v.currentSrc || '')
+        .find((src) => src && !/lf-creative-factory/.test(src)) || null;
+    const stills = __deepAll(card, (el) => el.tagName === 'IMG')
+        .filter((img) => /ad-creative-sg/.test(img.src || '')).length;
+    // Keys are card-prefixed so they never collide with an adapter's output
+    // columns — a same-named intermediate is what makes a dropped column silent.
+    return {
+        cardPrompt: lines[0] || null,
+        cardModel: lines[1] || null,
+        cardProgress: pct ? Number(pct[1]) : null,
+        cardErrorCode: code ? code[1] : null,
+        // The message sits between the model tag and the Task ID line.
+        cardErrorText: code ? (lines.find((l) => /violat|error|fail|try again/i.test(l)) || null) : null,
+        cardTaskId: task ? task[1] : null,
+        cardClip: clip,
+        cardStills: stills,
+    };
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Composer (the chat-style box shared by the Image and Video sub-apps)
+// ---------------------------------------------------------------------------
+
+/** The prompt editor is TipTap/ProseMirror, not a <textarea>. */
+export const PROMPT_SELECTOR = '[data-chatbox-part=textarea] .ProseMirror';
+
+/** The composer has no file input; references go in through this drop zone. */
+export const DROP_ZONE_SELECTOR = 'fieldset[aria-label="File drop zone"]';
+
+const MAX_REFERENCE_BYTES = 10 * 1024 * 1024;
+
+/** Base64 characters per bridge round-trip. Kept well under the message cap. */
+const B64_CHUNK_CHARS = 128 * 1024;
+
+const MIME_BY_EXT = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.webp': 'image/webp',
+    '.gif': 'image/gif',
+    '.avif': 'image/avif',
+};
+
+/** Count reference thumbnails currently attached to the composer. */
+export const REF_COUNT_SRC = `(() => {
+    ${DEEP_QUERY_SRC}
+    const header = document.querySelector('[data-chatbox-part=header]');
+    if (!header) return 0;
+    // Static chrome (logo, page art) also lives here; uploaded references are
+    // object URLs or land on the creative-tool upload host.
+    return [...header.querySelectorAll('img')].filter((img) => {
+        const s = img.src || '';
+        return s.startsWith('blob:') || s.startsWith('data:')
+            || /ibyteimg\\.com|creative-tool/.test(s);
+    }).length;
+})()`;
+
+/**
+ * Read every reference image up front so a bad path fails before we touch the
+ * UI — half-filling the composer and then throwing would leave the page dirty.
+ */
+export async function readReferenceImages(raw, max) {
+    const paths = String(raw ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+    if (paths.length > max) {
+        throw new ArgumentError(`refs accepts at most ${max} image(s) here, got ${paths.length}`);
+    }
+
+    const out = [];
+    for (const path of paths) {
+        let buf;
+        try {
+            buf = await readFile(path);
+        } catch (error) {
+            throw new ArgumentError(`cannot read reference image "${path}": ${error?.message || error}`);
+        }
+        if (buf.length === 0) throw new ArgumentError(`reference image "${path}" is empty`);
+        if (buf.length > MAX_REFERENCE_BYTES) {
+            throw new ArgumentError(`reference image "${path}" is larger than ${MAX_REFERENCE_BYTES} bytes`);
+        }
+        const ext = extname(path).toLowerCase();
+        const type = MIME_BY_EXT[ext];
+        if (!type) {
+            throw new ArgumentError(`unsupported reference image type "${ext || path}" (use ${Object.keys(MIME_BY_EXT).join(' / ')})`);
+        }
+        out.push({ name: basename(path), type, b64: buf.toString('base64') });
+    }
+    return out;
+}
+
+/**
+ * Attach one reference image.
+ *
+ * The page exposes no file input and CDP file injection is refused, so the
+ * supported path is the composer's own drop zone: build the File inside the
+ * page and dispatch a real drop.
+ */
+export async function attachReference(page, ref, index) {
+    // The base64 goes over in slices: a single ~1 MB evaluate argument exceeds
+    // what the browser bridge will carry and fails with "max attempts exhausted".
+    await page.evaluate(() => { window.__ocRefChunks = []; return true; });
+    for (let at = 0; at < ref.b64.length; at += B64_CHUNK_CHARS) {
+        const chunk = ref.b64.slice(at, at + B64_CHUNK_CHARS);
+        const ok = await page.evaluate((piece) => {
+            if (!window.__ocRefChunks) return false;
+            window.__ocRefChunks.push(piece);
+            return true;
+        }, chunk);
+        if (!ok) throw new CommandExecutionError(`reference image "${ref.name}" was dropped while being transferred to the page`);
+    }
+
+    const dropped = await page.evaluate((name, type, selector) => {
+        const b64 = (window.__ocRefChunks || []).join('');
+        delete window.__ocRefChunks;
+        if (!b64) return false;
+        const bin = atob(b64);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        const file = new File([bytes], name, { type });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        const zone = document.querySelector(selector);
+        if (!zone) return false;
+        for (const kind of ['dragenter', 'dragover', 'drop']) {
+            zone.dispatchEvent(new DragEvent(kind, { bubbles: true, cancelable: true, dataTransfer: dt }));
+        }
+        return true;
+    }, ref.name, ref.type, DROP_ZONE_SELECTOR);
+
+    if (!dropped) throw new CommandExecutionError(`could not find the composer drop zone for "${ref.name}"`);
+
+    const want = index + 1;
+    try {
+        await waitForValue(page, `(() => {
+            const n = ${REF_COUNT_SRC};
+            return n >= ${want} ? n : null;
+        })()`, { label: `reference upload "${ref.name}"`, timeoutMs: 60000, intervalMs: 700 });
+    } catch (error) {
+        if (error instanceof TimeoutError) {
+            throw new CommandExecutionError(`reference image "${ref.name}" did not attach to the composer`);
+        }
+        throw error;
+    }
+}
+
+/** Type the prompt and prove it registered in the ProseMirror editor. */
+export async function typePrompt(page, prompt) {
+    await page.typeText(PROMPT_SELECTOR, prompt);
+    const typed = await page.evaluate(`(() => {
+        const pm = document.querySelector('${PROMPT_SELECTOR}');
+        return pm ? pm.textContent : null;
+    })()`);
+    if (!typed || !typed.includes(prompt.slice(0, 20))) {
+        throw new CommandExecutionError('prompt did not register in the composer editor');
+    }
+}
+
+/**
+ * Page-context source reading the current label of the footer dropdown whose
+ * value is one of `allowed`.
+ *
+ * The footer holds several dropdowns and their number changes per sub-app, so
+ * indexing into them is fragile. Each control has a disjoint option set, which
+ * makes "the dropdown currently showing one of these values" a stable handle.
+ * Nested `ks-dropdown-menu` elements exist too — hence the own-text filter.
+ */
+export function footerDropdownLabelSrc(allowed) {
+    return `(() => {
+        ${DEEP_QUERY_SRC}
+        const allowed = ${JSON.stringify(allowed)};
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        if (!footer) return null;
+        for (const dd of __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))) {
+            const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
+            // Read the button's own text: the menu stays in the DOM, so the
+            // dropdown's textContent would contain every option at once.
+            const label = btn ? __ownText(btn) : '';
+            if (label && allowed.includes(label)) return label;
+        }
+        return null;
+    })()`;
+}
+
+/**
+ * Pick `target` from the footer dropdown identified by `allowed`, then confirm
+ * the trigger label actually changed.
+ */
+export async function selectFooterOption(page, { allowed, target, label }) {
+    const current = await waitForValue(page, footerDropdownLabelSrc(allowed), {
+        label: `${label} dropdown`,
+        timeoutMs: 20000,
+    });
+    if (current === target) return current;
+
+    const opened = await page.evaluate(`(() => {
+        ${DEEP_QUERY_SRC}
+        const allowed = ${JSON.stringify(allowed)};
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        for (const dd of __deepAll(footer, (el) => __ksTag(el, 'ks-dropdown-menu'))) {
+            const btn = __deepAll(dd, (el) => __ksTag(el, 'ks-button'))[0];
+            if (!btn || !allowed.includes(__ownText(btn))) continue;
+            const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
+            real.click();
+            return true;
+        }
+        return null;
+    })()`);
+    if (!opened) throw new CommandExecutionError(`could not open the ${label} dropdown`);
+
+    const picked = await waitForValue(page, `(() => {
+        ${DEEP_QUERY_SRC}
+        const want = ${JSON.stringify(target)};
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        // Match on own text so an option's description paragraph, which repeats
+        // the name, cannot be clicked instead of the option row itself.
+        const opt = __deepAll(footer, (el) => !__ksTag(el, 'ks-button') && __ownText(el) === want)[0];
+        if (!opt) return null;
+        opt.click();
+        return true;
+    })()`, { label: `${label} option "${target}"`, timeoutMs: 10000 }).catch(() => null);
+    if (!picked) throw new CommandExecutionError(`the ${label} dropdown has no option "${target}"`);
+
+    const now = await waitForValue(page, `(() => {
+        const v = ${footerDropdownLabelSrc(allowed)};
+        return v === ${JSON.stringify(target)} ? v : null;
+    })()`, { label: `${label} switch to ${target}`, timeoutMs: 15000 }).catch(() => null);
+    if (now !== target) throw new CommandExecutionError(`could not switch ${label} to "${target}"`);
+    return now;
+}
+
+/** Click the composer's send button once it is enabled. */
+export async function submitComposer(page) {
+    const clicked = await waitForValue(page, `(() => {
+        ${DEEP_QUERY_SRC}
+        const footer = document.querySelector('[data-chatbox-part=footer]');
+        if (!footer) return null;
+        const btn = __deepAll(footer, (el) => __ksTag(el, 'ks-icon-button')
+            && __deepAll(el, (x) => __ksTag(x, 'ks-icon-arrow-up')).length > 0)[0];
+        if (!btn) return null;
+        const real = (btn.shadowRoot && btn.shadowRoot.querySelector('button')) || btn;
+        if (real.disabled || btn.hasAttribute('disabled')) return null;
+        real.click();
+        return true;
+    })()`, { label: 'send button', timeoutMs: 20000 }).catch(() => null);
+
+    if (!clicked) {
+        throw new CommandExecutionError('the send button never became enabled — the composer may have rejected the input');
+    }
+}

--- a/clis/tiktok-symphony/utils.test.js
+++ b/clis/tiktok-symphony/utils.test.js
@@ -2,11 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
 import {
     IMAGE_MODELS,
+    VIDEO_DURATIONS,
+    VIDEO_MODELS,
+    VIDEO_MODES,
     assetIdFromUrl,
     isOutputAssetUrl,
     normalizeLimit,
     normalizePositiveInteger,
     resolveModel,
+    resolveVideoDuration,
+    resolveVideoFrameMode,
+    resolveVideoMode,
+    resolveVideoModel,
 } from './utils.js';
 
 describe('tiktok-symphony resolveModel', () => {
@@ -74,5 +81,64 @@ describe('tiktok-symphony asset identity', () => {
         // Both are CDN images; only the first is something `download` can fetch.
         expect(isOutputAssetUrl(output)).toBe(true);
         expect(isOutputAssetUrl(reference)).toBe(false);
+    });
+});
+
+describe('tiktok-symphony video mode resolution', () => {
+    it('accepts both the short key and the on-screen label', () => {
+        for (const mode of VIDEO_MODES) {
+            expect(resolveVideoMode(mode.key).key).toBe(mode.key);
+            expect(resolveVideoMode(mode.label).key).toBe(mode.key);
+        }
+        expect(resolveVideoMode('Image To Video').key).toBe('image');
+        expect(resolveVideoMode('REFERENCE').key).toBe('reference');
+    });
+
+    it('carries the sub-app URL fragment each mode is reached through', () => {
+        // Navigating straight to the sub-app is what removes the need to click
+        // the mode dropdown, so a missing subApp is a real breakage.
+        for (const mode of VIDEO_MODES) {
+            expect(mode.subApp).toMatch(/^CreativeStudio\//);
+        }
+    });
+
+    it('rejects an unknown mode instead of falling back', () => {
+        expect(() => resolveVideoMode('audio')).toThrow(ArgumentError);
+        expect(() => resolveVideoMode('img2vid')).toThrow(ArgumentError);
+    });
+});
+
+describe('tiktok-symphony video duration', () => {
+    it('accepts a bare number or the dropdown label', () => {
+        for (const seconds of VIDEO_DURATIONS) {
+            expect(resolveVideoDuration(seconds)).toEqual({ seconds, label: `${seconds}s` });
+            expect(resolveVideoDuration(`${seconds}s`)).toEqual({ seconds, label: `${seconds}s` });
+        }
+    });
+
+    it('rejects a length the dropdown does not offer', () => {
+        // Credits are charged per second, so a silently coerced duration would
+        // bill the caller for something they never asked for.
+        expect(() => resolveVideoDuration(7)).toThrow(ArgumentError);
+        expect(() => resolveVideoDuration('8s')).toThrow(ArgumentError);
+        expect(() => resolveVideoDuration('long')).toThrow(ArgumentError);
+    });
+});
+
+describe('tiktok-symphony video model and frames', () => {
+    it('accepts the canonical model name, case-insensitively', () => {
+        expect(resolveVideoModel(VIDEO_MODELS[0])).toBe(VIDEO_MODELS[0]);
+        expect(resolveVideoModel('video 1.5 pro')).toBe('Video 1.5 Pro');
+    });
+
+    it('rejects an image model on the video tab', () => {
+        expect(() => resolveVideoModel('Nano Banana')).toThrow(ArgumentError);
+    });
+
+    it('maps frame modes to the number of references they need', () => {
+        expect(resolveVideoFrameMode('first').refs).toBe(1);
+        expect(resolveVideoFrameMode('first-last').refs).toBe(2);
+        expect(resolveVideoFrameMode('First and last frame').key).toBe('first-last');
+        expect(() => resolveVideoFrameMode('middle')).toThrow(ArgumentError);
     });
 });

--- a/clis/tiktok-symphony/utils.test.js
+++ b/clis/tiktok-symphony/utils.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    IMAGE_MODELS,
+    assetIdFromUrl,
+    isOutputAssetUrl,
+    normalizeLimit,
+    normalizePositiveInteger,
+    resolveModel,
+} from './utils.js';
+
+describe('tiktok-symphony resolveModel', () => {
+    it('accepts the canonical names', () => {
+        for (const model of IMAGE_MODELS) {
+            expect(resolveModel(model)).toBe(model);
+        }
+    });
+
+    it('is forgiving about case, spacing and dashes', () => {
+        expect(resolveModel('nano banana')).toBe('Nano Banana');
+        expect(resolveModel('NANO-BANANA')).toBe('Nano Banana');
+        expect(resolveModel('flux_kontext_max')).toBe('Flux Kontext Max');
+        expect(resolveModel('  Flux Kontext Max  ')).toBe('Flux Kontext Max');
+    });
+
+    it('falls back to the default only when nothing was passed', () => {
+        expect(resolveModel(undefined)).toBe(IMAGE_MODELS[0]);
+        expect(resolveModel(null)).toBe(IMAGE_MODELS[0]);
+    });
+
+    it('rejects an unknown model instead of silently using the default', () => {
+        // A typo must not quietly bill the generation to a different model.
+        expect(() => resolveModel('Nano Bananna')).toThrow(ArgumentError);
+        expect(() => resolveModel('dall-e')).toThrow(ArgumentError);
+    });
+});
+
+describe('tiktok-symphony arg validation', () => {
+    it('accepts in-range values', () => {
+        expect(normalizePositiveInteger(5, 20, 'limit')).toBe(5);
+        expect(normalizePositiveInteger(undefined, 20, 'limit')).toBe(20);
+        expect(normalizeLimit(200, 20, 200, 'limit')).toBe(200);
+    });
+
+    it('rejects rather than clamps out-of-range input', () => {
+        expect(() => normalizePositiveInteger(0, 20, 'limit')).toThrow(ArgumentError);
+        expect(() => normalizePositiveInteger(-1, 20, 'limit')).toThrow(ArgumentError);
+        expect(() => normalizePositiveInteger(1.5, 20, 'limit')).toThrow(ArgumentError);
+        expect(() => normalizePositiveInteger('abc', 20, 'limit')).toThrow(ArgumentError);
+        expect(() => normalizeLimit(201, 20, 200, 'limit')).toThrow(ArgumentError);
+    });
+
+    it('enforces an explicit minimum', () => {
+        expect(() => normalizePositiveInteger(10, 300, 'timeout', { min: 30 })).toThrow(ArgumentError);
+        expect(normalizePositiveInteger(30, 300, 'timeout', { min: 30 })).toBe(30);
+    });
+});
+
+describe('tiktok-symphony asset identity', () => {
+    const output = 'https://p16-ad-site-sign-sg.tiktokcdn.com/ad-creative-sg/202607195d0d6178542d3c58473ba815~tplv-d5opwmad15-origin.image?lk3s=f193193c';
+    const reference = 'https://p19-creative-tool-sg.ibyteimg.com/tos-alisg-i-n2703mo9gi-sg/c34e306361494713b4d9703779bd292c~tplv-n270';
+
+    it('extracts the id from an output asset URL', () => {
+        expect(assetIdFromUrl(output)).toBe('202607195d0d6178542d3c58473ba815');
+    });
+
+    it('returns null when there is no asset id to read', () => {
+        expect(assetIdFromUrl(reference)).toBeNull();
+        expect(assetIdFromUrl('')).toBeNull();
+        expect(assetIdFromUrl(undefined)).toBeNull();
+    });
+
+    it('separates generated outputs from uploaded reference thumbnails', () => {
+        // Both are CDN images; only the first is something `download` can fetch.
+        expect(isOutputAssetUrl(output)).toBe(true);
+        expect(isOutputAssetUrl(reference)).toBe(false);
+    });
+});

--- a/docs/adapters/browser/tiktok-symphony.md
+++ b/docs/adapters/browser/tiktok-symphony.md
@@ -1,6 +1,6 @@
 # TikTok Symphony Creative Studio
 
-Drive **Symphony Creative Studio** image generation from the terminal. All commands run through your existing browser session — no API key needed.
+Drive **Symphony Creative Studio** image and video generation from the terminal. All commands run through your existing browser session — no API key needed.
 
 **Mode**: 🔐 Browser · **Domain**: `ads.tiktok.com`
 
@@ -10,10 +10,13 @@ Drive **Symphony Creative Studio** image generation from the terminal. All comma
 |---------|-------------|--------|
 | `opencli tiktok-symphony credits` | Credit balance, plan and signed-in account | read |
 | `opencli tiktok-symphony generations` | List generated assets in the Library | read |
+| `opencli tiktok-symphony jobs` | Show generations in the Create feed with render progress | read |
 | `opencli tiktok-symphony download <asset>` | Save a generated asset to a local file | read |
 | `opencli tiktok-symphony generate <prompt>` | Generate images from a prompt and reference images | write |
+| `opencli tiktok-symphony generate-video <prompt>` | Render a video clip | write |
+| `opencli tiktok-symphony delete <asset>` | Permanently delete a generation | write |
 
-`library` is an alias for `generations`.
+Aliases: `library` → `generations`, `queue` → `jobs`, `video` → `generate-video`, `rm` → `delete`.
 
 ## Usage Examples
 
@@ -24,20 +27,35 @@ opencli tiktok-symphony credits
 # Recent assets in the Library
 opencli tiktok-symphony generations --limit 10
 
-# Generate from a text prompt only
+# Generate images from a text prompt only
 opencli tiktok-symphony generate "a minimal 3D mascot on a plain background"
 
 # Generate using reference images (up to 4)
 opencli tiktok-symphony generate "turn this into 3D chibi style" --refs ./cat.png,./dog.png
 
-# Pick the model
-opencli tiktok-symphony generate "detailed product shot" --model "Flux Kontext Max"
+# Video, text only
+opencli tiktok-symphony generate-video "a paper boat drifting on a puddle, macro shot"
+
+# Video from one image (that image becomes the first frame)
+opencli tiktok-symphony generate-video "gentle camera push in" --refs ./hero.png --duration 10
+
+# Video between two frames
+opencli tiktok-symphony generate-video "morph between the two" \
+  --mode image --frames first-last --refs ./start.png,./end.png
+
+# Video that blends several references into one scene
+opencli tiktok-symphony generate-video "the character walks through the scene" \
+  --mode reference --refs ./character.png,./scene.png
+
+# Watch what is still rendering
+opencli tiktok-symphony jobs --pending true
 
 # Download an asset by id (from `generations`)
 opencli tiktok-symphony download 202607195d0d7ea36ed139b74eccb1e4 --out ./downloads
 
-# A full asset URL works too
-opencli tiktok-symphony download "https://p16-ad-site-sign-sg.tiktokcdn.com/ad-creative-sg/...~tplv-...image?..."
+# Delete — dry run first, then for real
+opencli tiktok-symphony delete 202607195d0d7ea36ed139b74eccb1e4
+opencli tiktok-symphony delete 202607195d0d7ea36ed139b74eccb1e4 --yes
 ```
 
 ## Options
@@ -51,11 +69,31 @@ opencli tiktok-symphony download "https://p16-ad-site-sign-sg.tiktokcdn.com/ad-c
 | `--model` | `Nano Banana` (default) or `Flux Kontext Max`; matching ignores case, spaces and dashes |
 | `--timeout` | Max seconds to wait for rendering (default: `300`, min `30`) |
 
+### `generate-video`
+
+| Option | Description |
+|--------|-------------|
+| `prompt` | What to generate (required positional) |
+| `--mode` | `text`, `image`, `reference`, or `auto` (default) — auto picks `text` with no refs, `image` with one, `reference` with two or more |
+| `--refs` | Comma-separated reference image paths (`image`: 1–2, `reference`: 1–4) |
+| `--frames` | `first` (default) or `first-last`; `--mode image` only, and `first-last` needs exactly two refs |
+| `--model` | `Video 1.5 Pro` (the only model the Video tab offers) |
+| `--duration` | `5` / `10` / `12` seconds, with or without the `s` (default: `5`) |
+| `--wait` | Block until the clip renders (default: `false`) |
+| `--timeout` | Max seconds to wait when `--wait true` (default: `5400`, min `60`) |
+
 ### `generations`
 
 | Option | Description |
 |--------|-------------|
 | `--limit` | Max assets to list (default: `20`, max `200`) |
+
+### `jobs`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max cards to list (default: `20`, max `50`) |
+| `--pending` | Only cards that have not produced an output yet (default: `false`) |
 
 ### `download`
 
@@ -64,14 +102,24 @@ opencli tiktok-symphony download "https://p16-ad-site-sign-sg.tiktokcdn.com/ad-c
 | `asset` | `assetId` from `generations`, or a full asset URL (required positional) |
 | `--out` | Directory to write the file into (default: `.`) |
 
+### `delete`
+
+| Option | Description |
+|--------|-------------|
+| `asset` | `assetId` from `generations` (required positional) |
+| `--yes` | Actually delete. Without it the asset is only located and reported as `dry-run` |
+
 ## Output Columns
 
 | Command | Columns |
 |---------|---------|
 | `credits` | `credits, plan, account` |
 | `generations` | `index, assetId, type, url` |
+| `jobs` | `index, status, progress, taskId, model, prompt, error` |
 | `download` | `assetId, file, bytes, contentType` |
 | `generate` | `index, assetId, url, model, prompt` |
+| `generate-video` | `index, status, assetId, url, mode, model, duration, prompt` |
+| `delete` | `assetId, status, type, url` |
 
 ## Prerequisites
 
@@ -81,13 +129,30 @@ opencli tiktok-symphony download "https://p16-ad-site-sign-sg.tiktokcdn.com/ad-c
 
 ## Notes
 
-- One `generate` run produces up to 4 images; each returned row is one output asset
-- `generate` is a **write** command — every run creates real assets on your account and can spend Symphony credits depending on your plan. Check `credits` first
-- `generate` always reloads the composer before it starts: submitting does **not** clear the prompt or reference images, so reusing a dirty tab would silently resend them
-- Reference images are attached through the composer's own drop zone. The page exposes no `input[type=file]`, so `--refs` reads each file and hands it to the page as a real drop
+### Cost and timing
+
+- `generate` is a **write** command — every run creates real assets on your account. One run produces up to 4 images; each returned row is one output asset
+- `generate-video` charges **one credit per second of clip**: a 5s clip costs 5, a 12s clip costs 12. A rejected render is charged too. Check `credits` first
+- Video rendering takes **tens of minutes** — over an hour has been observed, despite the on-screen "Check back in 5–10 minutes". That is why `--wait` defaults to `false`: the job is submitted, the row comes back as `status: generating`, and `jobs` or `generations` picks it up later
+
+### Reading job state
+
+- `jobs` reports four states and never guesses: `failed` (the card carries an error code), `ready` (an output is actually mounted), `generating` (a percentage is showing), and `finishing` — no percentage and no output yet. Losing the percentage is **not** completion; the site sits on "Almost there…" for a long stretch before the clip appears. A finished card scrolled out of view also reads as `finishing`, so treat `generations` as the authority on what exists
+- A render can be **rejected by moderation**. The failure arrives as ordinary card text with a task id and an error code — no dialog, no HTTP error. `generate-video --wait true` raises it as a `CommandExecutionError` instead of waiting forever, and `jobs` surfaces it in the `error` column. This is the only place the site exposes a real generation id
+
+### Assets
+
+- Clips and images live on **different CDNs with different identities**: an image is an `<img>` on `ad-creative-sg` identified by a path segment, a clip is a `<video>` on `v16-ad-creative.tiktokcdn-row.com` identified by its `vid` query parameter. `generations` reports both, and `type` comes from the element kind rather than the tile badge, which is localized and absent on clip tiles
 - Asset URLs are signed and short-lived, so `download` reads the live URL out of the Library rather than reconstructing it. If an `assetId` has scrolled out of the grid the command scrolls to find it
-- The Library holds the full history; the in-app Create feed only keeps the last 3 days
-- The DOM carries no generation id, so `assetId` comes from the asset's CDN path — that is the handle `generations` emits and `download` consumes
-- `plan` and `account` return `null` rather than a string sentinel when the header cannot be read — branch on `null` in agent code
-- `limit`, `timeout` and `refs` are validated and rejected with `ArgumentError` when out of range; no silent clamp
+- The Library holds the full history; the in-app Create feed only keeps the last 3 days and a handful of cards
+- `delete` is irreversible and therefore **dry-run by default** — pass `--yes` to actually delete. It confirms the site's dialog and then waits for the tile to leave the grid before reporting `deleted`. Despite the dialog wording ("this generation"), one tile is one asset: deleting an image leaves its siblings from the same run in place
+
+### Driving the page
+
+- These commands default to a **foreground window**. Library and feed tiles mount lazily through `IntersectionObserver`, and a background tab is never rendered, so nothing ever intersects and the grid stays empty
+- Reference images are attached through the composer's own drop zone. The page exposes no `input[type=file]`, so `--refs` reads each file and hands it to the page as a real drop. The base64 is transferred in chunks — a single ~1 MB `evaluate` argument exceeds what the browser bridge will carry
+- Each Video mode is its own `subApp` URL, so `generate-video` navigates straight to the mode instead of clicking the mode dropdown
+- `generate` always reloads the composer before it starts: submitting does **not** clear the prompt or reference images, so reusing a dirty tab would silently resend them
 - Symphony is a client-rendered SPA whose header and composer hydrate after navigation — every command polls for readiness instead of assuming the DOM is present
+- `plan` and `account` return `null` rather than a string sentinel when the header cannot be read — branch on `null` in agent code
+- `limit`, `timeout`, `duration`, `mode`, `frames` and `refs` are validated and rejected with `ArgumentError` when out of range; no silent clamp, and no silent fallback to a default model

--- a/docs/adapters/browser/tiktok-symphony.md
+++ b/docs/adapters/browser/tiktok-symphony.md
@@ -1,0 +1,93 @@
+# TikTok Symphony Creative Studio
+
+Drive **Symphony Creative Studio** image generation from the terminal. All commands run through your existing browser session — no API key needed.
+
+**Mode**: 🔐 Browser · **Domain**: `ads.tiktok.com`
+
+## Commands
+
+| Command | Description | Access |
+|---------|-------------|--------|
+| `opencli tiktok-symphony credits` | Credit balance, plan and signed-in account | read |
+| `opencli tiktok-symphony generations` | List generated assets in the Library | read |
+| `opencli tiktok-symphony download <asset>` | Save a generated asset to a local file | read |
+| `opencli tiktok-symphony generate <prompt>` | Generate images from a prompt and reference images | write |
+
+`library` is an alias for `generations`.
+
+## Usage Examples
+
+```bash
+# Sanity check — balance, plan, account
+opencli tiktok-symphony credits
+
+# Recent assets in the Library
+opencli tiktok-symphony generations --limit 10
+
+# Generate from a text prompt only
+opencli tiktok-symphony generate "a minimal 3D mascot on a plain background"
+
+# Generate using reference images (up to 4)
+opencli tiktok-symphony generate "turn this into 3D chibi style" --refs ./cat.png,./dog.png
+
+# Pick the model
+opencli tiktok-symphony generate "detailed product shot" --model "Flux Kontext Max"
+
+# Download an asset by id (from `generations`)
+opencli tiktok-symphony download 202607195d0d7ea36ed139b74eccb1e4 --out ./downloads
+
+# A full asset URL works too
+opencli tiktok-symphony download "https://p16-ad-site-sign-sg.tiktokcdn.com/ad-creative-sg/...~tplv-...image?..."
+```
+
+## Options
+
+### `generate`
+
+| Option | Description |
+|--------|-------------|
+| `prompt` | What to generate (required positional) |
+| `--refs` | Comma-separated reference image paths, max 4 (`.png` `.jpg` `.jpeg` `.webp` `.gif` `.avif`, 10 MB each) |
+| `--model` | `Nano Banana` (default) or `Flux Kontext Max`; matching ignores case, spaces and dashes |
+| `--timeout` | Max seconds to wait for rendering (default: `300`, min `30`) |
+
+### `generations`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Max assets to list (default: `20`, max `200`) |
+
+### `download`
+
+| Option | Description |
+|--------|-------------|
+| `asset` | `assetId` from `generations`, or a full asset URL (required positional) |
+| `--out` | Directory to write the file into (default: `.`) |
+
+## Output Columns
+
+| Command | Columns |
+|---------|---------|
+| `credits` | `credits, plan, account` |
+| `generations` | `index, assetId, type, url` |
+| `download` | `assetId, file, bytes, contentType` |
+| `generate` | `index, assetId, url, model, prompt` |
+
+## Prerequisites
+
+- Chrome is running
+- You are already signed into `ads.tiktok.com` (Symphony Creative Studio)
+- [Browser Bridge extension](/guide/browser-bridge) is installed
+
+## Notes
+
+- One `generate` run produces up to 4 images; each returned row is one output asset
+- `generate` is a **write** command — every run creates real assets on your account and can spend Symphony credits depending on your plan. Check `credits` first
+- `generate` always reloads the composer before it starts: submitting does **not** clear the prompt or reference images, so reusing a dirty tab would silently resend them
+- Reference images are attached through the composer's own drop zone. The page exposes no `input[type=file]`, so `--refs` reads each file and hands it to the page as a real drop
+- Asset URLs are signed and short-lived, so `download` reads the live URL out of the Library rather than reconstructing it. If an `assetId` has scrolled out of the grid the command scrolls to find it
+- The Library holds the full history; the in-app Create feed only keeps the last 3 days
+- The DOM carries no generation id, so `assetId` comes from the asset's CDN path — that is the handle `generations` emits and `download` consumes
+- `plan` and `account` return `null` rather than a string sentinel when the header cannot be read — branch on `null` in agent code
+- `limit`, `timeout` and `refs` are validated and rejected with `ArgumentError` when out of range; no silent clamp
+- Symphony is a client-rendered SPA whose header and composer hydrate after navigation — every command polls for readiness instead of assuming the DOM is present


### PR DESCRIPTION
Adds seven adapters for **TikTok Symphony Creative Studio** (`ads.tiktok.com`), covering
both the Image and the Video tab.

| Command | Access | Description |
|---------|--------|-------------|
| `credits` | read | Credit balance, plan, signed-in account |
| `generations` (alias `library`) | read | List generated assets in the Library |
| `jobs` (alias `queue`) | read | Render progress for the Create feed |
| `download <asset>` | read | Save a generated asset to a local file |
| `generate <prompt>` | write | Generate images from a prompt + up to 4 reference images |
| `generate-video <prompt>` | write | Render a video clip |
| `delete <asset>` | write | Permanently delete a generation |

## Strategy note

```
Strategy: UI_SELECTOR   Contract: visible-ui
Evidence:
- anchors: fieldset[aria-label="File drop zone"] wraps the composer, which exposes
  data-chatbox-part = topbar | body>header | textarea | footer | drop-overlay
- auth source: existing browser session cookie (analyze reports no anti-bot, 0 auth failures)
- replay result: exercised live — model switch, reference upload, prompt entry and
  submit all confirmed against the real page
```

The site does have internal XHR, but the composer's `data-chatbox-part` anchors are a
user-visible contract and a steadier bet than unversioned internal endpoints, so this
stays on the UI ladder rung rather than climbing to `PAGE_FETCH` / `INTERCEPT`.

## Two site-specific constraints worth flagging for reviewers

**`ks-*` web components carry a version suffix.** Elements are `ks-button-1-1-1m`,
`ks-tag-1-1-1m`, and so on. Every lookup matches on tag *prefix*
(`tagName.startsWith('ks-button')`) — hard-coding the full tag would break on the next
component version bump.

**Reference upload cannot use `page.uploadFiles`.** The page renders no
`input[type=file]` at all, and injecting one and driving it through CDP is refused
(`{"code":-32000,"message":"Not allowed"}`). Attaching a reference therefore goes
through the composer's own drop zone: the file is read Node-side, rebuilt as a `File`
inside the page, and dispatched as a real `drop`. This only reuses a capability the
page already offers to any user dragging a file in.

Symphony is a client-rendered SPA whose header and composer hydrate *after* navigation
resolves, so every command polls via a shared `waitForValue` helper rather than
assuming the DOM is ready — that gap was the first thing to bite during development.

## The Video tab

`generate-video` covers all three Video sub-apps. Each is its own `subApp` URL, so the
command navigates straight to the mode rather than clicking the mode dropdown - one
fewer fragile interaction, and the composer state is unambiguous from the first paint.

| `--mode` | sub-app | references |
|---|---|---|
| `text` | `CreativeStudio/MiniApp/TextToVideo` | none |
| `image` | `CreativeStudio/MiniApp/ImageToVideo` | 1, or 2 with `--frames first-last` |
| `reference` | `CreativeStudio/ReferenceToVideo/ReferenceToVideo` | 1-4 |

`--duration` is `5` / `10` / `12` seconds and `Video 1.5 Pro` is the only model the tab
offers. There is no aspect-ratio control.

### Four things about video that shaped the design

**A clip costs one credit per second.** 980 to 970 across a 10s render; a 5s clip costs
5. That is unlike image generation, which was free on this plan. A render refused by
moderation is charged too, so `--duration` is rejected rather than coerced - a silently
adjusted length would bill the caller for something they did not ask for.

**Rendering takes tens of minutes.** The card says "Check back in 5-10 minutes"; the
first clip measured took over an hour. `--wait` therefore defaults to **false**: the
command submits, returns `status: generating`, and `jobs` / `generations` pick the
result up later. `--wait true` is available and polls up to `--timeout` (default 5400s).

**Losing the progress percentage is not completion.** The lifecycle is `3% ... 98%`,
then the percentage disappears, then "Almost there. We'll notify you when ready." for a
long stretch, and only then does the `<video>` mount. Treating "no percentage" as done
would report success ten-plus minutes early, so `jobs` reports four states and claims
`ready` only when an output is actually mounted:

| status | condition |
|---|---|
| `failed` | the card carries an `Error code:` |
| `ready` | an output element is mounted (a non-demo `<video>`, or an `<img>` on the asset CDN) |
| `generating` | a percentage is showing |
| `finishing` | neither - the "Almost there" tail, and also a finished card scrolled out of view |

`finishing` is deliberately non-committal: it says "cannot confirm" instead of guessing.
No prose is parsed for any of this, since the UI is localized.

**A render can be refused by moderation, and it looks like nothing went wrong.** The
failure arrives as ordinary card text - no dialog, no HTTP error:

```
<prompt> | Video 1.5 Pro | This content may involve third-party intellectual property,
which violates our Community Guidelines. Try generating again. |
Task ID: 7664452848403234817 | Error code: 10001305
```

`generate-video --wait true` raises a `CommandExecutionError` carrying the code and task
id instead of waiting out the timeout, and `jobs` surfaces it in the `error` column.
Incidentally this is the *only* place the site exposes a real generation id - successful
cards have none.

### Clips are not on the image CDN

```
image  https://p16-ad-site-sign-sg.tiktokcdn.com/ad-creative-sg/<assetId>~tplv-...image
clip   https://v16-ad-creative.tiktokcdn-row.com/<h>/<h>/video/tos/alisg/.../<tosId>/?...&vid=<videoId>
```

A clip tile renders a `<video>` with no poster on the asset host, no `ad-creative-sg`
path segment, and its identity is the `vid` query parameter. `generations` reported no
video at all before this change, and `download` would have fetched a poster image.
`download` now returns a real MP4 (verified `content-type: video/mp4`, `ftyp isom`
magic bytes).

Relatedly, `generations` now derives `type` from the element kind rather than the tile
badge. The badge is localized, and clip tiles carry the tool name ("Reference to video")
instead of a `Video` badge at all.

## `delete`

Tile overflow button, then the menu row carrying `ks-icon[name=delete]`, then the
confirm dialog's `[part=confirmButton]`. Both anchors are structural rather than
textual, which matters here: the labels are localized, **and the menu differs by asset
kind** (an image offers Share / Generate video / Edit / Feedback / Delete; a clip offers
Open in editor / Feedback / Delete).

The command is irreversible, so it is **dry-run by default** - without `--yes` it only
locates the tile and reports `status: dry-run`. That also lets the fixture verify the
whole lookup path without destroying anything. After confirming, it waits for the tile
to leave the grid before reporting `deleted`, rather than trusting the click.

Worth knowing: the dialog says "If you delete this **generation**...", but deleting is
per-asset. Removing one image left its three siblings from the same run untouched.

## Fixes to the commands already in this PR

**Background windows never render, so the grid never loads.** Library and feed tiles
mount lazily through `IntersectionObserver`. A background tab is not rendered, so
nothing intersects and the grid stays empty forever. Same command, same moment:
`--window background` gave 1 row, `--window foreground` gave 20. The reading commands
now set `defaultWindowMode: 'foreground'`. This had been masquerading as flaky
thumbnails for a while before the cause turned up.

**`__deepAll` skipped the root node's own shadow root.** It walked
`root.querySelectorAll('*')` and recursed into the *children's* shadow roots. A
`ks-modal` keeps its title and buttons in its own shadow root while its light DOM holds
only the body text, so the delete dialog looked like it had no controls at all.

**`generate` could report a previous run's assets.** It snapshotted every asset id on
the page before submitting and diffed afterwards. The feed lazy-loads, so assets from an
earlier generation arrived *after* the snapshot and looked brand new - reproduced across
three consecutive verify runs, each returning one to three ids belonging to the run
before. It now scopes to the card carrying its own prompt, still subtracts a snapshot
taken once the feed has settled, and confirms the reading is stable before returning.

**Reference upload broke on files over roughly half a megabyte.** A single ~1 MB base64
`evaluate` argument fails the bridge with `sendCommand: max attempts exhausted` after
about four seconds. The base64 now goes over in 128 KB chunks and is reassembled into
the `File` in page context.

**The Library grid scrolls inside its own container.** `window.scrollY` stays 0, so
`page.scroll` left the grid untouched and everything below the fold stayed unrendered.
The container is now located by shape (`clientHeight` / `scrollHeight`) rather than by
class name, which survives a restyle.

## Identity

The DOM carries no generation id anywhere (only `data-inspector` hashes, which are
dev-tool artifacts). The only stable per-asset handle is the CDN path segment, so that
is what `generations` emits as `assetId` and what `download` consumes. Asset URLs are
signed and short-lived, so `download` reads the live URL out of the Library instead of
reconstructing it.

## Verification

Verified end-to-end against a live account, with hand-tuned fixtures (`patterns` +
`notEmpty` + tightened `rowCount`) under `~/.opencli/sites/tiktok-symphony/verify/`:

```
✓ tiktok-symphony/credits        ✓ tiktok-symphony/generations
✓ tiktok-symphony/download       ✓ tiktok-symphony/jobs
✓ tiktok-symphony/delete         ✓ tiktok-symphony/generate-video
```

`generate` is the one command `opencli browser verify` cannot run: the harness kills the
adapter after 30 seconds (`execFileSync(..., { timeout: 30000 })` in `cli.js`) and an
image generation takes about 50. Run directly it returns four fresh assets every time;
its fixture is committed for whenever that cap is lifted.

All three video modes were submitted for real (text-to-video, image-to-video,
reference-to-video), one of which came back refused by moderation - which is how that
failure path got covered. The `--wait` completion path was then exercised against the
finished card's real DOM without spending further credits.

Values were checked against the page by eye, not just for "the adapter didn't throw":

- `credits` matches the header (balance / plan / account).
- `download` produces a real PNG (magic bytes `89 50 4E 47`, ~1 MB).
- `generate` was run with a synthetic reference image (blue background, gold circle).
  The returned outputs are 3D chibi renders that **keep the blue background and gold
  circle**, which confirms the reference genuinely conditions the model rather than
  being silently dropped into a text-only generation. Both models were exercised.

One bug this caught: the Library tile badge regex `/^(Image|Video)\b/` never matches
`"ImageDownload"` (no word boundary between the two words), which silently produced a
`type` column that was `null` on every row while the command still "succeeded".

## Checks

```
npx tsc --noEmit                    clean
opencli validate                    Errors: 0   (8 warnings, all pre-existing, none in this site)
npm run check:typed-error-lint      new=0
npm run check:silent-column-drop    new=0
bash scripts/check-doc-coverage.sh  174/174 documented
npx vitest run --project adapter clis/tiktok-symphony/   18 passed
```

`npm test` has 11 pre-existing failures on this commit's base (instagram, suno, twitter,
xiaoyuzhou); I confirmed they reproduce on a clean tree with these changes stashed, so
they are unrelated to this PR.

## Notes for reviewers

- `generate` is `access: 'write'` — each run creates real assets on the account. On the
  Basic plan the observed cost was 0 credits (balance unchanged, composer showed cost
  `0`), but that is plan-dependent and the assets are real.
- `generate-video` is `access: 'write'` **and always costs credits** — one per second of
  clip, charged even when the render is refused.
- `delete` is `access: 'write'` and irreversible; `--yes` is required for it to do
  anything, and the fixture exercises only the dry-run path.
- `generate` deliberately reloads the composer before starting: submitting does **not**
  clear the prompt or references, so a reused tab would silently resend them. If stale
  references somehow survive the reload the command fails loudly rather than generating
  from unknown inputs.
- Out-of-range `limit` / `timeout` / `refs` raise `ArgumentError`; there is no silent
  clamp anywhere, and `plan` / `account` return `null` rather than a string sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

