### PR TITLE
fix(facebook): handle current feed and profile DOM

### DIFF
--- a/clis/facebook/feed.js
+++ b/clis/facebook/feed.js
@@ -309,12 +309,35 @@ async function loadFeedPosts(page, limit) {
         + Array.from(document.querySelectorAll('[aria-label]')).filter((el) => /^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test((el.getAttribute('aria-label') || '').trim())).length
       : 0;
   })()`;
-  let prev = -1;
+  const extractStep = buildFeedExtractScript(limit);
+  let prevMarkerCount = -1;
+  let prevRowCount = -1;
+  let stalledPasses = 0;
   for (let i = 0; i < 8; i += 1) {
-    let count = 0;
-    try { count = Number(unwrapBrowserResult(await page.evaluate(scrollStep))) || 0; } catch { break; }
-    if (count >= limit || count === prev) break;
-    prev = count;
+    let markerCount = 0;
+    try { markerCount = Number(unwrapBrowserResult(await page.evaluate(scrollStep))) || 0; } catch { break; }
+
+    // Raw article/menu counts include comments, suggestions, and other chrome.
+    // Do not stop merely because those markers reached --limit (#2195); stop
+    // when the actual feed extractor has enough valid rows.
+    let rowCount = 0;
+    try {
+      const payload = unwrapBrowserResult(await page.evaluate(extractStep));
+      rowCount = Array.isArray(payload && payload.rows) ? payload.rows.length : 0;
+    } catch {
+      // The final extraction below owns error classification. A transient
+      // observation failure here should only make the bounded scroll continue.
+    }
+    if (rowCount >= limit) break;
+
+    if (markerCount === prevMarkerCount && rowCount === prevRowCount) {
+      stalledPasses += 1;
+      if (stalledPasses >= 2) break;
+    } else {
+      stalledPasses = 0;
+    }
+    prevMarkerCount = markerCount;
+    prevRowCount = rowCount;
   }
 }
 
@@ -390,5 +413,6 @@ export const __test__ = {
   buildFeedExtractScript,
   command,
   getFacebookFeed,
+  loadFeedPosts,
   requireLimit,
 };

--- a/clis/facebook/feed.test.js
+++ b/clis/facebook/feed.test.js
@@ -156,6 +156,24 @@ describe('facebook feed', () => {
     }]);
   });
 
+  it('keeps scrolling when raw article markers reach the limit but valid rows do not (#2195)', async () => {
+    const page = {
+      evaluate: vi.fn()
+        .mockResolvedValueOnce(4)
+        .mockResolvedValueOnce({ status: 'no_rows', rows: [] })
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce({
+          status: 'ok',
+          rows: [{ index: 1, author: 'A', content: 'Body', likes: '-', comments: '-', shares: '-' }],
+        }),
+    };
+
+    await __test__.loadFeedPosts(page, 1);
+
+    expect(page.evaluate).toHaveBeenCalledTimes(4);
+    expect(String(page.evaluate.mock.calls[1][0])).toContain('primaryContainers');
+  });
+
   it('maps auth, real empty, parser drift, and malformed payloads to typed errors', async () => {
     await expect(__test__.command.func(createPage({ status: 'auth', rows: [] }), { limit: 1 }))
       .rejects.toBeInstanceOf(AuthRequiredError);

--- a/clis/facebook/profile.js
+++ b/clis/facebook/profile.js
@@ -17,19 +17,48 @@ cli({
     pipeline: [
         { navigate: { url: 'https://www.facebook.com/${{ args.username }}', settleMs: 3000 } },
         { evaluate: `(() => {
-  const h1 = document.querySelector('h1');
-  let name = h1 ? h1.textContent.trim() : '';
+  const username = \${{ args.username | json }};
+  const main = document.querySelector('[role="main"]') || document;
+  const clean = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+  const h1 = main.querySelector('h1');
+  let name = clean(h1 && h1.textContent);
 
-  // Find friends/followers links
-  const links = Array.from(document.querySelectorAll('a'));
-  const friendsLink = links.find(a => a.href && a.href.includes('/friends'));
-  const followersLink = links.find(a => a.href && a.href.includes('/followers'));
+  // Facebook's current profile header no longer uses an h1. The profile-avatar
+  // link carries the display name on both the link and its role=img child.
+  // Scope this fallback to the requested profile path so page chrome cannot win.
+  if (!name) {
+    const requestedPrefix = '/' + String(username).toLowerCase() + '/';
+    const profileMediaLink = Array.from(main.querySelectorAll('a[aria-label][href]')).find((link) => {
+      const href = link.getAttribute('href') || '';
+      let path = '';
+      try { path = new URL(href, window.location.href).pathname.toLowerCase(); } catch {}
+      const image = link.querySelector('[role="img"][aria-label]');
+      return path.startsWith(requestedPrefix)
+        && image
+        && clean(link.getAttribute('aria-label')) === clean(image.getAttribute('aria-label'));
+    });
+    name = clean(profileMediaLink && profileMediaLink.getAttribute('aria-label'));
+  }
+
+  // Scope relationship links to the profile main region. Global navigation also
+  // contains /friends and previously produced empty or generic chrome text.
+  const links = Array.from(main.querySelectorAll('a[href]'));
+  const hasProfilePath = (link, suffix) => {
+    try {
+      const path = new URL(link.getAttribute('href') || '', window.location.href).pathname
+        .replace(/\\/+$/, '')
+        .toLowerCase();
+      return path === '/' + String(username).toLowerCase() + suffix;
+    } catch { return false; }
+  };
+  const friendsLink = links.find((a) => hasProfilePath(a, '/friends'));
+  const followersLink = links.find((a) => hasProfilePath(a, '/followers'));
 
   return [{
     name: name,
-    username: \${{ args.username | json }},
-    friends: friendsLink ? friendsLink.textContent.trim() : '-',
-    followers: followersLink ? followersLink.textContent.trim() : '-',
+    username,
+    friends: friendsLink ? clean(friendsLink.textContent) : '-',
+    followers: followersLink ? clean(followersLink.textContent) : '-',
     url: window.location.href,
   }];
 })()

--- a/clis/facebook/profile.test.js
+++ b/clis/facebook/profile.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './profile.js';
+
+function runExtract(html, username = 'zuck') {
+    const dom = new JSDOM(html, { url: `https://www.facebook.com/${username}` });
+    const command = getRegistry().get('facebook/profile');
+    const script = command.pipeline.find((step) => step.evaluate).evaluate
+        .replace('${{ args.username | json }}', JSON.stringify(username));
+    return Function('window', 'document', `return ${script};`)(dom.window, dom.window.document);
+}
+
+describe('facebook profile', () => {
+    it('keeps the existing profile row contract', () => {
+        const command = getRegistry().get('facebook/profile');
+        expect(command).toBeDefined();
+        expect(command.columns).toEqual(['name', 'username', 'friends', 'followers', 'url']);
+    });
+
+    it('extracts the display name from the current profile-avatar header (#2195)', () => {
+        const rows = runExtract(`
+          <nav><a href="/friends/">Friends chrome</a></nav>
+          <main role="main">
+            <a aria-label="View cover photo" href="/photo/1">
+              <img role="img" aria-label="View cover photo">
+            </a>
+            <a aria-label="Mark Zuckerberg" href="/zuck/videos/123">
+              <svg role="img" aria-label="Mark Zuckerberg"></svg>
+            </a>
+            <div role="button">Mark Zuckerberg</div>
+            <a href="/zuck/followers/"><strong>1.2M</strong> followers</a>
+            <a href="/zuck/friends">1,234 friends</a>
+          </main>
+        `);
+
+        expect(rows).toEqual([{
+            name: 'Mark Zuckerberg',
+            username: 'zuck',
+            friends: '1,234 friends',
+            followers: '1.2M followers',
+            url: 'https://www.facebook.com/zuck',
+        }]);
+    });
+
+    it('prefers an h1 when Facebook still renders the legacy header', () => {
+        const rows = runExtract(`
+          <main role="main">
+            <h1>Legacy Profile Name</h1>
+            <a aria-label="Avatar Name" href="/legacy/photos/1">
+              <img role="img" aria-label="Avatar Name">
+            </a>
+          </main>
+        `, 'legacy');
+
+        expect(rows[0]).toMatchObject({
+            name: 'Legacy Profile Name',
+            username: 'legacy',
+            friends: '-',
+            followers: '-',
+        });
+    });
+
+    it('does not take a display name or friends label from global page chrome', () => {
+        const rows = runExtract(`
+          <nav>
+            <a aria-label="Wrong Name" href="/zuck/videos/123">
+              <svg role="img" aria-label="Wrong Name"></svg>
+            </a>
+            <a href="/friends/">Friends</a>
+          </nav>
+          <main role="main"></main>
+        `);
+
+        expect(rows[0]).toMatchObject({
+            name: '',
+            friends: '-',
+            followers: '-',
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- stop Facebook feed lazy-loading based on extracted feed rows instead of raw article/action-marker counts
- recover profile display names from the current avatar-link header when Facebook no longer renders an `h1`
- scope friends/followers links to the requested profile's main region

## Root cause

Facebook's current feed DOM can expose enough raw `role=article` markers to satisfy `--limit` even when those markers are comments, suggestions, or other chrome. The loader stopped before enough valid post rows had rendered. Current profile headers also no longer use an `h1`; the display name is carried on the profile avatar link and its `role=img` child.

## Validation

- current-main pre-fix live: `facebook feed --limit 3` returned 2 rows; `facebook profile zuck` returned `name: ""`
- branch live: feed returns 3/3 rows; profile returns `name: "Mark Zuckerberg"`
- `npx vitest run --project adapter clis/facebook`: 5 files / 74 tests passed
- `npm run typecheck`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `npm run build`
- `git diff --check`

Closes #2195
