### PR TITLE
feat(appmagic): add adapter for appmagic.rocks app & game market intelligence

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -2627,6 +2627,741 @@
     "sourceFile": "apple-podcasts/top.js"
   },
   {
+    "site": "appmagic",
+    "name": "app",
+    "description": "App store listing: publisher, price, rating, release date, store URL",
+    "access": "read",
+    "example": "opencli appmagic app 447188370 --country US",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. 447188370 (Apple) or com.whatsapp (Google Play)"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "US",
+        "required": false,
+        "help": "ISO country code for the store listing, e.g. US / VN"
+      }
+    ],
+    "columns": [
+      "name",
+      "publisher",
+      "store",
+      "country",
+      "price",
+      "currency",
+      "rating",
+      "reviewCount",
+      "released",
+      "containsAds",
+      "hasInAppPurchases",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app.js",
+    "sourceFile": "appmagic/app.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "app-competitors",
+    "description": "Competitors of an app, with trailing-30-day bucketed metrics. Free tier returns only ~3 of competitorTotal — check that column",
+    "access": "read",
+    "example": "opencli appmagic app-competitors com.ig.wool.rescue",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. com.ig.wool.rescue or 447188370"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "publisher",
+      "downloadsMin",
+      "downloadsMax",
+      "revenueMin",
+      "revenueMax",
+      "unitedId",
+      "competitorTotal"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app-competitors.js",
+    "sourceFile": "appmagic/app-competitors.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "app-featuring",
+    "description": "Store featuring placements for an app on the latest available date (history is premium-only)",
+    "access": "read",
+    "example": "opencli appmagic app-featuring com.snapchat.android --country WW",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. com.snapchat.android or 447188370"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "WW",
+        "required": false,
+        "help": "ISO code or WW for worldwide"
+      },
+      {
+        "name": "date",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "YYYY-MM-DD. Default and ONLY free value: the latest available date"
+      },
+      {
+        "name": "order",
+        "type": "string",
+        "default": "desc",
+        "required": false,
+        "help": "desc / asc by featuring count"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Number of placements (max 100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "country",
+      "category",
+      "placement",
+      "place",
+      "row",
+      "depth",
+      "featuring",
+      "date"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app-featuring.js",
+    "sourceFile": "appmagic/app-featuring.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "app-releases",
+    "description": "App version history (newest first): version, release date, release notes",
+    "access": "read",
+    "example": "opencli appmagic app-releases 447188370 --limit 10",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. 447188370 (Apple) or com.whatsapp (Google Play)"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "US",
+        "required": false,
+        "help": "ISO country code for the store listing, e.g. US / VN"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of versions, newest first (max 200)"
+      }
+    ],
+    "columns": [
+      "version",
+      "releaseDate",
+      "releaseNotes"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app-releases.js",
+    "sourceFile": "appmagic/app-releases.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "app-sdks",
+    "description": "SDKs detected in an app. Free tier returns only 1 of sdkTotal — compare those two columns",
+    "access": "read",
+    "example": "opencli appmagic app-sdks com.ig.wool.rescue",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. com.ig.wool.rescue or 447188370"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      }
+    ],
+    "columns": [
+      "name",
+      "category",
+      "firstDetected",
+      "returned",
+      "sdkTotal"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app-sdks.js",
+    "sourceFile": "appmagic/app-sdks.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "app-similar",
+    "description": "Apps similar to a given app, ranked by similarity score. Downloads are bucketed over the trailing 30 days",
+    "access": "read",
+    "example": "opencli appmagic app-similar com.ig.wool.rescue",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store app id, e.g. com.ig.wool.rescue or 447188370"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of similar apps (max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "publisher",
+      "score",
+      "depth",
+      "downloadsMin",
+      "downloadsMax",
+      "unitedId"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/app-similar.js",
+    "sourceFile": "appmagic/app-similar.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "game-competitors",
+    "description": "The competitive field around a game: the top games in its genre, with install buckets and rank movement",
+    "access": "read",
+    "example": "opencli appmagic game-competitors com.ig.wool.rescue --chart grossing",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "appId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Your game's store id, e.g. com.ig.wool.rescue or 447188370"
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "iphone / ipad / google-play. Default: inferred from appId"
+      },
+      {
+        "name": "genre",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Override the auto-detected genre: a tag id or name (e.g. \"Block Puzzle\"). Discover with: opencli appmagic tags --type games"
+      },
+      {
+        "name": "chart",
+        "type": "string",
+        "default": "free",
+        "required": false,
+        "help": "Rank by: free (downloads) or grossing (revenue)"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "WW",
+        "required": false,
+        "help": "ISO code or WW"
+      },
+      {
+        "name": "date",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Period start YYYY-MM-DD. Default: current month"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Number of games (max 100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "name",
+      "publisher",
+      "hq",
+      "downloadsMin",
+      "downloadsMax",
+      "rankChange",
+      "releaseDate",
+      "isSeed",
+      "genre",
+      "unitedId"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/game-competitors.js",
+    "sourceFile": "appmagic/game-competitors.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "game-genres",
+    "description": "Genre saturation map: how many games each sub-genre holds (supply/crowdedness, by app count — not revenue)",
+    "access": "read",
+    "example": "opencli appmagic game-genres --genre Puzzle",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "genre",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Genre tag id or name (e.g. \"Puzzle\", \"Racing\"). Default: all games (top-level genre map)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Number of sub-genres (max 100)"
+      }
+    ],
+    "columns": [
+      "genre",
+      "subGenre",
+      "tagId",
+      "appCount",
+      "sharePct",
+      "genreTotal"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/game-genres.js",
+    "sourceFile": "appmagic/game-genres.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "game-risers",
+    "description": "Fast-climbing games ranked by chart rank-change (the free-tier \"rising star\" proxy). Add --new-within for breakouts",
+    "access": "read",
+    "example": "opencli appmagic game-risers --genre Puzzle --period week --new-within 12",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "genre",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Genre tag id or name (e.g. \"Puzzle\", \"Racing\"). Default: all games. List with: opencli appmagic tags --type games"
+      },
+      {
+        "name": "period",
+        "type": "string",
+        "default": "week",
+        "required": false,
+        "help": "Rank-change window: day / week / month. Shorter = more short-term"
+      },
+      {
+        "name": "chart",
+        "type": "string",
+        "default": "free",
+        "required": false,
+        "help": "Which chart to climb: free (downloads) or grossing (revenue)"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "WW",
+        "required": false,
+        "help": "ISO code or WW"
+      },
+      {
+        "name": "date",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Period date YYYY-MM-DD. Default: latest available"
+      },
+      {
+        "name": "new-within",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Keep only games released within this many months (0 = no age filter)"
+      },
+      {
+        "name": "min-climb",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Minimum positive rank-change to include"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 25,
+        "required": false,
+        "help": "Number of risers to return (max 100)"
+      }
+    ],
+    "columns": [
+      "chartRank",
+      "rankChange",
+      "name",
+      "publisher",
+      "hq",
+      "genre",
+      "downloadsMin",
+      "downloadsMax",
+      "releaseDate",
+      "ageMonths",
+      "unitedId"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/game-risers.js",
+    "sourceFile": "appmagic/game-risers.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "publisher",
+    "description": "Publisher profile: app count, HQ, LinkedIn headcount. Downloads/revenue are bucketed ranges over the trailing 30 days, not lifetime",
+    "access": "read",
+    "example": "opencli appmagic publisher 2_1684349733",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "publisherId",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Store-prefixed id from the appmagic URL, e.g. 2_1684349733"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "appCount",
+      "storeListingCount",
+      "downloadsMin",
+      "downloadsMax",
+      "revenueMin",
+      "revenueMax",
+      "headquarter",
+      "linkedinHeadcount",
+      "firstReleaseDate",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/publisher.js",
+    "sourceFile": "appmagic/publisher.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "search",
+    "description": "Search apps and publishers by name. Downloads/revenue are bucketed ranges over the trailing 30 days, not exact and not lifetime",
+    "access": "read",
+    "example": "opencli appmagic search chatgpt --kind app",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "App or publisher name to search for"
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "Filter results: all / app / publisher"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of results (max 100)"
+      }
+    ],
+    "columns": [
+      "kind",
+      "id",
+      "name",
+      "publisher",
+      "storeListingCount",
+      "downloadsMin",
+      "downloadsMax",
+      "revenueMin",
+      "revenueMax",
+      "headquarter",
+      "unitedId"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/search.js",
+    "sourceFile": "appmagic/search.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "tags",
+    "description": "Tag taxonomy (games / apps / themes / ip / features ...). Use a tag id or name with top-charts --tag",
+    "access": "read",
+    "example": "opencli appmagic tags --query messenger",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Filter by name substring, case-insensitive"
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Filter by type: games / apps / themes / ip / features / settings / artstyles / meta / complexity / domain"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Number of tags (max 500)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "type",
+      "parentIds"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/tags.js",
+    "sourceFile": "appmagic/tags.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "top-chart-tags",
+    "description": "Tags you can filter top-charts (--tag) and game commands (--genre) by, with app counts, grouped and sized",
+    "access": "read",
+    "example": "opencli appmagic top-chart-tags --type games --min-apps 1000",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "type",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Filter by type: domain / meta / games / apps / artstyles / themes / features / ip / settings / complexity. Default: all"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Name substring, case-insensitive"
+      },
+      {
+        "name": "min-apps",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Only tags carried by at least this many apps (hide the long tail)"
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "size",
+        "required": false,
+        "help": "size (most apps first) or name (A-Z)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 50,
+        "required": false,
+        "help": "Number of tags (max 500)"
+      }
+    ],
+    "columns": [
+      "group",
+      "type",
+      "name",
+      "tagId",
+      "appCount",
+      "parentIds"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/top-chart-tags.js",
+    "sourceFile": "appmagic/top-chart-tags.js"
+  },
+  {
+    "site": "appmagic",
+    "name": "top-charts",
+    "description": "App rankings: top free / top grossing / top featuring. Downloads and revenue are bucketed lower bounds",
+    "access": "read",
+    "example": "opencli appmagic top-charts --tag Messenger --limit 20",
+    "domain": "appmagic.rocks",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "store",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "all / ios / iphone / ipad / google-play. Metrics only present for \"all\""
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "default": "WW",
+        "required": false,
+        "help": "ISO code, e.g. US / VN / JP. WW = worldwide. Metrics only present for WW"
+      },
+      {
+        "name": "date",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Period start, YYYY-MM-DD. Default: current month"
+      },
+      {
+        "name": "aggregation",
+        "type": "string",
+        "default": "month",
+        "required": false,
+        "help": "day / week / month / quarter / year. Metrics only present for month / year"
+      },
+      {
+        "name": "tag",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Filter by one tag id or name, e.g. 104 or \"Messenger\". Discover with: opencli appmagic tags"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of ranks (max 100)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "freeApp",
+      "freePublisher",
+      "downloadsMin",
+      "downloadsMax",
+      "grossingApp",
+      "grossingPublisher",
+      "revenueMin",
+      "revenueMax",
+      "featuringApp",
+      "featuringPublisher",
+      "featuring"
+    ],
+    "type": "js",
+    "modulePath": "appmagic/top-charts.js",
+    "sourceFile": "appmagic/top-charts.js"
+  },
+  {
     "site": "archive",
     "name": "item",
     "description": "Fetch metadata for a single Internet Archive item by identifier.",

--- a/clis/appmagic/app-competitors.js
+++ b/clis/appmagic/app-competitors.js
@@ -1,0 +1,72 @@
+// appmagic app-competitors — the site's Competitors Dashboard for one app.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/competitors with
+// {"ids":[{store, store_application_id}]} replays 200 + JSON, no auth.
+// See utils.js for the full note.
+//
+// SOFT PAYWALL — the reason `competitorTotal` is on every row. A free account
+// receives only 3 competitors while `total_count` reports the real number (30
+// for com.ig.wool.rescue). The response is a 200, not a 401, so nothing about
+// it announces the truncation; the web UI is explicit about it and prints
+// "+27 competitors — SEE PRICING" under the same three rows. Carrying
+// total_count on each row is what keeps "3 rows" from silently reading as
+// "this app has 3 competitors". There is no offset/limit param to page past it.
+//
+// PERIOD: downloads/revenue here are TRAILING 30 DAYS, matching the UI's
+// "Revenue / Last 30 days" column header — not lifetime. The column names are
+// period-neutral by convention across this site's adapters, so this comment and
+// the command description are where the window is stated. Values are bucketed,
+// same encoding as everywhere else — see decodeBucket() in utils.js.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { APP_STORES, decodeBucket, DOMAIN, inferStoreKey, postJson, resolveStore } from './utils.js';
+
+cli({
+  site: 'appmagic',
+  name: 'app-competitors',
+  description: 'Competitors of an app, with trailing-30-day bucketed metrics. Free tier returns only ~3 of competitorTotal — check that column',
+  access: 'read',
+  example: 'opencli appmagic app-competitors com.ig.wool.rescue',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. com.ig.wool.rescue or 447188370' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+  ],
+  columns: ['rank', 'name', 'publisher', 'downloadsMin', 'downloadsMax', 'revenueMin', 'revenueMax', 'unitedId', 'competitorTotal'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+
+    const payload = await postJson('/competitors', { ids: [{ store, store_application_id: appId }] }, 'app-competitors');
+    const found = Array.isArray(payload?.data?.competitors) ? payload.data.competitors : [];
+    if (found.length === 0) {
+      throw new EmptyResultError('appmagic app-competitors', `no competitors listed for ${appId} on ${storeKey}`);
+    }
+
+    const total = payload?.total_count ?? null;
+
+    return found.map((entry, i) => {
+      const app = entry?.application;
+      const downloads = decodeBucket(app?.downloads);
+      const revenue = decodeBucket(app?.revenue);
+      return {
+        rank: i + 1,
+        name: app?.name ?? null,
+        // application.publisher.name comes back empty here; unitedPublisher is
+        // the populated one (verified against the UI's publisher labels).
+        publisher: app?.unitedPublisher?.name || app?.publisher_name || null,
+        downloadsMin: downloads.min,
+        downloadsMax: downloads.max,
+        revenueMin: revenue.min,
+        revenueMax: revenue.max,
+        unitedId: app?.id != null ? String(app.id) : null,
+        competitorTotal: total,
+      };
+    });
+  },
+});

--- a/clis/appmagic/app-featuring.js
+++ b/clis/appmagic/app-featuring.js
@@ -1,0 +1,103 @@
+// appmagic app-featuring — store featuring placements for one app.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/featuring replays 200 +
+// JSON, no auth, for the latest available date. See utils.js for the full note.
+//
+// THE DATE IS SERVER-LOCKED TO A SINGLE DAY. The web UI draws a padlock on its
+// DATE field, and that padlock is real: only the exact date returned by
+// GET /api/v2/last-date responds 200. One day earlier, a week, a month, two
+// years, or any future date all return 403. So this command defaults to that
+// date and any other value fails as AuthRequiredError rather than pretending
+// history is reachable. Anonymous featuring is a one-day snapshot, not a series.
+//
+// `sort` is not exposed as an argument because the API accepts exactly one
+// value, "featuring" (bundle enum @3370623 has a single member); the column
+// sorts in the UI are done client-side and never reach the server. Offering a
+// --sort flag would imply a choice that does not exist.
+//
+// An empty result is normal here — most apps have no featuring placements at
+// all (com.ig.wool.rescue has none), which is why it is an EmptyResultError and
+// not a failure.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { APP_STORES, DOMAIN, getJson, inferStoreKey, normalizeCountry, normalizeLimit, postJson, resolveStore } from './utils.js';
+
+const MAX_LIMIT = 100; // limit=101 -> HTTP 400
+const ORDERS = ['desc', 'asc'];
+
+cli({
+  site: 'appmagic',
+  name: 'app-featuring',
+  description: 'Store featuring placements for an app on the latest available date (history is premium-only)',
+  access: 'read',
+  example: 'opencli appmagic app-featuring com.snapchat.android --country WW',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. com.snapchat.android or 447188370' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+    { name: 'country', type: 'string', default: 'WW', help: 'ISO code or WW for worldwide' },
+    { name: 'date', type: 'string', default: '', help: 'YYYY-MM-DD. Default and ONLY free value: the latest available date' },
+    { name: 'order', type: 'string', default: 'desc', help: 'desc / asc by featuring count' },
+    { name: 'limit', type: 'int', default: 25, help: `Number of placements (max ${MAX_LIMIT})` },
+  ],
+  columns: ['rank', 'country', 'category', 'placement', 'place', 'row', 'depth', 'featuring', 'date'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+    const country = normalizeCountry(args.country);
+    const limit = normalizeLimit(args.limit, 25, MAX_LIMIT);
+
+    const order = String(args.order ?? 'desc').toLowerCase();
+    if (!ORDERS.includes(order)) {
+      throw new ArgumentError(`Unknown order "${order}". Valid: ${ORDERS.join(', ')}`);
+    }
+
+    const latest = await getJson('/last-date', {}, 'app-featuring last-date');
+    const lastDate = latest?.lastDate;
+    if (!lastDate) {
+      throw new EmptyResultError('appmagic app-featuring', 'appmagic did not report a latest available date');
+    }
+
+    let date = String(args.date ?? '').trim();
+    if (date === '') {
+      date = lastDate;
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new ArgumentError(`date must be YYYY-MM-DD, got "${date}"`);
+    }
+
+    const payload = await postJson('/featuring', {
+      app_ids: [{ store, store_application_id: appId }],
+      offset: 0,
+      limit,
+      date,
+      order,
+      sort: 'featuring',
+      country,
+      types: null,
+    }, `app-featuring for ${date}`);
+
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    if (rows.length === 0) {
+      throw new EmptyResultError('appmagic app-featuring', `${appId} has no featuring placements in ${country} on ${date}`);
+    }
+
+    return rows.slice(0, limit).map((r, i) => ({
+      rank: i + 1,
+      country: r?.country ?? null,
+      category: r?.name ?? null,
+      // `path` is the store's breadcrumb to the placement, e.g.
+      // "Featured Home > Social networking".
+      placement: Array.isArray(r?.path) ? r.path.map((p) => p?.name).filter(Boolean).join(' > ') || null : null,
+      place: r?.place ?? null,
+      row: r?.row ?? null,
+      depth: r?.depth ?? null,
+      featuring: r?.featuring ?? null,
+      date: r?.date ?? date,
+    }));
+  },
+});

--- a/clis/appmagic/app-releases.js
+++ b/clis/appmagic/app-releases.js
@@ -1,0 +1,59 @@
+// appmagic app-releases — version history for one app.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/applications/app-info/releases
+// with {store, storeApplicationID, country} replays 200 + JSON, no auth.
+// See utils.js for the full note.
+//
+// Note on release_notes: the store returns whatever locale the publisher shipped
+// that version in, so notes for a single app can mix languages across versions.
+// They are passed through verbatim rather than filtered to the --country locale.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { APP_STORES, DOMAIN, inferStoreKey, normalizeCountry, normalizeLimit, postJson, resolveStore } from './utils.js';
+
+const MAX_LIMIT = 200;
+
+cli({
+  site: 'appmagic',
+  name: 'app-releases',
+  description: 'App version history (newest first): version, release date, release notes',
+  access: 'read',
+  example: 'opencli appmagic app-releases 447188370 --limit 10',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. 447188370 (Apple) or com.whatsapp (Google Play)' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+    { name: 'country', type: 'string', default: 'US', help: 'ISO country code for the store listing, e.g. US / VN' },
+    { name: 'limit', type: 'int', default: 20, help: `Number of versions, newest first (max ${MAX_LIMIT})` },
+  ],
+  columns: ['version', 'releaseDate', 'releaseNotes'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const country = normalizeCountry(args.country, 'US');
+    const limit = normalizeLimit(args.limit, 20, MAX_LIMIT);
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+
+    const payload = await postJson('/applications/app-info/releases', { store, storeApplicationID: appId, country }, 'app-releases');
+    const releases = Array.isArray(payload?.releases) ? payload.releases : [];
+    if (releases.length === 0) {
+      throw new EmptyResultError('appmagic app-releases', `no release history for ${appId} on ${storeKey} in ${country}`);
+    }
+
+    // The API returns releases oldest-first; a caller asking for "the latest N
+    // versions" means newest-first.
+    return releases
+      .slice()
+      .reverse()
+      .slice(0, limit)
+      .map((r) => ({
+        version: r?.version ?? null,
+        releaseDate: r?.release_date ?? null,
+        releaseNotes: String(r?.release_notes ?? '').trim() || null,
+      }));
+  },
+});

--- a/clis/appmagic/app-sdks.js
+++ b/clis/appmagic/app-sdks.js
@@ -1,0 +1,58 @@
+// appmagic app-sdks — SDKs / third-party tech detected in an app's binary.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/applications/sdks with
+// the flat {store, storeApplicationID} body (camelCase, same style as
+// app-info — NOT an ids array) replays 200 + JSON, no auth.
+//
+// SOFT PAYWALL, and the nastiest one on this site: anonymously the response
+// carries exactly ONE sdk entry while `total_count` reports the truth (33 for
+// com.ig.wool.rescue, 22 for com.snapchat.android). It is a 200 with a
+// well-formed body — nothing signals that 32 rows were withheld. An adapter
+// that returned just the array would present a single SDK as the app's entire
+// tech stack, which is worse than returning nothing.
+//
+// So `sdkTotal` rides on the row and `returned` counts what we actually got.
+// When sdkTotal > returned the caller can see the gap in the data itself
+// rather than having to know this comment exists.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { APP_STORES, DOMAIN, inferStoreKey, postJson, resolveStore } from './utils.js';
+
+cli({
+  site: 'appmagic',
+  name: 'app-sdks',
+  description: 'SDKs detected in an app. Free tier returns only 1 of sdkTotal — compare those two columns',
+  access: 'read',
+  example: 'opencli appmagic app-sdks com.ig.wool.rescue',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. com.ig.wool.rescue or 447188370' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+  ],
+  columns: ['name', 'category', 'firstDetected', 'returned', 'sdkTotal'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+
+    const payload = await postJson('/applications/sdks', { store, storeApplicationID: appId }, 'app-sdks');
+    const sdks = Array.isArray(payload?.sdks) ? payload.sdks : [];
+    if (sdks.length === 0) {
+      throw new EmptyResultError('appmagic app-sdks', `no SDKs detected for ${appId} on ${storeKey}`);
+    }
+
+    const total = payload?.total_count ?? null;
+
+    return sdks.map((sdk) => ({
+      name: sdk?.name ?? null,
+      category: sdk?.category ?? null,
+      firstDetected: sdk?.first_detected ?? null,
+      returned: sdks.length,
+      sdkTotal: total,
+    }));
+  },
+});

--- a/clis/appmagic/app-similar.js
+++ b/clis/appmagic/app-similar.js
@@ -1,0 +1,71 @@
+// appmagic app-similar — the app page's "Similar apps" widget.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/similarity/app-info with
+// {"id": "<storeAppId>"} — the id is a BARE STRING, not an object or an array
+// (bundle chunk-DJDumY0p.js @1253: `getWidgetData(e){return
+// this.http.post(i.AppInfoUrl,{id:e})}`). Replays 200 + JSON with 10 nodes, no
+// auth. Note this endpoint takes no store code: the id alone identifies the app.
+//
+// Not exposed here: the "Similarity Graph" button behind it, POST
+// /api/v2/similarity {id, country}, which is 403 anonymously — premium.
+// The related POST /api/v2/similarity/countries {id} IS public and returns the
+// countries the similarity model covers; it is not surfaced because it answers
+// a different question than "which apps are similar".
+//
+// `depth` is the site's own min_depth: 1 = directly similar, 2 = similar to a
+// similar app. The UI drops depth 0 (that is the queried app itself) and sorts
+// by score descending — this adapter does the same so the row order matches
+// the icon order on the page.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { decodeBucket, DOMAIN, normalizeLimit, postJson } from './utils.js';
+
+const MAX_LIMIT = 50;
+
+cli({
+  site: 'appmagic',
+  name: 'app-similar',
+  description: 'Apps similar to a given app, ranked by similarity score. Downloads are bucketed over the trailing 30 days',
+  access: 'read',
+  example: 'opencli appmagic app-similar com.ig.wool.rescue',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. com.ig.wool.rescue or 447188370' },
+    { name: 'limit', type: 'int', default: 20, help: `Number of similar apps (max ${MAX_LIMIT})` },
+  ],
+  columns: ['rank', 'name', 'publisher', 'score', 'depth', 'downloadsMin', 'downloadsMax', 'unitedId'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+    const limit = normalizeLimit(args.limit, 20, MAX_LIMIT);
+
+    const payload = await postJson('/similarity/app-info', { id: appId }, 'app-similar');
+    const nodes = Array.isArray(payload?.data?.nodes) ? payload.data.nodes : [];
+
+    // min_depth === 0 is the queried app itself, not a similar app.
+    const similar = nodes
+      .filter((n) => n?.min_depth !== 0)
+      .sort((a, b) => (b?.sum_score ?? 0) - (a?.sum_score ?? 0));
+
+    if (similar.length === 0) {
+      throw new EmptyResultError('appmagic app-similar', `no similar apps for ${appId}`);
+    }
+
+    return similar.slice(0, limit).map((node, i) => {
+      const app = node?.app;
+      const downloads = decodeBucket(app?.downloads);
+      return {
+        rank: i + 1,
+        name: app?.name ?? null,
+        publisher: app?.unitedPublisher?.name || app?.publisher_name || null,
+        score: node?.sum_score ?? null,
+        depth: node?.min_depth ?? null,
+        downloadsMin: downloads.min,
+        downloadsMax: downloads.max,
+        unitedId: app?.id != null ? String(app.id) : null,
+      };
+    });
+  },
+});

--- a/clis/appmagic/app.js
+++ b/clis/appmagic/app.js
@@ -1,0 +1,67 @@
+// appmagic app — store listing detail for one app.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/applications/app-info
+// with {store, storeApplicationID, country} replays 200 + JSON, no auth.
+// See utils.js for the full note.
+//
+// The store id is the one in the appmagic URL: /iphone/snapchat/447188370 ->
+// 447188370 (Apple), /google-play/whatsapp-messenger/com.whatsapp ->
+// com.whatsapp (Google). Find one with `opencli appmagic search <name>`.
+// Version history lives in the sibling `app-releases` command.
+//
+// Deliberately omitted: the response's `downloads` field. It is always 0 on a
+// free account — a premium-gated value, not a real zero — so surfacing it would
+// silently read as "this app has no downloads". Bucketed lifetime figures are
+// available from `opencli appmagic search` instead.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { APP_STORES, DOMAIN, inferStoreKey, normalizeCountry, postJson, resolveStore } from './utils.js';
+
+cli({
+  site: 'appmagic',
+  name: 'app',
+  description: 'App store listing: publisher, price, rating, release date, store URL',
+  access: 'read',
+  example: 'opencli appmagic app 447188370 --country US',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Store app id, e.g. 447188370 (Apple) or com.whatsapp (Google Play)' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+    { name: 'country', type: 'string', default: 'US', help: 'ISO country code for the store listing, e.g. US / VN' },
+  ],
+  // Capped at the 12-key row-shape convention. `subtitle` and the `free` flag
+  // are the two that lost the cut: subtitle is marketing copy, and free is just
+  // price === 0.
+  columns: ['name', 'publisher', 'store', 'country', 'price', 'currency', 'rating', 'reviewCount', 'released', 'containsAds', 'hasInAppPurchases', 'url'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const country = normalizeCountry(args.country, 'US');
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+
+    const payload = await postJson('/applications/app-info', { store, storeApplicationID: appId, country }, 'app');
+    const app = payload?.data;
+    if (!app || app.name == null) {
+      throw new EmptyResultError('appmagic app', `no listing for ${appId} on ${storeKey} in ${country}`);
+    }
+
+    return [{
+      name: app.name,
+      publisher: app.publisher_name || null,
+      store: storeKey,
+      country: app.country ?? country,
+      price: app.price ?? null,
+      currency: app.currency || null,
+      rating: app.rating ?? null,
+      reviewCount: app.reviews ?? null,
+      released: app.released ?? null,
+      containsAds: app.contains_ads ?? null,
+      hasInAppPurchases: app.has_in_app_purchases ?? null,
+      url: app.application_url || null,
+    }];
+  },
+});

--- a/clis/appmagic/game-competitors.js
+++ b/clis/appmagic/game-competitors.js
@@ -1,0 +1,111 @@
+// appmagic game-competitors — the competitive field around one game.
+//
+// Strategy: PUBLIC_API. Contract: stable. Composes two public endpoints:
+//   POST /api/v2/united-applications/search-by-ids  -> the seed game's genre tags
+//   GET  /api/v2/top/united-apps?tag=<genre>        -> the top games in that genre
+// See utils.js for the full strategy note.
+//
+// Why not just app-competitors? That endpoint returns AppMagic's own hand-picked
+// list but the free tier caps it at 3 rows (of ~30). This command instead takes
+// the seed game's most specific genre and returns the whole genre leaderboard —
+// an uncapped view of who you are actually competing against, with each rival's
+// install bucket, rank movement, and release date. Use both: app-competitors for
+// the tight 3, game-competitors for the broad field.
+//
+// The genre is auto-detected (the leaf games-type tag on the seed) and echoed in
+// the `genre` column so you can re-run with --genre to broaden or narrow it.
+// Your own game is flagged with isSeed=true if it appears in the leaderboard.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  APP_STORES, decodeBucket, DOMAIN, getJson, inferStoreKey,
+  normalizeCountry, normalizeLimit, pickGamesGenre, postJson, resolveStore, resolveTag,
+} from './utils.js';
+
+const CHARTS = { free: 'top_free', grossing: 'top_grossing' };
+const MAX_LIMIT = 100;
+
+cli({
+  site: 'appmagic',
+  name: 'game-competitors',
+  description: 'The competitive field around a game: the top games in its genre, with install buckets and rank movement',
+  access: 'read',
+  example: 'opencli appmagic game-competitors com.ig.wool.rescue --chart grossing',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'appId', type: 'string', required: true, positional: true, help: 'Your game\'s store id, e.g. com.ig.wool.rescue or 447188370' },
+    { name: 'store', type: 'string', default: '', help: `${APP_STORES.join(' / ')}. Default: inferred from appId` },
+    { name: 'genre', type: 'string', default: '', help: 'Override the auto-detected genre: a tag id or name (e.g. "Block Puzzle"). Discover with: opencli appmagic tags --type games' },
+    { name: 'chart', type: 'string', default: 'free', help: 'Rank by: free (downloads) or grossing (revenue)' },
+    { name: 'country', type: 'string', default: 'WW', help: 'ISO code or WW' },
+    { name: 'date', type: 'string', default: '', help: 'Period start YYYY-MM-DD. Default: current month' },
+    { name: 'limit', type: 'int', default: 30, help: `Number of games (max ${MAX_LIMIT})` },
+  ],
+  columns: ['rank', 'name', 'publisher', 'hq', 'downloadsMin', 'downloadsMax', 'rankChange', 'releaseDate', 'isSeed', 'genre', 'unitedId'],
+  func: async (args) => {
+    const appId = String(args.appId ?? '').trim();
+    if (appId === '') throw new ArgumentError('appId must not be empty');
+
+    const storeKey = inferStoreKey(args.store, appId);
+    const store = resolveStore(storeKey, { allow: APP_STORES });
+
+    const chartKey = String(args.chart ?? 'free').toLowerCase();
+    const chart = CHARTS[chartKey];
+    if (!chart) throw new ArgumentError(`Unknown chart "${chartKey}". Valid: ${Object.keys(CHARTS).join(', ')}`);
+
+    const country = normalizeCountry(args.country);
+    const limit = normalizeLimit(args.limit, 30, MAX_LIMIT);
+
+    let date = String(args.date ?? '').trim();
+    if (date === '') {
+      const now = new Date();
+      date = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`;
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new ArgumentError(`date must be YYYY-MM-DD, got "${date}"`);
+    }
+
+    // Resolve the seed game and its genre.
+    const seed = await postJson('/united-applications/search-by-ids', { ids: [{ store, store_application_id: appId }] }, 'game-competitors seed');
+    const seedApp = Array.isArray(seed?.data) ? seed.data[0] : null;
+    if (!seedApp?.id) {
+      throw new EmptyResultError('appmagic game-competitors', `no game found for ${appId} on ${storeKey}`);
+    }
+    const seedUnitedId = String(seedApp.id);
+
+    const genreInput = String(args.genre ?? '').trim();
+    const genre = genreInput !== ''
+      ? { id: await resolveTag(genreInput), name: genreInput }
+      : pickGamesGenre(seedApp.tags);
+
+    // Pull the genre leaderboard.
+    const payload = await getJson('/top/united-apps', {
+      aggregation: 'month', topDepth: limit, store: 5, country, date, tag: genre.id,
+    }, `game-competitors genre ${genre.id}`);
+    const entries = Array.isArray(payload?.data) ? payload.data : [];
+    if (entries.length === 0) {
+      throw new EmptyResultError('appmagic game-competitors', `no games ranked in genre "${genre.name}" for ${country} / ${date}`);
+    }
+
+    return entries.slice(0, limit).map((entry, i) => {
+      const slot = entry?.[chart];
+      const app = slot?.application;
+      const downloads = decodeBucket(slot?.[chartKey === 'grossing' ? 'revenue' : 'downloads']);
+      const unitedId = app?.united_application_id != null ? String(app.united_application_id) : null;
+      return {
+        rank: i + 1,
+        name: app?.name ?? null,
+        publisher: app?.publisher?.name ?? null,
+        hq: app?.publisher?.headquarter ?? null,
+        downloadsMin: downloads.min,
+        downloadsMax: downloads.max,
+        rankChange: slot?.diff ?? null,
+        releaseDate: app?.releaseDate ? String(app.releaseDate).slice(0, 10) : null,
+        isSeed: unitedId != null && unitedId === seedUnitedId,
+        genre: genre.name,
+        unitedId,
+      };
+    });
+  },
+});

--- a/clis/appmagic/game-genres.js
+++ b/clis/appmagic/game-genres.js
@@ -1,0 +1,91 @@
+// appmagic game-genres — how crowded a game genre is, broken down by sub-genre.
+//
+// Strategy: PUBLIC_API. Contract: stable. GET /api/v2/tags/apps-count?tags=<id>
+// returns, for the queried tag, the count of apps that ALSO carry each co-tag
+// (plus a single-element entry that is the genre's own total). Cross-referenced
+// against GET /api/v2/tags for names/types. See utils.js for the full note.
+//
+// This is market-SATURATION intelligence: it answers "how many games exist in
+// this genre, and which sub-genres are the most crowded" — the supply side a
+// studio weighs before entering a space. It is a COUNT of apps, not downloads or
+// revenue: AppMagic's genre revenue/download SIZE (and its trend over time) is
+// premium-only (POST /api/v2/charts/tags -> 401). So this tells you how
+// contested a genre is, not how much money is in it.
+//
+// Counts OVERLAP by design — an app carries many tags at once — so sharePct
+// (sub-genre count / genre total) is a crowdedness indicator, not a partition
+// that sums to 100%. Pair this with game-competitors (who leads a genre) and
+// game-risers (who is climbing) for the full picture.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, GAMES_DOMAIN_TAG, getJson, normalizeLimit, resolveTag } from './utils.js';
+
+const MAX_LIMIT = 100;
+
+cli({
+  site: 'appmagic',
+  name: 'game-genres',
+  description: 'Genre saturation map: how many games each sub-genre holds (supply/crowdedness, by app count — not revenue)',
+  access: 'read',
+  example: 'opencli appmagic game-genres --genre Puzzle',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'genre', type: 'string', default: '', help: 'Genre tag id or name (e.g. "Puzzle", "Racing"). Default: all games (top-level genre map)' },
+    { name: 'limit', type: 'int', default: 30, help: `Number of sub-genres (max ${MAX_LIMIT})` },
+  ],
+  columns: ['genre', 'subGenre', 'tagId', 'appCount', 'sharePct', 'genreTotal'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 30, MAX_LIMIT);
+
+    const genreInput = String(args.genre ?? '').trim();
+    const genre = genreInput !== ''
+      ? { id: Number(await resolveTag(genreInput)), name: genreInput }
+      : { ...GAMES_DOMAIN_TAG };
+
+    // Index the taxonomy so co-tag ids become names + types.
+    const catalog = await getJson('/tags', {}, 'game-genres taxonomy');
+    const byId = new Map();
+    for (const t of (Array.isArray(catalog?.data) ? catalog.data : [])) byId.set(Number(t.id), t);
+
+    // The genre's display name from the catalog is more reliable than the raw input.
+    const genreTag = byId.get(genre.id);
+    const genreName = genreTag?.name ?? genre.name;
+
+    const counts = await getJson('/tags/apps-count', { tags: genre.id }, `game-genres count ${genre.id}`);
+    const rows = Array.isArray(counts?.data) ? counts.data : [];
+    if (rows.length === 0) {
+      throw new EmptyResultError('appmagic game-genres', `no saturation data for genre "${genreName}"`);
+    }
+
+    // The single-element entry [genreId] is the genre's own total app count.
+    const totalEntry = rows.find((r) => Array.isArray(r?.tags) && r.tags.length === 1 && Number(r.tags[0]) === genre.id);
+    const genreTotal = totalEntry?.count ?? null;
+
+    // Two-tag entries pair the genre with a co-tag; keep only games-type co-tags
+    // (the sub-genres) and exclude the genre paired with itself.
+    const subGenres = [];
+    for (const r of rows) {
+      if (!Array.isArray(r?.tags) || r.tags.length !== 2) continue;
+      const otherId = Number(r.tags.find((id) => Number(id) !== genre.id));
+      const tag = byId.get(otherId);
+      if (tag?.type !== 'games') continue;
+      subGenres.push({
+        genre: genreName,
+        subGenre: tag.name,
+        tagId: otherId,
+        appCount: r.count ?? null,
+        sharePct: genreTotal && r.count != null ? Math.round((r.count / genreTotal) * 1000) / 10 : null,
+        genreTotal,
+      });
+    }
+
+    if (subGenres.length === 0) {
+      throw new EmptyResultError('appmagic game-genres', `"${genreName}" has no games sub-genres — try a broader genre (e.g. Puzzle, Racing) or Games`);
+    }
+
+    subGenres.sort((a, b) => (b.appCount ?? 0) - (a.appCount ?? 0));
+    return subGenres.slice(0, limit);
+  },
+});

--- a/clis/appmagic/game-risers.js
+++ b/clis/appmagic/game-risers.js
@@ -1,0 +1,143 @@
+// appmagic game-risers — fast-climbing ("rising star") games.
+//
+// Strategy: PUBLIC_API. Contract: stable. GET /api/v2/top/united-apps?tag=<genre>
+// then rank client-side by the `diff` field (period-over-period rank change).
+// See utils.js for the full strategy note.
+//
+// HONEST LIMIT — read this before trusting the output. AppMagic's exact
+// download/revenue GROWTH between two periods is premium-only: /period-comparison
+// /compare, /applications/history, and /charts/* all return 401 on a free
+// account (verified). The ONLY growth signal a free account can see is `diff`,
+// the app's RANK CHANGE over the selected period. So "rising" here means
+// "climbed the chart fast", not "downloads grew X%". A game that jumped +49
+// positions this week is climbing hard, but the underlying install/revenue delta
+// is not exposed — downloadsMin/Max are still just the coarse period buckets.
+//
+// The strongest breakout signal combines two public facts: a big positive
+// rankChange AND a recent releaseDate. Use --new-within to keep only games
+// released in the last N months — a new game already climbing the chart is the
+// clearest "rising star" the free tier can identify.
+//
+// Note on the download/revenue buckets: the API only fills them for
+// aggregation=month|year with country=WW (documented in top-charts). At the
+// default --period week they come back null — the rank-change is the signal
+// there. Run --period month for the coarse bucket alongside the climb.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  decodeBucket, DOMAIN, GAMES_DOMAIN_TAG, getJson,
+  normalizeCountry, normalizeLimit, pickGamesGenre, resolveTag,
+} from './utils.js';
+
+const CHARTS = { free: 'top_free', grossing: 'top_grossing' };
+const SHORT_PERIODS = ['day', 'week', 'month']; // rising = short window; quarter/year dilute it
+const SCAN_DEPTH = 100; // top/united-apps caps topDepth at 100
+const MAX_LIMIT = 100;
+
+function monthsSince(iso, now) {
+  if (!iso) return null;
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return null;
+  const months = (now.getUTCFullYear() - then.getUTCFullYear()) * 12 + (now.getUTCMonth() - then.getUTCMonth());
+  return months < 0 ? 0 : months;
+}
+
+cli({
+  site: 'appmagic',
+  name: 'game-risers',
+  description: 'Fast-climbing games ranked by chart rank-change (the free-tier "rising star" proxy). Add --new-within for breakouts',
+  access: 'read',
+  example: 'opencli appmagic game-risers --genre Puzzle --period week --new-within 12',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'genre', type: 'string', default: '', help: 'Genre tag id or name (e.g. "Puzzle", "Racing"). Default: all games. List with: opencli appmagic tags --type games' },
+    { name: 'period', type: 'string', default: 'week', help: 'Rank-change window: day / week / month. Shorter = more short-term' },
+    { name: 'chart', type: 'string', default: 'free', help: 'Which chart to climb: free (downloads) or grossing (revenue)' },
+    { name: 'country', type: 'string', default: 'WW', help: 'ISO code or WW' },
+    { name: 'date', type: 'string', default: '', help: 'Period date YYYY-MM-DD. Default: latest available' },
+    { name: 'new-within', type: 'int', default: 0, help: 'Keep only games released within this many months (0 = no age filter)' },
+    { name: 'min-climb', type: 'int', default: 1, help: 'Minimum positive rank-change to include' },
+    { name: 'limit', type: 'int', default: 25, help: `Number of risers to return (max ${MAX_LIMIT})` },
+  ],
+  columns: ['chartRank', 'rankChange', 'name', 'publisher', 'hq', 'genre', 'downloadsMin', 'downloadsMax', 'releaseDate', 'ageMonths', 'unitedId'],
+  func: async (args) => {
+    const chartKey = String(args.chart ?? 'free').toLowerCase();
+    const chart = CHARTS[chartKey];
+    if (!chart) throw new ArgumentError(`Unknown chart "${chartKey}". Valid: ${Object.keys(CHARTS).join(', ')}`);
+
+    const period = String(args.period ?? 'week').toLowerCase();
+    if (!SHORT_PERIODS.includes(period)) {
+      throw new ArgumentError(`Unknown period "${period}". Valid: ${SHORT_PERIODS.join(', ')} (rising is a short-window signal)`);
+    }
+
+    const country = normalizeCountry(args.country);
+    const limit = normalizeLimit(args.limit, 25, MAX_LIMIT);
+
+    const newWithin = Number(args['new-within'] ?? 0);
+    if (!Number.isInteger(newWithin) || newWithin < 0) throw new ArgumentError('new-within must be a non-negative integer (months)');
+    const minClimb = Number(args['min-climb'] ?? 1);
+    if (!Number.isInteger(minClimb)) throw new ArgumentError('min-climb must be an integer');
+
+    const genreInput = String(args.genre ?? '').trim();
+    const genre = genreInput !== ''
+      ? { id: await resolveTag(genreInput), name: genreInput }
+      : { ...GAMES_DOMAIN_TAG };
+
+    let date = String(args.date ?? '').trim();
+    if (date === '') {
+      const latest = await getJson('/last-date', {}, 'game-risers last-date');
+      date = latest?.lastDate || '';
+      if (date === '') throw new EmptyResultError('appmagic game-risers', 'appmagic did not report a latest available date');
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new ArgumentError(`date must be YYYY-MM-DD, got "${date}"`);
+    }
+
+    const payload = await getJson('/top/united-apps', {
+      aggregation: period, topDepth: SCAN_DEPTH, store: 5, country, date, tag: genre.id,
+    }, `game-risers genre ${genre.id}`);
+    const entries = Array.isArray(payload?.data) ? payload.data : [];
+    if (entries.length === 0) {
+      throw new EmptyResultError('appmagic game-risers', `no games ranked in "${genre.name}" for ${country} / ${period} / ${date}`);
+    }
+
+    const now = new Date();
+    const rows = [];
+    entries.forEach((entry, i) => {
+      const slot = entry?.[chart];
+      const app = slot?.application;
+      if (!app) return;
+      const climb = Number(slot?.diff ?? 0);
+      if (!Number.isFinite(climb) || climb < minClimb) return;
+
+      const age = monthsSince(app?.releaseDate, now);
+      if (newWithin > 0 && (age == null || age > newWithin)) return;
+
+      const downloads = decodeBucket(slot?.[chartKey === 'grossing' ? 'revenue' : 'downloads']);
+      rows.push({
+        chartRank: i + 1,
+        rankChange: climb,
+        name: app?.name ?? null,
+        publisher: app?.publisher?.name ?? null,
+        hq: app?.publisher?.headquarter ?? null,
+        genre: pickGamesGenre(app?.tags).name,
+        downloadsMin: downloads.min,
+        downloadsMax: downloads.max,
+        releaseDate: app?.releaseDate ? String(app.releaseDate).slice(0, 10) : null,
+        ageMonths: age,
+        unitedId: app?.united_application_id != null ? String(app.united_application_id) : null,
+      });
+    });
+
+    if (rows.length === 0) {
+      const filt = [newWithin > 0 && `released within ${newWithin}mo`, `rank-change >= ${minClimb}`].filter(Boolean).join(', ');
+      throw new EmptyResultError('appmagic game-risers', `no games in "${genre.name}" matched (${filt}) for ${period} ending ${date}`);
+    }
+
+    // Biggest climbers first; the chart only holds today's top SCAN_DEPTH, so a
+    // game must already rank to appear — this surfaces climbers within that set.
+    rows.sort((a, b) => b.rankChange - a.rankChange);
+    return rows.slice(0, limit);
+  },
+});

--- a/clis/appmagic/publisher.js
+++ b/clis/appmagic/publisher.js
@@ -1,0 +1,89 @@
+// appmagic publisher — publisher profile and portfolio size.
+//
+// Strategy: PUBLIC_API. Contract: stable. POST /api/v2/united-publishers/search-by-ids
+// with {"ids":[{store, store_publisher_id}]} replays 200 + JSON, no auth.
+// See utils.js for the full note.
+//
+// The id is the one in the appmagic URL: /publisher/openai-opco-llc/2_1684349733
+// -> pass "2_1684349733". Find one with `opencli appmagic search <name>
+// --kind publisher`, whose unitedId column is already in this format.
+//
+// PERIOD: downloads/revenue here are TRAILING 30 DAYS — NOT lifetime, which the
+// site shows behind a separate toggle. The column names are period-neutral by
+// convention across this site's adapters, so this comment and the command
+// description are where the window is stated.
+//
+// Values are BUCKETED, and are a min/max pair because the buckets are
+// open-ended on one side and the direction varies per row ("> 50,000,000" vs
+// "< $5,000" vs "—"). See decodeBucket() in utils.js.
+// Exact per-period figures are premium-only (POST /api/v2/charts/publishers
+// returns 401 even for a logged-in free account).
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { decodeBucket, DOMAIN, STORES, postJson } from './utils.js';
+
+// The publisher id embeds its own store prefix, e.g. "2_1684349733" or
+// "1_Meta Platforms, Inc.". The suffix is free-form, so only split on the first
+// underscore.
+function parsePublisherId(raw) {
+  const match = /^(\d+)_(.+)$/s.exec(raw);
+  if (!match) {
+    throw new ArgumentError(`publisherId must look like "<store>_<id>", e.g. 2_1684349733 — got "${raw}". Find one with: opencli appmagic search <name> --kind publisher`);
+  }
+  const store = Number(match[1]);
+  if (!Object.values(STORES).includes(store)) {
+    throw new ArgumentError(`Unknown store prefix "${store}" in "${raw}". Valid prefixes: ${Object.values(STORES).sort().join(', ')}`);
+  }
+  return { store, store_publisher_id: match[2] };
+}
+
+cli({
+  site: 'appmagic',
+  name: 'publisher',
+  description: 'Publisher profile: app count, HQ, LinkedIn headcount. Downloads/revenue are bucketed ranges over the trailing 30 days, not lifetime',
+  access: 'read',
+  example: 'opencli appmagic publisher 2_1684349733',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'publisherId', type: 'string', required: true, positional: true, help: 'Store-prefixed id from the appmagic URL, e.g. 2_1684349733' },
+  ],
+  columns: ['id', 'name', 'appCount', 'storeListingCount', 'downloadsMin', 'downloadsMax', 'revenueMin', 'revenueMax', 'headquarter', 'linkedinHeadcount', 'firstReleaseDate', 'url'],
+  func: async (args) => {
+    const raw = String(args.publisherId ?? '').trim();
+    if (raw === '') throw new ArgumentError('publisherId must not be empty');
+
+    const payload = await postJson('/united-publishers/search-by-ids', { ids: [parsePublisherId(raw)] }, 'publisher');
+    const found = Array.isArray(payload?.data) ? payload.data : [];
+    if (found.length === 0 || !found[0]?.name) {
+      throw new EmptyResultError('appmagic publisher', `no publisher matches "${raw}"`);
+    }
+
+    return found.map((p) => {
+      const downloads = decodeBucket(p?.downloads);
+      const revenue = decodeBucket(p?.revenue);
+      return {
+      id: p?.id ?? null,
+      name: p?.name ?? null,
+      // `united_apps` is what the site's publisher page labels "Apps" (verified:
+      // 3 for OpenAI, matching the UI). `apps` counts store listings instead —
+      // 5 for the same publisher — so it gets the explicit name.
+      appCount: p?.united_apps ?? null,
+      storeListingCount: p?.apps ?? null,
+      downloadsMin: downloads.min,
+      downloadsMax: downloads.max,
+      revenueMin: revenue.min,
+      revenueMax: revenue.max,
+      headquarter: p?.headquarter || null,
+      linkedinHeadcount: p?.linkedin_headcount ?? null,
+      firstReleaseDate: p?.min_release_date ?? null,
+      url: p?.url || null,
+      };
+    });
+    // Not surfaced: a country count. The page shows "Countries 72" for OpenAI
+    // while the response carries countries=161 and dataCountries=118; neither
+    // matches, and no field reproduces the UI figure, so reporting one would be
+    // a number the site itself contradicts.
+  },
+});

--- a/clis/appmagic/search.js
+++ b/clis/appmagic/search.js
@@ -1,0 +1,113 @@
+// appmagic search — find an app or a publisher by name.
+//
+// Strategy: PUBLIC_API. Contract: stable. GET /api/v2/search?name=chatgpt&limit=20
+// replays 200 + JSON with real results, no auth. See utils.js for the full note.
+//
+// PERIOD: downloads/revenue here are TRAILING 30 DAYS — not lifetime, and not
+// the caller's choice (this endpoint has no period argument). Verified by
+// toggling the app page's Last 30 days / Lifetime switch: for
+// com.ig.wool.rescue the API's revenue=1 / downloads=10000 render as "< $5,000"
+// / "> 10,000" under Last 30 days, while Lifetime shows a different "> $50,000"
+// / "> 500,000". The column names are period-neutral by convention across this
+// site's adapters, so this comment and the command description are where the
+// 30-day window is stated. No adapter here exposes a lifetime figure.
+//
+// Values are BUCKETED, never exact. Each metric is a min/max pair because the
+// site's buckets are open-ended on one side and the direction varies per row —
+// see decodeBucket() in utils.js:
+//   "> $500,000" -> revenueMin 500000, revenueMax null
+//   "< $5,000"   -> revenueMin null,   revenueMax 5000
+//   "—"          -> both null (no data)
+// Exact figures are premium-only (POST /api/v2/charts/*, 401 even when logged
+// in), so they are not available through any adapter here.
+//
+// The response mixes two entity kinds under one query, so `kind` is the first
+// column and rows of both kinds share the schema.
+//
+// `storeListingCount` is the response's `apps` field, which counts store
+// listings, NOT distinct apps: Snapchat reports apps=4 with store_ids
+// [2_447188370, 1_com.snapchat.android, 3_447188370, 1_me.sna.android] while
+// the site's own header says "3 APPS" (its 3 distinct store_application_ids).
+// Hence the explicit name rather than a bare `appCount`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { decodeBucket, DOMAIN, getJson, normalizeLimit } from './utils.js';
+
+const MAX_LIMIT = 100;
+const KINDS = ['all', 'app', 'publisher'];
+
+cli({
+  site: 'appmagic',
+  name: 'search',
+  description: 'Search apps and publishers by name. Downloads/revenue are bucketed ranges over the trailing 30 days, not exact and not lifetime',
+  access: 'read',
+  example: 'opencli appmagic search chatgpt --kind app',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'query', type: 'string', required: true, positional: true, help: 'App or publisher name to search for' },
+    { name: 'kind', type: 'string', default: 'all', help: 'Filter results: all / app / publisher' },
+    { name: 'limit', type: 'int', default: 20, help: `Number of results (max ${MAX_LIMIT})` },
+  ],
+  columns: ['kind', 'id', 'name', 'publisher', 'storeListingCount', 'downloadsMin', 'downloadsMax', 'revenueMin', 'revenueMax', 'headquarter', 'unitedId'],
+  func: async (args) => {
+    const query = String(args.query ?? '').trim();
+    if (query === '') throw new ArgumentError('query must not be empty');
+
+    const kind = String(args.kind ?? 'all').toLowerCase();
+    if (!KINDS.includes(kind)) {
+      throw new ArgumentError(`Unknown kind "${kind}". Valid: ${KINDS.join(', ')}`);
+    }
+
+    const limit = normalizeLimit(args.limit, 20, MAX_LIMIT);
+
+    const payload = await getJson('/search', { name: query, limit }, 'search');
+
+    const rows = [];
+    if (kind !== 'publisher') {
+      for (const app of payload?.applications ?? []) {
+        const downloads = decodeBucket(app?.downloads);
+        const revenue = decodeBucket(app?.revenue);
+        rows.push({
+          kind: 'app',
+          id: app?.id ?? null,
+          name: app?.name ?? null,
+          publisher: app?.unitedPublisher?.name || app?.publisher_name || null,
+          storeListingCount: app?.apps ?? null,
+          downloadsMin: downloads.min,
+          downloadsMax: downloads.max,
+          revenueMin: revenue.min,
+          revenueMax: revenue.max,
+          headquarter: app?.unitedPublisher?.headquarter || null,
+          unitedId: app?.id != null ? String(app.id) : null,
+        });
+      }
+    }
+    if (kind !== 'app') {
+      for (const pub of payload?.publishers ?? []) {
+        const downloads = decodeBucket(pub?.downloads);
+        const revenue = decodeBucket(pub?.revenue);
+        rows.push({
+          kind: 'publisher',
+          id: pub?.id ?? null,
+          name: pub?.name ?? null,
+          publisher: null,
+          storeListingCount: pub?.apps ?? null,
+          downloadsMin: downloads.min,
+          downloadsMax: downloads.max,
+          revenueMin: revenue.min,
+          revenueMax: revenue.max,
+          headquarter: pub?.headquarter || null,
+          // store_ids look like "2_1684349733" — feed one straight to
+          // `opencli appmagic publisher <id>`.
+          unitedId: Array.isArray(pub?.store_ids) ? (pub.store_ids[0] ?? null) : null,
+        });
+      }
+    }
+
+    if (rows.length === 0) throw new EmptyResultError('appmagic search', `no ${kind === 'all' ? 'app or publisher' : kind} matches "${query}"`);
+
+    return rows.slice(0, limit);
+  },
+});

--- a/clis/appmagic/tags.js
+++ b/clis/appmagic/tags.js
@@ -1,0 +1,54 @@
+// appmagic tags — the tag taxonomy that `top-charts --tag` filters on.
+//
+// Strategy: PUBLIC_API. Contract: stable. GET /api/v2/tags replays 200 + JSON
+// with the full 1494-tag catalog, no auth. See utils.js for the full note.
+//
+// The endpoint has no server-side search or paging — it returns the whole
+// catalog every call — so --query and --type filter client-side.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, getJson, normalizeLimit } from './utils.js';
+
+const MAX_LIMIT = 500;
+
+cli({
+  site: 'appmagic',
+  name: 'tags',
+  description: 'Tag taxonomy (games / apps / themes / ip / features ...). Use a tag id or name with top-charts --tag',
+  access: 'read',
+  example: 'opencli appmagic tags --query messenger',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'query', type: 'string', default: '', help: 'Filter by name substring, case-insensitive' },
+    { name: 'type', type: 'string', default: '', help: 'Filter by type: games / apps / themes / ip / features / settings / artstyles / meta / complexity / domain' },
+    { name: 'limit', type: 'int', default: 50, help: `Number of tags (max ${MAX_LIMIT})` },
+  ],
+  columns: ['id', 'name', 'type', 'parentIds'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 50, MAX_LIMIT);
+    const query = String(args.query ?? '').trim().toLowerCase();
+    const type = String(args.type ?? '').trim().toLowerCase();
+
+    const payload = await getJson('/tags', {}, 'tags');
+    let all = Array.isArray(payload?.data) ? payload.data : [];
+    if (all.length === 0) throw new EmptyResultError('appmagic tags', 'tag catalog is empty');
+
+    if (query !== '') all = all.filter((t) => String(t?.name ?? '').toLowerCase().includes(query));
+    if (type !== '') all = all.filter((t) => String(t?.type ?? '').toLowerCase() === type);
+
+    if (all.length === 0) {
+      const filters = [query && `query "${query}"`, type && `type "${type}"`].filter(Boolean).join(' + ');
+      throw new EmptyResultError('appmagic tags', `no tag matches ${filters}`);
+    }
+
+    return all.slice(0, limit).map((t) => ({
+      id: t?.id ?? null,
+      name: t?.name ?? null,
+      type: t?.type ?? null,
+      // parent_ids is a '-'-joined string of tag ids; '' means a root tag.
+      parentIds: String(t?.parent_ids ?? '') || null,
+    }));
+  },
+});

--- a/clis/appmagic/top-chart-tags.js
+++ b/clis/appmagic/top-chart-tags.js
@@ -1,0 +1,105 @@
+// appmagic top-chart-tags — the tags you can slice the charts by, with sizes.
+//
+// Strategy: PUBLIC_API. Contract: stable. GET /api/v2/tags returns the full
+// taxonomy, and each tag's `score` field IS its app count (verified: it equals
+// GET /api/v2/tags/apps-count for all 1273 tags present there, and matches the
+// number the top-charts filter dropdown prints next to each tag). One call.
+//
+// This is the discovery companion to `top-charts --tag` and the game commands'
+// `--genre`: it lists every tag those flags accept, grouped by the same sections
+// the site's filter picker uses (DOMAINS / SUPERGENRES / GAMES / ART STYLES /
+// THEMES / FEATURES / IP / SETTINGS / ...), sorted biggest-first so you can see
+// which slices are large enough to be worth charting. The appCount doubles as a
+// market-saturation read (how many apps carry the tag).
+//
+// vs the `tags` command: `tags` is a raw id-by-name lookup; this adds the app
+// count, the UI group label, a minimum-size filter, and size sorting — the view
+// you want when choosing a filter rather than resolving one known name.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, getJson, normalizeLimit } from './utils.js';
+
+// tag `type` -> the section label the top-charts filter dropdown groups it under.
+const TYPE_GROUP = {
+  domain: 'DOMAINS',
+  meta: 'SUPERGENRES',
+  games: 'GAMES',
+  apps: 'APP CATEGORIES',
+  artstyles: 'ART STYLES',
+  themes: 'THEMES',
+  features: 'FEATURES',
+  ip: 'IP',
+  settings: 'SETTINGS',
+  complexity: 'COMPLEXITY',
+};
+
+const TYPES = Object.keys(TYPE_GROUP);
+const SORTS = ['size', 'name'];
+const MAX_LIMIT = 500;
+
+cli({
+  site: 'appmagic',
+  name: 'top-chart-tags',
+  description: 'Tags you can filter top-charts (--tag) and game commands (--genre) by, with app counts, grouped and sized',
+  access: 'read',
+  example: 'opencli appmagic top-chart-tags --type games --min-apps 1000',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'type', type: 'string', default: '', help: `Filter by type: ${TYPES.join(' / ')}. Default: all` },
+    { name: 'query', type: 'string', default: '', help: 'Name substring, case-insensitive' },
+    { name: 'min-apps', type: 'int', default: 0, help: 'Only tags carried by at least this many apps (hide the long tail)' },
+    { name: 'sort', type: 'string', default: 'size', help: 'size (most apps first) or name (A-Z)' },
+    { name: 'limit', type: 'int', default: 50, help: `Number of tags (max ${MAX_LIMIT})` },
+  ],
+  columns: ['group', 'type', 'name', 'tagId', 'appCount', 'parentIds'],
+  func: async (args) => {
+    const limit = normalizeLimit(args.limit, 50, MAX_LIMIT);
+
+    const type = String(args.type ?? '').trim().toLowerCase();
+    if (type !== '' && !TYPES.includes(type)) {
+      throw new ArgumentError(`Unknown type "${type}". Valid: ${TYPES.join(', ')}`);
+    }
+
+    const query = String(args.query ?? '').trim().toLowerCase();
+
+    const minApps = Number(args['min-apps'] ?? 0);
+    if (!Number.isInteger(minApps) || minApps < 0) throw new ArgumentError('min-apps must be a non-negative integer');
+
+    const sort = String(args.sort ?? 'size').toLowerCase();
+    if (!SORTS.includes(sort)) throw new ArgumentError(`Unknown sort "${sort}". Valid: ${SORTS.join(', ')}`);
+
+    const catalog = await getJson('/tags', {}, 'top-chart-tags');
+    let all = Array.isArray(catalog?.data) ? catalog.data : [];
+    if (all.length === 0) throw new EmptyResultError('appmagic top-chart-tags', 'tag catalog is empty');
+
+    // Only keep tag types the top-charts filter actually groups by (excludes
+    // internal/analytics tag types that are not offered as chart filters).
+    all = all.filter((t) => TYPE_GROUP[t?.type] !== undefined);
+
+    if (type !== '') all = all.filter((t) => t.type === type);
+    if (query !== '') all = all.filter((t) => String(t?.name ?? '').toLowerCase().includes(query));
+    if (minApps > 0) all = all.filter((t) => Number(t?.score ?? 0) >= minApps);
+
+    if (all.length === 0) {
+      const filters = [type && `type "${type}"`, query && `query "${query}"`, minApps > 0 && `>= ${minApps} apps`].filter(Boolean).join(' + ');
+      throw new EmptyResultError('appmagic top-chart-tags', `no filter tag matches ${filters}`);
+    }
+
+    all.sort(sort === 'name'
+      ? (a, b) => String(a.name).localeCompare(String(b.name))
+      : (a, b) => Number(b?.score ?? 0) - Number(a?.score ?? 0));
+
+    return all.slice(0, limit).map((t) => ({
+      group: TYPE_GROUP[t.type],
+      type: t.type,
+      name: t.name ?? null,
+      tagId: t.id ?? null,
+      // score is the app count carrying this tag (verified == tags/apps-count).
+      appCount: t.score ?? null,
+      // '-'-joined parent tag ids; '' means a root/top-level filter.
+      parentIds: String(t?.parent_ids ?? '') || null,
+    }));
+  },
+});

--- a/clis/appmagic/top-charts.js
+++ b/clis/appmagic/top-charts.js
@@ -1,0 +1,120 @@
+// appmagic top-charts — app ranking: top free / top grossing / top featuring.
+//
+// Strategy: PUBLIC_API. Contract: stable. See utils.js for the full note.
+// Evidence: GET /api/v2/top/united-apps?aggregation=month&topDepth=100&store=5
+// &country=WW&date=2026-07-01 replays 200 + JSON with real data, no auth.
+//
+// Metric availability (probed 2026-07-17, identical anonymous and logged in).
+// The API returns the downloads/revenue/featuring fields ONLY for:
+//   store=all AND country=WW AND aggregation in {month, year}
+// Every other combination (any single store, any single country, day/week/
+// quarter) returns the ranking with the metric field absent entirely. That is
+// an API characteristic, not an auth failure and not a parse bug, so the metric
+// columns report null rather than a faked or clamped number. Ranks themselves
+// are valid for every combination.
+//
+// Downloads/revenue are BUCKETED, not exact: the web UI renders these very
+// numbers as "> 20,000,000" / "> $50,000,000", and ranks 1-5 all report an
+// identical 20000000. They are reported as a min/max pair because the bucket is
+// open-ended on one side and the direction varies per row — see decodeBucket()
+// in utils.js. Exact time series lives behind POST /api/v2/charts/applications,
+// which is 401 even for a logged-in free account.
+// `featuring` is a real exact count, not a bucket.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { decodeBucket, DOMAIN, getJson, normalizeCountry, normalizeLimit, resolveStore, resolveTag } from './utils.js';
+
+const AGGREGATIONS = ['day', 'week', 'month', 'quarter', 'year'];
+const MAX_TOP_DEPTH = 100; // topDepth=200 and above -> HTTP 400
+
+function pickApp(entry) {
+  const app = entry?.application;
+  return {
+    name: app?.name ?? null,
+    publisher: app?.publisher?.name ?? null,
+  };
+}
+
+cli({
+  site: 'appmagic',
+  name: 'top-charts',
+  description: 'App rankings: top free / top grossing / top featuring. Downloads and revenue are bucketed lower bounds',
+  access: 'read',
+  example: 'opencli appmagic top-charts --tag Messenger --limit 20',
+  domain: DOMAIN,
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    { name: 'store', type: 'string', default: 'all', help: 'all / ios / iphone / ipad / google-play. Metrics only present for "all"' },
+    { name: 'country', type: 'string', default: 'WW', help: 'ISO code, e.g. US / VN / JP. WW = worldwide. Metrics only present for WW' },
+    { name: 'date', type: 'string', default: '', help: 'Period start, YYYY-MM-DD. Default: current month' },
+    { name: 'aggregation', type: 'string', default: 'month', help: 'day / week / month / quarter / year. Metrics only present for month / year' },
+    { name: 'tag', type: 'string', default: '', help: 'Filter by one tag id or name, e.g. 104 or "Messenger". Discover with: opencli appmagic tags' },
+    { name: 'limit', type: 'int', default: 20, help: `Number of ranks (max ${MAX_TOP_DEPTH})` },
+  ],
+  columns: [
+    'rank',
+    'freeApp', 'freePublisher', 'downloadsMin', 'downloadsMax',
+    'grossingApp', 'grossingPublisher', 'revenueMin', 'revenueMax',
+    'featuringApp', 'featuringPublisher', 'featuring',
+  ],
+  func: async (args) => {
+    const store = resolveStore(args.store ?? 'all');
+    const country = normalizeCountry(args.country);
+    const limit = normalizeLimit(args.limit, 20, MAX_TOP_DEPTH);
+
+    const aggregation = String(args.aggregation ?? 'month').toLowerCase();
+    if (!AGGREGATIONS.includes(aggregation)) {
+      throw new ArgumentError(`Unknown aggregation "${aggregation}". Valid: ${AGGREGATIONS.join(', ')}`);
+    }
+
+    let date = String(args.date ?? '').trim();
+    if (date === '') {
+      const now = new Date();
+      date = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`;
+    } else if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new ArgumentError(`date must be YYYY-MM-DD, got "${date}"`);
+    }
+
+    const params = { aggregation, topDepth: limit, store, country, date };
+
+    const tagInput = String(args.tag ?? '').trim();
+    if (tagInput !== '') {
+      // Only one tag is honoured: `tag=104,101` and a repeated tag param both
+      // return output byte-identical to `tag=104` alone, so extra values would
+      // be silently dropped. Reject instead of pretending to filter.
+      if (/[,;]/.test(tagInput)) {
+        throw new ArgumentError('tag accepts a single tag only — the API silently ignores extra tags');
+      }
+      params.tag = await resolveTag(tagInput);
+    }
+
+    const payload = await getJson('/top/united-apps', params, 'top-charts');
+    const entries = Array.isArray(payload?.data) ? payload.data : [];
+    if (entries.length === 0) {
+      throw new EmptyResultError('appmagic top-charts', `no ranking for ${country} / ${aggregation} / ${date}${tagInput ? ` / tag ${tagInput}` : ''}`);
+    }
+
+    return entries.slice(0, limit).map((entry, i) => {
+      const free = pickApp(entry?.top_free);
+      const grossing = pickApp(entry?.top_grossing);
+      const featuring = pickApp(entry?.top_featuring);
+      const downloads = decodeBucket(entry?.top_free?.downloads);
+      const revenue = decodeBucket(entry?.top_grossing?.revenue);
+      return {
+        rank: i + 1,
+        freeApp: free.name,
+        freePublisher: free.publisher,
+        downloadsMin: downloads.min,
+        downloadsMax: downloads.max,
+        grossingApp: grossing.name,
+        grossingPublisher: grossing.publisher,
+        revenueMin: revenue.min,
+        revenueMax: revenue.max,
+        featuringApp: featuring.name,
+        featuringPublisher: featuring.publisher,
+        featuring: entry?.top_featuring?.featuring ?? null,
+      };
+    });
+  },
+});

--- a/clis/appmagic/utils.js
+++ b/clis/appmagic/utils.js
@@ -1,0 +1,177 @@
+// Shared helpers for the appmagic adapters.
+//
+// Strategy note (recorded 2026-07-17): every endpoint used by this site's
+// adapters is PUBLIC_API / contract: stable. Node-side fetch with no cookie and
+// no Authorization header returns 200 + JSON on all of them:
+//   GET  /api/v2/top/united-apps        (top-charts)
+//   GET  /api/v2/tags                   (tags)
+//   GET  /api/v2/search                 (search)
+//   POST /api/v2/applications/app-info            (app)
+//   POST /api/v2/applications/app-info/releases   (app --releases)
+//   POST /api/v2/united-publishers/search-by-ids  (publisher)
+// Sending the browser's cookies changes nothing, so no adapter needs browser:true.
+//
+// Deliberately NOT wrapped: POST /api/v2/charts/* (exact download/revenue time
+// series). Those return 401 even for a logged-in free account — they are
+// premium-only, not a bug to route around.
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const BASE = 'https://appmagic.rocks/api/v2';
+export const DOMAIN = 'appmagic.rocks';
+
+// Store codes read off the bundle's `unitedStoresMap={5:[1,2,3],4:[2,3]}`.
+// store=0 and store=6 return HTTP 400, confirming the enum is 1..5.
+export const STORES = {
+  all: 5,          // united: Google Play + iPhone + iPad
+  ios: 4,          // united Apple: iPhone + iPad
+  iphone: 2,
+  ipad: 3,
+  'google-play': 1,
+};
+
+// app-info addresses a single concrete store listing, so the united pseudo-
+// stores (all / ios) are not selectable there.
+export const APP_STORES = ['iphone', 'ipad', 'google-play'];
+
+// Mirrors the site's own getStoreFromAppId: a numeric id is an Apple id,
+// anything else is a Google Play package name.
+export function inferStoreKey(storeArg, appId) {
+  const explicit = String(storeArg ?? '').trim();
+  if (explicit !== '') return explicit.toLowerCase();
+  return /^\d+$/.test(appId) ? 'iphone' : 'google-play';
+}
+
+export function resolveStore(value, { allow } = {}) {
+  const key = String(value ?? '').toLowerCase();
+  const valid = allow ?? Object.keys(STORES);
+  if (!valid.includes(key)) {
+    throw new ArgumentError(`Unknown store "${key}". Valid: ${valid.join(', ')}`);
+  }
+  return STORES[key];
+}
+
+export function normalizeLimit(value, fallback, max) {
+  const n = Number(value ?? fallback);
+  if (!Number.isInteger(n) || n <= 0) throw new ArgumentError('limit must be a positive integer');
+  if (n > max) throw new ArgumentError(`limit must be <= ${max}`);
+  return n;
+}
+
+export function normalizeCountry(value, fallback = 'WW') {
+  const country = String(value ?? fallback).toUpperCase();
+  if (!/^[A-Z0-9]{2}$/.test(country)) {
+    throw new ArgumentError(`country must be a 2-letter code (e.g. US, VN, WW), got "${country}"`);
+  }
+  return country;
+}
+
+// Free-tier downloads/revenue are bucketed, and the bucket is encoded in the
+// number itself. Decoded from the site's own `formatPremiumValues` pipe
+// (bundle main-*.js @1546984), which renders the same fields in the UI:
+//
+//   transform(r, i='', f='—', c=false, u=false) {
+//     if (!r) return f;                                   // 0 -> "—"
+//     let e = i, t = r;
+//     return !u && (!this.userService.isPremium() || c) &&
+//       (t === 1 ? (t = 5e3, e = '< ' + e)                // 1 -> "< 5,000"
+//                : e = '> ' + e),                         // V -> "> V"
+//       e + t.toLocaleString(...)
+//   }
+//
+// So the raw number is NOT the value: 0 means "no data" (rendered as an em
+// dash), 1 is a sentinel meaning "nonzero but under 5,000", and anything else
+// is a lower bound. Verified against the live UI for query "knit away":
+// revenue 500000 -> "> $500,000", revenue 1 -> "< $5,000", revenue 0 -> "—".
+// Returning the raw number would report a $5,000-floor app as earning $1 and a
+// no-data app as earning $0.
+export const BUCKET_SENTINEL_CEILING = 5000;
+
+export function decodeBucket(value) {
+  if (value == null || value === 0) return { min: null, max: null };
+  if (value === 1) return { min: null, max: BUCKET_SENTINEL_CEILING };
+  return { min: value, max: null };
+}
+
+async function request(url, init, label) {
+  let resp;
+  try {
+    resp = await fetch(url, {
+      ...init,
+      headers: { 'User-Agent': 'Mozilla/5.0', Accept: 'application/json', ...(init?.headers ?? {}) },
+    });
+  } catch (error) {
+    throw new CommandExecutionError(`appmagic ${label} request failed: ${error?.message || error}`);
+  }
+  if (resp.status === 400) {
+    throw new ArgumentError(`appmagic rejected the ${label} query (HTTP 400) — check the store / country / id arguments`);
+  }
+  // appmagic uses 401/403 exclusively for its paywall, never for a malformed
+  // request (that is always a 400). Surfacing it as AuthRequiredError gives
+  // callers exit code 77 instead of a generic failure they might retry forever.
+  if (resp.status === 401 || resp.status === 403) {
+    throw new AuthRequiredError(DOMAIN, `appmagic ${label} needs a premium plan (HTTP ${resp.status})`);
+  }
+  if (!resp.ok) {
+    throw new CommandExecutionError(`appmagic ${label} request failed: HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export function getJson(path, params, label) {
+  const url = new URL(`${BASE}${path}`);
+  for (const [k, v] of Object.entries(params ?? {})) url.searchParams.set(k, String(v));
+  return request(url, {}, label);
+}
+
+export function postJson(path, body, label) {
+  return request(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }, label);
+}
+
+export const GAMES_DOMAIN_TAG = { id: 3, name: 'Games' };
+
+// From an app's tag list, pick the single genre a competitive comparison should
+// use. Prefer the MOST SPECIFIC games-type tag (the leaf: a games tag that is
+// not the parent of any other games tag on this app), because the tightest
+// genre gives the closest competitive field. Falls back to the "Games" domain
+// tag when the app carries no games-type sub-genre. Callers surface the chosen
+// genre so the user can re-run with a broader/narrower --genre.
+export function pickGamesGenre(tags) {
+  const games = (Array.isArray(tags) ? tags : []).filter((t) => t?.type === 'games');
+  if (games.length === 0) return { ...GAMES_DOMAIN_TAG };
+
+  const parentIds = new Set();
+  for (const t of games) {
+    // parent_ids arrives as an array (search-by-ids) or a "-"-joined string
+    // (top charts). Normalise both into ids.
+    const raw = t?.parent_ids;
+    const ids = Array.isArray(raw) ? raw : String(raw ?? '').split('-');
+    for (const id of ids) if (String(id).trim() !== '') parentIds.add(String(id).trim());
+  }
+  // A leaf is a games tag that no other games tag lists as a parent.
+  const leaves = games.filter((t) => !parentIds.has(String(t.id)));
+  const chosen = (leaves.length > 0 ? leaves : games).reduce((a, b) => (Number(b.id) > Number(a.id) ? b : a));
+  return { id: chosen.id, name: chosen.name };
+}
+
+// The API takes numeric tag ids; accept a human tag name too so callers do not
+// have to memorise 1494 ids.
+export async function resolveTag(value) {
+  if (/^\d+$/.test(value)) return value;
+
+  const catalog = await getJson('/tags', {}, 'tag lookup');
+  const all = Array.isArray(catalog?.data) ? catalog.data : [];
+  const hits = all.filter((t) => String(t?.name ?? '').toLowerCase() === value.toLowerCase());
+
+  if (hits.length === 0) {
+    throw new ArgumentError(`Unknown tag "${value}". Browse ids and names with: opencli appmagic tags --query ${value}`);
+  }
+  if (hits.length > 1) {
+    const options = hits.map((t) => `${t.id} (${t.type})`).join(', ');
+    throw new ArgumentError(`Tag "${value}" is ambiguous — pass one of these ids: ${options}`);
+  }
+  return String(hits[0].id);
+}

--- a/clis/appmagic/utils.test.js
+++ b/clis/appmagic/utils.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { BUCKET_SENTINEL_CEILING, decodeBucket, GAMES_DOMAIN_TAG, pickGamesGenre } from './utils.js';
+
+// appmagic encodes the bucket DIRECTION inside the number itself, so the raw
+// value is not the value: 0 means "no data" (the UI renders an em dash) and 1
+// means "nonzero but under 5,000" (the UI renders "< 5,000"). A "simplification"
+// back to the raw number silently reports a no-data app as earning 0 and a
+// sub-$5,000 app as earning $1 — plausible-looking and wrong. Expectations are
+// pinned to values observed live for the search query "knit away".
+describe('decodeBucket (free-tier bucket encoding)', () => {
+  it('treats 0 as "no data", not zero', () => {
+    expect(decodeBucket(0)).toEqual({ min: null, max: null });
+  });
+
+  it('treats a missing field as "no data"', () => {
+    expect(decodeBucket(null)).toEqual({ min: null, max: null });
+    expect(decodeBucket(undefined)).toEqual({ min: null, max: null });
+  });
+
+  it('treats 1 as the "< 5,000" sentinel — an UPPER bound, not $1', () => {
+    // Live: "Wool Sort: Knit Away" revenue=1 renders as "< $5,000".
+    expect(decodeBucket(1)).toEqual({ min: null, max: BUCKET_SENTINEL_CEILING });
+    expect(BUCKET_SENTINEL_CEILING).toBe(5000);
+  });
+
+  it('treats any other value as a LOWER bound', () => {
+    // Live: "Wool Crush" revenue=500000 -> "> $500,000"; downloads=2000000 -> "> 2,000,000".
+    expect(decodeBucket(500000)).toEqual({ min: 500000, max: null });
+    expect(decodeBucket(2000000)).toEqual({ min: 2000000, max: null });
+    // The bucket edge itself is a lower bound, NOT the 1-sentinel.
+    expect(decodeBucket(5000)).toEqual({ min: 5000, max: null });
+  });
+
+  it('never sets both bounds (buckets are open-ended on one side)', () => {
+    for (const raw of [0, 1, 5000, 10000, 500000, 2000000, 20000000]) {
+      const { min, max } = decodeBucket(raw);
+      expect(min === null || max === null).toBe(true);
+    }
+  });
+
+  it('decodes the full "knit away" search panel as the UI renders it', () => {
+    const rows = [
+      { revenue: 500000, expect: { min: 500000, max: null } }, // "> $500,000"
+      { revenue: 200000, expect: { min: 200000, max: null } }, // "> $200,000"
+      { revenue: 50000, expect: { min: 50000, max: null } }, // "> $50,000"
+      { revenue: 1, expect: { min: null, max: 5000 } }, // "< $5,000"
+      { revenue: 0, expect: { min: null, max: null } }, // "—"
+    ];
+    for (const row of rows) expect(decodeBucket(row.revenue)).toEqual(row.expect);
+  });
+});
+
+// pickGamesGenre chooses the tightest competitive genre from an app's tags: the
+// leaf games-type tag (one no other games tag lists as a parent), falling back
+// to the Games domain when the app has no games sub-genre.
+describe('pickGamesGenre (competitive genre selection)', () => {
+  it('falls back to the Games domain when there is no games sub-genre', () => {
+    expect(pickGamesGenre([{ id: 9, name: 'Apps', type: 'domain' }])).toEqual(GAMES_DOMAIN_TAG);
+    expect(pickGamesGenre([])).toEqual(GAMES_DOMAIN_TAG);
+    expect(pickGamesGenre(null)).toEqual(GAMES_DOMAIN_TAG);
+  });
+
+  it('picks the leaf (most specific) games tag over its ancestors', () => {
+    // Wool Sort: Knit Away's real chain — 78 Puzzle -> 243367 Block Puzzle ->
+    // 243820 Slide -> 243881 Slide: Other. The leaf is "Slide: Other".
+    const tags = [
+      { id: 3, name: 'Games', type: 'domain', parent_ids: [] },
+      { id: 78, name: 'Puzzle', type: 'games', parent_ids: [] },
+      { id: 243367, name: 'Block Puzzle', type: 'games', parent_ids: [78] },
+      { id: 243820, name: 'Slide', type: 'games', parent_ids: [243367] },
+      { id: 243881, name: 'Slide: Other', type: 'games', parent_ids: [243820] },
+      { id: 243425, name: 'Stylized', type: 'artstyles', parent_ids: [] },
+    ];
+    expect(pickGamesGenre(tags)).toEqual({ id: 243881, name: 'Slide: Other' });
+  });
+
+  it('accepts a "-"-joined parent_ids string (top-charts shape)', () => {
+    const tags = [
+      { id: 78, name: 'Puzzle', type: 'games', parent_ids: '' },
+      { id: 243367, name: 'Block Puzzle', type: 'games', parent_ids: '78' },
+    ];
+    expect(pickGamesGenre(tags)).toEqual({ id: 243367, name: 'Block Puzzle' });
+  });
+});

--- a/docs/adapters/browser/appmagic.md
+++ b/docs/adapters/browser/appmagic.md
@@ -1,0 +1,78 @@
+# AppMagic
+
+**Mode**: 🌐 Public · **Domain**: `appmagic.rocks`
+
+Mobile app & game market intelligence from [AppMagic](https://appmagic.rocks) — top charts, app/publisher lookup, competitor and genre discovery, and "rising star" detection. All commands are public (no login) and fetch JSON directly; none drive the browser.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli appmagic top-charts` | App rankings (top free / grossing / featuring) filtered by tag, store, country, period |
+| `opencli appmagic top-chart-tags` | The tags `top-charts --tag` and `game-* --genre` accept, grouped and sized by app count |
+| `opencli appmagic tags` | Raw tag taxonomy lookup (resolve a tag id by name / type) |
+| `opencli appmagic search` | Find apps and publishers by name |
+| `opencli appmagic app` | Store listing detail for one app |
+| `opencli appmagic app-releases` | Version history for one app, newest first |
+| `opencli appmagic publisher` | Publisher profile and portfolio size |
+| `opencli appmagic app-competitors` | AppMagic's Competitors Dashboard for an app |
+| `opencli appmagic app-sdks` | SDKs / third-party tech detected in an app |
+| `opencli appmagic app-similar` | Apps similar to a given app |
+| `opencli appmagic app-featuring` | Store featuring placements for an app (latest date) |
+| `opencli appmagic game-competitors` | The competitive field around a game: top games in its auto-detected genre |
+| `opencli appmagic game-risers` | Fast-climbing "rising star" games ranked by chart rank-change |
+| `opencli appmagic game-genres` | Genre saturation map: how many games each sub-genre holds |
+
+## Usage Examples
+
+```bash
+# Worldwide top apps this month (downloads / revenue / featuring)
+opencli appmagic top-charts --limit 20
+
+# Top games in a genre, filtered by tag name or id
+opencli appmagic top-charts --tag Messenger --limit 20
+
+# Discover which tags you can filter by, biggest first
+opencli appmagic top-chart-tags --type games --min-apps 5000
+
+# Search apps or publishers
+opencli appmagic search "knit away" --kind app
+opencli appmagic search openai --kind publisher
+
+# One app: listing, version history, competitors, SDKs, similar apps, featuring
+opencli appmagic app com.ig.wool.rescue
+opencli appmagic app-releases com.ig.wool.rescue --limit 10
+opencli appmagic app-competitors com.ig.wool.rescue
+opencli appmagic app-featuring com.snapchat.android
+
+# --- Game market discovery ---
+
+# Who leads your game's genre (genre auto-detected from the seed app)
+opencli appmagic game-competitors com.ig.wool.rescue --chart grossing
+
+# Fast-climbing new games (breakouts): big rank jump + released recently
+opencli appmagic game-risers --genre Puzzle --period month --new-within 12
+
+# How crowded a genre and its sub-genres are, by app count
+opencli appmagic game-genres --genre Puzzle
+```
+
+## Output Columns
+
+- **top-charts**: `rank` · `freeApp` · `freePublisher` · `downloadsMin` · `downloadsMax` · `grossingApp` · `grossingPublisher` · `revenueMin` · `revenueMax` · `featuringApp` · `featuringPublisher` · `featuring`
+- **game-risers**: `chartRank` · `rankChange` · `name` · `publisher` · `hq` · `genre` · `downloadsMin` · `downloadsMax` · `releaseDate` · `ageMonths` · `unitedId`
+- **game-competitors**: `rank` · `name` · `publisher` · `hq` · `downloadsMin` · `downloadsMax` · `rankChange` · `releaseDate` · `isSeed` · `genre` · `unitedId`
+- **game-genres**: `genre` · `subGenre` · `tagId` · `appCount` · `sharePct` · `genreTotal`
+
+Run any command with `--help` for its full option and column list.
+
+## Notes
+
+- **Downloads / revenue are bucketed lower bounds, not exact figures.** The site renders them as `> 20,000,000` / `< $5,000` / `—`, so metrics are exposed as `Min` / `Max` pairs (`0` → both `null` = no data; `1` → `Max: 5000` = "< $5,000"; any other value → `Min` = lower bound). These figures cover the trailing 30 days, not lifetime.
+- **`top-charts` metrics** only populate for `--store all` + `--country WW` + `--aggregation month|year`; other combinations still return valid ranks with `null` metrics.
+- **"Rising star" is rank-change, not % growth.** AppMagic's exact download/revenue growth, new-release feeds, and time-series are premium-gated (HTTP 401/403). The only public growth signal is a chart's rank movement (`diff`), so `game-risers` ranks by that; pair it with `--new-within` for breakout new releases.
+- **Soft paywalls**: `app-competitors` returns ~3 of `competitorTotal` and `app-sdks` returns 1 of `sdkTotal` on the public tier — both surface the true total on every row so the gap is visible.
+
+## Prerequisites
+
+None — all commands are public and require no login or browser extension.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -100,6 +100,7 @@ Run `opencli list` for the live registry.
 | Site                                           | Commands                                                                                                                                       | Mode         |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | **[hackernews](./browser/hackernews.md)**         | `top` `new` `best` `ask` `show` `jobs` `search` `user`                                                                                         | 🌐 Public    |
+| **[appmagic](./browser/appmagic.md)**             | `top-charts` `top-chart-tags` `tags` `search` `app` `app-releases` `publisher` `app-competitors` `app-sdks` `app-similar` `app-featuring` `game-competitors` `game-risers` `game-genres` | 🌐 Public    |
 | **[bbc](./browser/bbc.md)**                       | `news`                                                                                                                                         | 🌐 Public    |
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[juejin](./browser/juejin.md)**                 | `recommend` `hot`                                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
## Summary

Adds a new site adapter for [**appmagic.rocks**](https://appmagic.rocks) — mobile app & game market intelligence. **14 commands, all `PUBLIC_API` (`browser: false`, no login).**

| Group | Commands |
|---|---|
| Charts & discovery | `top-charts` · `top-chart-tags` · `tags` · `search` |
| App detail | `app` · `app-releases` · `publisher` · `app-competitors` · `app-sdks` · `app-similar` · `app-featuring` |
| 🎮 Game market | `game-competitors` · `game-risers` · `game-genres` |

The game commands target a concrete workflow: find a game's competitive field (auto-detected genre leaderboard), surface fast-climbing "rising star" games, and read genre saturation.

## Free-tier honesty (the interesting part)

This site gates most numbers behind a paywall, and the public responses are easy to misread. Each was handled so the CLI never reports a plausible-but-wrong figure:

- **Bucketed metrics.** Downloads/revenue are lower bounds encoded in the raw number — `0` = no data (`—`), `1` = "< 5,000", any other value = a lower bound (`> V`). They're decoded into `Min`/`Max` pairs via `decodeBucket()` rather than returned raw (which would report a sub-$5,000 app as `$1` and a no-data app as `$0`). Unit-tested in `utils.test.js`.
- **"Rising star" = rank movement, not % growth.** Real growth/history/period-comparison endpoints are premium (HTTP 401/403). `game-risers` ranks by the only public growth signal — a chart's rank-change (`diff`) — and says so; it does not fabricate growth. `--new-within` combines it with release date for breakouts.
- **Soft paywalls surface the truncation.** `app-competitors` returns ~3 of `competitorTotal` and `app-sdks` 1 of `sdkTotal` on the free tier; both carry the true total on every row so the gap is visible instead of silent.
- **Typed errors.** Premium endpoints raise `AuthRequiredError` (exit 77); empty results raise `EmptyResultError` (66); bad args raise `ArgumentError` (2).

## Testing

- `npm run build` + `npm run typecheck` — clean
- `check:typed-error-lint` and `check:silent-column-drop` — no new violations
- `npx vitest run clis/appmagic/utils.test.js` — 9/9 pass (`decodeBucket`, `pickGamesGenre`)
- Every command exercised against the live site (happy paths, arg variations, and each typed-error path) — all return the expected exit codes and data

## Notes

- All commands are public; no browser extension or login required.
- Metrics on `top-charts` only populate for `--store all` + `--country WW` + `--aggregation month|year` (an API characteristic); other combinations return valid ranks with `null` metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
