### PR TITLE
fix(tiktok): use the current explore feed endpoint

### DIFF
--- a/clis/tiktok/explore.js
+++ b/clis/tiktok/explore.js
@@ -60,32 +60,54 @@ function buildExploreScript(limit) {
     if (row && !dedup.has(row.id)) dedup.set(row.id, row);
   }
 
-  const msToken = getCookie('msToken');
-  let apiFailure = null;
-  if (dedup.size < limit) {
-    let cursor = 0;
+  async function collectEndpoint(path, label, extraParams, initialCursor) {
+    let cursor = initialCursor;
     for (let page = 0; page < maxPages && dedup.size < limit; page += 1) {
       const params = new URLSearchParams({
         aid,
         count: String(pageSize),
-        from_page: 'fyp',
-        cursor: String(cursor),
+        ...extraParams,
       });
+      if (cursor !== undefined) params.set('cursor', String(cursor));
       if (msToken) params.set('msToken', msToken);
-      try {
-        const data = await fetchJson('/api/recommend/item_list/?' + params.toString());
+      const data = await fetchJson(path + '?' + params.toString());
+      if (label === 'explore') {
+        assertTikTokApiSuccess(data, 'explore');
+      } else {
         assertTikTokApiSuccess(data, 'recommend');
-        const items = Array.isArray(data.itemList) ? data.itemList : [];
-        for (const item of items) {
-          const row = normalizeVideoItem(item, dedup.size + 1);
-          if (row && !dedup.has(row.id)) dedup.set(row.id, row);
-        }
-        if (data.hasMore !== true && items.length === 0) break;
-        cursor = asNumber(data.cursor) ?? cursor + items.length;
-      } catch (error) {
-        apiFailure = error instanceof Error ? error.message : String(error);
-        break;
       }
+      const items = Array.isArray(data.itemList)
+        ? data.itemList
+        : (Array.isArray(data.items) ? data.items : []);
+      for (const item of items) {
+        const row = normalizeVideoItem(item, dedup.size + 1);
+        if (row && !dedup.has(row.id)) dedup.set(row.id, row);
+      }
+      const nextCursor = asNumber(data.cursor);
+      const hasMore = data.hasMore === true || data.has_more === true;
+      if (!hasMore || items.length === 0 || (cursor !== undefined && nextCursor === cursor)) break;
+      cursor = nextCursor ?? ((cursor ?? 0) + items.length);
+    }
+  }
+
+  const msToken = getCookie('msToken');
+  const apiFailures = [];
+  if (dedup.size < limit) {
+    try {
+      // TikTok's current /explore page uses this endpoint. categoryType=120
+      // is the "All" tab shown by default.
+      await collectEndpoint('/api/explore/item_list/', 'explore', { categoryType: '120' });
+    } catch (error) {
+      apiFailures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  if (dedup.size < limit) {
+    try {
+      // Keep the previous recommend feed as a compatibility fallback for
+      // regions where /explore still hydrates from the For You endpoint.
+      await collectEndpoint('/api/recommend/item_list/', 'recommend', { from_page: 'fyp' }, 0);
+    } catch (error) {
+      apiFailures.push(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -94,7 +116,7 @@ function buildExploreScript(limit) {
     .map((row, index) => ({ ...row, index: index + 1 }));
 
   if (rows.length === 0) {
-    const suffix = apiFailure ? ' (recommend API failed: ' + apiFailure + ')' : '';
+    const suffix = apiFailures.length ? ' (explore APIs failed: ' + apiFailures.join('; ') + ')' : '';
     throw new Error('No videos found on /explore' + suffix);
   }
   return rows;


### PR DESCRIPTION
## Summary

- collect TikTok explore rows from the current `/api/explore/item_list/` endpoint used by the live `/explore` page
- keep the previous recommend endpoint as a regional compatibility fallback
- share bounded cursor pagination and preserve the existing full-row normalizer

## Evidence

A retained failure trace for #2178 showed 20+ rendered explore cards and successful signed `/api/explore/item_list/` responses, while the adapter called `/api/recommend/item_list/` and received an empty/error payload. The patched adapter was verified live twice: `--limit 5` returned 5 unique full rows, and `--limit 35` returned 35/35 unique IDs across cursor pages. `tiktok profile tiktok` also succeeds on current main, so this PR fixes only the still-broken explore half of the issue.

## Validation

- live `tiktok explore --limit 5`: 5 unique rows
- live `tiktok explore --limit 35`: 35 unique rows
- `npx vitest run --project adapter clis/tiktok` (3 files / 64 tests)
- `npm run typecheck`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run build`
- `git diff --check`

Closes #2178