### PR TITLE
[codex] fix extension background window focus steal on macOS

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1447,13 +1447,18 @@ async function ensureOwnedContainerWindowUnlocked(role, initialUrl, mode = "back
     };
   }
   const startUrl = initialUrl && isSafeNavigationUrl(initialUrl) ? initialUrl : BLANK_PAGE;
-  const win = await chrome.windows.create({
+  const createData = mode === "background" ? {
     url: startUrl,
-    focused: mode === "foreground",
+    state: "minimized",
+    type: "normal"
+  } : {
+    url: startUrl,
+    focused: true,
     width: 1280,
     height: 900,
     type: "normal"
-  });
+  };
+  const win = await chrome.windows.create(createData);
   container.windowId = win.id;
   await persistRuntimeState();
   console.log(`[opencli] Created owned ${role} window ${container.windowId} (start=${startUrl})`);

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1252,7 +1252,7 @@ describe('background tab isolation', () => {
     const { chrome, tabs, groups } = createChromeMock();
     let nextWindowId = 20;
     let nextTabId = 200;
-    chrome.windows.create = vi.fn(async ({ url, focused, width, height, type }: any) => {
+    chrome.windows.create = vi.fn(async ({ url, focused, width, height, type, state }: any) => {
       const windowId = nextWindowId++;
       const tab: MockTab = {
         id: nextTabId++,
@@ -1264,7 +1264,7 @@ describe('background tab isolation', () => {
         groupId: -1,
       };
       tabs.push(tab);
-      return { id: windowId, url, focused, width, height, type };
+      return { id: windowId, url, focused, width, height, type, state };
     });
     vi.stubGlobal('chrome', chrome);
 
@@ -1274,8 +1274,18 @@ describe('background tab isolation', () => {
 
     expect(tabs.find((tab) => tab.id === browserTabId)?.windowId).toBe(20);
     expect(tabs.find((tab) => tab.id === adapterTabId)?.windowId).toBe(21);
-    expect(chrome.windows.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ focused: true }));
-    expect(chrome.windows.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ focused: false }));
+    expect(chrome.windows.create).toHaveBeenNthCalledWith(1, {
+      url: 'about:blank',
+      focused: true,
+      width: 1280,
+      height: 900,
+      type: 'normal',
+    });
+    expect(chrome.windows.create).toHaveBeenNthCalledWith(2, {
+      url: 'about:blank',
+      state: 'minimized',
+      type: 'normal',
+    });
     expect(groups).toEqual([
       expect.objectContaining({ windowId: 20, title: 'OpenCLI Browser' }),
     ]);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -993,15 +993,22 @@ async function ensureOwnedContainerWindowUnlocked(
 
   const startUrl = (initialUrl && isSafeNavigationUrl(initialUrl)) ? initialUrl : BLANK_PAGE;
 
-  // Note: Do NOT set `state` parameter here. Chrome 146+ rejects 'normal' as an invalid
-  // state value for windows.create(). The window defaults to 'normal' state anyway.
-  const win = await chrome.windows.create({
-    url: startUrl,
-    focused: mode === 'foreground',
-    width: 1280,
-    height: 900,
-    type: 'normal',
-  });
+  // macOS may activate Chrome even when a new normal window uses focused:false.
+  // Minimized windows cannot include bounds, so size only foreground windows.
+  const createData: chrome.windows.CreateData = mode === 'background'
+    ? {
+        url: startUrl,
+        state: 'minimized',
+        type: 'normal',
+      }
+    : {
+        url: startUrl,
+        focused: true,
+        width: 1280,
+        height: 900,
+        type: 'normal',
+      };
+  const win = await chrome.windows.create(createData);
   container.windowId = win.id!;
   // Persist windowId before any further awaits so a worker crash between
   // `windows.create` returning and the subsequent `tabs.group` call still


### PR DESCRIPTION
## Description

On macOS, creating a normal Chrome window with `focused: false` can still activate Chrome and interrupt the foreground application.

This change creates background owned-container windows directly in the minimized state. It omits bounds for that path because Chrome rejects minimized creation when `left`, `top`, `width`, or `height` are also supplied. Foreground windows retain the existing focused 1280x900 behavior.

The regression test now checks the complete create payload for both modes, and the generated extension bundle is updated.

Related issue: Closes #2167

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the existing project style
- [x] I have performed a self-review
- [x] I have added or updated tests
- [x] New and existing targeted tests pass locally
- [x] The extension production build succeeds
- [x] I have tested the change with a real Chrome extension session

## Screenshots / Output

```text
npx vitest run --project extension extension/src/background.test.ts
Test Files  1 passed (1)
Tests       71 passed (71)

npm run build
dist/background.js  92.53 kB
built successfully
```

Manual macOS verification:

- Started with one user Chrome window and Orca focused.
- Opened `https://example.com/` in a fresh background OpenCLI session.
- Sampled the frontmost application every 50 ms while the command ran.
- Every sample remained `Orca`; the command returned successfully.
- Released the session and removed the probe window afterward.

`npm run typecheck` currently reports seven errors in existing test code. Running the same command against a clean `upstream/main` worktree reports the identical seven errors, so this PR does not add typecheck failures.