### PR TITLE
fix(discord-app): handle Draft.js search and reply context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 !extension/dist/
 *.tsbuildinfo
 .opencli/
+.codegraph/
 .worktrees/
 .mcp.json
 *.log

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -13,6 +13,7 @@ import {
     buildDiscordChannelUrl,
     buildListChannelsScript,
     buildListThreadsScript,
+    buildReadMessagesScript,
     listDiscordChannels,
     listDiscordServers,
     listDiscordThreads,
@@ -135,6 +136,33 @@ describe('discord-app DOM extraction scripts', () => {
             url: 'https://discord.com/channels/111/333/555',
         })]);
     });
+
+    it('reads the current message instead of its quoted reply context', () => {
+        const rows = runDomScript(`
+          <ol>
+            <li id="chat-messages-222-999">
+              <div id="message-reply-context-999">
+                <span class="username_reply">Quoted User</span>
+                <time datetime="2026-06-14T23:00:00.000Z">yesterday</time>
+                <div id="message-content-888">quoted question</div>
+              </div>
+              <h3>
+                <span id="message-username-999" class="username_current">Current User</span>
+                <time id="message-timestamp-999" datetime="2026-06-15T01:02:03.000Z">today</time>
+              </h3>
+              <div id="message-content-999">current answer</div>
+            </li>
+          </ol>
+        `, buildReadMessagesScript(10));
+
+        expect(rows).toEqual([{
+            Author: 'Current User',
+            Time: '2026-06-15T01:02:03.000Z',
+            Message: 'current answer',
+            channel_id: '222',
+            message_id: '999',
+        }]);
+    });
 });
 
 describe('discord-app command registration', () => {
@@ -151,19 +179,29 @@ describe('discord-app command registration', () => {
 
 describe('discord-app search', () => {
     function createSearchPage(bodyText = '', resultRows = []) {
+        let typedQuery = '';
         return {
             pressKey: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
+            nativeType: vi.fn(async (query) => {
+                typedQuery = query;
+            }),
+            cdp: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn(async (script) => {
-                if (script.includes('const input = document.querySelector')) return undefined;
+                if (script.includes('const editor = document.querySelector')) return true;
+                if (script.includes('document.activeElement?.textContent')) return typedQuery;
                 if (script.includes('const items = []')) {
                     const rowsHtml = resultRows.map((row, index) => `
-                      <div class="searchResult_${index}" id="search-result-${index}">
-                        <span class="username">${row.author}</span>
-                        <div id="message-content-${index}">${row.message}</div>
+                      <div id="search-results-${index}">
+                        <div class="searchResult_${index}">
+                          <div id="search-result-${index}">
+                            <span class="username">${row.author}</span>
+                            <div id="message-content-${index}">${row.message}</div>
+                          </div>
+                        </div>
                       </div>
                     `).join('');
-                    const dom = new JSDOM(`<!doctype html><body>${bodyText}${rowsHtml}</body>`, {
+                    const dom = new JSDOM(`<!doctype html><body>${bodyText}<div id="search-results">${rowsHtml}</div></body>`, {
                         url: 'https://discord.com/channels/111/222',
                         runScripts: 'outside-only',
                     });
@@ -173,6 +211,33 @@ describe('discord-app search', () => {
             }),
         };
     }
+
+    it('submits Draft.js search natively and returns each result once', async () => {
+        const cmd = getRegistry().get('discord-app/search');
+        const page = createSearchPage('', [
+            { author: 'Ada', message: 'iron condor result' },
+            { author: 'Lin', message: 'calendar spread result' },
+        ]);
+
+        await expect(cmd.func(page, { query: 'iron condor' })).resolves.toEqual([
+            { Index: 1, Author: 'Ada', Message: 'iron condor result' },
+            { Index: 2, Author: 'Lin', Message: 'calendar spread result' },
+        ]);
+
+        expect(page.nativeType).toHaveBeenCalledWith('iron condor');
+        expect(page.cdp).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
+            type: 'keyDown',
+            key: 'Enter',
+            code: 'Enter',
+            windowsVirtualKeyCode: 13,
+        }));
+        expect(page.cdp).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
+            type: 'keyUp',
+            key: 'Enter',
+            code: 'Enter',
+            windowsVirtualKeyCode: 13,
+        }));
+    });
 
     it('throws EmptyResultError when Discord shows an explicit no-results state', async () => {
         const cmd = getRegistry().get('discord-app/search');

--- a/clis/discord-app/search.js
+++ b/clis/discord-app/search.js
@@ -12,28 +12,64 @@ export const searchCommand = cli({
     columns: ['Index', 'Author', 'Message'],
     func: async (page, kwargs) => {
         const query = kwargs.query;
+        // Clear any previous Discord search result view so a new query cannot
+        // accidentally scrape stale rows while the next search is loading.
+        await page.pressKey('Escape');
+        await page.wait(0.2);
         // Open search with Cmd+F
         const isMac = process.platform === 'darwin';
         await page.pressKey(isMac ? 'Meta+F' : 'Control+F');
         await page.wait(0.5);
-        // Type query into search box
-        await page.evaluate(`
-      (function(q) {
-        const input = document.querySelector('[aria-label*="Search"], [class*="searchBar"] input, [placeholder*="Search"]');
-        if (!input) throw new Error('Search input not found');
-        input.focus();
-        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-        setter.call(input, q);
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-      })(${JSON.stringify(query)})
-    `);
-        await page.pressKey('Enter');
-        await page.wait(2);
+        // Discord currently renders search with Draft.js. Selecting the whole
+        // contenteditable before insertion updates the DOM but not Draft.js's
+        // internal state, so focus the freshly cleared editor and insert text
+        // through native browser input instead.
+        const searchSelector = '[role="combobox"][contenteditable="true"][aria-label*="Search"], input[aria-label*="Search"], [class*="searchBar"] input, input[placeholder*="Search"]';
+        const searchReady = await page.evaluate(`
+      (function(selector) {
+        const editor = document.querySelector(selector);
+        if (!editor) return false;
+        editor.focus();
+        if (editor.isContentEditable) {
+          const range = document.createRange();
+          range.selectNodeContents(editor);
+          range.collapse(false);
+          const selection = window.getSelection();
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+        return document.activeElement === editor && !(editor.textContent || editor.value || '');
+      })(${JSON.stringify(searchSelector)})
+        `);
+        if (!searchReady)
+            throw new CommandExecutionError('Discord search input was not ready for a new query.');
+        if (typeof page.nativeType !== 'function' || typeof page.cdp !== 'function') {
+            throw new CommandExecutionError('Discord search requires native browser input support.');
+        }
+        await page.nativeType(query);
+        const retainedQuery = await page.evaluate(`document.activeElement?.textContent || document.activeElement?.value || ''`);
+        if (retainedQuery !== query) {
+            throw new CommandExecutionError(`Discord search input did not retain query "${query}".`);
+        }
+        const enterEvent = {
+            key: 'Enter',
+            code: 'Enter',
+            windowsVirtualKeyCode: 13,
+            nativeVirtualKeyCode: 13,
+        };
+        await page.cdp('Input.dispatchKeyEvent', { type: 'keyDown', ...enterEvent });
+        await page.cdp('Input.dispatchKeyEvent', { type: 'keyUp', ...enterEvent });
+        // DOM-stability waits can return before Discord's asynchronous search
+        // response arrives. Wait for the result root instead.
+        await page.wait({ selector: '#search-results', timeout: 10 }).catch(() => undefined);
         // Scrape search results
         const searchState = await page.evaluate(`
       (function() {
         const items = [];
-        const resultNodes = document.querySelectorAll('[class*="searchResult_"], [id*="search-result"]');
+        let resultNodes = document.querySelectorAll('#search-results [id^="search-results-"]');
+        if (resultNodes.length === 0) {
+          resultNodes = document.querySelectorAll('[class*="searchResult_"]');
+        }
         
         resultNodes.forEach((node, i) => {
           const author = node.querySelector('[class*="username"]')?.textContent?.trim() || '—';

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -254,15 +254,28 @@ export function buildReadMessagesScript(count) {
 
         nodes.forEach(function(node) {
           var route = routeOfMessage(node);
-          var contentEl = node.querySelector('[id^="message-content-"], [class*="messageContent"]');
+          var contentEl = route.message_id
+            ? node.querySelector('#message-content-' + route.message_id)
+            : null;
+          if (!contentEl) {
+            contentEl = node.querySelector('[id^="message-content-"], [class*="messageContent"]');
+          }
           if (!contentEl) return;
 
           var key = route.message_id || textOf(contentEl);
           if (!key || seen.has(key)) return;
           seen.add(key);
 
-          var authorEl = node.querySelector('[class*="username"], [class*="headerText"] span, h3 span');
-          var timeEl = node.querySelector('time');
+          var authorEl = route.message_id
+            ? node.querySelector('#message-username-' + route.message_id)
+            : null;
+          if (!authorEl) {
+            authorEl = node.querySelector('[class*="username"], [class*="headerText"] span, h3 span');
+          }
+          var timeEl = route.message_id
+            ? node.querySelector('#message-timestamp-' + route.message_id)
+            : null;
+          if (!timeEl) timeEl = node.querySelector('time');
           results.push({
             Author: textOf(authorEl) || '—',
             Time: timeEl ? (timeEl.getAttribute('datetime') || textOf(timeEl)) : '',

--- a/skills/opencli-usage/SKILL.md
+++ b/skills/opencli-usage/SKILL.md
@@ -30,6 +30,22 @@ npx tsx src/main.ts <command>               # same surface, no global install
 
 `opencli doctor` prints a structured `DoctorReport` — daemon status, extension connection, version checks, and a live browser connectivity probe. Scope is narrow: it diagnoses the **browser bridge** (daemon + extension + Chrome wiring). `PUBLIC` / `LOCAL` adapters, `opencli list`, `validate`, `verify`, plugin commands, and external-CLI passthrough don't need it to be green — only `COOKIE` / `INTERCEPT` / `UI` adapters and the `opencli browser *` subcommands do. Flag: `-v` (verbose).
 
+### Multiple Browser Bridge profiles
+
+When `opencli profile list` shows more than one connected profile, do not hard-code a context named `default`. That string can be an ordinary extension context ID, including a stale or duplicate unpacked extension; it does not mean “the working profile”.
+
+Use a read-only browser-backed command to probe each candidate once, then persist the working route:
+
+```bash
+opencli profile list
+OPENCLI_PROFILE=<candidate> opencli <site> <read-command> ...
+opencli profile rename <working-context-id> automation  # optional stable alias
+opencli profile use automation                          # persists in browser-profiles.json
+opencli doctor -v
+```
+
+After that, run normal commands without `OPENCLI_PROFILE`; the persisted default is the durable route. Treat `OPENCLI_PROFILE=<name>` as a one-command diagnostic override only. If one candidate succeeds while another consistently reports `Debugger is not attached`, suspect duplicate Browser Bridge extensions in the same Chrome profile. Keep using the proven profile; do not request login or authorization unless the working profile itself returns `AUTH_REQUIRED`.
+
 ## Prerequisites by command type
 
 | Strategy tag on `opencli list` | What it needs |

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -118,6 +118,31 @@ describe('browser helpers', () => {
 });
 
 describe('BrowserBridge state', () => {
+  it('forwards a preferred profile into daemon readiness checks', async () => {
+    const healthSpy = vi.spyOn(daemonTransport, 'getDaemonHealth').mockResolvedValue({
+      state: 'ready',
+      status: {
+        ok: true,
+        pid: 123,
+        uptime: 0,
+        daemonVersion: '1.8.6',
+        extensionConnected: true,
+        contextId: 'work',
+        pending: 0,
+        memoryMB: 0,
+        port: 19825,
+      },
+    });
+    const bridge = new BrowserBridge();
+
+    await bridge.connect({ session: 'profile-routing-test', preferredContextId: 'work' });
+
+    expect(healthSpy).toHaveBeenCalledWith(expect.objectContaining({
+      contextId: undefined,
+      preferredContextId: 'work',
+    }));
+  });
+
   it('transitions to closed after close()', async () => {
     const bridge = new BrowserBridge();
 

--- a/src/browser/bridge-readiness.ts
+++ b/src/browser/bridge-readiness.ts
@@ -2,22 +2,27 @@ import type { DaemonHealth } from './daemon-transport.js';
 
 export type { DaemonHealth };
 
-export type HealthFetcher = (opts?: { timeout?: number; contextId?: string }) => Promise<DaemonHealth>;
+export type HealthFetcher = (opts?: {
+  timeout?: number;
+  contextId?: string;
+  preferredContextId?: string;
+}) => Promise<DaemonHealth>;
 
 const DEFAULT_POLL_INTERVAL_MS = 200;
 
 export async function waitForBridgeReady(
   fetchHealth: HealthFetcher,
-  opts: { timeoutMs: number; contextId?: string; intervalMs?: number },
+  opts: { timeoutMs: number; contextId?: string; preferredContextId?: string; intervalMs?: number },
 ): Promise<DaemonHealth> {
   const interval = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  let health = await fetchHealth({ contextId: opts.contextId });
+  const route = { contextId: opts.contextId, preferredContextId: opts.preferredContextId };
+  let health = await fetchHealth(route);
   if (health.state === 'ready') return health;
 
   const deadline = Date.now() + opts.timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, interval));
-    health = await fetchHealth({ contextId: opts.contextId });
+    health = await fetchHealth(route);
     if (health.state === 'ready') return health;
   }
   return health;

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -41,7 +41,7 @@ export class BrowserBridge implements IBrowserFactory {
       const routing = opts.contextId || opts.preferredContextId
         ? { contextId: opts.contextId, preferredContextId: opts.preferredContextId }
         : profileRouteParams(resolveProfileSelection());
-      await this._ensureDaemon(opts.timeout, routing.contextId);
+      await this._ensureDaemon(opts.timeout, routing.contextId, routing.preferredContextId);
       if (!opts.session?.trim()) throw new Error('Browser session is required');
       this._page = new Page(opts.session.trim(), opts.idleTimeout, routing.contextId, opts.windowMode, opts.surface, opts.siteSession, routing.preferredContextId);
       this._state = 'connected';
@@ -61,10 +61,15 @@ export class BrowserBridge implements IBrowserFactory {
     this._state = 'closed';
   }
 
-  private async _ensureDaemon(timeoutSeconds?: number, contextId?: string): Promise<void> {
+  private async _ensureDaemon(
+    timeoutSeconds?: number,
+    contextId?: string,
+    preferredContextId?: string,
+  ): Promise<void> {
     const result = await ensureBrowserBridgeReady({
       timeoutSeconds: timeoutSeconds ?? Math.ceil(DAEMON_SPAWN_TIMEOUT / 1000),
       contextId,
+      preferredContextId,
     });
     this._daemonProc = result.spawnedProcess;
   }

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -156,6 +156,25 @@ describe('daemon-client', () => {
     expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work$/);
   });
 
+  it('fetchDaemonStatus includes preferredContextId in the status query', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        ok: true,
+        pid: 1,
+        uptime: 0,
+        extensionConnected: true,
+        pending: 0,
+        memoryMB: 1,
+        port: 19825,
+      }),
+    } as Response);
+
+    await fetchDaemonStatus({ preferredContextId: 'automation' });
+
+    expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?preferredContextId=automation$/);
+  });
+
   it('rejects OPENCLI_DAEMON_PORT so CLI and extension cannot split bridge ports', async () => {
     vi.resetModules();
     vi.stubEnv('OPENCLI_DAEMON_PORT', '19999');

--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -94,14 +94,15 @@ export async function restartDaemon(opts: { stopTimeoutMs?: number; startTimeout
 }
 
 export async function ensureBrowserBridgeReady(
-  opts: { timeoutSeconds?: number; contextId?: string; verbose?: boolean } = {},
+  opts: { timeoutSeconds?: number; contextId?: string; preferredContextId?: string; verbose?: boolean } = {},
 ): Promise<EnsureBrowserBridgeReadyResult> {
   const timeoutSeconds = opts.timeoutSeconds && opts.timeoutSeconds > 0 ? opts.timeoutSeconds : 10;
   const timeoutMs = timeoutSeconds * 1000;
   const verbose = opts.verbose ?? true;
   const contextId = opts.contextId;
+  const preferredContextId = opts.preferredContextId;
 
-  const health = await getDaemonHealth({ contextId });
+  const health = await getDaemonHealth({ contextId, preferredContextId });
   const daemonVersion = health.status?.daemonVersion;
   const isStale = !!health.status && (!daemonVersion || daemonVersion !== PKG_VERSION);
   let staleDaemonReplaced = false;
@@ -158,7 +159,7 @@ export async function ensureBrowserBridgeReady(
     process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
   }
 
-  const finalHealth = await waitForBridgeReady(getDaemonHealth, { timeoutMs, contextId });
+  const finalHealth = await waitForBridgeReady(getDaemonHealth, { timeoutMs, contextId, preferredContextId });
   if (finalHealth.state === 'ready') return { health: finalHealth, spawnedProcess };
   throw browserConnectErrorFromHealth(finalHealth, contextId);
 }

--- a/src/browser/daemon-transport.ts
+++ b/src/browser/daemon-transport.ts
@@ -66,9 +66,19 @@ export async function requestDaemon(pathname: string, init?: RequestInit & { tim
   }
 }
 
-export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: string }): Promise<DaemonStatus | null> {
+export type DaemonRouteOptions = {
+  timeout?: number;
+  contextId?: string;
+  preferredContextId?: string;
+};
+
+export async function fetchDaemonStatus(opts?: DaemonRouteOptions): Promise<DaemonStatus | null> {
   try {
-    const params = opts?.contextId ? `?contextId=${encodeURIComponent(opts.contextId)}` : '';
+    const searchParams = new URLSearchParams();
+    if (opts?.contextId) searchParams.set('contextId', opts.contextId);
+    if (opts?.preferredContextId) searchParams.set('preferredContextId', opts.preferredContextId);
+    const query = searchParams.toString();
+    const params = query ? `?${query}` : '';
     const res = await requestDaemon(`/status${params}`, { timeout: opts?.timeout ?? 2000 });
     if (!res.ok) return null;
     return await res.json() as DaemonStatus;
@@ -78,7 +88,7 @@ export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: s
   }
 }
 
-export async function getDaemonHealth(opts?: { timeout?: number; contextId?: string }): Promise<DaemonHealth> {
+export async function getDaemonHealth(opts?: DaemonRouteOptions): Promise<DaemonHealth> {
   const status = await fetchDaemonStatus(opts);
   if (!status) return { state: 'stopped', status: null };
   if (status.profileRequired) return { state: 'profile-required', status };

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1109,6 +1109,11 @@ describe('browser tab targeting commands', () => {
 
   beforeEach(() => {
     process.exitCode = undefined;
+    // Browser command tests must not inherit the developer's real default
+    // Browser Bridge profile. A persisted default changes both connect options
+    // and the profile-scoped browser-state path, making this suite depend on
+    // ~/.opencli/browser-profiles.json.
+    process.env.OPENCLI_CONFIG_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-profile-config-'));
     process.env.OPENCLI_CACHE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tab-state-'));
     consoleLogSpy.mockClear();
     stderrSpy.mockClear();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -294,7 +294,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     const mem = process.memoryUsage();
     const params = new URL(url, `http://localhost:${PORT}`).searchParams;
     const requestedContextId = params.get('contextId')?.trim() || undefined;
-    const route = resolveExtensionConnection(requestedContextId);
+    const preferredContextId = params.get('preferredContextId')?.trim() || undefined;
+    const route = resolveExtensionConnection(requestedContextId, preferredContextId);
     const profiles = activeProfiles().map((profile) => ({
       contextId: profile.contextId,
       extensionConnected: true,
@@ -311,7 +312,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       extensionConnected: !!route.connection,
       extensionVersion: route.connection?.extensionVersion ?? undefined,
       extensionCompatRange: route.connection?.extensionCompatRange ?? undefined,
-      contextId: route.connection?.contextId ?? requestedContextId,
+      contextId: route.connection?.contextId ?? requestedContextId ?? preferredContextId,
       profileRequired: route.errorCode === 'profile_required',
       profileDisconnected: route.errorCode === 'profile_disconnected',
       profiles,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,7 +12,12 @@ import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
 import type { BrowserProfileStatus } from './browser/daemon-transport.js';
-import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
+import {
+  aliasForContextId,
+  loadProfileConfig,
+  profileRouteParams,
+  resolveProfileSelection,
+} from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
@@ -112,7 +117,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle.
-  const health = await getDaemonHealth();
+  const health = await getDaemonHealth(profileRouteParams(resolveProfileSelection()));
   const daemonRunning = health.state !== 'stopped';
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = connectivity.ok && !daemonRunning;


### PR DESCRIPTION
## Summary

- support Discord's current Draft.js `contenteditable` search box
- submit search with complete native Enter key metadata and wait for the asynchronous result root
- avoid stale and duplicate search rows when consecutive queries run
- bind message author, timestamp, and content extraction to the current Discord `message_id`
- add regression coverage for Draft.js search and reply-context extraction

## Root cause

Discord now renders search as a Draft.js `div[contenteditable]`, but the adapter invoked the `HTMLInputElement.value` setter on it, which raised `TypeError: Illegal invocation`.

The search command could also scrape the previous result set before the next query finished, and its broad selector matched multiple nested nodes for one result. For channel reads, broad descendant selectors selected the quoted reply context before the current message.

## Validation

- `npm test -- --run clis/discord-app/commands.test.js` — 23 passed
- `npm run typecheck`
- `npm run build`
- isolated full suite — 559 files passed, 6350 tests passed, 1 skipped
- `opencli validate discord-app/search`
- `opencli validate discord-app/read`
- live authenticated Discord Desktop regression:
  - consecutive queries returned 3 and 25 relevant rows with no exact duplicates
  - a known reply returned the current author and body instead of the quoted context
