### PR TITLE
fix(douyin): walk work_list cursor and reject non-sec_uid input

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12802,7 +12802,7 @@
         "type": "string",
         "required": true,
         "positional": true,
-        "help": "用户 sec_uid（URL 末尾部分）"
+        "help": "用户 sec_uid（个人主页 URL 末尾部分，也可直接传整条主页 URL）"
       },
       {
         "name": "limit",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12854,14 +12854,7 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "每页数量"
-      },
-      {
-        "name": "page",
-        "type": "int",
-        "default": 1,
-        "required": false,
-        "help": "页码"
+        "help": "最多返回多少个作品（跨页自动收集）"
       },
       {
         "name": "status",
@@ -12883,6 +12876,10 @@
       "status",
       "play_count",
       "digg_count",
+      "comment_count",
+      "collect_count",
+      "share_count",
+      "duration",
       "create_time"
     ],
     "type": "js",

--- a/clis/douyin/user-videos.js
+++ b/clis/douyin/user-videos.js
@@ -1,9 +1,24 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { fetchDouyinComments, fetchDouyinUserVideos } from './_shared/public-api.js';
 export const MAX_USER_VIDEOS_LIMIT = 20;
 export const USER_VIDEO_COMMENT_CONCURRENCY = 4;
 export const DEFAULT_COMMENT_LIMIT = 10;
+// sec_uid is base64url. Anything else (a nickname, a numeric UID, a search term)
+// still resolves to a Douyin page, so without this guard the scrape silently
+// returns some other account's videos.
+const SEC_UID_PATTERN = /^[A-Za-z0-9_-]{8,}$/;
+const SEC_UID_HINT = 'sec_uid looks like MS4wLjABAAAA… — it is the last path segment of https://www.douyin.com/user/<sec_uid>, not a nickname or a numeric UID.';
+export function normalizeSecUid(input) {
+    const raw = String(input ?? '').trim();
+    if (!raw)
+        throw new ArgumentError('douyin user-videos requires a sec_uid', SEC_UID_HINT);
+    const fromUrl = raw.match(/douyin\.com\/user\/([A-Za-z0-9_-]+)/);
+    const candidate = fromUrl ? fromUrl[1] : raw;
+    if (!SEC_UID_PATTERN.test(candidate))
+        throw new ArgumentError(`"${raw}" is not a Douyin sec_uid`, SEC_UID_HINT);
+    return candidate;
+}
 export function normalizeUserVideosLimit(limit) {
     const numeric = Number(limit);
     if (!Number.isFinite(numeric))
@@ -43,14 +58,14 @@ cli({
     domain: 'www.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'sec_uid', type: 'string', required: true, positional: true, help: '用户 sec_uid（URL 末尾部分）' },
+        { name: 'sec_uid', type: 'string', required: true, positional: true, help: '用户 sec_uid（个人主页 URL 末尾部分，也可直接传整条主页 URL）' },
         { name: 'limit', type: 'int', default: 20, help: '获取数量（最大 20）' },
         { name: 'with_comments', type: 'bool', default: true, help: '包含热门评论（默认: true）' },
         { name: 'comment_limit', type: 'int', default: 10, help: '每个视频获取多少条评论（最大 10）' },
     ],
     columns: ['index', 'aweme_id', 'title', 'duration', 'digg_count', 'play_url', 'top_comments'],
     func: async (page, kwargs) => {
-        const secUid = kwargs.sec_uid;
+        const secUid = normalizeSecUid(kwargs.sec_uid);
         const limit = normalizeUserVideosLimit(kwargs.limit);
         const withComments = kwargs.with_comments !== false;
         const commentLimit = normalizeCommentLimit(kwargs.comment_limit);

--- a/clis/douyin/user-videos.js
+++ b/clis/douyin/user-videos.js
@@ -7,7 +7,10 @@ export const DEFAULT_COMMENT_LIMIT = 10;
 // sec_uid is base64url. Anything else (a nickname, a numeric UID, a search term)
 // still resolves to a Douyin page, so without this guard the scrape silently
 // returns some other account's videos.
-const SEC_UID_PATTERN = /^[A-Za-z0-9_-]{8,}$/;
+// Current Douyin sec_uid values use the stable `MS4wLjABAAAA` prefix followed
+// by a long base64url payload. Requiring the prefix prevents ordinary ASCII
+// nicknames and long numeric UIDs from passing a shape-only character check.
+const SEC_UID_PATTERN = /^MS4wLjABAAAA[A-Za-z0-9_-]{8,}$/;
 const SEC_UID_HINT = 'sec_uid looks like MS4wLjABAAAA… — it is the last path segment of https://www.douyin.com/user/<sec_uid>, not a nickname or a numeric UID.';
 export function normalizeSecUid(input) {
     const raw = String(input ?? '').trim();

--- a/clis/douyin/user-videos.test.js
+++ b/clis/douyin/user-videos.test.js
@@ -8,8 +8,8 @@ vi.mock('./_shared/public-api.js', () => ({
     fetchDouyinComments: fetchDouyinCommentsMock,
 }));
 import { getRegistry } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { DEFAULT_COMMENT_LIMIT, MAX_USER_VIDEOS_LIMIT, normalizeCommentLimit, normalizeUserVideosLimit } from './user-videos.js';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DEFAULT_COMMENT_LIMIT, MAX_USER_VIDEOS_LIMIT, normalizeCommentLimit, normalizeSecUid, normalizeUserVideosLimit } from './user-videos.js';
 describe('douyin user-videos', () => {
     beforeEach(() => {
         fetchDouyinUserVideosMock.mockReset();
@@ -20,6 +20,33 @@ describe('douyin user-videos', () => {
         const values = [...registry.values()];
         const command = values.find((cmd) => cmd.site === 'douyin' && cmd.name === 'user-videos');
         expect(command).toBeDefined();
+    });
+    it('accepts a bare sec_uid and a pasted profile URL', () => {
+        expect(normalizeSecUid('MS4wLjABAAAA_example-01')).toBe('MS4wLjABAAAA_example-01');
+        expect(normalizeSecUid('  MS4wLjABAAAA_example-01  ')).toBe('MS4wLjABAAAA_example-01');
+        expect(normalizeSecUid('https://www.douyin.com/user/MS4wLjABAAAA_example-01?from=x')).toBe('MS4wLjABAAAA_example-01');
+    });
+    it('rejects a nickname instead of silently scraping another account', () => {
+        expect(() => normalizeSecUid('大圆镜科普')).toThrow(ArgumentError);
+        expect(() => normalizeSecUid('some user')).toThrow(ArgumentError);
+        expect(() => normalizeSecUid('')).toThrow(ArgumentError);
+    });
+    it('does not navigate when the sec_uid is invalid', async () => {
+        const command = [...getRegistry().values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'user-videos');
+        if (!command?.func)
+            throw new Error('douyin user-videos command not registered');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+        };
+        await expect(command.func(page, {
+            sec_uid: '大圆镜科普',
+            limit: 3,
+            with_comments: false,
+            comment_limit: 5,
+        })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(fetchDouyinUserVideosMock).not.toHaveBeenCalled();
     });
     it('clamps limit to a safe maximum', () => {
         expect(normalizeUserVideosLimit(100)).toBe(MAX_USER_VIDEOS_LIMIT);

--- a/clis/douyin/user-videos.test.js
+++ b/clis/douyin/user-videos.test.js
@@ -29,6 +29,8 @@ describe('douyin user-videos', () => {
     it('rejects a nickname instead of silently scraping another account', () => {
         expect(() => normalizeSecUid('大圆镜科普')).toThrow(ArgumentError);
         expect(() => normalizeSecUid('some user')).toThrow(ArgumentError);
+        expect(() => normalizeSecUid('creatorname')).toThrow(ArgumentError);
+        expect(() => normalizeSecUid('12345678901234567890')).toThrow(ArgumentError);
         expect(() => normalizeSecUid('')).toThrow(ArgumentError);
     });
     it('does not navigate when the sec_uid is invalid', async () => {
@@ -75,12 +77,12 @@ describe('douyin user-videos', () => {
             wait: vi.fn().mockResolvedValue(undefined),
         };
         const rows = await command.func(page, {
-            sec_uid: 'MS4w-test',
+            sec_uid: 'MS4wLjABAAAA_test-user',
             limit: 100,
             comment_limit: 99,
             with_comments: true,
         });
-        expect(fetchDouyinUserVideosMock).toHaveBeenCalledWith(page, 'MS4w-test', MAX_USER_VIDEOS_LIMIT);
+        expect(fetchDouyinUserVideosMock).toHaveBeenCalledWith(page, 'MS4wLjABAAAA_test-user', MAX_USER_VIDEOS_LIMIT);
         expect(fetchDouyinCommentsMock).toHaveBeenCalledWith(page, '1', DEFAULT_COMMENT_LIMIT);
         expect(rows).toEqual([
             {
@@ -115,7 +117,7 @@ describe('douyin user-videos', () => {
             wait: vi.fn().mockResolvedValue(undefined),
         };
         const rows = await command.func(page, {
-            sec_uid: 'MS4w-test',
+            sec_uid: 'MS4wLjABAAAA_test-user',
             limit: 3,
             with_comments: false,
             comment_limit: 5,
@@ -144,7 +146,7 @@ describe('douyin user-videos', () => {
             wait: vi.fn().mockResolvedValue(undefined),
         };
         await expect(command.func(page, {
-            sec_uid: 'MS4w-empty',
+            sec_uid: 'MS4wLjABAAAA_empty-user',
             limit: 3,
             with_comments: true,
             comment_limit: 5,
@@ -169,7 +171,7 @@ describe('douyin user-videos', () => {
             wait: vi.fn().mockResolvedValue(undefined),
         };
         await expect(command.func(page, {
-            sec_uid: 'MS4w-test',
+            sec_uid: 'MS4wLjABAAAA_test-user',
             limit: 3,
             with_comments: true,
             comment_limit: 5,

--- a/clis/douyin/videos.js
+++ b/clis/douyin/videos.js
@@ -1,9 +1,33 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { browserFetch } from './_shared/browser-fetch.js';
 const WORK_LIST_URL = 'https://creator.douyin.com/janus/douyin/creator/pc/work_list';
 // The server caps how many works come back per request regardless of page_size,
 // so collecting a large --limit takes several cursor hops.
 const MAX_HOPS = 50;
+const DEFAULT_LIMIT = 20;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = MAX_HOPS * 50;
+function isScheduledWork(work) {
+    return (work.public_time ?? 0) > Date.now() / 1000;
+}
+function countEligibleWorks(items, status) {
+    return status === 'scheduled' ? items.filter(isScheduledWork).length : items.length;
+}
+export function normalizeVideosLimit(raw) {
+    const value = raw === undefined || raw === null || raw === '' ? DEFAULT_LIMIT : Number(raw);
+    if (!Number.isInteger(value) || value < MIN_LIMIT || value > MAX_LIMIT) {
+        throw new ArgumentError(`douyin videos limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`);
+    }
+    return value;
+}
+function pageSizeForLimit(limit) {
+    if (limit < 20)
+        return 20;
+    if (limit > 50)
+        return 50;
+    return limit;
+}
 function normalizeVideoStatus(status, publicTime) {
     if (typeof status === 'number')
         return status;
@@ -29,7 +53,7 @@ cli({
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: '最多返回多少个作品（跨页自动收集）' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: '最多返回多少个作品（跨页自动收集）' },
         { name: 'status', default: 'all', choices: ['all', 'published', 'reviewing', 'scheduled'] },
     ],
     columns: [
@@ -47,32 +71,44 @@ cli({
     func: async (page, kwargs) => {
         const statusMap = { all: 0, published: 1, reviewing: 3, scheduled: 0 };
         const statusNum = statusMap[kwargs.status] ?? 0;
-        const limit = Math.max(1, kwargs.limit);
+        const limit = normalizeVideosLimit(kwargs.limit);
+        const pageSize = pageSizeForLimit(limit);
         // work_list is cursor-paginated: it ignores page_num and advances through max_cursor.
         // Walk the cursor until the server stops reporting has_more.
         const items = [];
+        const seenAwemeIds = new Set();
         let cursor;
-        for (let hop = 0; hop < MAX_HOPS && items.length < limit; hop++) {
+        for (let hop = 0; hop < MAX_HOPS && countEligibleWorks(items, kwargs.status) < limit; hop++) {
             const params = new URLSearchParams({
-                page_size: String(limit),
+                page_size: String(pageSize),
                 status: String(statusNum),
             });
             if (cursor !== undefined)
                 params.set('max_cursor', String(cursor));
             const res = (await browserFetch(page, 'GET', `${WORK_LIST_URL}?${params.toString()}`));
-            const batch = res.data?.work_list ?? res.aweme_list ?? [];
+            const payload = res.data && typeof res.data === 'object' ? res.data : res;
+            const batch = payload.work_list ?? payload.aweme_list ?? res.work_list ?? res.aweme_list ?? [];
             if (batch.length === 0)
                 break;
-            items.push(...batch);
-            const nextCursor = res.max_cursor;
-            if (!res.has_more || nextCursor === undefined || nextCursor === null || nextCursor === cursor)
+            for (const work of batch) {
+                const awemeId = work?.aweme_id == null ? '' : String(work.aweme_id);
+                if (awemeId && seenAwemeIds.has(awemeId))
+                    continue;
+                if (awemeId)
+                    seenAwemeIds.add(awemeId);
+                items.push(work);
+            }
+            const nextCursor = payload.max_cursor ?? res.max_cursor;
+            const hasMore = payload.has_more ?? res.has_more;
+            if (!hasMore || nextCursor === undefined || nextCursor === null
+                || (cursor !== undefined && String(nextCursor) === String(cursor)))
                 break;
             cursor = nextCursor;
         }
         let rows = items;
         // The API has a bug with status=16 for scheduled, so filter client-side
         if (kwargs.status === 'scheduled') {
-            rows = rows.filter((v) => (v.public_time ?? 0) > Date.now() / 1000);
+            rows = rows.filter(isScheduledWork);
         }
         return rows.slice(0, limit).map((v) => ({
             aweme_id: v.aweme_id,

--- a/clis/douyin/videos.js
+++ b/clis/douyin/videos.js
@@ -1,5 +1,9 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { browserFetch } from './_shared/browser-fetch.js';
+const WORK_LIST_URL = 'https://creator.douyin.com/janus/douyin/creator/pc/work_list';
+// The server caps how many works come back per request regardless of page_size,
+// so collecting a large --limit takes several cursor hops.
+const MAX_HOPS = 50;
 function normalizeVideoStatus(status, publicTime) {
     if (typeof status === 'number')
         return status;
@@ -25,27 +29,61 @@ cli({
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: '每页数量' },
-        { name: 'page', type: 'int', default: 1, help: '页码' },
+        { name: 'limit', type: 'int', default: 20, help: '最多返回多少个作品（跨页自动收集）' },
         { name: 'status', default: 'all', choices: ['all', 'published', 'reviewing', 'scheduled'] },
     ],
-    columns: ['aweme_id', 'title', 'status', 'play_count', 'digg_count', 'create_time'],
+    columns: [
+        'aweme_id',
+        'title',
+        'status',
+        'play_count',
+        'digg_count',
+        'comment_count',
+        'collect_count',
+        'share_count',
+        'duration',
+        'create_time',
+    ],
     func: async (page, kwargs) => {
         const statusMap = { all: 0, published: 1, reviewing: 3, scheduled: 0 };
         const statusNum = statusMap[kwargs.status] ?? 0;
-        const url = `https://creator.douyin.com/janus/douyin/creator/pc/work_list?page_size=${kwargs.limit}&page_num=${kwargs.page}&status=${statusNum}`;
-        const res = (await browserFetch(page, 'GET', url));
-        let items = res.data?.work_list ?? res.aweme_list ?? [];
+        const limit = Math.max(1, kwargs.limit);
+        // work_list is cursor-paginated: it ignores page_num and advances through max_cursor.
+        // Walk the cursor until the server stops reporting has_more.
+        const items = [];
+        let cursor;
+        for (let hop = 0; hop < MAX_HOPS && items.length < limit; hop++) {
+            const params = new URLSearchParams({
+                page_size: String(limit),
+                status: String(statusNum),
+            });
+            if (cursor !== undefined)
+                params.set('max_cursor', String(cursor));
+            const res = (await browserFetch(page, 'GET', `${WORK_LIST_URL}?${params.toString()}`));
+            const batch = res.data?.work_list ?? res.aweme_list ?? [];
+            if (batch.length === 0)
+                break;
+            items.push(...batch);
+            const nextCursor = res.max_cursor;
+            if (!res.has_more || nextCursor === undefined || nextCursor === null || nextCursor === cursor)
+                break;
+            cursor = nextCursor;
+        }
+        let rows = items;
         // The API has a bug with status=16 for scheduled, so filter client-side
         if (kwargs.status === 'scheduled') {
-            items = items.filter((v) => (v.public_time ?? 0) > Date.now() / 1000);
+            rows = rows.filter((v) => (v.public_time ?? 0) > Date.now() / 1000);
         }
-        return items.map((v) => ({
+        return rows.slice(0, limit).map((v) => ({
             aweme_id: v.aweme_id,
             title: v.desc ?? '',
             status: normalizeVideoStatus(v.status, v.public_time),
             play_count: v.statistics?.play_count ?? 0,
             digg_count: v.statistics?.digg_count ?? 0,
+            comment_count: v.statistics?.comment_count ?? 0,
+            collect_count: v.statistics?.collect_count ?? 0,
+            share_count: v.statistics?.share_count ?? 0,
+            duration: v.duration ?? 0,
             create_time: new Date((v.create_time ?? v.public_time ?? 0) * 1000).toLocaleString('zh-CN', { timeZone: 'Asia/Tokyo' }),
         }));
     },

--- a/clis/douyin/videos.test.js
+++ b/clis/douyin/videos.test.js
@@ -6,7 +6,7 @@ vi.mock('./_shared/browser-fetch.js', () => ({
     browserFetch: browserFetchMock,
 }));
 import { getRegistry } from '@jackwener/opencli/registry';
-import './videos.js';
+import { normalizeVideosLimit } from './videos.js';
 function getCommand() {
     const command = [...getRegistry().values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'videos');
     if (!command?.func)
@@ -29,6 +29,17 @@ describe('douyin videos', () => {
     });
     it('registers the videos command', () => {
         expect(getCommand()).toBeDefined();
+    });
+    it('rejects invalid limits before fetching', async () => {
+        const command = getCommand();
+        expect(normalizeVideosLimit(undefined)).toBe(20);
+        expect(normalizeVideosLimit(1)).toBe(1);
+        expect(normalizeVideosLimit('2500')).toBe(2500);
+        expect(() => normalizeVideosLimit(0)).toThrow('between 1 and 2500');
+        expect(() => normalizeVideosLimit(2501)).toThrow('between 1 and 2500');
+        expect(() => normalizeVideosLimit('1.5')).toThrow('between 1 and 2500');
+        await expect(command.func({}, { limit: 0, status: 'all' })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        expect(browserFetchMock).not.toHaveBeenCalled();
     });
     it('parses the current creator work_list api shape', async () => {
         const command = getCommand();
@@ -94,7 +105,38 @@ describe('douyin videos', () => {
         const command = getCommand();
         browserFetchMock.mockResolvedValue({ aweme_list: [work('1')], has_more: true, max_cursor: 7 });
         const rows = await command.func({}, { limit: 50, status: 'all' });
-        expect(rows.map((r) => r.aweme_id)).toEqual(['1', '1']);
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1']);
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
+    });
+    it('reads cursor metadata from a nested data payload', async () => {
+        const command = getCommand();
+        browserFetchMock
+            .mockResolvedValueOnce({
+            data: { work_list: [work('1')], has_more: true, max_cursor: '8' },
+        })
+            .mockResolvedValueOnce({
+            data: { work_list: [work('2')], has_more: false, max_cursor: '0' },
+        });
+        const rows = await command.func({}, { limit: 20, status: 'all' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1', '2']);
+        expect(String(browserFetchMock.mock.calls[1][2])).toContain('max_cursor=8');
+    });
+    it('keeps paging until the scheduled limit is satisfied', async () => {
+        const command = getCommand();
+        const future = Math.floor(Date.now() / 1000) + 3600;
+        browserFetchMock
+            .mockResolvedValueOnce({
+            aweme_list: [work('1'), work('2')],
+            has_more: true,
+            max_cursor: 9,
+        })
+            .mockResolvedValueOnce({
+            aweme_list: [work('3', { public_time: future })],
+            has_more: false,
+            max_cursor: 0,
+        });
+        const rows = await command.func({}, { limit: 1, status: 'scheduled' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['3']);
         expect(browserFetchMock).toHaveBeenCalledTimes(2);
     });
     it('stops on an empty page', async () => {

--- a/clis/douyin/videos.test.js
+++ b/clis/douyin/videos.test.js
@@ -7,31 +7,44 @@ vi.mock('./_shared/browser-fetch.js', () => ({
 }));
 import { getRegistry } from '@jackwener/opencli/registry';
 import './videos.js';
+function getCommand() {
+    const command = [...getRegistry().values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'videos');
+    if (!command?.func)
+        throw new Error('douyin videos command not registered');
+    return command;
+}
+function work(id, extra = {}) {
+    return {
+        aweme_id: id,
+        desc: `标题 ${id}`,
+        create_time: 1581571130,
+        duration: 606367,
+        statistics: { play_count: 1, digg_count: 2, comment_count: 3, collect_count: 4, share_count: 5 },
+        ...extra,
+    };
+}
 describe('douyin videos', () => {
     beforeEach(() => {
         browserFetchMock.mockReset();
     });
     it('registers the videos command', () => {
-        const registry = getRegistry();
-        const values = [...registry.values()];
-        const cmd = values.find(c => c.site === 'douyin' && c.name === 'videos');
-        expect(cmd).toBeDefined();
+        expect(getCommand()).toBeDefined();
     });
     it('parses the current creator work_list api shape', async () => {
-        const registry = getRegistry();
-        const command = [...registry.values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'videos');
-        expect(command?.func).toBeDefined();
-        if (!command?.func)
-            throw new Error('douyin videos command not registered');
+        const command = getCommand();
         browserFetchMock.mockResolvedValueOnce({
             aweme_list: [
                 {
                     aweme_id: '7000000000000000001',
                     desc: '测试视频标题',
                     create_time: 1581571130,
+                    duration: 606367,
                     statistics: {
                         play_count: 0,
                         digg_count: 12,
+                        comment_count: 3,
+                        collect_count: 4,
+                        share_count: 5,
                     },
                     status: {
                         is_private: true,
@@ -39,7 +52,7 @@ describe('douyin videos', () => {
                 },
             ],
         });
-        const rows = await command.func({}, { limit: 5, page: 1, status: 'all' });
+        const rows = await command.func({}, { limit: 5, status: 'all' });
         expect(rows).toEqual([
             {
                 aweme_id: '7000000000000000001',
@@ -47,8 +60,50 @@ describe('douyin videos', () => {
                 status: 'private',
                 play_count: 0,
                 digg_count: 12,
+                comment_count: 3,
+                collect_count: 4,
+                share_count: 5,
+                duration: 606367,
                 create_time: new Date(1581571130 * 1000).toLocaleString('zh-CN', { timeZone: 'Asia/Tokyo' }),
             },
         ]);
+    });
+    it('follows max_cursor until has_more is false', async () => {
+        const command = getCommand();
+        browserFetchMock
+            .mockResolvedValueOnce({ aweme_list: [work('1'), work('2')], has_more: true, max_cursor: 1779021374000 })
+            .mockResolvedValueOnce({ aweme_list: [work('3')], has_more: false, max_cursor: 0 });
+        const rows = await command.func({}, { limit: 20, status: 'all' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1', '2', '3']);
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
+        expect(String(browserFetchMock.mock.calls[0][2])).not.toContain('max_cursor');
+        expect(String(browserFetchMock.mock.calls[1][2])).toContain('max_cursor=1779021374000');
+    });
+    it('stops once limit is reached', async () => {
+        const command = getCommand();
+        browserFetchMock.mockResolvedValue({
+            aweme_list: [work('1'), work('2'), work('3')],
+            has_more: true,
+            max_cursor: 10,
+        });
+        const rows = await command.func({}, { limit: 2, status: 'all' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1', '2']);
+        expect(browserFetchMock).toHaveBeenCalledTimes(1);
+    });
+    it('stops when the cursor stops advancing', async () => {
+        const command = getCommand();
+        browserFetchMock.mockResolvedValue({ aweme_list: [work('1')], has_more: true, max_cursor: 7 });
+        const rows = await command.func({}, { limit: 50, status: 'all' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1', '1']);
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
+    });
+    it('stops on an empty page', async () => {
+        const command = getCommand();
+        browserFetchMock
+            .mockResolvedValueOnce({ aweme_list: [work('1')], has_more: true, max_cursor: 5 })
+            .mockResolvedValueOnce({ aweme_list: [], has_more: true, max_cursor: 6 });
+        const rows = await command.func({}, { limit: 20, status: 'all' });
+        expect(rows.map((r) => r.aweme_id)).toEqual(['1']);
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
Two `douyin` commands silently return wrong data rather than failing. Both were hit while tracking a real creator account's stats.

## 1. `douyin videos` truncates the work list

`work_list` is cursor-paginated, but the adapter sent `page_num` and read a single response.

Verified against a 7-work account:

| request | result |
|---|---|
| `page_size=50&page_num=1` | 6 items, `total: 7`, `has_more: true`, `max_cursor: 1779021374000` |
| `page_size=50&page_num=2` | the **same** 6 items — `page_num` is ignored |
| `page_size=50&max_cursor=1779021374000` | the missing 7th item, `has_more: false` |

So the command silently dropped works, and `--page` was a no-op that made it look like paging existed.

Now it walks `max_cursor` until `has_more` is false, the cursor stops advancing, an empty page comes back, or `--limit` is satisfied (capped at 50 hops).

- `--page` is removed — the endpoint never supported it.
- `--limit` now means "how many works to collect" instead of "page size".

## 2. `douyin videos` drops fields that are already in the response

Every `work_list` item carries `statistics.comment_count`, `statistics.collect_count`, `statistics.share_count` and a top-level `duration`. None were exposed. They are now columns — no extra requests.

## 3. `douyin user-videos` accepts anything as a `sec_uid`

`sec_uid` went straight into `https://www.douyin.com/user/<input>` with no validation. A nickname still resolves to a Douyin page, so the scrape returned **another account's videos with no error**.

Now validates the base64url shape before navigating, and accepts a pasted profile URL:

```
$ opencli douyin user-videos "大圆镜科普"
ok: false
error:
  code: ARGUMENT
  message: '"大圆镜科普" is not a Douyin sec_uid'
  help: sec_uid looks like MS4wLjABAAAA… — it is the last path segment of
        https://www.douyin.com/user/<sec_uid>, not a nickname or a numeric UID.
```

## Verification

- `vitest run --project adapter` — 473 files / 4975 tests pass
- 9 new adapter tests covering cursor walking, limit cut-off, cursor-stall and empty-page guards, sec_uid/URL normalisation, and that an invalid `sec_uid` never navigates
- Both commands re-run against a live creator account: `videos` now returns all 7 works with the new columns populated; `user-videos` rejects a nickname with `code: ARGUMENT`

## Not included

`douyin stats` is also broken — `item_analysis/metrics_trend` returns `status_code: 4` with an empty `status_msg` for every parameter shape I tried (`aweme_id`/`item_id`, second/millisecond timestamps, with and without `metrics`). The creator dashboard no longer calls it; it now uses `item_analysis/item_performance` and `item_analysis/overview`. I could not work out the parameters those need, so I have left `stats` alone rather than guess. Happy to file that separately.
