### PR TITLE
fix(facebook/search): preserve query identity + drop redirect shims (#2090)

### DIFF
--- a/clis/facebook/search.js
+++ b/clis/facebook/search.js
@@ -54,11 +54,28 @@ function buildSearchExtractScript(limit) {
       try { u = new URL(href, 'https://www.facebook.com'); } catch (e) { return false; }
       // drop hidden-domain .com spam — real results stay on facebook.com
       if (!/(^|\\.)facebook\\.com$/i.test(u.hostname)) return false;
+      // l.facebook.com / lm.facebook.com only wrap outbound links (/l.php?u=…);
+      // they are redirect shims, never search entities.
+      if (/^lm?\\.facebook\\.com$/i.test(u.hostname)) return false;
       const p = u.pathname;
       if (/^\\/search(\\/|$)/i.test(p)) return false;                  // decoy links back to search (incl. bare /search)
       // chrome / non-result destinations that the catch-all below would keep
       if (/^\\/(login|checkpoint|help|policies|privacy|settings|bookmarks|messages|notifications|marketplace|gaming|friends|requests|saved|me)\\b/i.test(p)) return false;
       return /^\\/(profile\\.php|groups\\/|events\\/|watch\\/|reel\\/|pages\\/|permalink\\.php|story\\.php|[^/]+\\/posts\\/|[^/]+\\/videos\\/|[A-Za-z0-9.\\-]{2,}\\/?$)/i.test(p);
+    }
+
+    // Query-identity destinations (permalink.php?story_fbid=…, story.php,
+    // photo.php?fbid=…, watch/?v=…) collapse into a single row when the query is
+    // dropped — different posts/videos share the same pathname. Keep the identity
+    // params, but only those: FB appends per-render tracking nonces (__cft__,
+    // __tn__, ref) that would otherwise defeat dedup by making the same post look
+    // unique on every render.
+    const ID_PARAMS = ['story_fbid', 'fbid', 'id', 'v', 'story_id'];
+    function entityKey(u) {
+      const ids = ID_PARAMS
+        .filter((k) => u.searchParams.has(k))
+        .map((k) => k + '=' + u.searchParams.get(k));
+      return ids.length ? (u.origin + u.pathname + '?' + ids.join('&')) : (u.origin + u.pathname);
     }
 
     function isAuthPage() {
@@ -81,8 +98,8 @@ function buildSearchExtractScript(limit) {
       const rawHref = a.href || a.getAttribute('href') || '';
       if (!isEntityHref(rawHref)) continue;
       let key;
-      try { const u = new URL(rawHref, 'https://www.facebook.com'); key = u.origin + u.pathname; }
-      catch (e) { key = rawHref.split('?')[0].split('#')[0]; }
+      try { const u = new URL(rawHref, 'https://www.facebook.com'); key = entityKey(u); }
+      catch (e) { key = rawHref.split('#')[0]; }
       if (seen.has(key)) continue;
 
       const title = clean(a.textContent).substring(0, 80);

--- a/clis/facebook/search.js
+++ b/clis/facebook/search.js
@@ -61,7 +61,7 @@ function buildSearchExtractScript(limit) {
       if (/^\\/search(\\/|$)/i.test(p)) return false;                  // decoy links back to search (incl. bare /search)
       // chrome / non-result destinations that the catch-all below would keep
       if (/^\\/(login|checkpoint|help|policies|privacy|settings|bookmarks|messages|notifications|marketplace|gaming|friends|requests|saved|me)\\b/i.test(p)) return false;
-      return /^\\/(profile\\.php|groups\\/|events\\/|watch\\/|reel\\/|pages\\/|permalink\\.php|story\\.php|[^/]+\\/posts\\/|[^/]+\\/videos\\/|[A-Za-z0-9.\\-]{2,}\\/?$)/i.test(p);
+      return /^\\/(profile\\.php|photo\\.php|groups\\/|events\\/|watch\\/|reel\\/|pages\\/|permalink\\.php|story\\.php|[^/]+\\/posts\\/|[^/]+\\/videos\\/|[A-Za-z0-9.\\-]{2,}\\/?$)/i.test(p);
     }
 
     // Query-identity destinations (permalink.php?story_fbid=…, story.php,
@@ -70,9 +70,15 @@ function buildSearchExtractScript(limit) {
     // params, but only those: FB appends per-render tracking nonces (__cft__,
     // __tn__, ref) that would otherwise defeat dedup by making the same post look
     // unique on every render.
-    const ID_PARAMS = ['story_fbid', 'fbid', 'id', 'v', 'story_id'];
     function entityKey(u) {
-      const ids = ID_PARAMS
+      const p = u.pathname.toLowerCase();
+      let identityParams = [];
+      if (p === '/profile.php') identityParams = ['id'];
+      else if (p === '/permalink.php' || p === '/story.php') {
+        identityParams = ['story_fbid', 'story_id', 'fbid', 'id'];
+      } else if (p === '/photo.php') identityParams = ['fbid', 'id'];
+      else if (p === '/watch' || p === '/watch/') identityParams = ['v'];
+      const ids = identityParams
         .filter((k) => u.searchParams.has(k))
         .map((k) => k + '=' + u.searchParams.get(k));
       return ids.length ? (u.origin + u.pathname + '?' + ids.join('&')) : (u.origin + u.pathname);

--- a/clis/facebook/search.test.js
+++ b/clis/facebook/search.test.js
@@ -88,6 +88,50 @@ describe('facebook search', () => {
     expect(payload.rows[0].url).toBe('https://www.facebook.com/carol.page');
   });
 
+  it('keeps distinct permalink.php posts apart by their identity query', () => {
+    // permalink.php / story.php / watch encode identity in the query string;
+    // deduping on pathname alone collapses different posts into one row.
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/permalink.php?story_fbid=1001&id=50">First distinct post about AI research</a></div>
+        <div><a role="link" href="https://www.facebook.com/permalink.php?story_fbid=2002&id=50">Second distinct post about AI safety</a></div>
+        <div><a role="link" href="https://www.facebook.com/watch/?v=111">Video one about AI agents here</a></div>
+        <div><a role="link" href="https://www.facebook.com/watch/?v=222">Video two about AI agents here</a></div>
+      </div>
+    `);
+    expect(payload.rows.map((r) => r.url)).toEqual([
+      'https://www.facebook.com/permalink.php?story_fbid=1001&id=50',
+      'https://www.facebook.com/permalink.php?story_fbid=2002&id=50',
+      'https://www.facebook.com/watch/?v=111',
+      'https://www.facebook.com/watch/?v=222',
+    ]);
+  });
+
+  it('dedupes one post rendered with different per-render tracking nonces', () => {
+    // FB appends __cft__ / __tn__ nonces that differ on every render; keeping
+    // them in the key would make the same post appear as multiple rows.
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/permalink.php?story_fbid=1001&id=50&__cft__[0]=nonceA&__tn__=R">Same post rendered once here now</a></div>
+        <div><a role="link" href="https://www.facebook.com/permalink.php?story_fbid=1001&id=50&__cft__[0]=nonceB&__tn__=H">Same post rendered twice here now</a></div>
+      </div>
+    `);
+    expect(payload.rows.map((r) => r.url)).toEqual(['https://www.facebook.com/permalink.php?story_fbid=1001&id=50']);
+  });
+
+  it('drops l.facebook.com / lm.facebook.com outbound-redirect shims', () => {
+    // /l.php?u=… wrappers are external-link redirects, not search entities; their
+    // pathname would otherwise slip through the vanity catch-all.
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/realpage">Real Page result here</a></div>
+        <a role="link" href="https://l.facebook.com/l.php?u=https%3A%2F%2Fexample.com&h=AbC">External article link in a post</a>
+        <a role="link" href="https://lm.facebook.com/l.php?u=https%3A%2F%2Fexample.org">Another external redirect link here</a>
+      </div>
+    `);
+    expect(payload.rows.map((r) => r.url)).toEqual(['https://www.facebook.com/realpage']);
+  });
+
   it('reports auth pages as an auth status', () => {
     const payload = runExtract('<div role="main">Log in to Facebook</div>', 10, 'https://www.facebook.com/login/');
     expect(payload.status).toBe('auth');

--- a/clis/facebook/search.test.js
+++ b/clis/facebook/search.test.js
@@ -107,6 +107,24 @@ describe('facebook search', () => {
     ]);
   });
 
+  it('keeps profile and photo identities without treating arbitrary query params as identity', () => {
+    const payload = runExtract(`
+      <div role="feed">
+        <div><a role="link" href="https://www.facebook.com/profile.php?id=1001&ref=search">First profile result with details</a></div>
+        <div><a role="link" href="https://www.facebook.com/profile.php?id=2002&ref=search">Second profile result with details</a></div>
+        <div><a role="link" href="https://www.facebook.com/photo.php?fbid=3003&id=1001&__tn__=R">Photo result with useful details</a></div>
+        <div><a role="link" href="https://www.facebook.com/realpage?id=tracking-a">Same vanity page first render</a></div>
+        <div><a role="link" href="https://www.facebook.com/realpage?id=tracking-b">Same vanity page second render</a></div>
+      </div>
+    `);
+    expect(payload.rows.map((r) => r.url)).toEqual([
+      'https://www.facebook.com/profile.php?id=1001',
+      'https://www.facebook.com/profile.php?id=2002',
+      'https://www.facebook.com/photo.php?fbid=3003&id=1001',
+      'https://www.facebook.com/realpage',
+    ]);
+  });
+
   it('dedupes one post rendered with different per-render tracking nonces', () => {
     // FB appends __cft__ / __tn__ nonces that differ on every render; keeping
     // them in the key would make the same post appear as multiple rows.


### PR DESCRIPTION
Follow-up to the merged #2126 facebook-search rewrite. Two residual defects, both confirmed by offline JSDOM reproduction against the current code:

## 1. Query-identity collision (correctness bug)

The extractor deduped and reported result URLs as `origin + pathname`, dropping the query string. For query-identity destinations — `permalink.php?story_fbid=…`, `story.php?…`, `watch/?v=…` — the query **is** the identity, so two different posts/videos collapse into one row and only the first survives dedup:

```
permalink.php?story_fbid=1001  ┐
permalink.php?story_fbid=2002  ┴─►  1 row  (https://www.facebook.com/permalink.php)
```

**Fix:** `entityKey(u)` keeps only the identity params (`story_fbid, fbid, id, v, story_id`) and strips FB's per-render tracking nonces (`__cft__`, `__tn__`, `ref`). Distinct posts stay distinct; the same post rendered twice with different nonces still dedupes to one row. Vanity paths without identity params keep collapsing to the bare pathname (existing dedup test unchanged).

## 2. Outbound-redirect shim leak

`l.facebook.com` / `lm.facebook.com` `/l.php?u=…` wrappers passed the host regex `(^|\.)facebook\.com$` and the vanity path catch-all, so external-link redirects showed up as "search results." Added a host guard rejecting the `l.` / `lm.` shims (`m.facebook.com` is intentionally **not** matched).

## Tests

`buildSearchExtractScript` is exercised via JSDOM (same harness as the existing tests). Added regression tests for distinct permalink/watch identities, nonce dedup, and the redirect-shim guard.

```
npx vitest run clis/facebook/search.test.js   # 11 passed
npm run typecheck                              # clean
npm run check:typed-error-lint                 # new=0
npm run check:silent-column-drop               # new=0
```

This supersedes my earlier #2132 (which predated #2126 and overlapped its role=feed rewrite) — closing that in favor of this focused delta.