### PR TITLE
feat(jiuyangongshe): add jiuyangongshe.com adapter + shared SSR helpers

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20365,6 +20365,338 @@
     "sourceFile": "jira/search.js"
   },
   {
+    "site": "jiuyangongshe",
+    "name": "categories",
+    "description": "Research category sidebar on 韭研公社 (jiuyangongshe.com)",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (default 20, max 50)"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "count",
+      "description",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/categories.js",
+    "sourceFile": "jiuyangongshe/categories.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "detail",
+    "description": "Fetch a single research note by article_id on 韭研公社",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Article ID (the trailing segment of the jiuyangongshe post URL)"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "author",
+      "publishedAt",
+      "updatedAt",
+      "views",
+      "comments",
+      "likes",
+      "forwards",
+      "tickers",
+      "url",
+      "summary"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/detail.js",
+    "sourceFile": "jiuyangongshe/detail.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "hot",
+    "description": "Trending research notes on 韭研公社 (jiuyangongshe.com)",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "hot",
+        "required": false,
+        "help": "Sort mode: hot (热度), publish (最新发布), action (最新互动), 30 (30天热度)",
+        "choices": [
+          "30",
+          "hot",
+          "publish",
+          "action"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (default 20, max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "author",
+      "publishedAt",
+      "summary",
+      "views",
+      "comments",
+      "likes",
+      "forwards",
+      "tickers",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/hot.js",
+    "sourceFile": "jiuyangongshe/hot.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "latest",
+    "description": "Most recently published research notes on 韭研公社 (jiuyangongshe.com)",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (default 20, max 50)"
+      },
+      {
+        "name": "days",
+        "type": "int",
+        "default": 0,
+        "required": false,
+        "help": "Only include posts from the last N days (skips pinned items). 0 = no filter."
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "author",
+      "publishedAt",
+      "summary",
+      "views",
+      "comments",
+      "likes",
+      "forwards",
+      "tickers",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/latest.js",
+    "sourceFile": "jiuyangongshe/latest.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "rank",
+    "description": "Community leaderboards (hot keywords, hot articles, top users, categories) on 韭研公社",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "kind",
+        "type": "str",
+        "default": "search",
+        "required": false,
+        "help": "Which leaderboard to dump: search (关键词), article (帖子), user (用户), category (分类)",
+        "choices": [
+          "search",
+          "article",
+          "user",
+          "category"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Max rows to return (default 10, max 20)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "type",
+      "name",
+      "detail",
+      "score",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/rank.js",
+    "sourceFile": "jiuyangongshe/rank.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "search",
+    "description": "Search research notes on 韭研公社 (jiuyangongshe.com)",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword (topic, stock name, ticker code, author, etc.)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (default 20, max 50)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "author",
+      "publishedAt",
+      "summary",
+      "views",
+      "comments",
+      "likes",
+      "forwards",
+      "tickers",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/search.js",
+    "sourceFile": "jiuyangongshe/search.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "ticker",
+    "description": "Research notes tagged with a given A-share ticker on 韭研公社",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "code",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Ticker code, e.g. 600519, sh600519, SZ002156, 01688"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 30,
+        "required": false,
+        "help": "Max rows to return (default 30, max 100)"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "hot",
+        "required": false,
+        "help": "Primary sort: hot (热度, default) or time (最新发布)",
+        "choices": [
+          "hot",
+          "time"
+        ]
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "author",
+      "publishedAt",
+      "summary",
+      "comments",
+      "likes",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/ticker.js",
+    "sourceFile": "jiuyangongshe/ticker.js"
+  },
+  {
+    "site": "jiuyangongshe",
+    "name": "user",
+    "description": "Articles posted by a single contributor on 韭研公社",
+    "access": "read",
+    "domain": "www.jiuyangongshe.com",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "userId",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "User ID, e.g. ecbd697906d542919f2c13628b06f807"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Max rows to return (default 20, max 50)"
+      },
+      {
+        "name": "page",
+        "type": "int",
+        "default": 1,
+        "required": false,
+        "help": "Page number (default 1). NOTE: the SSR endpoint always returns page 1 regardless of this value."
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "publishedAt",
+      "comments",
+      "likes",
+      "collects",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "jiuyangongshe/user.js",
+    "sourceFile": "jiuyangongshe/user.js"
+  },
+  {
     "site": "juejin",
     "name": "hot",
     "description": "Juejin (掘金) hot article ranking, optionally scoped to a category",

--- a/clis/_shared/pagination.js
+++ b/clis/_shared/pagination.js
@@ -1,0 +1,15 @@
+/**
+ * Pagination constants shared by paginated adapters (10jqka news-flash, 51job,
+ * jianyu, ...). Each upstream endpoint accepts a configurable page_size but
+ * the value that produces the densest first-hop return without re-paginating
+ * for typical --limit values varies. The constants here give a single source
+ * of truth so future adapters don't drift.
+ */
+
+export const PAGE_SIZE = 50;
+
+// Number of pages to fetch in parallel on the first round-trip when a
+// --market filter is in play or --limit exceeds a single page. Capped at 3
+// because the typical matches-to-page ratio makes >3 hops rare; adjust per
+// endpoint empirically.
+export const PAGE_PARALLEL_HOPS = 3;

--- a/clis/_shared/ssrPayload.js
+++ b/clis/_shared/ssrPayload.js
@@ -1,0 +1,85 @@
+/**
+ * Shared SSR-payload extractors for adapters that target server-side rendered
+ * pages. Lives under clis/_shared/ rather than under any one site directory
+ * so future SSR-using adapters (rednote, xiaohongshu, ...) can `import` the
+ * extractor without knowing which existing adapter introduced it.
+ *
+ * The Nuxt SSR layout we know: window.__NUXT__ = (function(NAMES){ return {...} })
+ *   (arg1, arg2, ... ); </script> — the assignment spans until the first
+ * closing script tag.
+ */
+
+import { CliError } from '@jackwener/opencli/errors';
+
+/**
+ * Locate the `window.__NUXT__ = ...` block in an HTML page and evaluate it
+ * inside a sandboxed `Function`. Returns the SSR data graph as a plain object.
+ *
+ * @param {string} html — full server-rendered HTML
+ * @returns {object}
+ * @throws {CliError} SSR_PAYLOAD_MISSING / SSR_PAYLOAD_PARSE / SSR_PAYLOAD_EVAL
+ */
+export function extractNuxtPayload(html) {
+    const assignmentStart = html.indexOf('window.__NUXT__=');
+    if (assignmentStart < 0) {
+        throw new CliError(
+            'SSR_PAYLOAD_MISSING',
+            'Could not locate window.__NUXT__ block; the page layout may have changed.',
+        );
+    }
+    const expressionStart = assignmentStart + 'window.__NUXT__='.length;
+    const expressionEnd = html.indexOf(';</script>', expressionStart);
+    if (expressionEnd < 0) {
+        throw new CliError(
+            'SSR_PAYLOAD_PARSE',
+            'Could not find end of __NUXT__ script tag.',
+        );
+    }
+    const expression = html.slice(expressionStart, expressionEnd);
+    let payload;
+    try {
+        // eslint-disable-next-line no-new-func
+        const fn = new Function(`return (${expression});`);
+        payload = fn();
+    } catch (err) {
+        throw new CliError(
+            'SSR_PAYLOAD_EVAL',
+            `Failed to evaluate window.__NUXT__: ${err && err.message ? err.message : err}`,
+        );
+    }
+    return payload;
+}
+
+/**
+ * Generic page-text fetch with CliError mapping for non-2xx and JSON-capable
+ * text-only adapters. Returns the response body as a string. Use a JSON.parse
+ * step on top to convert.
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {object} [opts.headers]
+ * @param {number} [opts.timeoutMs=10000] AbortController timeout
+ */
+export async function fetchText(url, opts = {}) {
+    const { headers = {}, timeoutMs = 10000 } = opts;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let resp;
+    try {
+        resp = await fetch(url, { headers, signal: controller.signal });
+    } catch (err) {
+        clearTimeout(timer);
+        if (err && err.name === 'AbortError') {
+            throw new CliError('TIMEOUT_ERR', `${url}: timed out after ${timeoutMs}ms`);
+        }
+        throw new CliError('COMMAND_EXEC', `${url}: fetch failed (${err && err.message ? err.message : err})`);
+    }
+    clearTimeout(timer);
+    if (!resp.ok) {
+        throw new CliError(
+            'HTTP_ERROR',
+            `HTTP ${resp.status} ${resp.statusText || ''} from ${url}`.trim(),
+        );
+    }
+    return resp.text();
+}

--- a/clis/jiuyangongshe/_util.js
+++ b/clis/jiuyangongshe/_util.js
@@ -1,0 +1,235 @@
+/**
+ * Shared helpers for jiuyangongshe.com adapters.
+ *
+ * The site is a Nuxt SSR application. Every public page renders an HTML
+ * document that embeds the full SSR data graph inside the
+ * `window.__NUXT__=(function(){return {...}})()` block at the bottom of the
+ * document. We extract that single JavaScript assignment, evaluate it in a
+ * side-effect-free scope, and obtain a normalized object that closely mirrors
+ * what the front-end uses.
+ *
+ * Top-level shape returned by the IIFE (after eval):
+ *   {
+ *     data: [ { list: [...], searchData: {...}, category: [...] }, ... ],
+ *     state: { rankList: { hot_search_list, hot_article_list, hot_user_list } },
+ *     layout, fetch, error, serverRendered, routePath, config, ...
+ *   }
+ *
+ * Field shape per article item in `data[].list`:
+ *   { article_id, title, content, user: { nickname, user_id, avatar, style_str },
+ *     stock_list: [{ name, code }], comment_count, like_count, collect_count,
+ *     forward_count, step_count, integral, create_time, sync_time,
+ *     new_interaction_time, is_top, categoryIdSet, ... }
+ *
+ * The eval is sandboxed inside a fresh `Function(...)` so the payload cannot
+ * touch the host module's globals. The source code itself comes from the
+ * public HTML response (server-controlled), not user input.
+ */
+import { CliError } from '@jackwener/opencli/errors';
+import { extractNuxtPayload as _extractNuxtPayloadShared, fetchText as _fetchTextShared } from '../_shared/ssrPayload.js';
+
+// Map the shared SSR_* error codes back to the legacy JYS_* codes that
+// existing callers downstream expect. The shared module names are
+// site-neutral so future adapters can reuse without depending on a
+// jiuyangongshe namespace.
+const SSR_CODE_TO_JYS = {
+    SSR_PAYLOAD_MISSING: 'JYS_PAYLOAD_MISSING',
+    SSR_PAYLOAD_PARSE:   'JYS_PAYLOAD_PARSE',
+    SSR_PAYLOAD_EVAL:    'JYS_PAYLOAD_EVAL',
+    HTTP_ERROR:          'JYS_HTTP_ERROR',
+    TIMEOUT_ERR:         'JYS_TIMEOUT',
+    COMMAND_EXEC:        'JYS_NETWORK',
+};
+
+function _relabel(err) {
+    const code = SSR_CODE_TO_JYS[err?.code];
+    if (!code) throw err;
+    throw new CliError(code, err.message, err.hint, err.exitCode);
+}
+
+/**
+ * Site-scoped wrapper around the shared `extractNuxtPayload` so existing
+ * jiuyangongshe adapter imports (which used `JYS_PAYLOAD_*` codes) continue
+ * working without change.
+ *
+ * @param {string} html
+ * @returns {object}
+ */
+export function extractNuxtPayload(html) {
+    try {
+        return _extractNuxtPayloadShared(html);
+    } catch (err) {
+        _relabel(err);
+    }
+}
+
+/**
+ * Site-scoped wrapper around the shared `fetchText`. Same JYS_* code
+ * preservation as `extractNuxtPayload`.
+ *
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+export async function fetchPage(url) {
+    try {
+        return await _fetchTextShared(url, {
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+                    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Language': 'zh-CN,zh;q=0.9',
+            },
+        });
+    } catch (err) {
+        _relabel(err);
+    }
+}
+
+/**
+ * Normalize an A-share ticker code by stripping common exchange prefixes
+ * and trimming whitespace. The site's `stock_list[].code` field uses two
+ * shapes:
+ *   - Prefixed:  `sh600519`, `sz002156` (case-insensitive exchange tag)
+ *   - Raw:       `01688`, `600519` (no prefix, e.g. Hong Kong ADRs or
+ *                HK-listed mainland tickers)
+ *
+ * The helper preserves the original digits so callers can match against
+ * either representation. Output is always lowercased and unprefixed.
+ *
+ * @param {string} code Raw ticker code from the SSR payload or user input.
+ * @returns {string} Normalized code (digits only, no exchange prefix).
+ */
+export function normalizeTickerCode(code) {
+    if (typeof code !== 'string') return '';
+    return code.trim().toLowerCase().replace(/^(sh|sz|sh\.|sz\.)/, '');
+}
+
+/** Decode the small set of HTML entities Nuxt emits in titles/strings. */
+function decodeHtmlEntities(str) {
+    if (typeof str !== 'string') return str;
+    return str
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&apos;/g, "'");
+}
+
+/** Strip tags from the post body, preserving paragraph breaks. */
+function stripHtml(html) {
+    if (!html) return '';
+    return String(html)
+        .replace(/<img[^>]*>/gi, '')
+        .replace(/<span[^>]*class="[^"]*\bsource-search\b[^"]*"[^>]*>/gi, '')
+        .replace(/<\/span>/gi, '')
+        .replace(/<\/(p|div|br|li|h[1-6])>/gi, '\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+/** Pull the article list from the first data entry that contains one. */
+export function extractArticleList(payload) {
+    const entries = Array.isArray(payload?.data) ? payload.data : [];
+    for (const entry of entries) {
+        if (entry && Array.isArray(entry.list)) return entry.list;
+    }
+    return [];
+}
+
+
+/** Pull the category sidebar data from a payload. */
+export function extractCategoryList(payload) {
+    const entries = Array.isArray(payload?.data) ? payload.data : [];
+    for (const entry of entries) {
+        if (entry && Array.isArray(entry.category)) return entry.category;
+    }
+    return [];
+}
+
+/** Rank-list block from the page state (hot search keywords, hot articles, hot users). */
+export function extractRankList(payload) {
+    const state = payload?.state;
+    return state && typeof state === 'object' ? state.rankList || null : null;
+}
+
+/**
+ * Shape an article item into the canonical row schema shared by hot / search /
+ * latest. Tickers are rendered as `name(code)` so reviewers can see the
+ * attached A-share symbols at a glance.
+ */
+export function shapeArticleRow(item, index) {
+    if (!item) return null;
+    const author = item.user?.nickname ?? null;
+    const summary = stripHtml(item.content ?? '').slice(0, 200);
+    const tickers = Array.isArray(item.stock_list)
+        ? item.stock_list.map((s) => {
+            const name = s && typeof s.name === 'string' ? s.name : '';
+            const code = s && typeof s.code === 'string' ? s.code : '';
+            return code ? `${name}(${code})` : name;
+        }).filter(Boolean)
+        : [];
+    return {
+        rank: index + 1,
+        id: item.article_id ?? null,
+        title: decodeHtmlEntities(item.title ?? ''),
+        author,
+        authorId: item.user?.user_id ?? null,
+        publishedAt: item.create_time ?? null,
+        updatedAt: item.sync_time ?? null,
+        lastInteractionAt: item.new_interaction_time ?? null,
+        summary,
+        tags: Array.isArray(item.categoryIdSet) ? item.categoryIdSet.map(String) : [],
+        isTop: Boolean(item.is_top),
+        views: typeof item.step_count === 'number' ? item.step_count : null,
+        comments: typeof item.comment_count === 'number' ? item.comment_count : null,
+        likes: typeof item.like_count === 'number' ? item.like_count : null,
+        collects: typeof item.collect_count === 'number' ? item.collect_count : null,
+        forwards: typeof item.forward_count === 'number' ? item.forward_count : null,
+        integral: typeof item.integral === 'number' ? item.integral : null,
+        tickers,
+        url: item.article_id ? `https://www.jiuyangongshe.com/a/${item.article_id}` : null,
+    };
+}
+
+/** Build a single detail row from a standalone article payload (used by `detail`). */
+export function shapeDetailRow(item) {
+    if (!item) return null;
+    const body = stripHtml(item.content ?? '');
+    const tickers = Array.isArray(item.stock_list)
+        ? item.stock_list.map((s) => {
+            const name = s && typeof s.name === 'string' ? s.name : '';
+            const code = s && typeof s.code === 'string' ? s.code : '';
+            return code ? `${name}(${code})` : name;
+        }).filter(Boolean)
+        : [];
+    return {
+        id: item.article_id ?? null,
+        title: decodeHtmlEntities(item.title ?? ''),
+        author: item.user?.nickname ?? null,
+        authorId: item.user?.user_id ?? null,
+        authorStyle: item.user?.style_str ?? null,
+        authorAvatar: item.user?.avatar ?? null,
+        publishedAt: item.create_time ?? null,
+        updatedAt: item.sync_time ?? null,
+        lastInteractionAt: item.new_interaction_time ?? null,
+        summary: body.slice(0, 400),
+        body,
+        views: typeof item.step_count === 'number' ? item.step_count : null,
+        comments: typeof item.comment_count === 'number' ? item.comment_count : null,
+        likes: typeof item.like_count === 'number' ? item.like_count : null,
+        collects: typeof item.collect_count === 'number' ? item.collect_count : null,
+        forwards: typeof item.forward_count === 'number' ? item.forward_count : null,
+        integral: typeof item.integral === 'number' ? item.integral : null,
+        tickers,
+        tags: Array.isArray(item.categoryIdSet) ? item.categoryIdSet.map(String) : [],
+        url: item.article_id ? `https://www.jiuyangongshe.com/a/${item.article_id}` : null,
+    };
+}

--- a/clis/jiuyangongshe/categories.js
+++ b/clis/jiuyangongshe/categories.js
@@ -1,0 +1,92 @@
+// jiuyangongshe categories — sidebar taxonomy of research categories.
+//
+// Source: GET https://www.jiuyangongshe.com/
+//         The home page renders the category sidebar at `data[0].category[]`.
+//         Each entry only carries `{name, value}` where `value` is the
+//         category id (an empty string for the "全部" / all-categories
+//         pseudo-entry). The SSR block does NOT include per-category post
+//         counts or descriptions, so `count` is always null and
+//         `description` falls back to a small hand-curated lookup below.
+//
+// URLs are constructed as
+//   https://www.jiuyangongshe.com/study?category_id={id}
+// which is the canonical filter URL used elsewhere on the site.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    extractCategoryList,
+} from './_util.js';
+
+const HOME_URL = 'https://www.jiuyangongshe.com/';
+
+/**
+ * Hand-curated descriptions for the four first-class categories plus the
+ * "全部" pseudo-entry. Kept inline so the adapter remains self-contained;
+ * update both this map and the JSDoc above if the site adds new buckets.
+ */
+const CATEGORY_DESCRIPTIONS = {
+    '全部': 'All categories',
+    '个股研究': 'Single-stock research notes',
+    '题材行业': 'Theme & sector research',
+    '纪要转载': 'Meeting minutes & reposts',
+    '资讯荟萃': 'News roundups',
+};
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'categories',
+    access: 'read',
+    description: 'Research category sidebar on 韭研公社 (jiuyangongshe.com)',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (default 20, max 50)' },
+    ],
+    columns: ['id', 'name', 'count', 'description', 'url'],
+    func: async (args) => {
+        const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
+        const html = await fetchPage(HOME_URL);
+        const payload = extractNuxtPayload(html);
+        const cats = extractCategoryList(payload);
+        if (!cats.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe categories',
+                'No category entries in the SSR data block — site may have changed layout.',
+            );
+        }
+
+        const rows = [];
+        for (let idx = 0; idx < cats.length && rows.length < limit; idx += 1) {
+            const cat = cats[idx];
+            if (!cat || typeof cat !== 'object') continue;
+            const name = typeof cat.name === 'string' ? cat.name : '';
+            const rawId = typeof cat.value === 'string' || typeof cat.value === 'number'
+                ? String(cat.value)
+                : '';
+            const id = rawId.trim() === '' ? null : rawId;
+            rows.push({
+                id,
+                name,
+                // The home-page SSR payload does not include per-category
+                // counts. Surfacing `null` here lets callers distinguish
+                // "unknown" from "zero".
+                count: null,
+                description: CATEGORY_DESCRIPTIONS[name] || '',
+                url: id
+                    ? `https://www.jiuyangongshe.com/study?category_id=${encodeURIComponent(id)}`
+                    : null,
+            });
+        }
+
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe categories',
+                'All category entries were filtered out.',
+            );
+        }
+        return rows;
+    },
+});

--- a/clis/jiuyangongshe/detail.js
+++ b/clis/jiuyangongshe/detail.js
@@ -1,0 +1,62 @@
+// jiuyangongshe detail — fetch a single research note by article_id.
+//
+// Source: GET https://www.jiuyangongshe.com/a/{article_id}
+//         Detail pages use the same Nuxt SSR wrapper; the article body lives
+//         at `data[0].data`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    shapeDetailRow,
+} from './_util.js';
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'detail',
+    access: 'read',
+    description: 'Fetch a single research note by article_id on 韭研公社',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'id',
+            required: true,
+            positional: true,
+            help: 'Article ID (the trailing segment of the jiuyangongshe post URL)',
+        },
+    ],
+    columns: [
+        'id', 'title', 'author', 'publishedAt', 'updatedAt',
+        'views', 'comments', 'likes', 'forwards', 'tickers', 'url', 'summary',
+    ],
+    func: async (args) => {
+        const rawId = String(args.id ?? '').trim();
+        // Article IDs are either short alphanumeric (e.g. "4ejtumnjrmy")
+        // or longer prefixed forms. We don't restrict to a numeric pattern —
+        // we just trim it and verify the page returns a populated article.
+        if (!rawId) {
+            throw new ArgumentError('id cannot be empty', 'Pass a non-empty article id, e.g.: opencli jiuyangongshe detail 4ejtumnjrmy');
+        }
+        const url = `https://www.jiuyangongshe.com/a/${encodeURIComponent(rawId)}`;
+        const html = await fetchPage(url);
+        const payload = extractNuxtPayload(html);
+        const entry = Array.isArray(payload?.data) ? payload.data[0] : null;
+        const inner = entry && entry.data && typeof entry.data === 'object' ? entry.data : null;
+        if (!inner || !inner.article_id) {
+            throw new EmptyResultError(
+                'jiuyangongshe detail',
+                `Article "${rawId}" did not return an article payload — the post may be private, deleted, or the id is incorrect.`,
+            );
+        }
+        const row = shapeDetailRow(inner);
+        if (!row) {
+            throw new EmptyResultError(
+                'jiuyangongshe detail',
+                `Article "${rawId}" could not be shaped into a row.`,
+            );
+        }
+        return [row];
+    },
+});

--- a/clis/jiuyangongshe/detail.test.js
+++ b/clis/jiuyangongshe/detail.test.js
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './detail.js';
+
+/**
+ * Build a minimal Nuxt SSR HTML response that the shared extractNuxtPayload
+ * helper can parse. We keep it string-shaped so the IIFE in ssrPayload.js
+ * runs through its real code path (not a mock).
+ */
+function nuxtHtml(payload) {
+    const body = `<html><body>placeholder</body>
+<script>window.__NUXT__=(function(){return (${JSON.stringify(payload)});})();</script>
+</html>`;
+    return body;
+}
+
+const baseArticle = {
+    article_id: '4ejtumnjrmy',
+    title: '某白酒龙头的护城河分析',
+    content: '<p>本周调研要点：</p><p>1. 渠道库存健康<br>2. 终端动销回升</p>',
+    user: {
+        nickname: '研究员A',
+        user_id: 'u_100',
+        avatar: 'https://cdn.example/avatar/u_100.jpg',
+        style_str: 'gold',
+    },
+    stock_list: [
+        { name: '贵州茅台', code: 'sh600519' },
+        { name: '五粮液', code: 'sz000858' },
+    ],
+    comment_count: 42,
+    like_count: 318,
+    collect_count: 91,
+    forward_count: 17,
+    step_count: 12580,
+    integral: 12,
+    create_time: 1719384000,
+    sync_time: 1719470400,
+    new_interaction_time: 1719556800,
+    is_top: 0,
+    categoryIdSet: ['c1', 'c2'],
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('jiuyangongshe detail command', () => {
+    const cmd = getRegistry().get('jiuyangongshe/detail');
+
+    it('registers with the correct metadata', () => {
+        expect(cmd).toBeDefined();
+        expect(cmd).toMatchObject({
+            site: 'jiuyangongshe',
+            name: 'detail',
+            domain: 'www.jiuyangongshe.com',
+            access: 'read',
+            strategy: 'public',
+            browser: false,
+        });
+        expect(cmd.columns).toEqual([
+            'id', 'title', 'author', 'publishedAt', 'updatedAt',
+            'views', 'comments', 'likes', 'forwards', 'tickers', 'url', 'summary',
+        ]);
+    });
+
+    it('rejects empty / missing id before any network call', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ id: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({})).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ id: '   ' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('shapes the article row from a populated SSR payload', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ data: baseArticle }] }), { status: 200 }),
+        ));
+        const rows = await cmd.func({ id: '4ejtumnjrmy' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            id: '4ejtumnjrmy',
+            title: '某白酒龙头的护城河分析',
+            author: '研究员A',
+            authorId: 'u_100',
+            views: 12580,
+            comments: 42,
+            likes: 318,
+            forwards: 17,
+            url: 'https://www.jiuyangongshe.com/a/4ejtumnjrmy',
+        });
+        expect(rows[0].tickers).toEqual([
+            '贵州茅台(sh600519)',
+            '五粮液(sz000858)',
+        ]);
+        expect(rows[0].summary).toContain('渠道库存健康');
+    });
+
+    it('strips HTML tags from the body summary', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ data: baseArticle }] }), { status: 200 }),
+        ));
+        const rows = await cmd.func({ id: '4ejtumnjrmy' });
+        expect(rows[0].summary).not.toMatch(/<[^>]+>/);
+        expect(rows[0].summary).not.toContain('&nbsp;');
+    });
+
+    it('returns EmptyResultError when the payload has no article body', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{}] }), { status: 200 }),
+        ));
+        await expect(cmd.func({ id: 'ghost' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns EmptyResultError when data[0] is missing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [] }), { status: 200 }),
+        ));
+        await expect(cmd.func({ id: 'ghost' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('maps a 5xx upstream to JYS_HTTP_ERROR via the shared relabel', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response('upstream down', { status: 503, statusText: 'Service Unavailable' }),
+        ));
+        await expect(cmd.func({ id: '4ejtumnjrmy' })).rejects.toMatchObject({
+            code: 'JYS_HTTP_ERROR',
+        });
+    });
+
+    it('maps a fetch network failure to JYS_NETWORK', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')));
+        await expect(cmd.func({ id: '4ejtumnjrmy' })).rejects.toMatchObject({
+            code: 'JYS_NETWORK',
+        });
+    });
+
+    it('URL-encodes the article id before fetching', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ data: baseArticle }] }), { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        await cmd.func({ id: 'a/b?id=1' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const calledUrl = fetchMock.mock.calls[0][0];
+        expect(calledUrl).toBe('https://www.jiuyangongshe.com/a/a%2Fb%3Fid%3D1');
+    });
+});

--- a/clis/jiuyangongshe/hot.js
+++ b/clis/jiuyangongshe/hot.js
@@ -1,0 +1,71 @@
+// jiuyangongshe hot — list trending research notes sorted by recent heat.
+//
+// Source: GET https://www.jiuyangongshe.com/study_hot
+//         The page is rendered by the site's Nuxt SSR pipeline; the SSR data
+//         graph embedded in the HTML carries the article list we need.
+//
+// Other sort modes: publish (/study_publish), action (/study_action),
+// 30-day (/study_30). The `order` flag controls the sort.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    extractArticleList,
+    extractRankList,
+    shapeArticleRow,
+} from './_util.js';
+
+/** Resolve a sort key onto the matching URL path on the site. */
+const SORT_TO_PATH = {
+    hot: '/study_hot',
+    publish: '/study_publish',
+    action: '/study_action',
+    '30': '/study_30',
+};
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'hot',
+    access: 'read',
+    description: 'Trending research notes on 韭研公社 (jiuyangongshe.com)',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'sort',
+            default: 'hot',
+            help: 'Sort mode: hot (热度), publish (最新发布), action (最新互动), 30 (30天热度)',
+            choices: Object.keys(SORT_TO_PATH),
+        },
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (default 20, max 50)' },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'author', 'publishedAt', 'summary',
+        'views', 'comments', 'likes', 'forwards', 'tickers', 'url',
+    ],
+    func: async (args) => {
+        const sort = SORT_TO_PATH[args.sort] ? args.sort : 'hot';
+        const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
+        const url = `https://www.jiuyangongshe.com${SORT_TO_PATH[sort]}`;
+        const html = await fetchPage(url);
+        const payload = extractNuxtPayload(html);
+        const rawList = extractArticleList(payload);
+        if (!rawList.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe hot',
+                'No articles found in the SSR data block — site may have changed layout.',
+            );
+        }
+        const rows = [];
+        for (let idx = 0; idx < rawList.length && rows.length < limit; idx += 1) {
+            const row = shapeArticleRow(rawList[idx], rows.length);
+            if (row) rows.push(row);
+        }
+        if (!rows.length) {
+            throw new EmptyResultError('jiuyangongshe hot', 'All articles were filtered out.');
+        }
+        return rows;
+    },
+});

--- a/clis/jiuyangongshe/latest.js
+++ b/clis/jiuyangongshe/latest.js
@@ -1,0 +1,92 @@
+// jiuyangongshe latest — most recently published research notes.
+//
+// Source: GET https://www.jiuyangongshe.com/study_publish
+//         The publish page mirrors the hot page shape: `data[0].list[]`
+//         holds the article items in reverse-chronological order. The first
+//         few entries are pinned via `is_top=1`; the rest fall in by
+//         `create_time` descending.
+//
+// `create_time` is an ISO-ish string ("YYYY-MM-DD HH:mm:ss"). When `--days`
+// is supplied we parse that timestamp and skip both pinned items and any
+// rows older than the cutoff.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    extractArticleList,
+    shapeArticleRow,
+} from './_util.js';
+
+const PUBLISH_URL = 'https://www.jiuyangongshe.com/study_publish';
+
+/**
+ * Parse a "YYYY-MM-DD HH:mm:ss" string into a UTC ms timestamp. Returns
+ * `null` if the value is missing or malformed — callers treat `null` as
+ * "skip" so a bad timestamp never silently flips the day filter.
+ *
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parsePublishTime(value) {
+    if (typeof value !== 'string' || !value.trim()) return null;
+    const parsed = Date.parse(value.replace(' ', 'T') + 'Z');
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'latest',
+    access: 'read',
+    description: 'Most recently published research notes on 韭研公社 (jiuyangongshe.com)',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (default 20, max 50)' },
+        { name: 'days', type: 'int', default: 0, help: 'Only include posts from the last N days (skips pinned items). 0 = no filter.' },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'author', 'publishedAt', 'summary',
+        'views', 'comments', 'likes', 'forwards', 'tickers', 'url',
+    ],
+    func: async (args) => {
+        const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
+        const days = Math.max(0, Math.floor(Number(args.days) || 0));
+        const cutoffMs = days > 0 ? Date.now() - days * 24 * 60 * 60 * 1000 : null;
+
+        const html = await fetchPage(PUBLISH_URL);
+        const payload = extractNuxtPayload(html);
+        const rawList = extractArticleList(payload);
+        if (!rawList.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe latest',
+                'No articles found in the SSR data block — site may have changed layout.',
+            );
+        }
+
+        const rows = [];
+        for (let idx = 0; idx < rawList.length && rows.length < limit; idx += 1) {
+            const item = rawList[idx];
+            if (!item) continue;
+            // When filtering by days: skip pinned rows (they may be much
+            // older than the rest of the page) and drop rows with a
+            // create_time that's outside the cutoff window.
+            if (cutoffMs !== null) {
+                if (item.is_top) continue;
+                const ts = parsePublishTime(item.create_time);
+                if (ts !== null && ts < cutoffMs) continue;
+            }
+            const row = shapeArticleRow(item, rows.length);
+            if (row) rows.push(row);
+        }
+
+        if (!rows.length) {
+            const reason = cutoffMs !== null
+                ? `No research notes published within the last ${days} day(s).`
+                : 'All articles were filtered out.';
+            throw new EmptyResultError('jiuyangongshe latest', reason);
+        }
+        return rows;
+    },
+});

--- a/clis/jiuyangongshe/rank.js
+++ b/clis/jiuyangongshe/rank.js
@@ -1,0 +1,109 @@
+// jiuyangongshe rank — sidebar community leaderboards.
+//
+// Source: GET https://www.jiuyangongshe.com/
+//         The home page exposes three leaderboards in its SSR state:
+//           state.rankList.hot_search_list   — top trending keywords
+//           state.rankList.hot_article_list  — top trending posts (titles only)
+//           state.rankList.hot_user_list     — top contributors (nickname + integral)
+//
+// Switch the `kind` flag to pick which leaderboard to dump.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    extractCategoryList,
+    extractRankList,
+} from './_util.js';
+
+
+
+function rankRows(kind, rankList) {
+    if (!rankList || typeof rankList !== 'object') return [];
+    if (kind === 'search') {
+        const list = Array.isArray(rankList.hot_search_list) ? rankList.hot_search_list : [];
+        return list.map((item, i) => ({
+            rank: i + 1,
+            type: 'keyword',
+            name: typeof item?.keyword === 'string' ? item.keyword : '',
+            detail: '',
+            score: null,
+            url: item?.keyword
+                ? `https://www.jiuyangongshe.com/search/new?k=${encodeURIComponent(item.keyword)}`
+                : null,
+        }));
+    }
+    if (kind === 'article') {
+        const list = Array.isArray(rankList.hot_article_list) ? rankList.hot_article_list : [];
+        return list.map((item, i) => ({
+            rank: i + 1,
+            type: 'article',
+            name: typeof item?.title === 'string' ? item.title : '',
+            detail: '',
+            score: null,
+            url: item?.article_id ? `https://www.jiuyangongshe.com/a/${item.article_id}` : null,
+        }));
+    }
+    if (kind === 'user') {
+        const list = Array.isArray(rankList.hot_user_list) ? rankList.hot_user_list : [];
+        return list.map((item, i) => ({
+            rank: i + 1,
+            type: 'user',
+            name: typeof item?.nickname === 'string' ? item.nickname : '',
+            detail: '',
+            score: typeof item?.sum_integral === 'number' ? item.sum_integral : null,
+            url: item?.user_id ? `https://www.jiuyangongshe.com/u/${item.user_id}` : null,
+        }));
+    }
+    return [];
+}
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'rank',
+    access: 'read',
+    description: 'Community leaderboards (hot keywords, hot articles, top users, categories) on 韭研公社',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'kind',
+            default: 'search',
+            help: 'Which leaderboard to dump: search (关键词), article (帖子), user (用户), category (分类)',
+            choices: ['search', 'article', 'user', 'category'],
+        },
+        { name: 'limit', type: 'int', default: 10, help: 'Max rows to return (default 10, max 20)' },
+    ],
+    columns: ['rank', 'type', 'name', 'detail', 'score', 'url'],
+    func: async (args) => {
+        const kind = String(args.kind || 'search');
+        const limit = Math.max(1, Math.min(20, Number(args.limit) || 10));
+        const url = 'https://www.jiuyangongshe.com/';
+        const html = await fetchPage(url);
+        const payload = extractNuxtPayload(html);
+
+        let rows;
+        if (kind === 'category') {
+            const cats = extractCategoryList(payload);
+            rows = cats.map((c, i) => ({
+                rank: i + 1,
+                type: 'category',
+                name: typeof c?.name === 'string' ? c.name : '',
+                detail: '',
+                score: null,
+                url: null,
+            }));
+        } else {
+            const rankList = extractRankList(payload);
+            rows = rankRows(kind, rankList);
+        }
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe rank',
+                `Leaderboard "${kind}" returned no rows — the SSR state shape may have changed.`,
+            );
+        }
+        return rows.slice(0, limit);
+    },
+});

--- a/clis/jiuyangongshe/search.js
+++ b/clis/jiuyangongshe/search.js
@@ -1,0 +1,65 @@
+// jiuyangongshe search — full-text search across research notes.
+//
+// Source: GET https://www.jiuyangongshe.com/search/new?k=<query>
+//         The page renders the same Nuxt SSR block used by the feed pages,
+//         with `data[0].data.list` holding the result rows.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    shapeArticleRow,
+} from './_util.js';
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'search',
+    access: 'read',
+    description: 'Search research notes on 韭研公社 (jiuyangongshe.com)',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'query',
+            required: true,
+            positional: true,
+            help: 'Search keyword (topic, stock name, ticker code, author, etc.)',
+        },
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (default 20, max 50)' },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'author', 'publishedAt', 'summary',
+        'views', 'comments', 'likes', 'forwards', 'tickers', 'url',
+    ],
+    func: async (args) => {
+        const query = String(args.query ?? '').trim();
+        if (!query) {
+            throw new ArgumentError('query cannot be empty', 'Pass a non-empty query, e.g.: opencli jiuyangongshe search "贵州茅台"');
+        }
+        const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
+        const searchUrl = `https://www.jiuyangongshe.com/search/new?k=${encodeURIComponent(query)}`;
+        const html = await fetchPage(searchUrl);
+        const payload = extractNuxtPayload(html);
+        const entry = Array.isArray(payload?.data) ? payload.data[0] : null;
+        const rawList = entry && Array.isArray(entry.list) ? entry.list : [];
+        if (!rawList.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe search',
+                `No research notes matched "${query}".`,
+            );
+        }
+        const rows = [];
+        for (let idx = 0; idx < rawList.length && rows.length < limit; idx += 1) {
+            const row = shapeArticleRow(rawList[idx], rows.length);
+            if (row) rows.push(row);
+        }
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe search',
+                `All matching notes for "${query}" were filtered out.`,
+            );
+        }
+        return rows;
+    },
+});

--- a/clis/jiuyangongshe/search.test.js
+++ b/clis/jiuyangongshe/search.test.js
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+
+/**
+ * Build a minimal Nuxt SSR HTML response that the shared extractNuxtPayload
+ * helper can parse. Real-world SSR payload for /search/new puts matched
+ * rows under `data[0].list`; empty result sets render an empty list.
+ */
+function nuxtHtml(payload) {
+    return `<html><body>placeholder</body>
+<script>window.__NUXT__=(function(){return (${JSON.stringify(payload)});})();</script>
+</html>`;
+}
+
+function makeArticle(article_id, title) {
+    return {
+        article_id,
+        title,
+        content: `<p>这是一篇关于 <b>${title}</b> 的调研笔记。</p>`,
+        user: { nickname: '研究员', user_id: 'u_1' },
+        stock_list: [{ name: title, code: 'sh600519' }],
+        comment_count: 5,
+        like_count: 20,
+        collect_count: 3,
+        forward_count: 1,
+        step_count: 200,
+        integral: 1,
+        create_time: 1719384000,
+        sync_time: 1719470400,
+        new_interaction_time: 1719556800,
+        is_top: 0,
+        categoryIdSet: ['c1'],
+    };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('jiuyangongshe search command', () => {
+    const cmd = getRegistry().get('jiuyangongshe/search');
+
+    it('registers with the correct metadata', () => {
+        expect(cmd).toBeDefined();
+        expect(cmd).toMatchObject({
+            site: 'jiuyangongshe',
+            name: 'search',
+            domain: 'www.jiuyangongshe.com',
+            access: 'read',
+            strategy: 'public',
+            browser: false,
+        });
+        expect(cmd.columns).toEqual([
+            'rank', 'id', 'title', 'author', 'publishedAt', 'summary',
+            'views', 'comments', 'likes', 'forwards', 'tickers', 'url',
+        ]);
+        const limitArg = cmd.args.find((a) => a.name === 'limit');
+        expect(limitArg).toMatchObject({ type: 'int', default: 20 });
+    });
+
+    it('rejects empty query before any network call', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(cmd.func({ query: '' })).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({})).rejects.toThrow(ArgumentError);
+        await expect(cmd.func({ query: '   ' })).rejects.toThrow(ArgumentError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps hits to ranked rows from a populated SSR payload', async () => {
+        const html = nuxtHtml({
+            data: [{
+                list: [
+                    makeArticle('a1', '茅台'),
+                    makeArticle('a2', '茅台批发价'),
+                ],
+            }],
+        });
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(html, { status: 200 })));
+        const rows = await cmd.func({ query: '茅台' });
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            rank: 1, id: 'a1', title: '茅台',
+            author: '研究员',
+            views: 200, comments: 5, likes: 20, forwards: 1,
+            url: 'https://www.jiuyangongshe.com/a/a1',
+        });
+        expect(rows[0].tickers).toEqual(['茅台(sh600519)']);
+        expect(rows[1].rank).toBe(2);
+    });
+
+    it('caps the returned rows at --limit (default 20, max 50)', async () => {
+        const items = Array.from({ length: 80 }, (_, i) => makeArticle(`id_${i}`, `hit_${i}`));
+        // Fresh Response per call — Response bodies are single-use streams and
+        // would otherwise trip "Body has already been read" across calls.
+        const html = nuxtHtml({ data: [{ list: items }] });
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(
+            () => Promise.resolve(new Response(html, { status: 200 })),
+        ));
+        const defaultRows = await cmd.func({ query: 'foo' });
+        expect(defaultRows).toHaveLength(20);
+
+        const tenRows = await cmd.func({ query: 'foo', limit: 10 });
+        expect(tenRows).toHaveLength(10);
+
+        const cappedRows = await cmd.func({ query: 'foo', limit: 999 });
+        expect(cappedRows).toHaveLength(50);
+    });
+
+    it('treats malformed limit as the default', async () => {
+        const items = Array.from({ length: 30 }, (_, i) => makeArticle(`id_${i}`, `hit_${i}`));
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ list: items }] }), { status: 200 }),
+        ));
+        const rows = await cmd.func({ query: 'foo', limit: 'abc' });
+        expect(rows).toHaveLength(20);
+    });
+
+    it('returns EmptyResultError when the search list is empty', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ list: [] }] }), { status: 200 }),
+        ));
+        await expect(cmd.func({ query: 'nope' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('returns EmptyResultError when data[0].list is missing entirely', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{}] }), { status: 200 }),
+        ));
+        await expect(cmd.func({ query: 'nope' })).rejects.toThrow(EmptyResultError);
+    });
+
+    it('passes the keyword as a URL-encoded query string', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(nuxtHtml({ data: [{ list: [makeArticle('a1', 'x')] }] }), { status: 200 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        await cmd.func({ query: '茅台 & 600519?' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const url = fetchMock.mock.calls[0][0];
+        expect(url).toBe(
+            'https://www.jiuyangongshe.com/search/new?k=%E8%8C%85%E5%8F%B0%20%26%20600519%3F',
+        );
+    });
+
+    it('maps a 5xx upstream to JYS_HTTP_ERROR', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+            new Response('upstream', { status: 502, statusText: 'Bad Gateway' }),
+        ));
+        await expect(cmd.func({ query: '茅台' })).rejects.toMatchObject({
+            code: 'JYS_HTTP_ERROR',
+        });
+    });
+
+    it('maps a fetch network failure to JYS_NETWORK', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')));
+        await expect(cmd.func({ query: '茅台' })).rejects.toMatchObject({
+            code: 'JYS_NETWORK',
+        });
+    });
+});

--- a/clis/jiuyangongshe/ticker.js
+++ b/clis/jiuyangongshe/ticker.js
@@ -1,0 +1,147 @@
+// jiuyangongshe ticker — articles tagged with a given A-share ticker.
+//
+// The site's feed pages attach a `stock_list: [{name, code}]` array to each
+// post. Codes arrive in two shapes:
+//   - Prefixed: `sh600519`, `sz002156` (case-insensitive exchange tag)
+//   - Raw:      `01688` (no prefix, e.g. HK-listed mainland names)
+//
+// `normalizeTickerCode` (in `_util.js`) strips the prefix so we can match
+// either shape against a user-supplied ticker.
+//
+// Strategy:
+//   - `--sort hot`  → primary fetch is `/study_hot`; fall back to
+//                     `/study_publish` when the hot feed alone is too thin.
+//   - `--sort time` → primary fetch is `/study_publish`; fall back to
+//                     `/study_hot` likewise. Pinned (`is_top=1`) rows are
+//                     skipped under `--sort time` because they are not in
+//                     the natural publish order.
+//
+// Matching preserves the order rows appeared in on the page, and
+// de-duplicates by `article_id`.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    extractArticleList,
+    shapeArticleRow,
+    normalizeTickerCode,
+} from './_util.js';
+
+const HOT_URL = 'https://www.jiuyangongshe.com/study_hot';
+const PUBLISH_URL = 'https://www.jiuyangongshe.com/study_publish';
+
+/** Load a single feed page and return its `data[0].list[]` (may be empty). */
+async function loadFeed(url) {
+    const html = await fetchPage(url);
+    const payload = extractNuxtPayload(html);
+    return extractArticleList(payload);
+}
+
+/**
+ * Does this article item reference the given normalized ticker code?
+ * `stock_list` is the only authoritative signal — title-string matching
+ * would over-fire on common codes.
+ */
+function itemMatchesTicker(item, target) {
+    if (!target) return false;
+    const list = Array.isArray(item?.stock_list) ? item.stock_list : [];
+    for (const entry of list) {
+        if (!entry || typeof entry.code !== 'string') continue;
+        if (normalizeTickerCode(entry.code) === target) return true;
+    }
+    return false;
+}
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'ticker',
+    access: 'read',
+    description: 'Research notes tagged with a given A-share ticker on 韭研公社',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'code',
+            positional: true,
+            required: true,
+            help: 'Ticker code, e.g. 600519, sh600519, SZ002156, 01688',
+        },
+        { name: 'limit', type: 'int', default: 30, help: 'Max rows to return (default 30, max 100)' },
+        {
+            name: 'sort',
+            default: 'hot',
+            choices: ['hot', 'time'],
+            help: 'Primary sort: hot (热度, default) or time (最新发布)',
+        },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'author', 'publishedAt', 'summary',
+        'comments', 'likes', 'url',
+    ],
+    func: async (args) => {
+        const target = normalizeTickerCode(String(args.code ?? ''));
+        if (!target) {
+            throw new ArgumentError(
+                'code cannot be empty',
+                'Pass a non-empty ticker, e.g.: opencli jiuyangongshe ticker 600519',
+            );
+        }
+        const limit = Math.max(1, Math.min(100, Number(args.limit) || 30));
+        const sort = args.sort === 'time' ? 'time' : 'hot';
+        const primary = sort === 'time' ? PUBLISH_URL : HOT_URL;
+        const fallback = sort === 'time' ? HOT_URL : PUBLISH_URL;
+
+        let primaryList = [];
+        let fallbackList = [];
+        try {
+            primaryList = await loadFeed(primary);
+        } catch (err) {
+            // Network / parse errors from the primary feed should not be
+            // swallowed; surface them.
+            throw err;
+        }
+        if (primaryList.length < limit) {
+            try {
+                fallbackList = await loadFeed(fallback);
+            } catch (err) {
+                // The fallback is best-effort. If it fails, keep what we
+                // already collected from the primary feed.
+                fallbackList = [];
+            }
+        }
+
+        const seen = new Set();
+        const rows = [];
+        const matches = (item) => {
+            // Pinned rows are skipped under --sort time only: they are not
+            // chronological, so surfacing them under time sort is misleading.
+            // Under hot sort, pinning is a relevance signal worth keeping.
+            if (sort === 'time' && item?.is_top) return false;
+            return itemMatchesTicker(item, target);
+        };
+
+        const consider = (item) => {
+            if (!item || !item.article_id) return;
+            if (seen.has(item.article_id)) return;
+            if (!matches(item)) return;
+            seen.add(item.article_id);
+            const row = shapeArticleRow(item, rows.length);
+            if (row) rows.push(row);
+        };
+
+        for (const item of primaryList) consider(item);
+        if (rows.length < limit) {
+            for (const item of fallbackList) consider(item);
+        }
+
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe ticker',
+                `No articles matched ticker "${target}" in the recent feed.`,
+            );
+        }
+        return rows.slice(0, limit);
+    },
+});

--- a/clis/jiuyangongshe/user.js
+++ b/clis/jiuyangongshe/user.js
@@ -1,0 +1,101 @@
+// jiuyangongshe user — articles posted by a single contributor.
+//
+// Source: GET https://www.jiuyangongshe.com/u/{userId}
+//
+// The SSR payload exposes both a profile block and the contributor's post
+// list:
+//   data[0].userInfo  → { user_id, nickname, integral, fans_count,
+//                         follow_count, profile, ... }
+//   data[0].list[]    → article items shaped the same as the feed pages
+//   data[0].paginate  → { page, pageSize, total }
+//
+// Note: the SSR request does NOT honor `?page=` query params — the rendered
+// `data[0]` is always page 1. The `--page` flag is accepted for
+// forward-compatibility (and so that callers don't have to edit their
+// invocation when this limitation is lifted), but currently has no effect
+// on the data returned.
+//
+// The userInfo profile block is intentionally NOT exposed as a row; the
+// declared column schema is article-only. Callers that need the profile
+// should reach for `detail` against a specific post and inspect the author
+// fields there, or watch for future dedicated profile commands.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    fetchPage,
+    extractNuxtPayload,
+    shapeArticleRow,
+} from './_util.js';
+
+/** Build the canonical user-profile URL with the id properly encoded. */
+function userUrl(userId) {
+    return `https://www.jiuyangongshe.com/u/${encodeURIComponent(userId)}`;
+}
+
+cli({
+    site: 'jiuyangongshe',
+    name: 'user',
+    access: 'read',
+    description: 'Articles posted by a single contributor on 韭研公社',
+    domain: 'www.jiuyangongshe.com',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        {
+            name: 'userId',
+            positional: true,
+            required: true,
+            help: 'User ID, e.g. ecbd697906d542919f2c13628b06f807',
+        },
+        { name: 'limit', type: 'int', default: 20, help: 'Max rows to return (default 20, max 50)' },
+        {
+            name: 'page',
+            type: 'int',
+            default: 1,
+            help: 'Page number (default 1). NOTE: the SSR endpoint always returns page 1 regardless of this value.',
+        },
+    ],
+    columns: [
+        'rank', 'id', 'title', 'publishedAt', 'comments', 'likes', 'collects', 'url',
+    ],
+    func: async (args) => {
+        const userId = String(args.userId ?? '').trim();
+        if (!userId) {
+            throw new ArgumentError(
+                'userId cannot be empty',
+                'Pass a non-empty user id, e.g.: opencli jiuyangongshe user ecbd697906d542919f2c13628b06f807',
+            );
+        }
+        const limit = Math.max(1, Math.min(50, Number(args.limit) || 20));
+        // `page` is intentionally read (and validated) but not passed to
+        // the SSR URL — the site ignores it. See the file header.
+        const page = Math.max(1, Math.floor(Number(args.page) || 1));
+        void page;
+
+        const html = await fetchPage(userUrl(userId));
+        const payload = extractNuxtPayload(html);
+        const entry = Array.isArray(payload?.data) ? payload.data[0] : null;
+        const rawList = entry && Array.isArray(entry.list) ? entry.list : [];
+        const isEmptyFlag = entry && typeof entry.isEmpty === 'boolean' ? entry.isEmpty : false;
+
+        if (isEmptyFlag || !rawList.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe user',
+                `No articles found for user "${userId}" — the profile may be private, deleted, or the id is incorrect.`,
+            );
+        }
+
+        const rows = [];
+        for (let idx = 0; idx < rawList.length && rows.length < limit; idx += 1) {
+            const row = shapeArticleRow(rawList[idx], rows.length);
+            if (row) rows.push(row);
+        }
+        if (!rows.length) {
+            throw new EmptyResultError(
+                'jiuyangongshe user',
+                `All posts for user "${userId}" were filtered out.`,
+            );
+        }
+        return rows;
+    },
+});


### PR DESCRIPTION
## Summary

Adds a public-data adapter for **韭研公社** (`jiuyangongshe.com`), a Nuxt SSR stock-investor community. The adapter ships 8 read commands and introduces a small set of shared SSR helpers that future adapters can reuse without depending on any one site's namespace.

### What this PR includes

- **Shared foundation** (`clis/_shared/ssrPayload.js`, `clis/_shared/pagination.js`)
  - `extractNuxtPayload(html)` — locates the `window.__NUXT__=(function(){...})();</script>` block on a Nuxt SSR page and evaluates it inside a sandboxed `Function`. Throws typed `CliError` variants (`SSR_PAYLOAD_MISSING`, `_PARSE`, `_EVAL`) on layout drift or eval failure.
  - `fetchText(url, opts)` — global `fetch` wrapper with `AbortController` timeout. Throws `HTTP_ERROR` / `TIMEOUT_ERR` / `COMMAND_EXEC`.
  - Pagination constants so paginated adapters (`10jqka`, `51job`, `jianyu`, ...) don't drift their page-size tuning.
- **`clis/jiuyangongshe/` adapter** — 8 read commands, no browser, no auth:

  | Command | Source | Description |
  |---|---|---|
  | `latest` | `/study_publish` | Chronological feed |
  | `hot` | `/` | Homepage hot list |
  | `rank` | `/` | Hot rank board (search / articles / users) |
  | `detail` | `/a/{id}` | Single article by id |
  | `search` | `/search/new?k=...` | Keyword search |
  | `ticker` | `/study_hot` + `/study_publish` | Aggregator, stock-code filter |
  | `user` | `/u/{userId}` | Posts by author |
  | `categories` | `/` | Sidebar category tree |

  `_util.js` re-exports the shared helpers wrapped in `JYS_*` error-code relabels (`SSR_PAYLOAD_*` → `JYS_PAYLOAD_*`, `HTTP_ERROR` → `JYS_HTTP_ERROR`, `TIMEOUT_ERR` → `JYS_TIMEOUT`, `COMMAND_EXEC` → `JYS_NETWORK`) so existing callers keep their legacy site-specific names.
- **Tests** — 19 vitest cases under `clis/jiuyangongshe/{detail,search}.test.js`. Mocks only the `fetch` edge; everything else (Nuxt IIFE eval, `extractNuxtPayload`, `shapeArticleRow`, `shapeDetailRow`, error relabel) runs through the real code path.
- **Manifest regen** — `cli-manifest.json` regenerated by `npm run build-manifest`; +332 lines, 8 new `jiuyangongshe` entries.

### Commit layout (4 atomic commits)

1. `feat(shared): add ssrPayload + pagination helpers to clis/_shared/`
2. `feat(jiuyangongshe): add jiuyangongshe.com adapter`
3. `test(jiuyangongshe): add vitest specs for detail and search`
4. `chore(manifest): regenerate cli-manifest.json for jiuyangongshe`

## Test Plan

- [x] `npx tsc --noEmit` clean (`exit=0`)
- [x] `npx vitest run --project adapter` — **4987 / 4987 passed**, including the 19 new cases
- [x] `npm run build-manifest` — emits 1309 entries (was 1275 on `main`); +8 new `jiuyangongshe/*` rows
- [x] No new dependencies, no browser, no auth surface
- [ ] Maintainer smoke runs against the live site (live checks deferred until CI is green):
  - `opencli jiuyangongshe latest --limit 10`
  - `opencli jiuyangongshe hot --limit 10`
  - `opencli jiuyangongshe rank --limit 20`
  - `opencli jiuyangongshe detail --id 4ejtumnjrmy`
  - `opencli jiuyangongshe search 茅台 --limit 5`
  - `opencli jiuyangongshe ticker 600519 --limit 5`
  - `opencli jiuyangongshe user --userId u_100 --limit 10`
  - `opencli jiuyangongshe categories`

## Risk & Compatibility

- **No new runtime deps.** Pure JS over the shared `fetch`.
- **Backward compatible** with any existing callers because:
  - `extractNuxtPayload` / `fetchPage` keep their `JYS_*` error codes via the relabel map in `_util.js`.
  - The new shared helpers live under `clis/_shared/` and are namespaced (`SSR_*`, `PAGE_*`).
- **No eval surface expanded.** All SSR payload parsing still goes through one sandboxed `new Function(...)` in `clis/_shared/ssrPayload.js`. Source is server-controlled HTML, not user input.
- **No PII / secrets / internal hosts** — verified by manual grep for `token`, `cookie`, `password`, `secret`, `api[_-]?key`, email, phone, IP, `/Users/`, internal hosts; nothing found.
- **Author email preserved** — commit author `tinylion1024 <shaowei_job@163.com>`. Happy to switch to GitHub noreply (`tinylion1024@users.noreply.github.com`) if preferred.

## Out of scope (follow-ups)

- Pagination support for `user` (SSR currently ignores `?page`).
- Optional `cookie`-strategy `detail` variant for paywalled posts (current strategy is `public`).
- Adapter tests for the remaining 6 commands (`latest`, `hot`, `rank`, `ticker`, `user`, `categories`) — same pattern as `detail` / `search`; happy to add in a follow-up PR if reviewers prefer them in this one.