### PR TITLE
fix(download): keep a row-less table from crashing markdown conversion

### DIFF
--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -70,6 +70,26 @@ describe('downloadArticle', () => {
       expect(md).toMatch(/\|\s*1\s*\|\s*2\s*\|/);
     });
 
+    it('keeps the text of a table that carries no rows instead of failing the download', async () => {
+      const md = await runAndRead(
+        '<p>before</p>' +
+        '<table><tbody><div>orphan cell</div></tbody></table>' +
+        '<p>after</p>',
+      );
+      expect(md).toContain('orphan cell');
+      expect(md).toContain('before');
+      expect(md).toContain('after');
+    });
+
+    it('converts a real table in the same document as a row-less one', async () => {
+      const md = await runAndRead(
+        '<table></table>' +
+        '<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>',
+      );
+      expect(md).toMatch(/\|\s*a\s*\|/);
+      expect(md).toMatch(/\|\s*1\s*\|/);
+    });
+
     it('converts strikethrough and task lists', async () => {
       const md = await runAndRead(
         '<p><del>gone</del></p>' +

--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -70,10 +70,12 @@ describe('downloadArticle', () => {
       expect(md).toMatch(/\|\s*1\s*\|\s*2\s*\|/);
     });
 
+    // A caption is the only child that survives inside a row-less table: the parser
+    // foster-parents any other content out of the table before turndown sees it.
     it('keeps the text of a table that carries no rows instead of failing the download', async () => {
       const md = await runAndRead(
         '<p>before</p>' +
-        '<table><tbody><div>orphan cell</div></tbody></table>' +
+        '<table><caption>orphan cell</caption></table>' +
         '<p>after</p>',
       );
       expect(md).toContain('orphan cell');
@@ -81,7 +83,7 @@ describe('downloadArticle', () => {
       expect(md).toContain('after');
     });
 
-    it('converts a real table in the same document as a row-less one', async () => {
+    it('drops an empty table and still converts a real one beside it', async () => {
       const md = await runAndRead(
         '<table></table>' +
         '<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>',

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -111,10 +111,10 @@ function createTurndown(
   td.use(gfm);
   td.remove(STRIPPED_TAGS);
   // turndown-plugin-gfm@1.0.2 reads `table.rows[0].parentNode` from both its
-  // table rule and its keep filter, so a table carrying no `tr` (rich-text
-  // editors emit them around plain blocks) throws before either can decide.
-  // Rules added here are matched before the plugin's, so claim those tables and
-  // keep their text rather than losing the whole document.
+  // table rule and its keep filter, so a table carrying no `tr` throws before
+  // either can decide, taking the whole document with it. Claiming those tables
+  // here bypasses both: `addRule` unshifts onto the rule array, and `forNode`
+  // exhausts that array before it consults the keep list.
   td.addRule('rowlessTable', {
     filter: (node) => node.nodeName === 'TABLE' && !(node as HTMLTableElement).rows?.length,
     replacement: (content) => (content.trim() ? `\n\n${content.trim()}\n\n` : ''),

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -110,6 +110,15 @@ function createTurndown(
   });
   td.use(gfm);
   td.remove(STRIPPED_TAGS);
+  // turndown-plugin-gfm@1.0.2 reads `table.rows[0].parentNode` from both its
+  // table rule and its keep filter, so a table carrying no `tr` (rich-text
+  // editors emit them around plain blocks) throws before either can decide.
+  // Rules added here are matched before the plugin's, so claim those tables and
+  // keep their text rather than losing the whole document.
+  td.addRule('rowlessTable', {
+    filter: (node) => node.nodeName === 'TABLE' && !(node as HTMLTableElement).rows?.length,
+    replacement: (content) => (content.trim() ? `\n\n${content.trim()}\n\n` : ''),
+  });
   // turndown-plugin-gfm@1.0.2 emits single-tilde strikethrough (`~x~`), which
   // is not the canonical GFM form. Override it so exported markdown is
   // portable across common renderers.


### PR DESCRIPTION
## Description

`turndown-plugin-gfm` reads `table.rows[0].parentNode` in `isHeadingRow`, and it does so from two places: the `table` rule's filter and the `keep` filter it installs. A `<table>` that carries no `tr` makes `rows[0]` `undefined`, so the read throws `Cannot read properties of undefined (reading 'parentNode')` while turndown is still deciding which rule applies, before either filter can return a verdict. The throw escapes `downloadArticle()` and the whole export fails with `code: UNKNOWN`, so one such table costs the reader the entire document.

Rich-text editors produce these tables routinely: WeChat's editor wraps plain blocks in a `<table>` whose cells are `div` / `section` rather than `tr`, which is what #2154 hit with 34 tables in one article. A bare `<table></table>` is enough to reproduce it.

Rules registered with `addRule` are matched ahead of the plugin's own, and that covers both entry points for a different reason each: `add` unshifts onto the rule array so the new rule is tried before the plugin's `table` rule, and `forNode` exhausts that array before it ever consults the `keep` list. Every other table is untouched: a table with a heading row still converts to GFM, and a table with rows but no heading row is still preserved as raw HTML by the plugin's existing `keep` rule, byte for byte. Only the crash goes away.

To be explicit about what this does not do, since the report also asked for table text as line-broken markdown: heading-less tables that do have rows never crashed and still emit raw HTML, which is deliberate upstream `turndown-plugin-gfm` behaviour. Changing that is a rendering decision affecting every caller including `zhihu download` and `web read`, so it is not folded in here.

This sits in the shared conversion path, so it also covers `zhihu download` and `web read`, where the same malformed table on an arbitrary URL fails the command today.

Related issue: Closes #2154.

The `audit` check fails on `js-yaml` advisory GHSA-52cp-r559-cp3m, which reproduces on `main` itself and is unrelated to this change; no dependency file is touched here. #2186 bumps it.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

The reported article, which failed before, now exports:

```
$ opencli weixin download --url "https://mp.weixin.qq.com/s/1nUI9K0IT8s6NG4sS9rkXw" --output ./out
- title: 五万字实操手册：以物抵债全方位解读（2026年版）
  author: 负险不彬
  publish_time: 2026年6月11日 13:01
  status: success
  size: 386.6 KB
```

Every shape that reaches the failing read is covered, and each one throws the reported error on `main`:

```
$ node -e '<turndown + gfm, no override>'
CRASH empty table                  => Cannot read properties of undefined (reading 'parentNode')
CRASH table, text only, no tr      => Cannot read properties of undefined (reading 'parentNode')
CRASH table > colgroup only        => Cannot read properties of undefined (reading 'parentNode')
CRASH table > div (no tr)          => Cannot read properties of undefined (reading 'parentNode')
CRASH tbody, no tr, with text      => Cannot read properties of undefined (reading 'parentNode')
OK    normal table                 => "| A |\n| --- |\n| 1 |"
```

With the rule in place the same inputs convert, keeping the text and leaving a real table alone:

```
OK    empty table                => ""
OK    text only, no tr           => "hello"
OK    colgroup only              => ""
OK    div, no tr                 => "cell text"
OK    tbody, no tr               => "text"
OK    normal table               => "| A |\n| --- |\n| 1 |"
```

The two new cases in `src/download/article-download.test.ts` are genuine regression tests: restoring only `article-download.ts` to `main` and rerunning fails both with `TypeError: Cannot read properties of undefined (reading 'parentNode')`, the exact error from the report. The text-preservation case uses a `<caption>` deliberately, because it is the only child that survives inside a row-less table; any other content is foster-parented out by the HTML parser before turndown sees the tree, which would make the assertion pass without the rule doing anything.

`src/download`, `clis/zhihu`, `clis/weixin` and `clis/web` pass 273 / 273 together, so the two other consumers of `downloadArticle()` are covered. `npm run typecheck`, `npm run check:typed-error-lint`, `npm run check:silent-column-drop` and `scripts/check-doc-coverage.sh --strict` all pass. No command signature, argument, or column changed, so `cli-manifest.json` is untouched.
