### PR TITLE
fix(browser-bridge): point remediation at the local extension checkout when running from source

### DIFF
--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { DEFAULT_DAEMON_PORT } from '../constants.js';
 import { BrowserConnectError } from '../errors.js';
+import { findPackageRoot, hasLocalExtensionSource } from '../package-paths.js';
 import { PKG_VERSION } from '../version.js';
 import { waitForBridgeReady } from './bridge-readiness.js';
 import { fetchDaemonStatus, getDaemonHealth, requestDaemonShutdown, type DaemonHealth, type DaemonStatus } from './daemon-transport.js';
@@ -181,12 +182,17 @@ function browserConnectErrorFromHealth(health: DaemonHealth, contextId?: string)
     );
   }
   if (health.state === 'no-extension') {
+    const packageRoot = findPackageRoot(fileURLToPath(import.meta.url));
+    const installSteps = hasLocalExtensionSource(packageRoot)
+      ? '  1. Open chrome://extensions → Developer Mode → Load unpacked\n' +
+        `  2. Select this checkout's extension/ folder (${path.join(packageRoot, 'extension')})`
+      : '  1. Download: https://github.com/jackwener/opencli/releases\n' +
+        '  2. Open chrome://extensions → Developer Mode → Load unpacked';
     return new BrowserConnectError(
       'Browser Bridge extension not connected',
       'Make sure Chrome/Chromium is open and the OpenCLI extension is enabled.\n' +
       'If not installed:\n' +
-      '  1. Download: https://github.com/jackwener/opencli/releases\n' +
-      '  2. Open chrome://extensions → Developer Mode → Load unpacked',
+      installSteps,
       'extension-not-connected',
     );
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,6 +4,8 @@
  * Simplified for the daemon-based architecture.
  */
 
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
 import { DEFAULT_DAEMON_PORT } from './constants.js';
 import { BrowserBridge } from './browser/index.js';
 import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
@@ -15,6 +17,7 @@ import type { BrowserProfileStatus } from './browser/daemon-transport.js';
 import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
+import { findPackageRoot, hasLocalExtensionSource } from './package-paths.js';
 
 const DOCTOR_LIVE_TIMEOUT_SECONDS = 8;
 const DOCTOR_SESSION = '__doctor__';
@@ -151,13 +154,18 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
         '  Open that Chrome profile and make sure the OpenCLI extension is enabled.',
       );
     } else {
+      const packageRoot = findPackageRoot(fileURLToPath(import.meta.url));
+      const installSteps = hasLocalExtensionSource(packageRoot)
+        ? '  1. Open chrome://extensions/ → Enable Developer Mode\n' +
+          `  2. Click "Load unpacked" → select this checkout's extension/ folder (${path.join(packageRoot, 'extension')})`
+        : '  1. Download from https://github.com/jackwener/opencli/releases\n' +
+          '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
+          '  3. Click "Load unpacked" → select the unzipped folder';
       issues.push(
         'Daemon is running but the Chrome/Chromium extension is not connected.\n' +
         'If the extension is already installed, try: opencli daemon restart\n' +
         'If the extension is not installed:\n' +
-        '  1. Download from https://github.com/jackwener/opencli/releases\n' +
-        '  2. Open chrome://extensions/ → Enable Developer Mode\n' +
-        '  3. Click "Load unpacked" → select the extension folder',
+        installSteps,
       );
     }
   }

--- a/src/package-paths.ts
+++ b/src/package-paths.ts
@@ -56,3 +56,16 @@ export function getCliManifestPath(clisDir: string): string {
 export function getFetchAdaptersScriptPath(packageRoot: string): string {
   return path.join(packageRoot, 'scripts', 'fetch-adapters.js');
 }
+
+/**
+ * True when a Browser Bridge extension source tree is sitting next to this
+ * checkout (dev/source checkout of the OpenCLI repo itself). The published
+ * npm package's `files` list excludes `extension/`, so this is false for a
+ * real global install — those users need the release zip instead.
+ */
+export function hasLocalExtensionSource(
+  packageRoot: string,
+  fileExists: (candidate: string) => boolean = fs.existsSync,
+): boolean {
+  return fileExists(path.join(packageRoot, 'extension', 'manifest.json'));
+}


### PR DESCRIPTION
## The problem

When the Browser Bridge extension is not connected, both `doctor` and the `no-extension` `BrowserConnectError` tell the user to download a release zip.

That is correct for a global npm install — `package.json`'s `files` array ships `dist/src/`, `clis/`, `skills/`, `cli-manifest.json`, `scripts/`, README and LICENSE, but **not** `extension/`. So an installed copy genuinely has no extension on disk.

It is wrong when running from a source checkout, where `extension/manifest.json` and a built `extension/dist/background.js` are already sitting right there. The user gets sent to a download page for files they already have.

## The fix

Adds `hasLocalExtensionSource(packageRoot)` to `src/package-paths.ts` — checks for `extension/manifest.json` next to the resolved package root, which is false for a real install per the `files` list above and true for a checkout — and branches the remediation text on it.

Fixed in **both** places the stale advice appeared, not just the obvious one:
- `src/doctor.ts`
- `src/browser/daemon-lifecycle.ts` (the `no-extension` `BrowserConnectError` path)

Output from a checkout now:

```
[MISSING] Extension: not connected
Issues:
  • Daemon is running but the Chrome/Chromium extension is not connected.
If the extension is already installed, try: opencli daemon restart
If the extension is not installed:
  1. Open chrome://extensions/ → Enable Developer Mode
  2. Click "Load unpacked" → select this checkout's extension/ folder (<repo>/extension)
```

An installed copy keeps the existing download-the-release guidance unchanged.

## Test plan

- [x] `npx tsc --noEmit -p .` clean.
- [x] `unit`: 83 files / 1284 tests pass (1 pre-existing unrelated skip).
- [x] `extension`: 3 files / 96 tests pass.
- [x] `adapter`: 473 files / 4969 tests pass.
- [x] `src/doctor.test.ts` specifically: 18/18. Confirmed no test pins the old exact remediation string, so nothing needed updating there.
- [x] Verified the live output above from an actual source checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRqKZ1vQa29kYHJEr4iRGj