### PR TITLE
fix(autoresearch): pass claude prompt via stdin

### DIFF
--- a/autoresearch/commands/run.ts
+++ b/autoresearch/commands/run.ts
@@ -11,7 +11,7 @@
  * Engine handles commit, verify, guard, keep/discard, and logging.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs, type AutoResearchConfig } from '../config.js';
@@ -20,6 +20,31 @@ import { PRESETS } from '../presets/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..', '..');
+const CLAUDE_ALLOWED_TOOLS = 'Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep';
+
+export function buildClaudeModifyInvocation(prompt: string) {
+  const options: ExecFileSyncOptionsWithStringEncoding = {
+    cwd: ROOT,
+    timeout: 300_000,
+    encoding: 'utf-8',
+    input: prompt,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: process.env,
+  };
+  return {
+    command: 'claude',
+    args: [
+      '-p',
+      '--dangerously-skip-permissions',
+      '--allowedTools',
+      CLAUDE_ALLOWED_TOOLS,
+      '--output-format',
+      'text',
+      '--no-session-persistence',
+    ],
+    options,
+  };
+}
 
 function buildModifyPrompt(ctx: ModifyContext, config: AutoResearchConfig): string {
   const recent = ctx.recentLog.slice(-10).map(r =>
@@ -60,20 +85,13 @@ async function modify(ctx: ModifyContext, config: AutoResearchConfig): Promise<s
 
   console.log('  Claude Code making a change...');
   try {
-    // Pass prompt via stdin `input` option to avoid shell metacharacter injection
-    // (prompt is built from git log messages and file names, which may contain
-    // untrusted characters such as $(...), backticks, or backslashes that are
-    // not neutralized by simple double-quote escaping).
-    const result = execSync(
-      'claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence',
-      {
-        cwd: ROOT,
-        timeout: 300_000,
-        encoding: 'utf-8',
-        input: prompt,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: process.env,
-      }
+    // Keep command structure and the repository-derived prompt out of a shell.
+    // Claude reads the prompt from stdin when -p has no positional prompt.
+    const invocation = buildClaudeModifyInvocation(prompt);
+    const result = execFileSync(
+      invocation.command,
+      invocation.args,
+      invocation.options
     ).trim();
 
     // Extract description from Claude's response (last non-empty line or summary)
@@ -140,4 +158,6 @@ async function main() {
   }
 }
 
-main();
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/autoresearch/commands/run.ts
+++ b/autoresearch/commands/run.ts
@@ -60,12 +60,17 @@ async function modify(ctx: ModifyContext, config: AutoResearchConfig): Promise<s
 
   console.log('  Claude Code making a change...');
   try {
+    // Pass prompt via stdin `input` option to avoid shell metacharacter injection
+    // (prompt is built from git log messages and file names, which may contain
+    // untrusted characters such as $(...), backticks, or backslashes that are
+    // not neutralized by simple double-quote escaping).
     const result = execSync(
-      `claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence "${prompt.replace(/"/g, '\\"')}"`,
+      'claude -p --dangerously-skip-permissions --allowedTools "Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep" --output-format text --no-session-persistence',
       {
         cwd: ROOT,
         timeout: 300_000,
         encoding: 'utf-8',
+        input: prompt,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: process.env,
       }

--- a/src/autoresearch-run.test.ts
+++ b/src/autoresearch-run.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildClaudeModifyInvocation } from '../autoresearch/commands/run.js';
+
+describe('autoresearch Claude invocation', () => {
+  it('passes repository-derived prompts through stdin instead of shell arguments', () => {
+    const prompt = 'try $(touch /tmp/opencli-pwned) and `id` and "quotes"';
+    const invocation = buildClaudeModifyInvocation(prompt);
+
+    expect(invocation.command).toBe('claude');
+    expect(invocation.args).toEqual([
+      '-p',
+      '--dangerously-skip-permissions',
+      '--allowedTools',
+      'Bash(npm:*),Bash(npx:*),Bash(git:*),Read,Edit,Write,Glob,Grep',
+      '--output-format',
+      'text',
+      '--no-session-persistence',
+    ]);
+    expect(invocation.args.join(' ')).not.toContain(prompt);
+    expect(invocation.options.input).toBe(prompt);
+    expect(invocation.options).not.toHaveProperty('shell');
+  });
+});


### PR DESCRIPTION
## Description

Fixes a shell metacharacter injection in `autoresearch/commands/run.ts` where the prompt passed to `claude -p` is interpolated into a shell command string with only double-quote escaping. Values that reach the prompt include git log messages and scope file names, so characters such as `` ` ``, `$(...)`, and `\` survive the `prompt.replace(/"/g, '\\"')` escaping and are evaluated by the shell.

The fix passes the prompt via `execSync`'s `input` option instead of embedding it as a shell argument, and removes the trailing prompt argument. This mirrors the pattern already used in `autoresearch/commands/fix.ts`, which sends its prompt through stdin.

Related issue: none — reporting inline.

## Type of Change

- [x] 🐛 Bug fix

## Vulnerability details

- **CWE**: CWE-78, OS command injection through shell-string interpolation.
- **Severity**: Low to moderate in this project because exploitation is local and requires control over repository content that the developer then runs through `autoresearch`. The sink is still real and worth removing as defense-in-depth.
- **Affected code**: `autoresearch/commands/run.ts`, `modify()`.
- **Data flow**: `Engine.run()` reads recent commit subjects with `git log --oneline -20` and passes configured scope patterns as `ctx.gitLog` and `ctx.scopeFiles`. `buildModifyPrompt()` includes both values in `prompt`. The old `modify()` implementation inserted that prompt into a string passed to `child_process.execSync()`, so Node executed it via `/bin/sh -c`. Escaping only double quotes does not neutralize command substitution or backticks.

## Fix and rationale

The command string now contains only the fixed `claude` invocation. The untrusted prompt is supplied through stdin with `input: prompt`, which means shell metacharacters in the prompt are not parsed by the shell at all. This keeps the same `claude -p` behavior while separating command structure from prompt data. A short comment was added near the call site to document why stdin is intentional and why quote replacement is not sufficient.

## Proof of Concept

The shell parsing issue can be reproduced with a minimal local harness. This demonstrates the same escaping pattern that was previously used in `modify()`; no `claude` installation is required because the payload executes before the target process receives its argument.

```bash
node -e '
  const { execSync } = require("node:child_process");
  const prompt = "git subject $(id > /tmp/opencli-autoresearch-poc) scope";
  const cmd = `echo "${prompt.replace(/"/g, "\\\"")}"`;
  execSync(cmd, { stdio: "inherit" });
'
test -s /tmp/opencli-autoresearch-poc && cat /tmp/opencli-autoresearch-poc
```

On the vulnerable pattern, `/tmp/opencli-autoresearch-poc` is created because `/bin/sh -c` evaluates `$(id ...)` inside the interpolated prompt. In the real code path, the same prompt content can come from a recent git commit message shown by `git log --oneline -20` or from a configured scope filename/pattern included in `ctx.scopeFiles`, then reaches `modify()` in `autoresearch/commands/run.ts`.

After this patch, the prompt is sent as stdin data. Replacing the fixed `claude` command with `cat` during local validation showed the payload appears as literal text on stdout and no side-effect file is created, because the shell never reparses the prompt.

## Tests

- `npm run typecheck` — passed cleanly.
- Existing automated tests were not changed; this is a call-site hardening change and there was no existing test coverage for invoking the external `claude` binary.
- Manually checked the analogous safe pattern in `autoresearch/commands/fix.ts` and verified that the affected function and command path (`modify()` in `autoresearch/commands/run.ts`, invoked via `npx tsx autoresearch/commands/run.ts ...`) exist in the repository.

## Security analysis

The practical preconditions are that a developer runs `autoresearch/commands/run.ts` in a repository where an attacker can influence a recent commit message or a scope file name/pattern. That can happen when working with an untrusted branch, fork, or local repository. The impact of the specific sink is local command execution in the developer's environment at the moment `execSync()` invokes the shell.

This should not be treated as a high-severity unauthenticated remote issue. `autoresearch` intentionally runs `claude -p --dangerously-skip-permissions` with npm, npx, git, read, edit, and write capabilities, so the overall tool is already designed to let an AI act on repository content with broad local permissions. However, command substitution in the shell wrapper is an avoidable extra execution path that happens before `claude` receives or reasons about the prompt. Moving untrusted prompt data to stdin removes that footgun and preserves the intended behavior.

## Adversarial review

Before submitting, we tried to disprove this by checking whether the existing double-quote escaping, the `claude` CLI boundary, or the tool's normal permission model would prevent exploitation. They do not prevent the shell from evaluating `$(...)` or backticks before `claude` starts. The main limiting factor is the local-repository precondition and the already-powerful `autoresearch` workflow, which is why this is best viewed as defense-in-depth rather than a severe escalation.

## Checklist

- [x] I ran the checks relevant to this PR (`npm run typecheck`)
- [x] I updated tests or docs if needed (no user-facing behavior change; explanatory comment added at the call site)
- [x] I included output or screenshots when useful (PoC commands above)