### PR TITLE
fix(amazon): honor the input marketplace instead of rewriting to amazon.com

### DIFF
--- a/clis/amazon/discussion.js
+++ b/clis/amazon/discussion.js
@@ -9,7 +9,7 @@ function normalizeDiscussionPayload(payload) {
     const provenance = buildProvenance(sourceUrl);
     return {
         asin,
-        product_url: asin ? normalizeProductUrl(asin) : null,
+        product_url: asin ? normalizeProductUrl(sourceUrl) : null,
         discussion_url: sourceUrl,
         ...provenance,
         average_rating_text: averageRatingText,
@@ -111,7 +111,8 @@ cli({
         const payload = await readDiscussionPayload(page, input, limit);
         const normalized = normalizeDiscussionPayload(payload);
         if (!normalized.average_rating_text && !normalized.total_review_count_text) {
-            throw new CommandExecutionError('amazon discussion page did not expose review summary', 'The review page may have changed or hit a robot check. Open the review page in Chrome and retry.');
+            const landedUrl = cleanText(payload.href) || buildDiscussionUrl(input);
+            throw new CommandExecutionError(`amazon discussion page did not expose review summary (landed on ${landedUrl})`, 'The review page may have changed or hit a robot check. Open the review page in Chrome and retry.');
         }
         return [normalized];
     },

--- a/clis/amazon/discussion.js
+++ b/clis/amazon/discussion.js
@@ -1,6 +1,6 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { buildProductUrl, buildDiscussionUrl, buildProvenance, cleanText, extractAsin, normalizeProductUrl, parseRatingValue, parseReviewCount, trimRatingPrefix, uniqueNonEmpty, assertUsableState, gotoAndReadState, } from './shared.js';
+import { DOMAIN, amazonHostFromInput, buildProductUrl, buildDiscussionUrl, buildProvenance, cleanText, extractAsin, normalizeProductUrl, parseRatingValue, parseReviewCount, trimRatingPrefix, uniqueNonEmpty, assertUsableState, gotoAndReadState, } from './shared.js';
 function normalizeDiscussionPayload(payload) {
     const sourceUrl = cleanText(payload.href) || buildDiscussionUrl(payload.href ?? '');
     const asin = extractAsin(payload.href ?? '') ?? null;
@@ -71,7 +71,7 @@ async function readDiscussionPayload(page, input, limit) {
     const productState = await gotoAndReadState(page, productUrl, 2500, 'discussion');
     assertUsableState(productState, 'discussion');
     if (isSignInState(reviewState) && isSignInState(productState)) {
-        throw new AuthRequiredError('amazon.com', 'Amazon review discussion requires an active signed-in Amazon session in the shared Chrome profile.');
+        throw new AuthRequiredError(amazonHostFromInput(input) ?? DOMAIN, 'Amazon review discussion requires an active signed-in Amazon session in the shared Chrome profile.');
     }
     const productPayload = await readCurrentDiscussionPayload(page, limit);
     if (hasDiscussionSummary(productPayload)) {

--- a/clis/amazon/discussion.test.js
+++ b/clis/amazon/discussion.test.js
@@ -41,6 +41,41 @@ describe('amazon discussion normalization', () => {
     ]);
   });
 
+  it('keeps the review marketplace in every emitted url', () => {
+    const result = __test__.normalizeDiscussionPayload({
+      href: 'https://www.amazon.co.uk/product-reviews/B0FGCPFY9L',
+      average_rating_text: '4.4 out of 5',
+      total_review_count_text: '40 global ratings',
+      qa_links: [],
+      review_samples: [],
+    });
+
+    expect(result.asin).toBe('B0FGCPFY9L');
+    expect(result.discussion_url).toBe('https://www.amazon.co.uk/product-reviews/B0FGCPFY9L');
+    expect(result.product_url).toBe('https://www.amazon.co.uk/dp/B0FGCPFY9L');
+  });
+
+  it('requests the review page on the marketplace the input names', async () => {
+    const command = getRegistry().get('amazon/discussion');
+    const page = createPageMock([
+      {
+        href: 'https://www.amazon.co.uk/product-reviews/B0FGCPFY9L',
+        title: 'Amazon.co.uk: Example product',
+        body_text: 'Customer reviews',
+      },
+      {
+        href: 'https://www.amazon.co.uk/product-reviews/B0FGCPFY9L',
+        average_rating_text: '4.4 out of 5',
+        total_review_count_text: '40 global ratings',
+        review_samples: [],
+      },
+    ]);
+
+    await command.func(page, { input: 'https://www.amazon.co.uk/product-reviews/B0FGCPFY9L', limit: 1 });
+
+    expect(page.goto.mock.calls[0][0]).toBe('https://www.amazon.co.uk/product-reviews/B0FGCPFY9L');
+  });
+
   it('falls back to the product page when the review page redirects to sign-in', async () => {
     const command = getRegistry().get('amazon/discussion');
     const page = createPageMock([

--- a/clis/amazon/discussion.test.js
+++ b/clis/amazon/discussion.test.js
@@ -76,6 +76,33 @@ describe('amazon discussion normalization', () => {
     expect(page.goto.mock.calls[0][0]).toBe('https://www.amazon.co.uk/product-reviews/B0FGCPFY9L');
   });
 
+  it('names the loaded url when neither page exposes a review summary', async () => {
+    const command = getRegistry().get('amazon/discussion');
+    const emptyPayload = { href: 'https://www.amazon.co.uk/dp/B0FGCPFY9L', average_rating_text: '', total_review_count_text: '', review_samples: [] };
+    const page = createPageMock([
+      { href: 'https://www.amazon.co.uk/product-reviews/B0FGCPFY9L', title: 'Amazon.co.uk', body_text: 'Customer reviews' },
+      emptyPayload,
+      { href: 'https://www.amazon.co.uk/dp/B0FGCPFY9L', title: 'Amazon.co.uk', body_text: 'Product' },
+      emptyPayload,
+    ]);
+
+    await expect(command.func(page, { input: 'https://www.amazon.co.uk/dp/B0FGCPFY9L', limit: 1 }))
+      .rejects.toThrow('landed on https://www.amazon.co.uk/dp/B0FGCPFY9L');
+  });
+
+  it('points a gated non-US review page at that marketplace, not the US store', async () => {
+    const command = getRegistry().get('amazon/discussion');
+    const signIn = { href: 'https://www.amazon.co.uk/ap/signin', title: 'Amazon Sign-In', body_text: 'Sign in Create account' };
+    const page = createPageMock([
+      signIn,
+      { href: signIn.href, average_rating_text: '', total_review_count_text: '', review_samples: [] },
+      signIn,
+    ]);
+
+    await expect(command.func(page, { input: 'https://www.amazon.co.uk/dp/B0FGCPFY9L', limit: 1 }))
+      .rejects.toMatchObject({ domain: 'www.amazon.co.uk' });
+  });
+
   it('falls back to the product page when the review page redirects to sign-in', async () => {
     const command = getRegistry().get('amazon/discussion');
     const page = createPageMock([

--- a/clis/amazon/product.js
+++ b/clis/amazon/product.js
@@ -83,7 +83,8 @@ cli({
         const input = String(kwargs.input ?? '');
         const payload = await readProductPayload(page, input);
         if (!cleanText(payload.product_title)) {
-            throw new CommandExecutionError('amazon product page did not expose product content', 'The product page may have changed or hit a robot check. Open the product page in Chrome and retry.');
+            const landedUrl = cleanText(payload.href) || buildProductUrl(input);
+            throw new CommandExecutionError(`amazon product page did not expose product content (landed on ${landedUrl})`, 'The product page may have changed or hit a robot check. Open the product page in Chrome and retry.');
         }
         return [normalizeProductPayload(payload)];
     },

--- a/clis/amazon/shared.js
+++ b/clis/amazon/shared.js
@@ -9,6 +9,9 @@ export const SEARCH_URL_PREFIX = 'https://www.amazon.com/s?k=';
 export const PRODUCT_URL_PREFIX = 'https://www.amazon.com/dp/';
 export const DISCUSSION_URL_PREFIX = 'https://www.amazon.com/product-reviews/';
 export const STRATEGY = 'cookie';
+// Anchored so sibling marketplaces (amazon.co.uk, amazon.com.au) resolve while
+// look-alike hosts such as evilamazon.com do not.
+const MARKETPLACE_HOST_PATTERN = /^(?:[a-z0-9-]+\.)*amazon\.[a-z]{2,}(?:\.[a-z]{2,})?$/i;
 export const PRIMARY_PRICE_SELECTORS = [
     '#corePrice_feature_div .a-offscreen',
     '#corePriceDisplay_desktop_feature_div .a-offscreen',
@@ -91,19 +94,33 @@ export function extractAsin(input) {
     const match = normalized.match(/\/(?:dp|gp\/product|product-reviews)\/([A-Z0-9]{10})/i);
     return match ? match[1].toUpperCase() : null;
 }
+export function amazonHostFromInput(input) {
+    const normalized = cleanText(input);
+    if (!normalized)
+        return null;
+    try {
+        const url = new URL(normalized);
+        return MARKETPLACE_HOST_PATTERN.test(url.hostname) ? url.hostname : null;
+    }
+    catch {
+        return null;
+    }
+}
 export function buildProductUrl(input) {
     const asin = extractAsin(input);
     if (!asin) {
         throw new ArgumentError('amazon product expects an ASIN or product URL', 'Example: opencli amazon product B0FJS72893');
     }
-    return `${PRODUCT_URL_PREFIX}${asin}`;
+    const host = amazonHostFromInput(input);
+    return host ? `https://${host}/dp/${asin}` : `${PRODUCT_URL_PREFIX}${asin}`;
 }
 export function buildDiscussionUrl(input) {
     const asin = extractAsin(input);
     if (!asin) {
         throw new ArgumentError('amazon discussion expects an ASIN or product URL', 'Example: opencli amazon discussion B0FJS72893');
     }
-    return `${DISCUSSION_URL_PREFIX}${asin}`;
+    const host = amazonHostFromInput(input);
+    return host ? `https://${host}/product-reviews/${asin}` : `${DISCUSSION_URL_PREFIX}${asin}`;
 }
 function getRankingSpec(listType) {
     return AMAZON_RANKING_SPECS[listType];
@@ -206,7 +223,7 @@ export function resolveBestsellersUrl(input) {
 export function canonicalizeAmazonUrl(input) {
     try {
         const url = new URL(input);
-        if (!url.hostname.endsWith(DOMAIN)) {
+        if (!MARKETPLACE_HOST_PATTERN.test(url.hostname)) {
             throw new Error('not-amazon');
         }
         return url.toString();
@@ -230,7 +247,7 @@ export function normalizeProductUrl(value) {
     const normalized = cleanText(value);
     const asin = extractAsin(normalized);
     if (asin)
-        return buildProductUrl(asin);
+        return buildProductUrl(normalized);
     return toAbsoluteAmazonUrl(normalized);
 }
 export function parsePriceText(text) {
@@ -347,8 +364,11 @@ export function assertUsableState(state, action) {
 export const __test__ = {
     buildSearchUrl,
     extractAsin,
+    amazonHostFromInput,
     buildProductUrl,
     buildDiscussionUrl,
+    normalizeProductUrl,
+    canonicalizeAmazonUrl,
     resolveBestsellersUrl,
     resolveRankingUrl,
     isSupportedRankingPath,

--- a/clis/amazon/shared.js
+++ b/clis/amazon/shared.js
@@ -20,10 +20,42 @@ export const PRIMARY_PRICE_SELECTORS = [
     '#priceblock_dealprice',
     '#tp_price_block_total_price_ww',
 ];
-// Every Amazon storefront is amazon.<tld> or amazon.co<m?>.<tld>, so anchoring on
-// that shape accepts the sibling marketplaces while rejecting hosts that merely
-// contain the name (evilamazon.com) or park it on another domain (amazon.evil.com).
-const MARKETPLACE_HOST_PATTERN = /^(?:[a-z0-9-]+\.)*amazon\.(?:[a-z]{2,}|co(?:m)?\.[a-z]{2,})$/i;
+// Keep this explicit because these hosts are navigation targets in the user's
+// signed-in browser. A shape-only `amazon.<tld>` pattern also accepts unrelated
+// registrable domains such as amazon.shop or amazon.zip.
+const MARKETPLACE_DOMAINS = new Set([
+    'amazon.com',
+    'amazon.ca',
+    'amazon.com.mx',
+    'amazon.com.br',
+    'amazon.co.uk',
+    'amazon.de',
+    'amazon.fr',
+    'amazon.it',
+    'amazon.es',
+    'amazon.nl',
+    'amazon.pl',
+    'amazon.se',
+    'amazon.com.be',
+    'amazon.ie',
+    'amazon.com.tr',
+    'amazon.ae',
+    'amazon.sa',
+    'amazon.eg',
+    'amazon.co.za',
+    'amazon.in',
+    'amazon.co.jp',
+    'amazon.com.au',
+    'amazon.sg',
+]);
+function isAmazonMarketplaceHost(hostname) {
+    const normalized = cleanText(hostname).toLowerCase().replace(/\.$/, '');
+    for (const domain of MARKETPLACE_DOMAINS) {
+        if (normalized === domain || normalized.endsWith(`.${domain}`))
+            return true;
+    }
+    return false;
+}
 const ROBOT_TEXT_PATTERNS = [
     'Sorry, we just need to make sure you\'re not a robot',
     'Enter the characters you see below',
@@ -101,7 +133,7 @@ export function amazonHostFromInput(input) {
         return null;
     try {
         const url = new URL(normalized);
-        return MARKETPLACE_HOST_PATTERN.test(url.hostname) ? url.hostname : null;
+        return isAmazonMarketplaceHost(url.hostname) ? url.hostname : null;
     }
     catch {
         return null;
@@ -224,7 +256,7 @@ export function resolveBestsellersUrl(input) {
 export function canonicalizeAmazonUrl(input) {
     try {
         const url = new URL(input);
-        if (!MARKETPLACE_HOST_PATTERN.test(url.hostname)) {
+        if (!isAmazonMarketplaceHost(url.hostname)) {
             throw new Error('not-amazon');
         }
         return url.toString();

--- a/clis/amazon/shared.js
+++ b/clis/amazon/shared.js
@@ -9,9 +9,6 @@ export const SEARCH_URL_PREFIX = 'https://www.amazon.com/s?k=';
 export const PRODUCT_URL_PREFIX = 'https://www.amazon.com/dp/';
 export const DISCUSSION_URL_PREFIX = 'https://www.amazon.com/product-reviews/';
 export const STRATEGY = 'cookie';
-// Anchored so sibling marketplaces (amazon.co.uk, amazon.com.au) resolve while
-// look-alike hosts such as evilamazon.com do not.
-const MARKETPLACE_HOST_PATTERN = /^(?:[a-z0-9-]+\.)*amazon\.[a-z]{2,}(?:\.[a-z]{2,})?$/i;
 export const PRIMARY_PRICE_SELECTORS = [
     '#corePrice_feature_div .a-offscreen',
     '#corePriceDisplay_desktop_feature_div .a-offscreen',
@@ -23,6 +20,10 @@ export const PRIMARY_PRICE_SELECTORS = [
     '#priceblock_dealprice',
     '#tp_price_block_total_price_ww',
 ];
+// Every Amazon storefront is amazon.<tld> or amazon.co<m?>.<tld>, so anchoring on
+// that shape accepts the sibling marketplaces while rejecting hosts that merely
+// contain the name (evilamazon.com) or park it on another domain (amazon.evil.com).
+const MARKETPLACE_HOST_PATTERN = /^(?:[a-z0-9-]+\.)*amazon\.(?:[a-z]{2,}|co(?:m)?\.[a-z]{2,})$/i;
 const ROBOT_TEXT_PATTERNS = [
     'Sorry, we just need to make sure you\'re not a robot',
     'Enter the characters you see below',

--- a/clis/amazon/shared.test.js
+++ b/clis/amazon/shared.test.js
@@ -23,11 +23,14 @@ describe('amazon shared helpers', () => {
         expect(__test__.amazonHostFromInput('https://www.amazon.co.uk/dp/B0FJS72893')).toBe('www.amazon.co.uk');
         expect(__test__.amazonHostFromInput('https://amazon.de/dp/B0FJS72893')).toBe('amazon.de');
         expect(__test__.amazonHostFromInput('https://amazon.com.au/dp/B0FJS72893')).toBe('amazon.com.au');
+        expect(__test__.amazonHostFromInput('https://smile.amazon.com.be/dp/B0FJS72893')).toBe('smile.amazon.com.be');
         expect(__test__.amazonHostFromInput('https://evilamazon.com/dp/B0FJS72893')).toBeNull();
         expect(__test__.amazonHostFromInput('https://amazon.com.evil.com/dp/B0FJS72893')).toBeNull();
         expect(__test__.amazonHostFromInput('https://amazon.evil.com/dp/B0FJS72893')).toBeNull();
         expect(__test__.amazonHostFromInput('https://x.amazon.evil.com/dp/B0FJS72893')).toBeNull();
         expect(__test__.amazonHostFromInput('https://amazon.attacker.io/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://amazon.shop/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://amazon.zip/dp/B0FJS72893')).toBeNull();
         expect(() => __test__.canonicalizeAmazonUrl('https://amazon.evil.com/gp/bestsellers')).toThrow('Invalid Amazon URL');
         expect(__test__.canonicalizeAmazonUrl('https://www.amazon.co.uk/gp/bestsellers/books')).toBe('https://www.amazon.co.uk/gp/bestsellers/books');
         expect(() => __test__.canonicalizeAmazonUrl('https://evilamazon.com/gp/bestsellers')).toThrow('Invalid Amazon URL');

--- a/clis/amazon/shared.test.js
+++ b/clis/amazon/shared.test.js
@@ -22,8 +22,13 @@ describe('amazon shared helpers', () => {
     it('accepts sibling marketplaces but rejects look-alike hosts', () => {
         expect(__test__.amazonHostFromInput('https://www.amazon.co.uk/dp/B0FJS72893')).toBe('www.amazon.co.uk');
         expect(__test__.amazonHostFromInput('https://amazon.de/dp/B0FJS72893')).toBe('amazon.de');
+        expect(__test__.amazonHostFromInput('https://amazon.com.au/dp/B0FJS72893')).toBe('amazon.com.au');
         expect(__test__.amazonHostFromInput('https://evilamazon.com/dp/B0FJS72893')).toBeNull();
         expect(__test__.amazonHostFromInput('https://amazon.com.evil.com/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://amazon.evil.com/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://x.amazon.evil.com/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://amazon.attacker.io/dp/B0FJS72893')).toBeNull();
+        expect(() => __test__.canonicalizeAmazonUrl('https://amazon.evil.com/gp/bestsellers')).toThrow('Invalid Amazon URL');
         expect(__test__.canonicalizeAmazonUrl('https://www.amazon.co.uk/gp/bestsellers/books')).toBe('https://www.amazon.co.uk/gp/bestsellers/books');
         expect(() => __test__.canonicalizeAmazonUrl('https://evilamazon.com/gp/bestsellers')).toThrow('Invalid Amazon URL');
     });

--- a/clis/amazon/shared.test.js
+++ b/clis/amazon/shared.test.js
@@ -6,6 +6,27 @@ describe('amazon shared helpers', () => {
         expect(__test__.buildProductUrl('https://www.amazon.com/dp/B0FJS72893/ref=something')).toBe('https://www.amazon.com/dp/B0FJS72893');
         expect(__test__.buildDiscussionUrl('https://www.amazon.com/dp/B0FJS72893')).toBe('https://www.amazon.com/product-reviews/B0FJS72893');
     });
+    it('keeps the input marketplace instead of rewriting it to the US store', () => {
+        expect(__test__.buildProductUrl('https://www.amazon.co.uk/dp/B0FGCPFY9L')).toBe('https://www.amazon.co.uk/dp/B0FGCPFY9L');
+        expect(__test__.buildProductUrl('https://www.amazon.de/dp/B0FJS72893/ref=something')).toBe('https://www.amazon.de/dp/B0FJS72893');
+        expect(__test__.buildProductUrl('https://www.amazon.com.au/dp/B0FJS72893')).toBe('https://www.amazon.com.au/dp/B0FJS72893');
+        expect(__test__.buildDiscussionUrl('https://www.amazon.co.uk/product-reviews/B0FGCPFY9L?pageNumber=1')).toBe('https://www.amazon.co.uk/product-reviews/B0FGCPFY9L');
+        expect(__test__.normalizeProductUrl('https://www.amazon.co.uk/dp/B0FGCPFY9L')).toBe('https://www.amazon.co.uk/dp/B0FGCPFY9L');
+    });
+    it('defaults to the US store for bare ASINs and non-marketplace hosts', () => {
+        expect(__test__.amazonHostFromInput('B0FJS72893')).toBeNull();
+        expect(__test__.buildProductUrl('B0FJS72893')).toBe('https://www.amazon.com/dp/B0FJS72893');
+        expect(__test__.buildDiscussionUrl('B0FJS72893')).toBe('https://www.amazon.com/product-reviews/B0FJS72893');
+        expect(__test__.normalizeProductUrl('B0FJS72893')).toBe('https://www.amazon.com/dp/B0FJS72893');
+    });
+    it('accepts sibling marketplaces but rejects look-alike hosts', () => {
+        expect(__test__.amazonHostFromInput('https://www.amazon.co.uk/dp/B0FJS72893')).toBe('www.amazon.co.uk');
+        expect(__test__.amazonHostFromInput('https://amazon.de/dp/B0FJS72893')).toBe('amazon.de');
+        expect(__test__.amazonHostFromInput('https://evilamazon.com/dp/B0FJS72893')).toBeNull();
+        expect(__test__.amazonHostFromInput('https://amazon.com.evil.com/dp/B0FJS72893')).toBeNull();
+        expect(__test__.canonicalizeAmazonUrl('https://www.amazon.co.uk/gp/bestsellers/books')).toBe('https://www.amazon.co.uk/gp/bestsellers/books');
+        expect(() => __test__.canonicalizeAmazonUrl('https://evilamazon.com/gp/bestsellers')).toThrow('Invalid Amazon URL');
+    });
     it('parses price, rating, and review-count text', () => {
         expect(__test__.parsePriceText('1 offer from $34.11')).toEqual({
             price_text: '$34.11',

--- a/docs/adapters/browser/amazon.md
+++ b/docs/adapters/browser/amazon.md
@@ -47,6 +47,7 @@ opencli amazon discussion B0FJS72893 --limit 5 -f json
 - `bestsellers`, `movers-shakers`, `new-releases`, and `search` are for candidate discovery; `product`, `offer`, and `discussion` are the validation surfaces.
 - `offer` is the right surface for `sold_by`, `ships_from`, and Amazon-retail exclusion.
 - `discussion` may return review data even when Q&A is absent. Missing Q&A is a normal outcome, not an error.
+- A product or review URL from a sibling marketplace (`amazon.co.uk`, `amazon.de`, `amazon.com.au`, …) is read on that marketplace, and the emitted URLs stay on it. A bare ASIN still defaults to `amazon.com`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

`amazon product` / `amazon discussion` pull the ASIN out of the input URL and then throw the host away, so every call is rewritten onto `https://www.amazon.com/`. For a marketplace-exclusive ASIN that lands on a 404 and the command fails with `amazon product page did not expose product content`, which reads like DOM drift or a robot check rather than a URL bug. For an ASIN that exists on both stores it is worse than a hard failure: the command returns the US listing's price, rating, and review count for a request that named `amazon.co.uk`, and the emitted `product_url` is rewritten to `.com` as well, so nothing in the payload reveals the substitution.

`buildProductUrl` / `buildDiscussionUrl` now resolve the marketplace host from the input and build on it, falling back to the existing US prefixes when the input is a bare ASIN, so bare-ASIN behaviour is unchanged. This also covers the two related spots the report calls out: `normalizeProductUrl` was passing the bare ASIN back into `buildProductUrl` and losing the host a second time, and `canonicalizeAmazonUrl` gated on `hostname.endsWith('amazon.com')`, which rejected every sibling marketplace.

Host matching is now one anchored pattern shared by both paths. Since that pattern is the only thing standing between a URL argument and a navigation in the user's signed-in Chrome profile, it is written to the shape Amazon storefronts actually take, `amazon.<tld>` or `amazon.co<m?>.<tld>`, rather than a looser "contains amazon" test. It accepts the 28 real marketplace hosts plus `www.` / `smile.` subdomains, and rejects both the class the old `endsWith` check let through (`evilamazon.com`) and the class a naive anchored pattern would let through (`amazon.evil.com`, `amazon.attacker.io`, where an attacker owns the registrable domain). Those hosts are asserted in the tests.

Per the report's last suggestion, the two "did not expose" failures now name the URL that was actually loaded, since that single detail is what distinguishes a marketplace-routing bug from real page drift.

One consequence worth stating rather than burying: `canonicalizeAmazonUrl` is reached only by `resolveRankingUrl`, so relaxing it also means the ranking commands now accept a sibling-marketplace URL, and `opencli amazon bestsellers "https://www.amazon.de/gp/bestsellers/zgbs/ce-de"` returns rows where it previously raised `Invalid Amazon URL`. That follows from the spot the issue asks to fix, and the default root URLs are unchanged, so a bare `amazon bestsellers` is still the US list.

Out of scope and unchanged, called out so the boundary is explicit: `search` still builds US-only URLs, comma-decimal prices (`19,99 €`) still yield `price_value: null`, and `parsePriceText` still maps a bare `$` to USD, so a `$`-denominated sibling store such as `amazon.ca` reports a correct price number under a `USD` label. That last one is a strictly smaller error than today's behaviour of returning the US listing outright, and fixing it means threading the host into `parsePriceText` and its callers, which belongs in its own change.

Related issue: Closes #2172.

The `audit` check on this PR fails on `js-yaml` advisory GHSA-52cp-r559-cp3m, which reproduces on `main` itself and is unrelated to this change; no dependency file is touched here. #2186 bumps it.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, on `upstream/main`, the reported input fails:

```
$ opencli amazon product "https://www.amazon.co.uk/dp/B0FGCPFY9L" -f json
ok: false
error:
  code: COMMAND_EXEC
  message: amazon product page did not expose product content
  help: The product page may have changed or hit a robot check. Open the product page in Chrome and retry.
  exitCode: 1
```

The URL construction is deterministic, so the rewrite is visible without a browser:

```
$ node -e 'import("./clis/amazon/shared.js").then(m => console.log(m.buildProductUrl("https://www.amazon.co.uk/dp/B0FGCPFY9L")))'
https://www.amazon.com/dp/B0FGCPFY9L
```

After, the same input is read on the marketplace it names:

```
$ opencli amazon product "https://www.amazon.co.uk/dp/B0FGCPFY9L" -f json
[
  {"asin":"B0FGCPFY9L","title":"12 PCS Pirate Bath Bombs for Kids with Toys Inside, Bath Bombs Gift Set with Bathtub Toys Pretend Play Shower Toys Birthday Gifts for Boys Girls","product_url":"https://www.amazon.co.uk/dp/B0FGCPFY9L","source_url":"https://www.amazon.co.uk/dp/B0FGCPFY9L","brand_text":"Brand: TinkerPlay","rating_text":"4.4 out of 5 stars","rating_value":4.4,"review_count_text":"(40)","review_count":40}
]
```

The exact command from the report, which previously failed, now returns UK review data with every emitted URL on the requested store:

```
$ opencli amazon discussion "https://www.amazon.co.uk/product-reviews/B0FGCPFY9L?sortBy=recent&reviewerType=all_reviews&pageNumber=1" --limit 1 -f json
[
  {"asin":"B0FGCPFY9L","product_url":"https://www.amazon.co.uk/dp/B0FGCPFY9L","discussion_url":"https://www.amazon.co.uk/dp/B0FGCPFY9L","source_url":"https://www.amazon.co.uk/dp/B0FGCPFY9L","average_rating_text":"4.4 out of 5","average_rating_value":4.4,"total_review_count_text":"40 global ratings","total_review_count":40,"review_samples":[{"rating_text":"5 out of 5 stars","rating_value":5,"author":"Daisy","date_text":"Reviewed in the United Kingdom on 13 June 2026","verified_purchase":true}]}
]
```

`product_url` on that row is the one live-only regression this fix caught: `normalizeDiscussionPayload` fed the bare ASIN into `normalizeProductUrl`, so the review URL resolved to `.co.uk` while the product URL beside it still said `.com`. It now passes the source URL, and `clis/amazon/discussion.test.js` asserts every emitted URL stays on one marketplace.

A failure on the wrong store is now self-diagnosing:

```
$ opencli amazon product "https://www.amazon.com/dp/0439708184" -f json
ok: false
error:
  code: COMMAND_EXEC
  message: amazon product page did not expose product content (landed on https://www.amazon.com/dp/0439708184)
```

A gated non-US review page also used to tell the user to sign in at `https://amazon.com`, which cannot clear a `.co.uk` gate; `AuthRequiredError` now names the marketplace that was actually loaded.

`clis/amazon` passes 25 / 25 locally, covering sibling-marketplace product / discussion / normalize URLs, the bare-ASIN US default, look-alike host rejection (`evilamazon.com`, `amazon.evil.com`, `x.amazon.evil.com`, `amazon.attacker.io`, `amazon.com.evil.com`), the marketplace-specific auth hint, and the loaded-url failure message. `npm run typecheck`, `npm run check:typed-error-lint`, `npm run check:silent-column-drop`, and `scripts/check-doc-coverage.sh --strict` all pass. No command signature, argument, or column changed, so `cli-manifest.json` is untouched.
