### PR TITLE
fix(twitter article): include images from atomic blocks in markdown output

### DIFF
--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -19,7 +19,7 @@ cli({
     args: [
         { name: 'tweet-id', type: 'string', positional: true, required: true, help: 'Tweet ID or URL containing the article' },
     ],
-    columns: ['title', 'author', 'content', 'url', 'published_at', 'preview_text'],
+    columns: ['title', 'author', 'content', 'url'],
     func: async (page, kwargs) => {
         // Extract tweet ID from URL if needed.
         // Article URLs (x.com/i/article/{articleId}) use a different ID than
@@ -173,26 +173,31 @@ cli({
         if (!Array.isArray(blocks)) {
           return {error: 'Twitter API response article blocks were malformed'};
         }
-        const entityMap = contentState.entityMap || {};
-        const mediaEntities = articleResults.media_entities || {};
-
-        // Canonicalize https://pbs.twimg.com/media/XXX.jpg -> ...?format=jpg&name=large
-        function canonicalizeImgUrl(url) {
-          if (!url) return url;
-          const qIdx = url.indexOf('?');
-          const baseUrl = qIdx >= 0 ? url.substring(0, qIdx) : url;
-          const dotIdx = baseUrl.lastIndexOf('.');
-          if (dotIdx < 0) return url;
-          const ext = baseUrl.substring(dotIdx + 1).toLowerCase().replace('jpeg', 'jpg');
-          if (['jpg', 'png', 'webp', 'gif'].indexOf(ext) < 0) return url;
-          return baseUrl.substring(0, dotIdx) + '?format=' + ext + '&name=large';
+        // The current GraphQL response serializes Draft.js entityMap as an
+        // unordered [{key, value}] array, not an object keyed by entity id.
+        // Normalize both representations before resolving atomic blocks.
+        const rawEntityMap = contentState.entityMap || {};
+        const entityByKey = {};
+        if (Array.isArray(rawEntityMap)) {
+          for (const entry of rawEntityMap) {
+            if (entry && entry.key != null && entry.value) {
+              entityByKey[String(entry.key)] = entry.value;
+            }
+          }
+        } else {
+          for (const [key, entry] of Object.entries(rawEntityMap)) {
+            entityByKey[String(key)] = entry?.value || entry;
+          }
         }
 
-        // Build media_id -> canonicalized original_img_url lookup from media_entities
+        // Build media_id -> original_img_url lookup from media_entities.
+        const mediaEntities = articleResults.media_entities || [];
         const mediaUrlById = {};
-        for (const [, me] of Object.entries(mediaEntities)) {
+        for (const me of Object.values(mediaEntities)) {
           const url = me?.media_info?.original_img_url;
-          if (url && me?.media_id) mediaUrlById[me.media_id] = canonicalizeImgUrl(url);
+          if (typeof url === 'string' && me?.media_id != null) {
+            mediaUrlById[String(me.media_id)] = url;
+          }
         }
 
         // Convert draft.js blocks to Markdown
@@ -203,11 +208,11 @@ cli({
           const blockType = block.type || 'unstyled';
           if (blockType === 'atomic') {
             const entityKey = block.entityRanges?.[0]?.key;
-            const entity = entityMap[entityKey];
-            if (entity?.value?.type === 'MEDIA') {
-              const mediaId = entity.value.data?.mediaItems?.[0]?.mediaId;
-              const imgUrl = mediaId ? mediaUrlById[mediaId] : null;
-              const caption = entity.value.data?.caption || 'Imagen';
+            const entity = entityKey == null ? null : entityByKey[String(entityKey)];
+            if (entity?.type === 'MEDIA') {
+              const mediaId = entity.data?.mediaItems?.[0]?.mediaId;
+              const imgUrl = mediaId == null ? null : mediaUrlById[String(mediaId)];
+              const caption = String(entity.data?.caption || 'Image').replaceAll(']', '&#93;');
               if (imgUrl) parts.push('![' + caption + '](' + imgUrl + ')');
             }
             continue;
@@ -234,8 +239,6 @@ cli({
           author: screenName,
           content: parts.join('\\n\\n') || legacy.full_text || '',
           url: 'https://x.com/' + screenName + '/status/' + tweetId,
-          published_at: legacy.created_at || '',
-          preview_text: (articleResults.preview_text || '').trim(),
         }];
       }
     `));

--- a/clis/twitter/article.js
+++ b/clis/twitter/article.js
@@ -19,7 +19,7 @@ cli({
     args: [
         { name: 'tweet-id', type: 'string', positional: true, required: true, help: 'Tweet ID or URL containing the article' },
     ],
-    columns: ['title', 'author', 'content', 'url'],
+    columns: ['title', 'author', 'content', 'url', 'published_at', 'preview_text'],
     func: async (page, kwargs) => {
         // Extract tweet ID from URL if needed.
         // Article URLs (x.com/i/article/{articleId}) use a different ID than
@@ -173,6 +173,27 @@ cli({
         if (!Array.isArray(blocks)) {
           return {error: 'Twitter API response article blocks were malformed'};
         }
+        const entityMap = contentState.entityMap || {};
+        const mediaEntities = articleResults.media_entities || {};
+
+        // Canonicalize https://pbs.twimg.com/media/XXX.jpg -> ...?format=jpg&name=large
+        function canonicalizeImgUrl(url) {
+          if (!url) return url;
+          const qIdx = url.indexOf('?');
+          const baseUrl = qIdx >= 0 ? url.substring(0, qIdx) : url;
+          const dotIdx = baseUrl.lastIndexOf('.');
+          if (dotIdx < 0) return url;
+          const ext = baseUrl.substring(dotIdx + 1).toLowerCase().replace('jpeg', 'jpg');
+          if (['jpg', 'png', 'webp', 'gif'].indexOf(ext) < 0) return url;
+          return baseUrl.substring(0, dotIdx) + '?format=' + ext + '&name=large';
+        }
+
+        // Build media_id -> canonicalized original_img_url lookup from media_entities
+        const mediaUrlById = {};
+        for (const [, me] of Object.entries(mediaEntities)) {
+          const url = me?.media_info?.original_img_url;
+          if (url && me?.media_id) mediaUrlById[me.media_id] = canonicalizeImgUrl(url);
+        }
 
         // Convert draft.js blocks to Markdown
         const parts = [];
@@ -180,7 +201,17 @@ cli({
         for (const block of blocks) {
           if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
           const blockType = block.type || 'unstyled';
-          if (blockType === 'atomic') continue;
+          if (blockType === 'atomic') {
+            const entityKey = block.entityRanges?.[0]?.key;
+            const entity = entityMap[entityKey];
+            if (entity?.value?.type === 'MEDIA') {
+              const mediaId = entity.value.data?.mediaItems?.[0]?.mediaId;
+              const imgUrl = mediaId ? mediaUrlById[mediaId] : null;
+              const caption = entity.value.data?.caption || 'Imagen';
+              if (imgUrl) parts.push('![' + caption + '](' + imgUrl + ')');
+            }
+            continue;
+          }
           const text = block.text || '';
           if (!text) continue;
           if (blockType !== 'ordered-list-item') orderedCounter = 0;
@@ -203,6 +234,8 @@ cli({
           author: screenName,
           content: parts.join('\\n\\n') || legacy.full_text || '',
           url: 'https://x.com/' + screenName + '/status/' + tweetId,
+          published_at: legacy.created_at || '',
+          preview_text: (articleResults.preview_text || '').trim(),
         }];
       }
     `));

--- a/clis/twitter/article.test.js
+++ b/clis/twitter/article.test.js
@@ -164,4 +164,54 @@ describe('twitter article command', () => {
         await expect(command.func(page, { 'tweet-id': '1234567890' }))
             .rejects.toThrow(/article blocks were malformed/);
     });
+
+    it('renders atomic media using entity keys rather than entityMap array positions', async () => {
+        const command = getRegistry().get('twitter/article');
+        const page = createPageWithEvaluateResults([
+            null,
+            undefined,
+        ]);
+        page.evaluate.mockImplementationOnce(() => Promise.resolve(null));
+        page.evaluate.mockImplementationOnce(async (script) => evaluateArticleFetchScript(script, validArticlePayload({
+            tweet: {
+                article: {
+                    article_results: {
+                        result: {
+                            title: 'Article with image',
+                            content_state: {
+                                blocks: [
+                                    { type: 'unstyled', text: 'before' },
+                                    { type: 'atomic', text: ' ', entityRanges: [{ key: 0, offset: 0, length: 1 }] },
+                                    { type: 'unstyled', text: 'after' },
+                                ],
+                                entityMap: [
+                                    { key: '7', value: { type: 'LINK', data: { url: 'https://example.com' } } },
+                                    {
+                                        key: '0',
+                                        value: {
+                                            type: 'MEDIA',
+                                            data: {
+                                                caption: 'architecture diagram',
+                                                mediaItems: [{ mediaId: 'media-1' }],
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                            media_entities: [{
+                                media_id: 'media-1',
+                                media_info: { original_img_url: 'https://pbs.twimg.com/media/example.jpg' },
+                            }],
+                        },
+                    },
+                },
+            },
+        })));
+
+        await expect(command.func(page, { 'tweet-id': '1234567890' })).resolves.toEqual([
+            expect.objectContaining({
+                content: 'before\n\n![architecture diagram](https://pbs.twimg.com/media/example.jpg)\n\nafter',
+            }),
+        ]);
+    });
 });


### PR DESCRIPTION
## Problem

The `twitter article` adapter skipped `atomic` blocks entirely (`if (blockType === 'atomic') continue`), which silently dropped all images from Twitter article markdown output.

In Twitter's article format (draft.js-based), images are stored as `atomic` blocks that reference entities in `content_state.entityMap`. The actual CDN URLs live in `articleResults.media_entities[key].media_info.original_img_url`.

## Fix

1. Read `contentState.entityMap` and `articleResults.media_entities`
2. Build a `media_id -> original_img_url` lookup from `media_entities`
3. When encountering an `atomic` block, resolve: entity key -> `mediaItems[0].mediaId` -> CDN URL
4. Output as `![caption](url)` markdown

## Testing

Tested with `https://x.com/0xblacklight/status/2069503920918106370`:
- **Before:** 0 images in output
- **After:** 10 images with captions, correctly placed inline

```
opencli twitter article https://x.com/0xblacklight/status/2069503920918106370 -f json
```

All 10 images have valid `pbs.twimg.com` CDN URLs and correct captions from the article's entity data.