### PR TITLE
fix(browser): forward preferred profile through health checks

### DIFF
--- a/src/browser/bridge-readiness.test.ts
+++ b/src/browser/bridge-readiness.test.ts
@@ -54,6 +54,18 @@ describe('waitForBridgeReady', () => {
     expect(fetchHealth).toHaveBeenCalledTimes(3);
   });
 
+  it('forwards a preferred profile on every health poll', async () => {
+    const fetchHealth: HealthFetcher = vi.fn(async () => readyHealth());
+
+    await waitForBridgeReady(fetchHealth, {
+      timeoutMs: 10_000,
+      preferredContextId: 'personal profile',
+      intervalMs: 1,
+    });
+
+    expect(fetchHealth).toHaveBeenCalledWith({ contextId: undefined, preferredContextId: 'personal profile' });
+  });
+
   it('returns the last observed non-ready health when the deadline expires', async () => {
     const fetchHealth: HealthFetcher = vi.fn(async () => notReadyHealth('profile-disconnected'));
 

--- a/src/browser/bridge-readiness.ts
+++ b/src/browser/bridge-readiness.ts
@@ -2,22 +2,22 @@ import type { DaemonHealth } from './daemon-transport.js';
 
 export type { DaemonHealth };
 
-export type HealthFetcher = (opts?: { timeout?: number; contextId?: string }) => Promise<DaemonHealth>;
+export type HealthFetcher = (opts?: { timeout?: number; contextId?: string; preferredContextId?: string }) => Promise<DaemonHealth>;
 
 const DEFAULT_POLL_INTERVAL_MS = 200;
 
 export async function waitForBridgeReady(
   fetchHealth: HealthFetcher,
-  opts: { timeoutMs: number; contextId?: string; intervalMs?: number },
+  opts: { timeoutMs: number; contextId?: string; preferredContextId?: string; intervalMs?: number },
 ): Promise<DaemonHealth> {
   const interval = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  let health = await fetchHealth({ contextId: opts.contextId });
+  let health = await fetchHealth({ contextId: opts.contextId, preferredContextId: opts.preferredContextId });
   if (health.state === 'ready') return health;
 
   const deadline = Date.now() + opts.timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, interval));
-    health = await fetchHealth({ contextId: opts.contextId });
+    health = await fetchHealth({ contextId: opts.contextId, preferredContextId: opts.preferredContextId });
     if (health.state === 'ready') return health;
   }
   return health;

--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -41,7 +41,7 @@ export class BrowserBridge implements IBrowserFactory {
       const routing = opts.contextId || opts.preferredContextId
         ? { contextId: opts.contextId, preferredContextId: opts.preferredContextId }
         : profileRouteParams(resolveProfileSelection());
-      await this._ensureDaemon(opts.timeout, routing.contextId);
+      await this._ensureDaemon(opts.timeout, routing.contextId, routing.preferredContextId);
       if (!opts.session?.trim()) throw new Error('Browser session is required');
       this._page = new Page(opts.session.trim(), opts.idleTimeout, routing.contextId, opts.windowMode, opts.surface, opts.siteSession, routing.preferredContextId);
       this._state = 'connected';
@@ -61,10 +61,11 @@ export class BrowserBridge implements IBrowserFactory {
     this._state = 'closed';
   }
 
-  private async _ensureDaemon(timeoutSeconds?: number, contextId?: string): Promise<void> {
+  private async _ensureDaemon(timeoutSeconds?: number, contextId?: string, preferredContextId?: string): Promise<void> {
     const result = await ensureBrowserBridgeReady({
       timeoutSeconds: timeoutSeconds ?? Math.ceil(DAEMON_SPAWN_TIMEOUT / 1000),
       contextId,
+      preferredContextId,
     });
     this._daemonProc = result.spawnedProcess;
   }

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -453,6 +453,49 @@ describe('daemon-client', () => {
     expect(ids[0]).toBe(ids[1]);
   });
 
+  it('sendCommand forwards the soft preferred profile through bridge recovery', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-recovery-profile-'));
+    fs.writeFileSync(
+      path.join(configDir, 'browser-profiles.json'),
+      JSON.stringify({ version: 1, aliases: {}, defaultContextId: 'zvypsyje' }),
+    );
+    vi.stubEnv('OPENCLI_CONFIG_DIR', configDir);
+    vi.stubEnv('OPENCLI_PROFILE', '');
+    const ensureSpy = mockEnsureReady('1.0.22');
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({
+          ok: false,
+          errorCode: 'extension_not_connected',
+          error: 'Extension not connected.',
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'server', ok: true, data: 7 }),
+      } as Response);
+
+    try {
+      await expect(sendCommand('exec', { code: '1 + 6' })).resolves.toBe(7);
+
+      expect(ensureSpy).toHaveBeenCalledWith(expect.objectContaining({
+        contextId: undefined,
+        preferredContextId: 'zvypsyje',
+        verbose: false,
+      }));
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
   it('sendCommand runs full bridge ensure on a pre-connect TypeError (ECONNREFUSED) before resending', async () => {
     const ensureSpy = mockEnsureReady();
     const refused = new TypeError('fetch failed');

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -137,7 +137,7 @@ describe('daemon-client', () => {
     await expect(getDaemonHealth()).resolves.toEqual({ state: 'profile-required', status });
   });
 
-  it('fetchDaemonStatus includes contextId in the status query', async () => {
+  it('fetchDaemonStatus includes profile routing in the status query', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
@@ -151,9 +151,9 @@ describe('daemon-client', () => {
       }),
     } as Response);
 
-    await fetchDaemonStatus({ contextId: 'work' });
+    await fetchDaemonStatus({ contextId: 'work', preferredContextId: 'personal profile' });
 
-    expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work$/);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toMatch(/\/status\?contextId=work&preferredContextId=personal\+profile$/);
   });
 
   it('rejects OPENCLI_DAEMON_PORT so CLI and extension cannot split bridge ports', async () => {

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -352,10 +352,10 @@ async function sendCommandRaw(
     const remainingSeconds = Math.ceil((deadlineAt - Date.now()) / 1000);
     const ready = await ensureBrowserBridgeReady({
       timeoutSeconds: Math.max(1, Math.min(DEFAULT_BROWSER_CONNECT_TIMEOUT, remainingSeconds)),
-      // Only an explicit requirement pins readiness to a specific profile —
-      // waiting for a stale preferred profile to come back would hang the
-      // ensure path even though the daemon can already serve the command.
       contextId,
+      // Keep the persisted default soft during recovery: the daemon prefers it
+      // when live, but can still fall back to an unambiguous connected profile.
+      preferredContextId,
       verbose: false,
     });
     executorJournaled = versionAtLeast(ready.health.status?.extensionVersion, MIN_JOURNAL_EXTENSION_VERSION);

--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -94,14 +94,15 @@ export async function restartDaemon(opts: { stopTimeoutMs?: number; startTimeout
 }
 
 export async function ensureBrowserBridgeReady(
-  opts: { timeoutSeconds?: number; contextId?: string; verbose?: boolean } = {},
+  opts: { timeoutSeconds?: number; contextId?: string; preferredContextId?: string; verbose?: boolean } = {},
 ): Promise<EnsureBrowserBridgeReadyResult> {
   const timeoutSeconds = opts.timeoutSeconds && opts.timeoutSeconds > 0 ? opts.timeoutSeconds : 10;
   const timeoutMs = timeoutSeconds * 1000;
   const verbose = opts.verbose ?? true;
   const contextId = opts.contextId;
+  const preferredContextId = opts.preferredContextId;
 
-  const health = await getDaemonHealth({ contextId });
+  const health = await getDaemonHealth({ contextId, preferredContextId });
   const daemonVersion = health.status?.daemonVersion;
   const isStale = !!health.status && (!daemonVersion || daemonVersion !== PKG_VERSION);
   let staleDaemonReplaced = false;
@@ -158,7 +159,7 @@ export async function ensureBrowserBridgeReady(
     process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
   }
 
-  const finalHealth = await waitForBridgeReady(getDaemonHealth, { timeoutMs, contextId });
+  const finalHealth = await waitForBridgeReady(getDaemonHealth, { timeoutMs, contextId, preferredContextId });
   if (finalHealth.state === 'ready') return { health: finalHealth, spawnedProcess };
   throw browserConnectErrorFromHealth(finalHealth, contextId);
 }

--- a/src/browser/daemon-transport.ts
+++ b/src/browser/daemon-transport.ts
@@ -66,9 +66,12 @@ export async function requestDaemon(pathname: string, init?: RequestInit & { tim
   }
 }
 
-export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: string }): Promise<DaemonStatus | null> {
+export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: string; preferredContextId?: string }): Promise<DaemonStatus | null> {
   try {
-    const params = opts?.contextId ? `?contextId=${encodeURIComponent(opts.contextId)}` : '';
+    const searchParams = new URLSearchParams();
+    if (opts?.contextId) searchParams.set('contextId', opts.contextId);
+    if (opts?.preferredContextId) searchParams.set('preferredContextId', opts.preferredContextId);
+    const params = searchParams.size ? `?${searchParams}` : '';
     const res = await requestDaemon(`/status${params}`, { timeout: opts?.timeout ?? 2000 });
     if (!res.ok) return null;
     return await res.json() as DaemonStatus;
@@ -78,7 +81,7 @@ export async function fetchDaemonStatus(opts?: { timeout?: number; contextId?: s
   }
 }
 
-export async function getDaemonHealth(opts?: { timeout?: number; contextId?: string }): Promise<DaemonHealth> {
+export async function getDaemonHealth(opts?: { timeout?: number; contextId?: string; preferredContextId?: string }): Promise<DaemonHealth> {
   const status = await fetchDaemonStatus(opts);
   if (!status) return { state: 'stopped', status: null };
   if (status.profileRequired) return { state: 'profile-required', status };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -294,7 +294,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     const mem = process.memoryUsage();
     const params = new URL(url, `http://localhost:${PORT}`).searchParams;
     const requestedContextId = params.get('contextId')?.trim() || undefined;
-    const route = resolveExtensionConnection(requestedContextId);
+    const preferredContextId = params.get('preferredContextId')?.trim() || undefined;
+    const route = resolveExtensionConnection(requestedContextId, preferredContextId);
     const profiles = activeProfiles().map((profile) => ({
       contextId: profile.contextId,
       extensionConnected: true,
@@ -311,7 +312,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       extensionConnected: !!route.connection,
       extensionVersion: route.connection?.extensionVersion ?? undefined,
       extensionCompatRange: route.connection?.extensionCompatRange ?? undefined,
-      contextId: route.connection?.contextId ?? requestedContextId,
+      contextId: route.connection?.contextId ?? requestedContextId ?? preferredContextId,
       profileRequired: route.errorCode === 'profile_required',
       profileDisconnected: route.errorCode === 'profile_disconnected',
       profiles,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -203,6 +203,8 @@ describe('doctor report rendering', () => {
 
       const report = await runBrowserDoctor();
 
+      expect(mockGetDaemonHealth).toHaveBeenCalledWith({ preferredContextId: 'zvypsyje' });
+
       expect(report.issues).toEqual(expect.arrayContaining([
         expect.stringContaining('Default browser profile is stale: work (zvypsyje)'),
       ]));

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,7 +12,7 @@ import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
 import { getCachedLatestExtensionVersion } from './update-check.js';
 import type { BrowserProfileStatus } from './browser/daemon-transport.js';
-import { aliasForContextId, loadProfileConfig } from './browser/profile.js';
+import { aliasForContextId, loadProfileConfig, profileRouteParams, resolveProfileSelection } from './browser/profile.js';
 import { formatDaemonVersion, isDaemonStale, staleDaemonIssue } from './browser/daemon-version.js';
 import { findShadowedUserAdapters, formatAdapterShadowIssue, type AdapterShadow } from './adapter-shadow.js';
 
@@ -112,7 +112,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle.
-  const health = await getDaemonHealth();
+  const health = await getDaemonHealth(profileRouteParams(resolveProfileSelection()));
   const daemonRunning = health.state !== 'stopped';
   const extensionConnected = health.state === 'ready';
   const daemonFlaky = connectivity.ok && !daemonRunning;

--- a/tests/e2e/daemon-transport.test.ts
+++ b/tests/e2e/daemon-transport.test.ts
@@ -294,6 +294,23 @@ describe('daemon transport contracts (real daemon)', () => {
     }
   });
 
+  it('uses preferredContextId when reporting daemon status', async () => {
+    if (guard()) return;
+    const ext = new FakeExtension();
+    await ext.connect('ctx-status');
+    try {
+      const res = await fetch(`${BASE}/status?preferredContextId=ctx-status`, { headers: HEADERS });
+      const status = await res.json();
+
+      expect(res.ok).toBe(true);
+      expect(status.extensionConnected).toBe(true);
+      expect(status.contextId).toBe('ctx-status');
+      expect(status.profileRequired).toBe(false);
+    } finally {
+      ext.close();
+    }
+  });
+
   it('flushes a structured daemon_shutting_down 503 to in-flight dispatched commands on shutdown', async () => {
     if (guard()) return;
     const ext = new FakeExtension();


### PR DESCRIPTION
## Summary

Fixes #2164 by forwarding a persisted `preferredContextId` through the browser daemon health and readiness routes.

- Keep explicit `contextId` routing strict.
- Thread the soft preference through bridge startup, lifecycle readiness, transport URL serialization, `/status`, and doctor.
- Cover preference forwarding in focused unit tests and the real-daemon transport E2E.

## Validation

- Focused unit tests: 60 passed
- TypeScript typecheck
- Real-daemon transport E2E: 7 passed
- `git diff --check`

The full suite was also run; 41 tests failed only because this hosted sandbox has no writable `/root` home for OpenCLI's home-directory fixtures. The production build's `tsx` wrapper could not open its local IPC socket in this sandbox, while its TypeScript compile and direct manifest generation completed successfully.
