### PR TITLE
chore(deps): bump js-yaml to 4.3.0 for GHSA-52cp-r559-cp3m

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mozilla/readability": "^0.6.0",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
         "undici": "^6.27.0",
@@ -2950,9 +2950,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@mozilla/readability": "^0.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "undici": "^6.27.0",


### PR DESCRIPTION
## Description

The `audit` job fails on every pull request right now, including ones that touch no dependencies. `js-yaml` is a direct production dependency pinned at 4.2.0 in the lockfile, and advisory GHSA-52cp-r559-cp3m covers 4.0.0 through 4.2.0 at high severity, so `npm audit --omit=dev --audit-level=high` exits non-zero on `main` itself. This bumps the resolved version to the patched 4.3.0.

The declared range moves from `^4.1.0` to `^4.3.0` so the security floor is recorded in `package.json` rather than only in the lockfile. Nothing else changes.

`js-yaml` is the serializer behind the default output format, so the risk of the bump is output drift rather than a build break. `src/serialization.test.ts`, `src/engine.test.ts`, `src/help.test.ts` and `tests/e2e/output-formats.test.ts` pass unchanged (33 / 33), `npm run typecheck` is clean, and a real command still renders identical YAML.

Related issue: none filed; the advisory is GHSA-52cp-r559-cp3m and the failure is reproducible on `main` with `npm audit --omit=dev --audit-level=high`.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, on `main`:

```
$ npm audit --omit=dev --audit-level=high
js-yaml  4.0.0 - 4.2.0
Severity: high
js-yaml: YAML merge-key chains can force quadratic CPU consumption - https://github.com/advisories/GHSA-52cp-r559-cp3m
1 high severity vulnerability
```

After:

```
$ npm audit --omit=dev --audit-level=high
found 0 vulnerabilities
```

Output is byte-identical on the default YAML formatter:

```
$ opencli trip search Tokyo --limit 2
- rank: 1
  name: Tokyo
  type: city
  cityId: 228
  airportCode: null
  province: null
  country: Japan
```
