### PR TITLE
fix(boss): probe the current geek jobs route

### DIFF
--- a/clis/boss/auth.js
+++ b/clis/boss/auth.js
@@ -1,6 +1,8 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 
+const BOSS_GEEK_JOBS_URL = 'https://www.zhipin.com/web/geek/jobs';
+
 async function hasBossSessionCookie(page) {
   const cookies = await page.getCookies({ url: 'https://www.zhipin.com' });
   const names = new Set(cookies.map(c => c.name));
@@ -11,7 +13,7 @@ async function verifyBossIdentity(page) {
   if (!await hasBossSessionCookie(page)) {
     throw new AuthRequiredError('zhipin.com', 'Boss wt2 / t cookies missing');
   }
-  await page.goto('https://www.zhipin.com/web/geek/job-recommend');
+  await page.goto(BOSS_GEEK_JOBS_URL);
   await page.wait(3);
   const probe = await page.evaluate(`
     (() => {
@@ -45,3 +47,8 @@ registerSiteAuthCommands({
     return verifyBossIdentity(page);
   },
 });
+
+export const __test__ = {
+  BOSS_GEEK_JOBS_URL,
+  verifyBossIdentity,
+};

--- a/clis/boss/auth.test.js
+++ b/clis/boss/auth.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { __test__ } from './auth.js';
+
+describe('boss auth identity probe', () => {
+  it('navigates to the current geek jobs route instead of the retired reload-loop route', async () => {
+    const page = {
+      getCookies: vi.fn().mockResolvedValue([{ name: 'wt2' }]),
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue({ ok: true, user_type: 'geek' }),
+    };
+
+    await expect(__test__.verifyBossIdentity(page)).resolves.toEqual({ user_type: 'geek' });
+    expect(page.goto).toHaveBeenCalledOnce();
+    expect(page.goto).toHaveBeenCalledWith('https://www.zhipin.com/web/geek/jobs');
+    expect(__test__.BOSS_GEEK_JOBS_URL).not.toContain('job-recommend');
+  });
+});


### PR DESCRIPTION
## Summary

- replace the retired `/web/geek/job-recommend` identity-probe route with current `/web/geek/jobs`
- add a regression test that pins the navigation target

The old route returns the same SPA shell over HTTP but is not handled by the current client router; it can self-reload indefinitely and leave a persistent automation window burning CPU. The current jobs route preserves the existing user-type probe without changing auth/session semantics.

## Validation

- `npx vitest run --project adapter clis/boss` (5 files / 35 tests)
- `npm run typecheck`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run build`
- `git diff --check`

Closes #2192