### PR TITLE
fix(github-trending): accept singular '1 star today' in the since-period regex

### DIFF
--- a/clis/github-trending/repos.js
+++ b/clis/github-trending/repos.js
@@ -80,7 +80,7 @@ function parseTrendingHtml(html, limit) {
         const escapedRepo = escapeRegExp(repo);
         const starsMatch = block.match(new RegExp(`<a\\b[^>]*href="/${escapedRepo}/stargazers"[^>]*>([\\s\\S]*?)</a>`));
         const forksMatch = block.match(new RegExp(`<a\\b[^>]*href="/${escapedRepo}/forks"[^>]*>([\\s\\S]*?)</a>`));
-        const sinceMatch = block.match(/([\d,]+)\s+stars\s+(?:today|this week|this month)/i);
+        const sinceMatch = block.match(/([\d,]+)\s+stars?\s+(?:today|this week|this month)/i);
 
         rows.push({
             repo,

--- a/clis/github-trending/repos.test.js
+++ b/clis/github-trending/repos.test.js
@@ -62,6 +62,23 @@ describe('github-trending/repos', () => {
         ]);
     });
 
+    it('parses the singular "1 star today" GitHub renders for a single-star day', async () => {
+        // GitHub drops the plural "s" when the period count is exactly 1
+        // (e.g. delta-io/delta-rs on a slow trending day). The `since` regex
+        // must accept "star" as well as "stars".
+        const html = pageHtml([
+            article({ repo: 'delta-io/delta-rs', desc: 'A native Rust library for Delta Lake', lang: 'Rust', stars: '3,271', forks: '642', since: '1' })
+                .replace('1 stars today', '1 star today'),
+        ]);
+        mockHtmlOnce(html);
+
+        const rows = await loadCommand().func({ since: 'daily', language: 'rust', limit: 25 });
+
+        expect(rows).toEqual([
+            { rank: 1, repo: 'delta-io/delta-rs', description: 'A native Rust library for Delta Lake', language: 'Rust', stars: 3271, forks: 642, starsSince: 1, url: 'https://github.com/delta-io/delta-rs' },
+        ]);
+    });
+
     it('honors --limit by truncating the result set', async () => {
         const html = pageHtml([
             article({ repo: 'a/a', desc: 'a', lang: 'Go', stars: '1', forks: '1', since: '1' }),


### PR DESCRIPTION
## The bug

```
$ opencli github-trending repos --language rust --since daily -f json
CommandExecutionError: github-trending parser drift: missing period stars for delta-io/delta-rs
```
Exit 1.

github.com/trending renders **"1 star today"** — singular — when a repo's period count is exactly 1. The adapter's regex at `clis/github-trending/repos.js:83` required the literal plural `stars`, so any listing containing a one-star-today repo failed the whole command rather than that single row.

## The fix

`stars` → `stars?`. One character.

## Test plan

- [x] Added a regression case to the adapter's existing `repos.test.js`, following its fixture conventions. The file already had good coverage but no singular-star case.
- [x] Watched it fail before the fix:
  ```
  ❯ parses the singular "1 star today" GitHub renders for a single-star day
    CommandExecutionError: github-trending parser drift: missing period stars for delta-io/delta-rs
    Tests  1 failed | 11 passed (12)
  ```
- [x] Passing after: `Tests 12 passed (12)`.
- [x] Full `adapter` project green: 473 files / 4969 tests, no other regressions.
- [x] Live command re-run against the real page succeeds.
- [x] `opencli validate`: 1311 commands, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRqKZ1vQa29kYHJEr4iRGj