### PR TITLE
fix(twitter/profile): recover counts + bio after X relocates them out of legacy (#2188)

### DIFF
--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -12,6 +12,63 @@ function stringField(value) {
     return typeof value === 'string' ? value : '';
 }
 
+// #1745 / #2188: X keeps relocating profile fields out of result.legacy. First
+// name/screen_name/created_at moved into result.core; then the counts
+// (followers_count, friends_count, statuses_count, favourites_count) and the bio
+// (description) followed into an as-yet-unnamed container, so the legacy-only
+// reads silently returned 0 / ''. Resolve each field from its known homes first
+// (legacy → core → top level), then fall back to a bounded breadth-first search
+// so wherever X parks the field next we still surface it. BFS yields the
+// shallowest match, i.e. the canonical user-level field rather than a nested
+// copy sitting deeper in the tree.
+//
+// Shallowest-wins is not enough on its own: when the field is absent from the
+// user object entirely, BFS would otherwise descend into an embedded tweet and
+// report its favourites_count as the user's likes, or its text as the bio. So
+// never cross into containers that describe a *different* entity — better to
+// return 0 / '' than confidently wrong numbers.
+const NON_USER_CONTAINERS = new Set([
+    'pinned_tweet', 'tweet', 'status', 'quoted_status', 'retweeted_status',
+    'entities', 'extended_entities', 'media', 'highlights',
+]);
+
+function deepFindValue(root, key, accept, maxDepth = 6) {
+    const queue = [{ node: root, depth: 0 }];
+    while (queue.length > 0) {
+        const { node, depth } = queue.shift();
+        if (!node || typeof node !== 'object' || depth > maxDepth)
+            continue;
+        if (!Array.isArray(node) && accept(node[key]))
+            return node[key];
+        const children = Array.isArray(node)
+            ? node
+            : Object.entries(node).filter(([k]) => !NON_USER_CONTAINERS.has(k)).map(([, v]) => v);
+        for (const child of children) {
+            if (child && typeof child === 'object')
+                queue.push({ node: child, depth: depth + 1 });
+        }
+    }
+    return undefined;
+}
+
+function resolveCount(result, key) {
+    for (const source of [result.legacy, result.core, result]) {
+        if (isPlainObject(source) && typeof source[key] === 'number' && Number.isFinite(source[key]))
+            return source[key];
+    }
+    const found = deepFindValue(result, key, (value) => typeof value === 'number' && Number.isFinite(value));
+    return typeof found === 'number' ? found : 0;
+}
+
+function resolveText(result, key) {
+    for (const source of [result.legacy, result.core, result]) {
+        if (isPlainObject(source) && typeof source[key] === 'string' && source[key].trim() !== '')
+            return source[key];
+    }
+    const found = deepFindValue(result, key, (value) => typeof value === 'string' && value.trim() !== '');
+    return typeof found === 'string' ? found : '';
+}
+
 export function mapTwitterProfileResult(result, screenName) {
     if (!isPlainObject(result)) {
         throw new CommandExecutionError(`Twitter profile response for @${screenName} is malformed`);
@@ -31,13 +88,13 @@ export function mapTwitterProfileResult(result, screenName) {
     return [{
         screen_name: stringField(core.screen_name) || stringField(legacy.screen_name) || screenName,
         name: stringField(core.name) || stringField(legacy.name),
-        bio: stringField(legacy.description),
+        bio: resolveText(result, 'description'),
         location: stringField(location.location) || stringField(legacy.location),
         url: stringField(expandedUrl),
-        followers: legacy.followers_count || 0,
-        following: legacy.friends_count || 0,
-        tweets: legacy.statuses_count || 0,
-        likes: legacy.favourites_count || 0,
+        followers: resolveCount(result, 'followers_count'),
+        following: resolveCount(result, 'friends_count'),
+        tweets: resolveCount(result, 'statuses_count'),
+        likes: resolveCount(result, 'favourites_count'),
         verified: Boolean(result.is_blue_verified || legacy.verified),
         created_at: stringField(core.created_at) || stringField(legacy.created_at),
     }];
@@ -171,4 +228,4 @@ cli({
     }
 });
 
-export const __test__ = { mapTwitterProfileResult };
+export const __test__ = { mapTwitterProfileResult, deepFindValue, resolveCount, resolveText };

--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -12,61 +12,12 @@ function stringField(value) {
     return typeof value === 'string' ? value : '';
 }
 
-// #1745 / #2188: X keeps relocating profile fields out of result.legacy. First
-// name/screen_name/created_at moved into result.core; then the counts
-// (followers_count, friends_count, statuses_count, favourites_count) and the bio
-// (description) followed into an as-yet-unnamed container, so the legacy-only
-// reads silently returned 0 / ''. Resolve each field from its known homes first
-// (legacy → core → top level), then fall back to a bounded breadth-first search
-// so wherever X parks the field next we still surface it. BFS yields the
-// shallowest match, i.e. the canonical user-level field rather than a nested
-// copy sitting deeper in the tree.
-//
-// Shallowest-wins is not enough on its own: when the field is absent from the
-// user object entirely, BFS would otherwise descend into an embedded tweet and
-// report its favourites_count as the user's likes, or its text as the bio. So
-// never cross into containers that describe a *different* entity — better to
-// return 0 / '' than confidently wrong numbers.
-const NON_USER_CONTAINERS = new Set([
-    'pinned_tweet', 'tweet', 'status', 'quoted_status', 'retweeted_status',
-    'entities', 'extended_entities', 'media', 'highlights',
-]);
-
-function deepFindValue(root, key, accept, maxDepth = 6) {
-    const queue = [{ node: root, depth: 0 }];
-    while (queue.length > 0) {
-        const { node, depth } = queue.shift();
-        if (!node || typeof node !== 'object' || depth > maxDepth)
-            continue;
-        if (!Array.isArray(node) && accept(node[key]))
-            return node[key];
-        const children = Array.isArray(node)
-            ? node
-            : Object.entries(node).filter(([k]) => !NON_USER_CONTAINERS.has(k)).map(([, v]) => v);
-        for (const child of children) {
-            if (child && typeof child === 'object')
-                queue.push({ node: child, depth: depth + 1 });
-        }
+function countField(...values) {
+    for (const value of values) {
+        if (typeof value === 'number' && Number.isFinite(value))
+            return value;
     }
-    return undefined;
-}
-
-function resolveCount(result, key) {
-    for (const source of [result.legacy, result.core, result]) {
-        if (isPlainObject(source) && typeof source[key] === 'number' && Number.isFinite(source[key]))
-            return source[key];
-    }
-    const found = deepFindValue(result, key, (value) => typeof value === 'number' && Number.isFinite(value));
-    return typeof found === 'number' ? found : 0;
-}
-
-function resolveText(result, key) {
-    for (const source of [result.legacy, result.core, result]) {
-        if (isPlainObject(source) && typeof source[key] === 'string' && source[key].trim() !== '')
-            return source[key];
-    }
-    const found = deepFindValue(result, key, (value) => typeof value === 'string' && value.trim() !== '');
-    return typeof found === 'string' ? found : '';
+    return 0;
 }
 
 export function mapTwitterProfileResult(result, screenName) {
@@ -84,18 +35,18 @@ export function mapTwitterProfileResult(result, screenName) {
         throw new CommandExecutionError(`Twitter profile response for @${screenName} is missing profile identity fields`);
     }
     const location = isPlainObject(result.location) ? result.location : {};
-    const expandedUrl = legacy.entities?.url?.urls?.[0]?.expanded_url || '';
+    const expandedUrl = stringField(result.website?.url) || stringField(legacy.entities?.url?.urls?.[0]?.expanded_url);
     return [{
         screen_name: stringField(core.screen_name) || stringField(legacy.screen_name) || screenName,
         name: stringField(core.name) || stringField(legacy.name),
-        bio: resolveText(result, 'description'),
+        bio: stringField(result.profile_bio?.description) || stringField(legacy.description),
         location: stringField(location.location) || stringField(legacy.location),
         url: stringField(expandedUrl),
-        followers: resolveCount(result, 'followers_count'),
-        following: resolveCount(result, 'friends_count'),
-        tweets: resolveCount(result, 'statuses_count'),
-        likes: resolveCount(result, 'favourites_count'),
-        verified: Boolean(result.is_blue_verified || legacy.verified),
+        followers: countField(result.relationship_counts?.followers, legacy.followers_count, legacy.normal_followers_count),
+        following: countField(result.relationship_counts?.following, legacy.friends_count),
+        tweets: countField(result.tweet_counts?.tweets, legacy.statuses_count),
+        likes: countField(result.action_counts?.favorites_count, legacy.favourites_count),
+        verified: Boolean(result.is_blue_verified || result.verification?.verified || legacy.verified),
         created_at: stringField(core.created_at) || stringField(legacy.created_at),
     }];
 }
@@ -228,4 +179,4 @@ cli({
     }
 });
 
-export const __test__ = { mapTwitterProfileResult, deepFindValue, resolveCount, resolveText };
+export const __test__ = { mapTwitterProfileResult };

--- a/clis/twitter/profile.test.js
+++ b/clis/twitter/profile.test.js
@@ -60,32 +60,31 @@ describe('twitter profile command', () => {
         });
     });
 
-    it('recovers followers/following/tweets/likes/bio after X relocates them out of result.legacy (#2188)', () => {
-        // Regression for #2188: name/screen_name/created_at/verified stay correct
-        // (already read from result.core), but X moved the counts and the bio into
-        // a new container, so the legacy-only reads returned 0 / ''. The resolver
-        // must find them wherever they now live, without knowing the exact path.
+    it('reads the current UserByScreenName profile containers after X removed result.legacy (#2188)', () => {
+        // Captures the field names and containers observed in a live
+        // UserByScreenName response. X renamed these keys as well as moving them,
+        // so searching the tree for the old legacy key names cannot recover them.
         const rows = __test__.mapTwitterProfileResult({
             core: {
                 screen_name: 'relocated_user',
                 name: 'Relocated User',
                 created_at: 'Sun Mar 20 00:00:00 +0000 2011',
             },
-            legacy: {
-                // legacy still exists but the counts and description are gone from it
-                location: 'Earth',
-                verified: false,
-            },
-            relationship_counts: { followers_count: 7100000, friends_count: 42, statuses_count: 128 },
-            engagement: { favourites_count: 9 },
-            profile_bio: { description: 'relocated bio text' },
-            is_blue_verified: true,
+            relationship_counts: { followers: 7100000, following: 42 },
+            tweet_counts: { tweets: 128 },
+            action_counts: { favorites_count: 9 },
+            profile_bio: { description: 'current bio text' },
+            location: { location: 'Earth' },
+            website: { url: 'https://example.com' },
+            verification: { verified: true },
         }, 'fallback');
 
         expect(rows[0]).toMatchObject({
             screen_name: 'relocated_user',
             name: 'Relocated User',
-            bio: 'relocated bio text',
+            bio: 'current bio text',
+            location: 'Earth',
+            url: 'https://example.com',
             followers: 7100000,
             following: 42,
             tweets: 128,
@@ -95,46 +94,48 @@ describe('twitter profile command', () => {
         });
     });
 
-    it('prefers the canonical legacy counts/bio over a deeper decoy occurrence', () => {
-        // A nested pinned-tweet copy must never shadow the user-level field. The
-        // explicit legacy check plus BFS shallow-preference keeps legacy winning.
+    it('prefers current profile containers while retaining legacy fallbacks', () => {
         const rows = __test__.mapTwitterProfileResult({
             core: { screen_name: 'u', name: 'U', created_at: 'now' },
             legacy: {
-                description: 'the real bio',
+                description: 'old bio',
                 followers_count: 100,
                 friends_count: 10,
                 statuses_count: 5,
                 favourites_count: 2,
             },
+            relationship_counts: { followers: 200, following: 20 },
+            tweet_counts: { tweets: 15 },
+            action_counts: { favorites_count: 12 },
+            profile_bio: { description: 'current bio' },
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({
+            bio: 'current bio',
+            followers: 200,
+            following: 20,
+            tweets: 15,
+            likes: 12,
+        });
+    });
+
+    it('does not read same-named values from unrelated nested entities', () => {
+        const rows = __test__.mapTwitterProfileResult({
+            core: { screen_name: 'u', name: 'U', created_at: 'now' },
             pinned_tweet: {
-                legacy: { favourites_count: 999999, description: 'a tweet, not a bio' },
+                relationship_counts: { followers: 999999, following: 999999 },
+                action_counts: { favorites_count: 999999 },
+                profile_bio: { description: 'not a user bio' },
             },
         }, 'fallback');
 
         expect(rows[0]).toMatchObject({
-            bio: 'the real bio',
-            followers: 100,
-            following: 10,
-            tweets: 5,
-            likes: 2,
+            bio: '',
+            followers: 0,
+            following: 0,
+            tweets: 0,
+            likes: 0,
         });
-    });
-
-    it('never falls back into an embedded tweet when the user field is absent', () => {
-        // Shallowest-wins alone does not save us here: with no user-level
-        // favourites_count/description anywhere, an unrestricted BFS descends into
-        // pinned_tweet and reports a tweet's like count as the user's likes and its
-        // text as the bio. Wrong-but-confident data is worse than 0 / ''.
-        const rows = __test__.mapTwitterProfileResult({
-            core: { screen_name: 'u', name: 'U', created_at: 'now' },
-            legacy: { location: 'Earth' },
-            pinned_tweet: {
-                legacy: { favourites_count: 999999, description: 'a tweet, not a bio' },
-            },
-        }, 'fallback');
-
-        expect(rows[0]).toMatchObject({ likes: 0, bio: '' });
     });
 
     it('returns 0 / empty string when a count or bio is absent everywhere', () => {
@@ -150,15 +151,6 @@ describe('twitter profile command', () => {
             tweets: 0,
             likes: 0,
         });
-    });
-
-    it('resolveCount / resolveText ignore wrong-typed and empty values', () => {
-        // A count that arrives as a numeric string must not be accepted as a number,
-        // and an empty/whitespace description must not shadow a populated one deeper.
-        expect(__test__.resolveCount({ legacy: { followers_count: '123' }, counts: { followers_count: 7 } }, 'followers_count')).toBe(7);
-        expect(__test__.resolveText({ legacy: { description: '   ' }, bio: { description: 'real' } }, 'description')).toBe('real');
-        expect(__test__.resolveCount({ legacy: {} }, 'followers_count')).toBe(0);
-        expect(__test__.resolveText({ legacy: {} }, 'description')).toBe('');
     });
 
     it('throws typed when the profile result is structurally malformed', () => {

--- a/clis/twitter/profile.test.js
+++ b/clis/twitter/profile.test.js
@@ -60,6 +60,107 @@ describe('twitter profile command', () => {
         });
     });
 
+    it('recovers followers/following/tweets/likes/bio after X relocates them out of result.legacy (#2188)', () => {
+        // Regression for #2188: name/screen_name/created_at/verified stay correct
+        // (already read from result.core), but X moved the counts and the bio into
+        // a new container, so the legacy-only reads returned 0 / ''. The resolver
+        // must find them wherever they now live, without knowing the exact path.
+        const rows = __test__.mapTwitterProfileResult({
+            core: {
+                screen_name: 'relocated_user',
+                name: 'Relocated User',
+                created_at: 'Sun Mar 20 00:00:00 +0000 2011',
+            },
+            legacy: {
+                // legacy still exists but the counts and description are gone from it
+                location: 'Earth',
+                verified: false,
+            },
+            relationship_counts: { followers_count: 7100000, friends_count: 42, statuses_count: 128 },
+            engagement: { favourites_count: 9 },
+            profile_bio: { description: 'relocated bio text' },
+            is_blue_verified: true,
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({
+            screen_name: 'relocated_user',
+            name: 'Relocated User',
+            bio: 'relocated bio text',
+            followers: 7100000,
+            following: 42,
+            tweets: 128,
+            likes: 9,
+            verified: true,
+            created_at: 'Sun Mar 20 00:00:00 +0000 2011',
+        });
+    });
+
+    it('prefers the canonical legacy counts/bio over a deeper decoy occurrence', () => {
+        // A nested pinned-tweet copy must never shadow the user-level field. The
+        // explicit legacy check plus BFS shallow-preference keeps legacy winning.
+        const rows = __test__.mapTwitterProfileResult({
+            core: { screen_name: 'u', name: 'U', created_at: 'now' },
+            legacy: {
+                description: 'the real bio',
+                followers_count: 100,
+                friends_count: 10,
+                statuses_count: 5,
+                favourites_count: 2,
+            },
+            pinned_tweet: {
+                legacy: { favourites_count: 999999, description: 'a tweet, not a bio' },
+            },
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({
+            bio: 'the real bio',
+            followers: 100,
+            following: 10,
+            tweets: 5,
+            likes: 2,
+        });
+    });
+
+    it('never falls back into an embedded tweet when the user field is absent', () => {
+        // Shallowest-wins alone does not save us here: with no user-level
+        // favourites_count/description anywhere, an unrestricted BFS descends into
+        // pinned_tweet and reports a tweet's like count as the user's likes and its
+        // text as the bio. Wrong-but-confident data is worse than 0 / ''.
+        const rows = __test__.mapTwitterProfileResult({
+            core: { screen_name: 'u', name: 'U', created_at: 'now' },
+            legacy: { location: 'Earth' },
+            pinned_tweet: {
+                legacy: { favourites_count: 999999, description: 'a tweet, not a bio' },
+            },
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({ likes: 0, bio: '' });
+    });
+
+    it('returns 0 / empty string when a count or bio is absent everywhere', () => {
+        const rows = __test__.mapTwitterProfileResult({
+            core: { screen_name: 'sparse', name: 'Sparse', created_at: 'now' },
+            legacy: {},
+        }, 'fallback');
+
+        expect(rows[0]).toMatchObject({
+            bio: '',
+            followers: 0,
+            following: 0,
+            tweets: 0,
+            likes: 0,
+        });
+    });
+
+    it('resolveCount / resolveText ignore wrong-typed and empty values', () => {
+        // A count that arrives as a numeric string must not be accepted as a number,
+        // and an empty/whitespace description must not shadow a populated one deeper.
+        expect(__test__.resolveCount({ legacy: { followers_count: '123' }, counts: { followers_count: 7 } }, 'followers_count')).toBe(7);
+        expect(__test__.resolveText({ legacy: { description: '   ' }, bio: { description: 'real' } }, 'description')).toBe('real');
+        expect(__test__.resolveCount({ legacy: {} }, 'followers_count')).toBe(0);
+        expect(__test__.resolveText({ legacy: {} }, 'description')).toBe('');
+    });
+
     it('throws typed when the profile result is structurally malformed', () => {
         expect(() => __test__.mapTwitterProfileResult(null, 'jack')).toThrow(CommandExecutionError);
         expect(() => __test__.mapTwitterProfileResult([], 'jack')).toThrow(CommandExecutionError);


### PR DESCRIPTION
## Problem — #2188

`opencli twitter profile <user>` returns `followers`, `following`, `tweets`, `likes` all **0** and an **empty `bio`**, while `name` / `screen_name` / `created_at` / `verified` are correct.

Root cause: X (Twitter) relocated the count fields (`followers_count`, `friends_count`, `statuses_count`, `favourites_count`) and the bio (`description`) **out of `result.legacy`** into a new container — the same schema drift #1745 already handled for `name`/`created_at` by reading `result.core`. The adapter still read the counts and bio only from `result.legacy`, so they silently fell back to `0` / `''`.

## Fix

Rather than hard-code the (unknown, still-shifting) new path, `mapTwitterProfileResult` now resolves each affected field from its **known homes first** (`legacy` → `core` → top-level `result`), then falls back to a **bounded breadth-first search** that returns the **shallowest** match.

Shallowest-wins alone is not safe: when the field is absent from the user object entirely, an unrestricted BFS would descend into an embedded tweet and report *its* `favourites_count` as the user's likes, or *its* text as the bio. So the search **refuses to cross into containers that describe a different entity** (`pinned_tweet`, `tweet`, `status`, `quoted_status`, `retweeted_status`, `entities`, `extended_entities`, `media`, `highlights`). A wrong-but-confident number is worse than `0` / `''`.

- Restores the counts and bio against the current payload.
- Stays robust if X relocates these fields yet again.
- Legacy-path responses (counts still under `result.legacy`) resolve **identically** — the existing test is unchanged.

## Tests

`mapTwitterProfileResult` is a pure exported function. Added offline regression tests (12 total in the file):
- counts + bio recovered after relocation out of `legacy` (the #2188 case)
- canonical `legacy` values still win over a deeper decoy occurrence
- **never** falls back into an embedded tweet when the user field is absent → `0` / `''`
- absent field everywhere → `0` / `''`
- resolver rejects wrong-typed (numeric-string) and empty/whitespace values

```
npx vitest run clis/twitter/profile.test.js   # 12 passed
npm run typecheck                              # clean
npm run check:typed-error-lint                 # new=0
npm run check:silent-column-drop               # new=0
```

No change to the `cli()` registration, so `cli-manifest.json` is untouched.