### PR TITLE
feat(twitter): add bounded collection command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -37826,6 +37826,52 @@
   },
   {
     "site": "twitter",
+    "name": "collection",
+    "description": "Fetch a user timeline with relationship facts and a bounded completion receipt.",
+    "access": "read",
+    "domain": "x.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "username",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Twitter screen name (with or without @)."
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "required": true,
+        "help": "RFC3339 lower time boundary that must be reached or exhausted."
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10000,
+        "required": false,
+        "help": "Safety ceiling; reaching it is a typed failure."
+      },
+      {
+        "name": "page-delay",
+        "type": "int",
+        "default": 2,
+        "required": false,
+        "help": "Seconds to wait between cursor pages."
+      }
+    ],
+    "columns": [
+      "posts",
+      "receipt"
+    ],
+    "type": "js",
+    "modulePath": "twitter/collection.js",
+    "sourceFile": "twitter/collection.js",
+    "navigateBefore": "https://x.com"
+  },
+  {
+    "site": "twitter",
     "name": "delete",
     "description": "Delete a specific tweet by URL",
     "access": "write",

--- a/clis/twitter/collection.js
+++ b/clis/twitter/collection.js
@@ -1,0 +1,292 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { extractMedia, extractQuotedTweet, normalizeTwitterScreenName } from './shared.js';
+import {
+    DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS,
+    MAX_USER_TWEETS_LIMIT,
+    MAX_USER_TWEETS_PAGES,
+    USER_TWEETS_PAGE_SIZE,
+    fetchUserTimelinePage,
+    resolveUserTimelineContext,
+} from './user-timeline.js';
+
+const RFC3339_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function normalizeUntil(raw) {
+    const value = String(raw ?? '').trim();
+    if (!RFC3339_TIMESTAMP.test(value)) {
+        throw new ArgumentError(
+            'twitter collection --until must be an RFC3339 timestamp',
+            'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z',
+        );
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        throw new ArgumentError(
+            'twitter collection --until must be an RFC3339 timestamp',
+            'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z',
+        );
+    }
+    return parsed;
+}
+
+function normalizeCollectionLimit(rawLimit) {
+    const limit = rawLimit ?? MAX_USER_TWEETS_LIMIT;
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_USER_TWEETS_LIMIT) {
+        throw new ArgumentError(
+            `twitter collection --limit must be an integer between 1 and ${MAX_USER_TWEETS_LIMIT}`,
+            'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z --limit 250',
+        );
+    }
+    return limit;
+}
+
+function normalizeCollectionPageDelaySeconds(rawDelay) {
+    const delay = rawDelay ?? DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS;
+    if (!Number.isInteger(delay) || delay < 0 || delay > 60) {
+        throw new ArgumentError(
+            'twitter collection --page-delay must be an integer between 0 and 60 seconds',
+            'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z --page-delay 2',
+        );
+    }
+    return delay;
+}
+
+function unwrapTweetResult(result) {
+    if (!result) return null;
+    if (result.__typename === 'TweetWithVisibilityResults' && result.tweet) return result.tweet;
+    return result.tweet || result;
+}
+
+function relationshipTarget(result, fallbackId = null, contextStatus = 'complete') {
+    const tweet = unwrapTweetResult(result);
+    const user = tweet?.core?.user_results?.result;
+    const rawHandle = user?.legacy?.screen_name || user?.core?.screen_name || null;
+    const authorHandle = typeof rawHandle === 'string' && normalizeTwitterScreenName(rawHandle)
+        ? normalizeTwitterScreenName(rawHandle)
+        : null;
+    const rawAuthorId = user?.rest_id || user?.legacy?.id_str || null;
+    const authorId = typeof rawAuthorId === 'string' && rawAuthorId.trim() ? rawAuthorId : null;
+    const rawPostId = tweet?.rest_id || fallbackId || null;
+    const postId = typeof rawPostId === 'string' && rawPostId.trim() ? rawPostId : null;
+    const hasVisibleContext = Boolean(tweet?.note_tweet?.note_tweet_results?.result?.text || tweet?.legacy?.full_text);
+    const resolvedContextStatus = contextStatus === 'complete' && !hasVisibleContext
+        ? (postId ? 'unavailable' : 'unknown')
+        : contextStatus;
+    return {
+        post_id: postId,
+        author_handle: authorHandle,
+        author_id: authorId,
+        url: postId && authorHandle ? `https://x.com/${authorHandle}/status/${postId}` : null,
+        context_status: resolvedContextStatus,
+    };
+}
+
+function extractRelationship(result) {
+    const tweet = unwrapTweetResult(result);
+    const legacy = tweet?.legacy || {};
+    const repostResult = tweet?.retweeted_status_result?.result || legacy.retweeted_status_result?.result || null;
+    const repostId = legacy.retweeted_status_id_str || null;
+    if (repostResult || repostId) {
+        const target = relationshipTarget(repostResult, repostId, repostResult ? 'complete' : 'unknown');
+        if (!repostResult || !target.post_id) {
+            throw new CommandExecutionError('twitter_collection_unresolved_relationship: repost target is unavailable');
+        }
+        return { kind: 'repost', target };
+    }
+    const quoteResult = tweet?.quoted_status_result?.result || legacy.quoted_status_result?.result || null;
+    const quoteId = legacy.quoted_status_id_str || null;
+    if (legacy.is_quote_status || quoteResult || quoteId) {
+        return {
+            kind: 'quote',
+            target: relationshipTarget(quoteResult, quoteId, quoteResult ? 'complete' : 'unavailable'),
+        };
+    }
+    const replyId = legacy.in_reply_to_status_id_str || null;
+    const replyHandle = normalizeTwitterScreenName(legacy.in_reply_to_screen_name || '') || null;
+    const replyAuthorId = typeof legacy.in_reply_to_user_id_str === 'string' && legacy.in_reply_to_user_id_str.trim()
+        ? legacy.in_reply_to_user_id_str
+        : null;
+    if (replyId || replyHandle || replyAuthorId) {
+        return {
+            kind: 'reply',
+            target: {
+                post_id: replyId,
+                author_handle: replyHandle,
+                author_id: replyAuthorId,
+                url: replyId && replyHandle ? `https://x.com/${replyHandle}/status/${replyId}` : null,
+                context_status: replyId ? 'unavailable' : 'unknown',
+            },
+        };
+    }
+    return { kind: 'original', target: null };
+}
+
+function extractCollectionPost(result, seen) {
+    const tweet = unwrapTweetResult(result);
+    if (!tweet?.rest_id || typeof tweet.rest_id !== 'string') {
+        throw new CommandExecutionError('twitter_collection_protocol_error: timeline post is missing a stable ID');
+    }
+    if (seen.has(tweet.rest_id)) return null;
+    seen.add(tweet.rest_id);
+    const legacy = tweet.legacy || {};
+    const user = tweet.core?.user_results?.result;
+    const author = user?.legacy?.screen_name || user?.core?.screen_name || null;
+    if (!author || !normalizeTwitterScreenName(author)) {
+        throw new CommandExecutionError('twitter_collection_protocol_error: timeline post is missing an author handle');
+    }
+    return {
+        id: tweet.rest_id,
+        author,
+        name: user?.legacy?.name || user?.core?.name || '',
+        text: tweet.note_tweet?.note_tweet_results?.result?.text || legacy.full_text || '',
+        likes: legacy.favorite_count || 0,
+        retweets: legacy.retweet_count || 0,
+        replies: legacy.reply_count || 0,
+        views: Number(tweet.views?.count) || 0,
+        is_retweet: Boolean(legacy.retweeted_status_result),
+        created_at: legacy.created_at || '',
+        url: `https://x.com/${author}/status/${tweet.rest_id}`,
+        ...extractMedia(legacy),
+        quoted_tweet: extractQuotedTweet(tweet),
+        relationship: extractRelationship(tweet),
+    };
+}
+
+function parseCollectionPage(payload, seen) {
+    const result = payload?.data?.user?.result;
+    if (!result || typeof result !== 'object') {
+        throw new CommandExecutionError('twitter_collection_protocol_error: missing UserTweets result');
+    }
+    const instructionSets = [
+        result.timeline_v2?.timeline?.instructions,
+        result.timeline?.timeline?.instructions,
+    ].filter(Array.isArray);
+    const posts = [];
+    let nextCursor = null;
+    const visit = (value) => {
+        if (!value || typeof value !== 'object') return;
+        if (value.type === 'TimelinePinEntry') return;
+        if (value.tweet_results?.result) {
+            const post = extractCollectionPost(value.tweet_results.result, seen);
+            if (post) posts.push(post);
+        }
+        if (
+            (value.entryType === 'TimelineTimelineCursor' || value.__typename === 'TimelineTimelineCursor')
+            && (value.cursorType === 'Bottom' || value.cursorType === 'ShowMore')
+            && value.value
+        ) {
+            nextCursor = value.value;
+        }
+        if (Array.isArray(value)) {
+            for (const item of value) visit(item);
+            return;
+        }
+        for (const child of Object.values(value)) {
+            if (child && typeof child === 'object') visit(child);
+        }
+    };
+    for (const instructions of instructionSets) visit(instructions);
+    return [posts, nextCursor];
+}
+
+function parseCreatedAt(post) {
+    const parsed = new Date(post.created_at);
+    if (typeof post.created_at !== 'string' || !post.created_at || Number.isNaN(parsed.getTime())) {
+        throw new CommandExecutionError(`twitter_collection_invalid_timestamp: post ${post.id}`);
+    }
+    return parsed;
+}
+
+function completedReceipt(stopReason, until, pagesFetched, oldestSeenAt) {
+    return {
+        completed: true,
+        stop_reason: stopReason,
+        requested_until: until.toISOString(),
+        pages_fetched: pagesFetched,
+        oldest_seen_at: oldestSeenAt ? oldestSeenAt.toISOString() : null,
+    };
+}
+
+async function paginateCollection({ until, limit, maxPages = MAX_USER_TWEETS_PAGES, fetchPage, wait }) {
+    const seen = new Set();
+    const seenCursors = new Set();
+    const posts = [];
+    let cursor = null;
+    let oldestSeenAt = null;
+    for (let pageIndex = 0; pageIndex < maxPages; pageIndex++) {
+        if (pageIndex > 0 && wait) await wait();
+        const payload = await fetchPage(cursor, USER_TWEETS_PAGE_SIZE);
+        if (payload?.error) {
+            throw new CommandExecutionError(`twitter_collection_request_error: UserTweets returned ${payload.error}`);
+        }
+        const [pagePosts, nextCursor] = parseCollectionPage(payload, seen);
+        for (const post of pagePosts) {
+            if (posts.length >= limit) {
+                throw new CommandExecutionError('twitter_collection_limit_reached: pagination cannot prove completion');
+            }
+            const createdAt = parseCreatedAt(post);
+            if (!oldestSeenAt || createdAt < oldestSeenAt) oldestSeenAt = createdAt;
+            posts.push(post);
+            if (createdAt <= until) {
+                return {
+                    posts,
+                    receipt: completedReceipt('time_boundary_reached', until, pageIndex + 1, oldestSeenAt),
+                };
+            }
+        }
+        if (!nextCursor) {
+            return {
+                posts,
+                receipt: completedReceipt('cursor_exhausted', until, pageIndex + 1, oldestSeenAt),
+            };
+        }
+        if (nextCursor === cursor || seenCursors.has(nextCursor)) {
+            throw new CommandExecutionError('twitter_collection_repeated_cursor: pagination cannot prove completion');
+        }
+        if (posts.length >= limit) {
+            throw new CommandExecutionError('twitter_collection_limit_reached: pagination cannot prove completion');
+        }
+        seenCursors.add(nextCursor);
+        cursor = nextCursor;
+    }
+    throw new CommandExecutionError('twitter_collection_page_guard_hit: pagination cannot prove completion');
+}
+
+cli({
+    site: 'twitter',
+    name: 'collection',
+    access: 'read',
+    description: 'Fetch a user timeline with relationship facts and a bounded completion receipt.',
+    domain: 'x.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    args: [
+        { name: 'username', type: 'string', positional: true, required: true, help: 'Twitter screen name (with or without @).' },
+        { name: 'until', type: 'string', required: true, help: 'RFC3339 lower time boundary that must be reached or exhausted.' },
+        { name: 'limit', type: 'int', default: MAX_USER_TWEETS_LIMIT, help: 'Safety ceiling; reaching it is a typed failure.' },
+        { name: 'page-delay', type: 'int', default: DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS, help: 'Seconds to wait between cursor pages.' },
+    ],
+    columns: ['posts', 'receipt'],
+    func: async (page, kwargs) => {
+        const until = normalizeUntil(kwargs.until);
+        const limit = normalizeCollectionLimit(kwargs.limit);
+        const pageDelaySeconds = normalizeCollectionPageDelaySeconds(kwargs['page-delay']);
+        const context = await resolveUserTimelineContext(page, kwargs.username, { allowLoggedInDefault: false });
+        return paginateCollection({
+            until,
+            limit,
+            fetchPage: (cursor, count) => fetchUserTimelinePage(page, context, cursor, count),
+            wait: pageDelaySeconds > 0 ? () => page.wait(pageDelaySeconds) : null,
+        });
+    },
+});
+
+export const __test__ = {
+    normalizeUntil,
+    normalizeCollectionLimit,
+    normalizeCollectionPageDelaySeconds,
+    extractRelationship,
+    parseCollectionPage,
+    paginateCollection,
+};

--- a/clis/twitter/collection.js
+++ b/clis/twitter/collection.js
@@ -1,6 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { extractMedia, extractQuotedTweet, normalizeTwitterScreenName } from './shared.js';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    extractMedia,
+    extractQuotedTweet,
+    looksLikePrivateTwitterTimeline,
+    normalizeTwitterScreenName,
+} from './shared.js';
 import {
     DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS,
     MAX_USER_TWEETS_LIMIT,
@@ -10,11 +15,39 @@ import {
     resolveUserTimelineContext,
 } from './user-timeline.js';
 
-const RFC3339_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+const RFC3339_TIMESTAMP = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/;
+
+function isLeapYear(year) {
+    return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
 
 function normalizeUntil(raw) {
     const value = String(raw ?? '').trim();
-    if (!RFC3339_TIMESTAMP.test(value)) {
+    const match = value.match(RFC3339_TIMESTAMP);
+    if (!match) {
+        throw new ArgumentError(
+            'twitter collection --until must be an RFC3339 timestamp',
+            'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z',
+        );
+    }
+    const [, yearRaw, monthRaw, dayRaw, hourRaw, minuteRaw, secondRaw, , zone, , offsetHourRaw, offsetMinuteRaw] = match;
+    const year = Number(yearRaw);
+    const month = Number(monthRaw);
+    const day = Number(dayRaw);
+    const hour = Number(hourRaw);
+    const minute = Number(minuteRaw);
+    const second = Number(secondRaw);
+    const offsetHour = zone === 'Z' ? 0 : Number(offsetHourRaw);
+    const offsetMinute = zone === 'Z' ? 0 : Number(offsetMinuteRaw);
+    const daysInMonth = month === 2
+        ? (isLeapYear(year) ? 29 : 28)
+        : ([4, 6, 9, 11].includes(month) ? 30 : 31);
+    if (
+        month < 1 || month > 12
+        || day < 1 || day > daysInMonth
+        || hour > 23 || minute > 59 || second > 59
+        || offsetHour > 23 || offsetMinute > 59
+    ) {
         throw new ArgumentError(
             'twitter collection --until must be an RFC3339 timestamp',
             'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z',
@@ -154,6 +187,12 @@ function extractCollectionPost(result, seen) {
 }
 
 function parseCollectionPage(payload, seen) {
+    if (looksLikePrivateTwitterTimeline(payload)) {
+        throw new EmptyResultError(
+            'twitter collection',
+            'Timeline is private or unavailable to the current X account; completion cannot be proven.',
+        );
+    }
     const result = payload?.data?.user?.result;
     if (!result || typeof result !== 'object') {
         throw new CommandExecutionError('twitter_collection_protocol_error: missing UserTweets result');
@@ -162,6 +201,11 @@ function parseCollectionPage(payload, seen) {
         result.timeline_v2?.timeline?.instructions,
         result.timeline?.timeline?.instructions,
     ].filter(Array.isArray);
+    if (instructionSets.length === 0) {
+        throw new CommandExecutionError(
+            'twitter_collection_protocol_error: missing UserTweets timeline instructions',
+        );
+    }
     const posts = [];
     let nextCursor = null;
     const visit = (value) => {
@@ -272,7 +316,10 @@ cli({
         const until = normalizeUntil(kwargs.until);
         const limit = normalizeCollectionLimit(kwargs.limit);
         const pageDelaySeconds = normalizeCollectionPageDelaySeconds(kwargs['page-delay']);
-        const context = await resolveUserTimelineContext(page, kwargs.username, { allowLoggedInDefault: false });
+        const context = await resolveUserTimelineContext(page, kwargs.username, {
+            allowLoggedInDefault: false,
+            commandName: 'collection',
+        });
         return paginateCollection({
             until,
             limit,

--- a/clis/twitter/collection.test.js
+++ b/clis/twitter/collection.test.js
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import './tweets.js';
+import { __test__ } from './collection.js';
+
+function syntheticTweet(id, {
+    author = 'synth_author',
+    createdAt = '2026-07-23T12:00:00.000Z',
+    legacy = {},
+    quotedStatusResult,
+    retweetedStatusResult,
+} = {}) {
+    return {
+        rest_id: String(id),
+        legacy: {
+            full_text: `synthetic post ${id}`,
+            favorite_count: 0,
+            retweet_count: 0,
+            reply_count: 0,
+            created_at: createdAt,
+            ...legacy,
+        },
+        core: {
+            user_results: {
+                result: {
+                    rest_id: `user-${author}`,
+                    legacy: { screen_name: author, name: author },
+                },
+            },
+        },
+        ...(quotedStatusResult ? { quoted_status_result: quotedStatusResult } : {}),
+        ...(retweetedStatusResult ? { retweeted_status_result: retweetedStatusResult } : {}),
+    };
+}
+
+function tweetEntry(tweet) {
+    return { content: { itemContent: { tweet_results: { result: tweet } } } };
+}
+
+function collectionPayload(tweets, nextCursor = null) {
+    const entries = tweets.map(tweetEntry);
+    if (nextCursor) {
+        entries.push({
+            content: {
+                entryType: 'TimelineTimelineCursor',
+                cursorType: 'Bottom',
+                value: nextCursor,
+            },
+        });
+    }
+    return {
+        data: {
+            user: {
+                result: {
+                    timeline_v2: { timeline: { instructions: [{ entries }] } },
+                },
+            },
+        },
+    };
+}
+
+describe('twitter collection', () => {
+    it('registers an independent read command with posts and receipt columns', () => {
+        const command = getRegistry().get('twitter/collection');
+        expect(command).toMatchObject({
+            access: 'read',
+            browser: true,
+            columns: ['posts', 'receipt'],
+        });
+        expect(command?.args?.map((arg) => arg.name)).toEqual([
+            'username', 'until', 'limit', 'page-delay',
+        ]);
+        expect(getRegistry().get('twitter/tweets')?.args?.map((arg) => arg.name))
+            .not.toContain('collection-receipt');
+    });
+
+    it('classifies original, quote, reply and repost without inventing context', () => {
+        expect(__test__.extractRelationship(syntheticTweet('10'))).toEqual({
+            kind: 'original',
+            target: null,
+        });
+        expect(__test__.extractRelationship(syntheticTweet('11', {
+            legacy: {
+                in_reply_to_status_id_str: '30',
+                in_reply_to_screen_name: 'parent_author',
+                in_reply_to_user_id_str: 'user-parent_author',
+            },
+        }))).toMatchObject({
+            kind: 'reply',
+            target: { post_id: '30', context_status: 'unavailable' },
+        });
+        expect(__test__.extractRelationship(syntheticTweet('12', {
+            legacy: { is_quote_status: true, quoted_status_id_str: '50' },
+            quotedStatusResult: { result: { __typename: 'TweetTombstone' } },
+        }))).toMatchObject({
+            kind: 'quote',
+            target: { post_id: '50', context_status: 'unavailable' },
+        });
+        expect(__test__.extractRelationship(syntheticTweet('13', {
+            legacy: { retweeted_status_id_str: '60' },
+            retweetedStatusResult: { result: syntheticTweet('60', { author: 'repost_target' }) },
+        }))).toMatchObject({
+            kind: 'repost',
+            target: {
+                post_id: '60',
+                author_handle: 'repost_target',
+                context_status: 'complete',
+            },
+        });
+    });
+
+    it('rejects an unresolved repost instead of inferring it from text', () => {
+        expect(() => __test__.extractRelationship(syntheticTweet('14', {
+            legacy: { full_text: 'RT @someone: synthetic', retweeted_status_id_str: '70' },
+        }))).toThrow(CommandExecutionError);
+        expect(() => __test__.extractRelationship(syntheticTweet('14', {
+            legacy: { full_text: 'RT @someone: synthetic', retweeted_status_id_str: '70' },
+        }))).toThrow(/twitter_collection_unresolved_relationship/);
+    });
+
+    it('accepts only RFC3339 lower boundaries', () => {
+        expect(__test__.normalizeUntil('2026-07-23T00:00:00Z')).toBeInstanceOf(Date);
+        expect(() => __test__.normalizeUntil('2026-07-23')).toThrow(ArgumentError);
+        expect(() => __test__.normalizeUntil('not-a-date')).toThrow(ArgumentError);
+    });
+
+    it('completes only after the lower boundary is reached', async () => {
+        const result = await __test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 10,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('20', { createdAt: '2026-07-23T01:00:00.000Z' }),
+                syntheticTweet('21', { createdAt: '2026-07-22T23:59:59.000Z' }),
+            ], 'unused-cursor'),
+        });
+        expect(result).toMatchObject({
+            posts: [
+                { id: '20' },
+                { id: '21' },
+            ],
+            receipt: {
+                completed: true,
+                stop_reason: 'time_boundary_reached',
+                requested_until: '2026-07-23T00:00:00.000Z',
+                pages_fetched: 1,
+                oldest_seen_at: '2026-07-22T23:59:59.000Z',
+            },
+        });
+    });
+
+    it('completes on cursor exhaustion and exposes no cursor', async () => {
+        const result = await __test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 10,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('22', { createdAt: '2026-07-23T01:00:00.000Z' }),
+            ]),
+        });
+        expect(result).toMatchObject({
+            receipt: { completed: true, stop_reason: 'cursor_exhausted', pages_fetched: 1 },
+        });
+        expect(Object.keys(result.receipt)).not.toContain('cursor');
+    });
+
+    it('returns the posts and receipt envelope from the registered command', async () => {
+        const command = getRegistry().get('twitter/collection');
+        const page = {
+            getCookies: vi.fn(async () => [{ name: 'ct0', value: 'test-only' }]),
+            wait: vi.fn(async () => undefined),
+            evaluate: vi.fn(async (script) => {
+                const source = String(script);
+                if (source.includes('operationName')) return null;
+                if (source.includes('/UserByScreenName')) return '42';
+                if (source.includes('/UserTweets')) {
+                    return collectionPayload([
+                        syntheticTweet('27', { createdAt: '2026-07-22T23:59:59.000Z' }),
+                    ]);
+                }
+                return null;
+            }),
+        };
+        const result = await command.func(page, {
+            username: 'synth_author',
+            until: '2026-07-23T00:00:00Z',
+            limit: 10,
+            'page-delay': 0,
+        });
+        expect(result).toMatchObject({
+            posts: [{ id: '27', relationship: { kind: 'original' } }],
+            receipt: { completed: true, stop_reason: 'time_boundary_reached' },
+        });
+    });
+
+    it('fails on repeated cursor, limit, page guard, and malformed timestamps', async () => {
+        await expect(__test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 10,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('23', { createdAt: '2026-07-23T01:00:00.000Z' }),
+            ], 'same-cursor'),
+        })).rejects.toThrow(/twitter_collection_repeated_cursor/);
+        await expect(__test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 1,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('24', { createdAt: '2026-07-23T01:00:00.000Z' }),
+            ], 'next-cursor'),
+        })).rejects.toThrow(/twitter_collection_limit_reached/);
+        await expect(__test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 1,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('24a', { createdAt: '2026-07-23T01:00:00.000Z' }),
+                syntheticTweet('24b', { createdAt: '2026-07-22T23:59:59.000Z' }),
+            ]),
+        })).rejects.toThrow(/twitter_collection_limit_reached/);
+        await expect(__test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 10,
+            maxPages: 1,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('25', { createdAt: '2026-07-23T01:00:00.000Z' }),
+            ], 'next-cursor'),
+        })).rejects.toThrow(/twitter_collection_page_guard_hit/);
+        await expect(__test__.paginateCollection({
+            until: __test__.normalizeUntil('2026-07-23T00:00:00Z'),
+            limit: 10,
+            maxPages: 5,
+            fetchPage: async () => collectionPayload([
+                syntheticTweet('26', { createdAt: 'not-a-timestamp' }),
+            ]),
+        })).rejects.toThrow(/twitter_collection_invalid_timestamp/);
+    });
+});

--- a/clis/twitter/collection.test.js
+++ b/clis/twitter/collection.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './tweets.js';
 import { __test__ } from './collection.js';
 
@@ -121,8 +121,25 @@ describe('twitter collection', () => {
 
     it('accepts only RFC3339 lower boundaries', () => {
         expect(__test__.normalizeUntil('2026-07-23T00:00:00Z')).toBeInstanceOf(Date);
+        expect(__test__.normalizeUntil('2026-07-23T00:00:00.123456Z')).toBeInstanceOf(Date);
+        expect(__test__.normalizeUntil('2024-02-29T00:00:00+08:00')).toBeInstanceOf(Date);
         expect(() => __test__.normalizeUntil('2026-07-23')).toThrow(ArgumentError);
         expect(() => __test__.normalizeUntil('not-a-date')).toThrow(ArgumentError);
+        expect(() => __test__.normalizeUntil('2026-02-29T00:00:00Z')).toThrow(ArgumentError);
+        expect(() => __test__.normalizeUntil('2026-07-23T24:00:00Z')).toThrow(ArgumentError);
+        expect(() => __test__.normalizeUntil('2026-07-23T00:00:00+24:00')).toThrow(ArgumentError);
+    });
+
+    it('fails closed for private, unavailable, and malformed timelines', () => {
+        expect(() => __test__.parseCollectionPage({
+            data: { user: { result: { __typename: 'User', timeline_v2: { timeline: {} } } } },
+        }, new Set())).toThrow(EmptyResultError);
+        expect(() => __test__.parseCollectionPage({
+            data: { user: { result: { __typename: 'UserUnavailable' } } },
+        }, new Set())).toThrow(/missing UserTweets timeline instructions/);
+        expect(() => __test__.parseCollectionPage({
+            data: { user: { result: { timeline_v2: { timeline: { unexpected: true } } } } },
+        }, new Set())).toThrow(/missing UserTweets timeline instructions/);
     });
 
     it('completes only after the lower boundary is reached', async () => {
@@ -192,6 +209,25 @@ describe('twitter collection', () => {
             posts: [{ id: '27', relationship: { kind: 'original' } }],
             receipt: { completed: true, stop_reason: 'time_boundary_reached' },
         });
+    });
+
+    it('uses collection-specific validation errors before touching the browser', async () => {
+        const command = getRegistry().get('twitter/collection');
+        const page = {
+            goto: vi.fn(),
+            getCookies: vi.fn(),
+            evaluate: vi.fn(),
+        };
+
+        await expect(command.func(page, {
+            username: 'home/extra',
+            until: '2026-07-23T00:00:00Z',
+            limit: 10,
+            'page-delay': 0,
+        })).rejects.toThrow(/twitter collection username/);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.getCookies).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
     });
 
     it('fails on repeated cursor, limit, page guard, and malformed timestamps', async () => {

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -1,155 +1,20 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { resolveTwitterOperationMetadata, sanitizeQueryId, extractMedia, extractQuotedTweet, normalizeTwitterGraphqlPayload, unwrapBrowserResult, normalizeTwitterScreenName, describeTwitterApiError } from './shared.js';
-import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { sanitizeQueryId, extractMedia, extractQuotedTweet, describeTwitterApiError } from './shared.js';
+import { applyTopByEngagement } from './utils.js';
+import {
+    MAX_USER_TWEETS_PAGES,
+    USER_TWEETS_PAGE_SIZE,
+    MAX_USER_TWEETS_LIMIT,
+    DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS,
+    buildUserTweetsUrl,
+    buildUserByScreenNameUrl,
+    fetchUserTimelinePage,
+    resolveUserTimelineContext,
+} from './user-timeline.js';
 
-const USER_TWEETS_QUERY_ID = 'lrMzG9qPQHpqJdP3AbM-bQ';
-const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
-const MAX_PAGINATION_PAGES = 100;
-const USER_TWEETS_PAGE_SIZE = 100;
-const MAX_TWEETS_LIMIT = MAX_PAGINATION_PAGES * USER_TWEETS_PAGE_SIZE;
-const DEFAULT_PAGE_DELAY_SECONDS = 2;
-
-const USER_TWEETS_FEATURES = {
-    rweb_video_screen_enabled: true,
-    rweb_cashtags_enabled: true,
-    payments_enabled: false,
-    profile_label_improvements_pcf_label_in_post_enabled: true,
-    responsive_web_profile_redirect_enabled: true,
-    rweb_tipjar_consumption_enabled: true,
-    verified_phone_label_enabled: false,
-    creator_subscriptions_tweet_preview_api_enabled: true,
-    responsive_web_graphql_timeline_navigation_enabled: true,
-    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-    premium_content_api_read_enabled: false,
-    communities_web_enable_tweet_community_results_fetch: true,
-    c9s_tweet_anatomy_moderator_badge_enabled: true,
-    responsive_web_grok_analyze_button_fetch_trends_enabled: false,
-    responsive_web_grok_analyze_post_followups_enabled: true,
-    rweb_cashtags_composer_attachment_enabled: true,
-    responsive_web_jetfuel_frame: true,
-    responsive_web_grok_share_attachment_enabled: true,
-    responsive_web_grok_annotations_enabled: true,
-    articles_preview_enabled: true,
-    responsive_web_edit_tweet_api_enabled: true,
-    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
-    view_counts_everywhere_api_enabled: true,
-    longform_notetweets_consumption_enabled: true,
-    responsive_web_twitter_article_tweet_consumption_enabled: true,
-    tweet_awards_web_tipping_enabled: false,
-    content_disclosure_indicator_enabled: true,
-    content_disclosure_ai_generated_indicator_enabled: true,
-    responsive_web_grok_show_grok_translated_post: false,
-    responsive_web_grok_analysis_button_from_backend: true,
-    post_ctas_fetch_enabled: false,
-    freedom_of_speech_not_reach_fetch_enabled: true,
-    standardized_nudges_misinfo: true,
-    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
-    longform_notetweets_rich_text_read_enabled: true,
-    longform_notetweets_inline_media_enabled: true,
-    responsive_web_grok_image_annotation_enabled: true,
-    responsive_web_grok_imagine_annotation_enabled: true,
-    responsive_web_grok_community_note_auto_translation_is_enabled: false,
-    responsive_web_enhance_cards_enabled: false,
-};
-
-const USER_TWEETS_FIELD_TOGGLES = {
-    withPayments: true,
-    withAuxiliaryUserLabels: true,
-    withArticleRichContentState: true,
-    withArticlePlainText: true,
-    withArticleSummaryText: true,
-    withArticleVoiceOver: true,
-    withGrokAnalyze: true,
-    withDisallowedReplyControls: true,
-};
-
-const USER_BY_SCREEN_NAME_FEATURES = {
-    hidden_profile_subscriptions_enabled: true,
-    profile_label_improvements_pcf_label_in_post_enabled: true,
-    responsive_web_profile_redirect_enabled: true,
-    rweb_tipjar_consumption_enabled: true,
-    responsive_web_graphql_exclude_directive_enabled: true,
-    verified_phone_label_enabled: false,
-    subscriptions_verification_info_is_identity_verified_enabled: true,
-    subscriptions_verification_info_verified_since_enabled: true,
-    highlights_tweets_tab_ui_enabled: true,
-    responsive_web_twitter_article_notes_tab_enabled: true,
-    subscriptions_feature_can_gift_premium: true,
-    creator_subscriptions_tweet_preview_api_enabled: true,
-    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-    responsive_web_graphql_timeline_navigation_enabled: true,
-};
-
-const USER_BY_SCREEN_NAME_FIELD_TOGGLES = {
-    withPayments: true,
-    withAuxiliaryUserLabels: true,
-};
-
-const USER_TWEETS_OPERATION = {
-    queryId: USER_TWEETS_QUERY_ID,
-    features: USER_TWEETS_FEATURES,
-    fieldToggles: USER_TWEETS_FIELD_TOGGLES,
-};
-
-const USER_BY_SCREEN_NAME_OPERATION = {
-    queryId: USER_BY_SCREEN_NAME_QUERY_ID,
-    features: USER_BY_SCREEN_NAME_FEATURES,
-    fieldToggles: USER_BY_SCREEN_NAME_FIELD_TOGGLES,
-};
-
-function normalizeUserTweetsOperation(operation) {
-    if (typeof operation === 'string') {
-        return { queryId: operation, features: USER_TWEETS_FEATURES, fieldToggles: USER_TWEETS_FIELD_TOGGLES };
-    }
-    return {
-        queryId: operation?.queryId || USER_TWEETS_QUERY_ID,
-        features: operation?.features || USER_TWEETS_FEATURES,
-        fieldToggles: operation?.fieldToggles || USER_TWEETS_FIELD_TOGGLES,
-    };
-}
-
-function normalizeUserByScreenNameOperation(operation) {
-    if (typeof operation === 'string') {
-        return { queryId: operation, features: USER_BY_SCREEN_NAME_FEATURES, fieldToggles: USER_BY_SCREEN_NAME_FIELD_TOGGLES };
-    }
-    return {
-        queryId: operation?.queryId || USER_BY_SCREEN_NAME_QUERY_ID,
-        features: operation?.features || USER_BY_SCREEN_NAME_FEATURES,
-        fieldToggles: operation?.fieldToggles || USER_BY_SCREEN_NAME_FIELD_TOGGLES,
-    };
-}
-
-function appendGraphqlParams(path, variables, operation) {
-    const fieldToggles = operation.fieldToggles || {};
-    const params = [
-        `variables=${encodeURIComponent(JSON.stringify(variables))}`,
-        `features=${encodeURIComponent(JSON.stringify(operation.features || {}))}`,
-    ];
-    if (Object.keys(fieldToggles).length > 0) {
-        params.push(`fieldToggles=${encodeURIComponent(JSON.stringify(fieldToggles))}`);
-    }
-    return `${path}?${params.join('&')}`;
-}
-
-function buildUserTweetsUrl(operation, userId, count, cursor) {
-    const normalized = normalizeUserTweetsOperation(operation);
-    const vars = {
-        userId,
-        count,
-        includePromotedContent: false,
-        withQuickPromoteEligibilityTweetFields: true,
-        withVoice: true,
-    };
-    if (cursor) vars.cursor = cursor;
-    return appendGraphqlParams(`/i/api/graphql/${normalized.queryId}/UserTweets`, vars, normalized);
-}
-
-function buildUserByScreenNameUrl(operation, screenName) {
-    const normalized = normalizeUserByScreenNameOperation(operation);
-    const vars = { screen_name: screenName, withSafetyModeUserFields: true };
-    return appendGraphqlParams(`/i/api/graphql/${normalized.queryId}/UserByScreenName`, vars, normalized);
-}
+const MAX_TWEETS_LIMIT = MAX_USER_TWEETS_LIMIT;
+const DEFAULT_PAGE_DELAY_SECONDS = DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS;
 
 function extractTweet(result, seen) {
     if (!result) return null;
@@ -221,7 +86,7 @@ function normalizeLimit(rawLimit) {
     if (!Number.isInteger(limit) || limit < 1 || limit > MAX_TWEETS_LIMIT) {
         throw new ArgumentError(
             `twitter tweets --limit must be an integer between 1 and ${MAX_TWEETS_LIMIT}`,
-            `Example: opencli twitter tweets @jack --limit 250`
+            'Example: opencli twitter tweets @jack --limit 250',
         );
     }
     return limit;
@@ -232,7 +97,7 @@ function normalizePageDelaySeconds(rawDelay) {
     if (!Number.isInteger(delay) || delay < 0 || delay > 60) {
         throw new ArgumentError(
             'twitter tweets --page-delay must be an integer between 0 and 60 seconds',
-            'Example: opencli twitter tweets @jack --limit 250 --page-delay 2'
+            'Example: opencli twitter tweets @jack --limit 250 --page-delay 2',
         );
     }
     return delay;
@@ -256,69 +121,18 @@ cli({
     func: async (page, kwargs) => {
         const limit = normalizeLimit(kwargs.limit);
         const pageDelaySeconds = normalizePageDelaySeconds(kwargs['page-delay']);
-        const rawUsername = String(kwargs.username ?? '').trim();
-        let username = normalizeTwitterScreenName(rawUsername);
-        if (rawUsername && !username) {
-            throw new ArgumentError('twitter tweets username must be a valid Twitter/X handle', 'Example: opencli twitter tweets @jack --limit 20');
-        }
-        // When no username is given, detect the logged-in user (own tweets).
-        // Mirrors the self-detection pattern used by twitter/profile and
-        // twitter/likes so agents can pull own-account data without having
-        // to know their own screen name up front.
-        if (!username) {
-            await page.goto('https://x.com/home');
-            await page.wait({ selector: '[data-testid="primaryColumn"]' });
-            // Bridge wraps primitive page.evaluate returns as { session, data:<value> }.
-            // unwrapBrowserResult drops that envelope so the href string is usable.
-            const href = unwrapBrowserResult(await page.evaluate(`() => {
-        const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
-        return link ? link.getAttribute('href') : null;
-      }`));
-            if (!href || typeof href !== 'string')
-                throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
-            username = normalizeTwitterScreenName(href);
-            if (!username) {
-                throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
-            }
-        }
-
-        const cookies = await page.getCookies({ url: 'https://x.com' });
-        const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
-        if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
-
-        const userTweetsOperation = await resolveTwitterOperationMetadata(page, 'UserTweets', USER_TWEETS_OPERATION);
-        const userByScreenNameOperation = await resolveTwitterOperationMetadata(page, 'UserByScreenName', USER_BY_SCREEN_NAME_OPERATION);
-
-        const headers = JSON.stringify({
-            'Authorization': `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
-            'X-Csrf-Token': ct0,
-            'X-Twitter-Auth-Type': 'OAuth2Session',
-            'X-Twitter-Active-User': 'yes',
-        });
-
-        const ubsUrl = buildUserByScreenNameUrl(userByScreenNameOperation, username);
-        const userId = unwrapBrowserResult(await page.evaluate(`async () => {
-      const resp = await fetch("${ubsUrl}", { headers: ${headers}, credentials: 'include' });
-      if (!resp.ok) return null;
-      const d = await resp.json();
-      return d?.data?.user?.result?.rest_id || null;
-    }`));
-        if (!userId) throw new CommandExecutionError(`Could not resolve @${username}`);
-
+        const context = await resolveUserTimelineContext(page, kwargs.username, { allowLoggedInDefault: true });
+        const { username } = context;
         const seen = new Set();
         const all = [];
         let cursor = null;
         // Runaway guard only; --limit and cursor exhaustion control normal pagination.
-        for (let i = 0; i < MAX_PAGINATION_PAGES && all.length < limit; i++) {
+        for (let i = 0; i < MAX_USER_TWEETS_PAGES && all.length < limit; i++) {
             if (i > 0 && pageDelaySeconds > 0) {
                 await page.wait(pageDelaySeconds);
             }
             const fetchCount = Math.min(USER_TWEETS_PAGE_SIZE, limit - all.length + 10);
-            const url = buildUserTweetsUrl(userTweetsOperation, userId, fetchCount, cursor);
-            const data = normalizeTwitterGraphqlPayload(await page.evaluate(`async () => {
-        const r = await fetch("${url}", { headers: ${headers}, credentials: 'include' });
-        return r.ok ? await r.json() : { error: r.status };
-      }`));
+            const data = await fetchUserTimelinePage(page, context, cursor, fetchCount);
             if (data?.error) {
                 if (all.length === 0) throw new CommandExecutionError(describeTwitterApiError('UserTweets', data.error));
                 break;
@@ -328,10 +142,8 @@ cli({
             if (!nextCursor || nextCursor === cursor) break;
             cursor = nextCursor;
         }
-
         if (all.length === 0) throw new EmptyResultError(`@${username} has no recent tweets`, 'Account may be private or suspended');
-        const trimmed = all.slice(0, limit);
-        return applyTopByEngagement(trimmed, kwargs['top-by-engagement']);
+        return applyTopByEngagement(all.slice(0, limit), kwargs['top-by-engagement']);
     },
 });
 

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
 import { __test__ } from './tweets.js';
+import { buildUserTweetsUrl } from './user-timeline.js';
 
 function makeTweetEntry(id, author = 'jakevin7') {
     return {
@@ -56,6 +57,19 @@ function makeTimelinePayload(startId, count, nextCursor = null) {
 }
 
 describe('twitter tweets helpers', () => {
+    it('keeps tweets command arguments and columns unchanged after transport extraction', () => {
+        const cmd = getRegistry().get('twitter/tweets');
+        expect(cmd?.args?.map((arg) => arg.name)).toEqual([
+            'username', 'limit', 'page-delay', 'top-by-engagement',
+        ]);
+        expect(cmd?.columns).toEqual([
+            'id', 'author', 'created_at', 'is_retweet', 'text', 'likes',
+            'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls',
+            'media_posters', 'quoted_tweet',
+        ]);
+        expect(buildUserTweetsUrl('query', '42', 20, 'cursor')).toContain('/UserTweets');
+    });
+
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
         expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet']);

--- a/clis/twitter/user-timeline.js
+++ b/clis/twitter/user-timeline.js
@@ -1,0 +1,208 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { resolveTwitterOperationMetadata, normalizeTwitterGraphqlPayload, unwrapBrowserResult, normalizeTwitterScreenName } from './shared.js';
+import { TWITTER_BEARER_TOKEN } from './utils.js';
+
+const USER_TWEETS_QUERY_ID = 'lrMzG9qPQHpqJdP3AbM-bQ';
+const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
+
+export const MAX_USER_TWEETS_PAGES = 100;
+export const USER_TWEETS_PAGE_SIZE = 100;
+export const MAX_USER_TWEETS_LIMIT = MAX_USER_TWEETS_PAGES * USER_TWEETS_PAGE_SIZE;
+export const DEFAULT_USER_TWEETS_PAGE_DELAY_SECONDS = 2;
+
+const USER_TWEETS_FEATURES = {
+    rweb_video_screen_enabled: true,
+    rweb_cashtags_enabled: true,
+    payments_enabled: false,
+    profile_label_improvements_pcf_label_in_post_enabled: true,
+    responsive_web_profile_redirect_enabled: true,
+    rweb_tipjar_consumption_enabled: true,
+    verified_phone_label_enabled: false,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    premium_content_api_read_enabled: false,
+    communities_web_enable_tweet_community_results_fetch: true,
+    c9s_tweet_anatomy_moderator_badge_enabled: true,
+    responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+    responsive_web_grok_analyze_post_followups_enabled: true,
+    rweb_cashtags_composer_attachment_enabled: true,
+    responsive_web_jetfuel_frame: true,
+    responsive_web_grok_share_attachment_enabled: true,
+    responsive_web_grok_annotations_enabled: true,
+    articles_preview_enabled: true,
+    responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true,
+    longform_notetweets_consumption_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    content_disclosure_indicator_enabled: true,
+    content_disclosure_ai_generated_indicator_enabled: true,
+    responsive_web_grok_show_grok_translated_post: false,
+    responsive_web_grok_analysis_button_from_backend: true,
+    post_ctas_fetch_enabled: false,
+    freedom_of_speech_not_reach_fetch_enabled: true,
+    standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true,
+    longform_notetweets_inline_media_enabled: true,
+    responsive_web_grok_image_annotation_enabled: true,
+    responsive_web_grok_imagine_annotation_enabled: true,
+    responsive_web_grok_community_note_auto_translation_is_enabled: false,
+    responsive_web_enhance_cards_enabled: false,
+};
+
+const USER_TWEETS_FIELD_TOGGLES = {
+    withPayments: true,
+    withAuxiliaryUserLabels: true,
+    withArticleRichContentState: true,
+    withArticlePlainText: true,
+    withArticleSummaryText: true,
+    withArticleVoiceOver: true,
+    withGrokAnalyze: true,
+    withDisallowedReplyControls: true,
+};
+
+const USER_BY_SCREEN_NAME_FEATURES = {
+    hidden_profile_subscriptions_enabled: true,
+    profile_label_improvements_pcf_label_in_post_enabled: true,
+    responsive_web_profile_redirect_enabled: true,
+    rweb_tipjar_consumption_enabled: true,
+    responsive_web_graphql_exclude_directive_enabled: true,
+    verified_phone_label_enabled: false,
+    subscriptions_verification_info_is_identity_verified_enabled: true,
+    subscriptions_verification_info_verified_since_enabled: true,
+    highlights_tweets_tab_ui_enabled: true,
+    responsive_web_twitter_article_notes_tab_enabled: true,
+    subscriptions_feature_can_gift_premium: true,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+};
+
+const USER_BY_SCREEN_NAME_FIELD_TOGGLES = {
+    withPayments: true,
+    withAuxiliaryUserLabels: true,
+};
+
+const USER_TWEETS_OPERATION = {
+    queryId: USER_TWEETS_QUERY_ID,
+    features: USER_TWEETS_FEATURES,
+    fieldToggles: USER_TWEETS_FIELD_TOGGLES,
+};
+
+const USER_BY_SCREEN_NAME_OPERATION = {
+    queryId: USER_BY_SCREEN_NAME_QUERY_ID,
+    features: USER_BY_SCREEN_NAME_FEATURES,
+    fieldToggles: USER_BY_SCREEN_NAME_FIELD_TOGGLES,
+};
+
+function normalizeUserTweetsOperation(operation) {
+    if (typeof operation === 'string') {
+        return { queryId: operation, features: USER_TWEETS_FEATURES, fieldToggles: USER_TWEETS_FIELD_TOGGLES };
+    }
+    return {
+        queryId: operation?.queryId || USER_TWEETS_QUERY_ID,
+        features: operation?.features || USER_TWEETS_FEATURES,
+        fieldToggles: operation?.fieldToggles || USER_TWEETS_FIELD_TOGGLES,
+    };
+}
+
+function normalizeUserByScreenNameOperation(operation) {
+    if (typeof operation === 'string') {
+        return { queryId: operation, features: USER_BY_SCREEN_NAME_FEATURES, fieldToggles: USER_BY_SCREEN_NAME_FIELD_TOGGLES };
+    }
+    return {
+        queryId: operation?.queryId || USER_BY_SCREEN_NAME_QUERY_ID,
+        features: operation?.features || USER_BY_SCREEN_NAME_FEATURES,
+        fieldToggles: operation?.fieldToggles || USER_BY_SCREEN_NAME_FIELD_TOGGLES,
+    };
+}
+
+function appendGraphqlParams(path, variables, operation) {
+    const fieldToggles = operation.fieldToggles || {};
+    const params = [
+        `variables=${encodeURIComponent(JSON.stringify(variables))}`,
+        `features=${encodeURIComponent(JSON.stringify(operation.features || {}))}`,
+    ];
+    if (Object.keys(fieldToggles).length > 0) {
+        params.push(`fieldToggles=${encodeURIComponent(JSON.stringify(fieldToggles))}`);
+    }
+    return `${path}?${params.join('&')}`;
+}
+
+export function buildUserTweetsUrl(operation, userId, count, cursor) {
+    const normalized = normalizeUserTweetsOperation(operation);
+    const vars = {
+        userId,
+        count,
+        includePromotedContent: false,
+        withQuickPromoteEligibilityTweetFields: true,
+        withVoice: true,
+    };
+    if (cursor) vars.cursor = cursor;
+    return appendGraphqlParams(`/i/api/graphql/${normalized.queryId}/UserTweets`, vars, normalized);
+}
+
+export function buildUserByScreenNameUrl(operation, screenName) {
+    const normalized = normalizeUserByScreenNameOperation(operation);
+    const vars = { screen_name: screenName, withSafetyModeUserFields: true };
+    return appendGraphqlParams(`/i/api/graphql/${normalized.queryId}/UserByScreenName`, vars, normalized);
+}
+
+export async function resolveUserTimelineContext(page, rawUsername, { allowLoggedInDefault = false } = {}) {
+    const raw = String(rawUsername ?? '').trim();
+    let username = normalizeTwitterScreenName(raw);
+    if (raw && !username) {
+        throw new ArgumentError('twitter tweets username must be a valid Twitter/X handle', 'Example: opencli twitter tweets @jack --limit 20');
+    }
+    if (!username && !allowLoggedInDefault) {
+        throw new ArgumentError('twitter collection username must be a valid Twitter/X handle', 'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z');
+    }
+    if (!username) {
+        await page.goto('https://x.com/home');
+        await page.wait({ selector: '[data-testid="primaryColumn"]' });
+        const href = unwrapBrowserResult(await page.evaluate(`() => {
+            const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
+            return link ? link.getAttribute('href') : null;
+        }`));
+        if (!href || typeof href !== 'string') {
+            throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
+        }
+        username = normalizeTwitterScreenName(href);
+        if (!username) {
+            throw new AuthRequiredError('x.com', 'Could not detect logged-in user. Are you logged in?');
+        }
+    }
+
+    const cookies = await page.getCookies({ url: 'https://x.com' });
+    const ct0 = cookies.find((cookie) => cookie.name === 'ct0')?.value || null;
+    if (!ct0) throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+
+    const userTweetsOperation = await resolveTwitterOperationMetadata(page, 'UserTweets', USER_TWEETS_OPERATION);
+    const userByScreenNameOperation = await resolveTwitterOperationMetadata(page, 'UserByScreenName', USER_BY_SCREEN_NAME_OPERATION);
+    const headers = JSON.stringify({
+        Authorization: `Bearer ${decodeURIComponent(TWITTER_BEARER_TOKEN)}`,
+        'X-Csrf-Token': ct0,
+        'X-Twitter-Auth-Type': 'OAuth2Session',
+        'X-Twitter-Active-User': 'yes',
+    });
+    const userByScreenNameUrl = buildUserByScreenNameUrl(userByScreenNameOperation, username);
+    const userId = unwrapBrowserResult(await page.evaluate(`async () => {
+        const resp = await fetch(${JSON.stringify(userByScreenNameUrl)}, { headers: ${headers}, credentials: 'include' });
+        if (!resp.ok) return null;
+        const data = await resp.json();
+        return data?.data?.user?.result?.rest_id || null;
+    }`));
+    if (!userId) throw new CommandExecutionError(`Could not resolve @${username}`);
+    return { username, userId, headers, userTweetsOperation };
+}
+
+export async function fetchUserTimelinePage(page, context, cursor, count) {
+    const url = buildUserTweetsUrl(context.userTweetsOperation, context.userId, count, cursor);
+    return normalizeTwitterGraphqlPayload(await page.evaluate(`async () => {
+        const response = await fetch(${JSON.stringify(url)}, { headers: ${context.headers}, credentials: 'include' });
+        return response.ok ? await response.json() : { error: response.status };
+    }`));
+}

--- a/clis/twitter/user-timeline.js
+++ b/clis/twitter/user-timeline.js
@@ -151,11 +151,20 @@ export function buildUserByScreenNameUrl(operation, screenName) {
     return appendGraphqlParams(`/i/api/graphql/${normalized.queryId}/UserByScreenName`, vars, normalized);
 }
 
-export async function resolveUserTimelineContext(page, rawUsername, { allowLoggedInDefault = false } = {}) {
+export async function resolveUserTimelineContext(
+    page,
+    rawUsername,
+    { allowLoggedInDefault = false, commandName = 'tweets' } = {},
+) {
     const raw = String(rawUsername ?? '').trim();
     let username = normalizeTwitterScreenName(raw);
     if (raw && !username) {
-        throw new ArgumentError('twitter tweets username must be a valid Twitter/X handle', 'Example: opencli twitter tweets @jack --limit 20');
+        throw new ArgumentError(
+            `twitter ${commandName} username must be a valid Twitter/X handle`,
+            commandName === 'collection'
+                ? 'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z'
+                : 'Example: opencli twitter tweets @jack --limit 20',
+        );
     }
     if (!username && !allowLoggedInDefault) {
         throw new ArgumentError('twitter collection username must be a valid Twitter/X handle', 'Example: opencli twitter collection @jack --until 2026-07-23T00:00:00Z');


### PR DESCRIPTION
## Summary

- Adds `opencli twitter collection <username> --until <RFC3339> -f json`.
- Keeps `opencli twitter tweets` arguments, columns and output unchanged.
- Completion requires a reached lower boundary or cursor exhaustion; partial reads fail explicitly.
- Uses only artificial fixtures; no browser credentials or real X content are included.

## Verification

- `npx vitest run clis/twitter/collection.test.js clis/twitter/tweets.test.js`
- `npm run test:adapter`
- `npm run typecheck`
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`
- `npm run build`
- `./dist/src/main.js validate twitter/tweets`
- `./dist/src/main.js validate twitter/collection`
