### PR TITLE
test: add Windows coverage for adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,16 @@ jobs:
       - name: Run unit tests under Bun
         run: bun vitest run --project unit --reporter=verbose
 
-  # Adapter tests are pure unit tests — OS doesn't affect results. Gated off
-  # `pull_request` to keep PR CI under ~2 minutes; adapter authors run focused
-  # tests locally before pushing, and `push` to main / nightly cron / manual
-  # dispatch still guard the merged state.
+  # Adapter tests are isolated, but filesystem behavior can still vary by OS.
+  # Keep them off `pull_request` to preserve fast PR feedback, while Linux and
+  # Windows guard the merged state on push / nightly cron / manual dispatch.
   adapter-test:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     needs: build
     steps:
       - uses: actions/checkout@v6

--- a/clis/instagram/download.test.js
+++ b/clis/instagram/download.test.js
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
@@ -99,9 +100,9 @@ describe('instagram download command', () => {
         });
         expect(result).toBeNull();
         expect(page.goto.mock.calls[0]?.[0]).toBe('https://www.instagram.com/p/DWUR_azCWbN/');
-        expect(mockHttpDownload).toHaveBeenNthCalledWith(1, 'https://cdn.example.com/photo.webp?foo=1', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_01.webp'), expect.objectContaining({ timeout: 60000 }));
-        expect(mockHttpDownload).toHaveBeenNthCalledWith(2, 'https://cdn.example.com/video.mp4?bar=2', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_02.mp4'), expect.objectContaining({ timeout: 120000 }));
-        expect(logSpy).toHaveBeenCalledWith('📁 saved: instagram-test/DWUR_azCWbN');
+        expect(mockHttpDownload).toHaveBeenNthCalledWith(1, 'https://cdn.example.com/photo.webp?foo=1', path.join('instagram-test', 'DWUR_azCWbN', 'DWUR_azCWbN_01.webp'), { timeout: 60000 });
+        expect(mockHttpDownload).toHaveBeenNthCalledWith(2, 'https://cdn.example.com/video.mp4?bar=2', path.join('instagram-test', 'DWUR_azCWbN', 'DWUR_azCWbN_02.mp4'), { timeout: 120000 });
+        expect(logSpy).toHaveBeenCalledWith(`📁 saved: ${path.join('instagram-test', 'DWUR_azCWbN')}`);
     });
     it('uses a cross-platform Downloads default when path is omitted', async () => {
         mockHttpDownload.mockResolvedValueOnce({ success: true, size: 120_000 });
@@ -113,6 +114,6 @@ describe('instagram download command', () => {
             ],
         });
         await cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/' });
-        expect(mockHttpDownload).toHaveBeenCalledWith('https://cdn.example.com/photo.webp?foo=1', expect.stringContaining(`${os.homedir()}/Downloads/Instagram/DWUR_azCWbN/DWUR_azCWbN_01.webp`), expect.objectContaining({ timeout: 60000 }));
+        expect(mockHttpDownload).toHaveBeenCalledWith('https://cdn.example.com/photo.webp?foo=1', path.join(os.homedir(), 'Downloads', 'Instagram', 'DWUR_azCWbN', 'DWUR_azCWbN_01.webp'), { timeout: 60000 });
     });
 });

--- a/clis/instagram/reel.test.js
+++ b/clis/instagram/reel.test.js
@@ -108,7 +108,9 @@ describe('instagram reel registration', () => {
             },
         ]);
     });
-    it('copies query-style local video filenames to a safe temp upload path before setFileInput', async () => {
+    // Windows does not permit '?' in filenames, so this POSIX-only filesystem
+    // case cannot be represented there.
+    it.skipIf(process.platform === 'win32')('copies query-style local video filenames to a safe temp upload path before setFileInput', async () => {
         const videoPath = createTempVideo('demo.mp4?sign=abc&t=123video.MP4');
         const page = createPageMock([
             { ok: false },

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -63,7 +63,7 @@ describe('suno utils — resolveSunoOutputDir', () => {
     });
 
     it('absolute paths are returned as-is (resolved)', () => {
-        expect(resolveSunoOutputDir('/tmp/suno')).toBe('/tmp/suno');
+        expect(resolveSunoOutputDir('/tmp/suno')).toBe(path.resolve('/tmp/suno'));
     });
 });
 

--- a/clis/twitter/quote.test.js
+++ b/clis/twitter/quote.test.js
@@ -127,7 +127,8 @@ describe('twitter quote command', () => {
         expect(fetchMock).toHaveBeenCalledWith('https://example.com/banner');
         expect(setFileInput).toHaveBeenCalledTimes(1);
         const uploadedPath = setFileInput.mock.calls[0][0][0];
-        expect(uploadedPath).toMatch(/opencli-twitter-.*\/image\.png$/);
+        expect(path.basename(path.dirname(uploadedPath))).toMatch(/^opencli-twitter-/);
+        expect(path.basename(uploadedPath)).toBe('image.png');
         // Per-call tmp dir is removed in the adapter's finally block.
         expect(fs.existsSync(uploadedPath)).toBe(false);
         expect(result).toEqual([

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -95,7 +95,8 @@ describe('twitter reply command', () => {
         const uploadedPath = setFileInput.mock.calls[0][0][0];
         // Tmp dir is created by utils.downloadRemoteImage with the
         // 'opencli-twitter-' prefix; final extension comes from Content-Type.
-        expect(uploadedPath).toMatch(/opencli-twitter-.*\/image\.png$/);
+        expect(path.basename(path.dirname(uploadedPath))).toMatch(/^opencli-twitter-/);
+        expect(path.basename(uploadedPath)).toBe('image.png');
         // Per-call tmp dir is removed in the adapter's finally block, so the
         // downloaded file no longer exists once the command returns.
         expect(fs.existsSync(uploadedPath)).toBe(false);

--- a/clis/xiaoyuzhou/auth.test.js
+++ b/clis/xiaoyuzhou/auth.test.js
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockExistsSync, mockReadFileSync, mockMkdirSync, mockWriteFileSync, mockHomedir } = vi.hoisted(() => ({
@@ -68,8 +69,9 @@ describe('xiaoyuzhou auth helpers', () => {
         expect(refreshed.access_token).toBe('new-access');
         expect(refreshed.refresh_token).toBe('new-refresh');
         expect(refreshed.expires_at).toBe(Date.now() + XIAOYUZHOU_TOKEN_TTL_MS);
-        expect(mockMkdirSync).toHaveBeenCalledWith('/Users/tester/.opencli', { recursive: true });
-        expect(mockWriteFileSync).toHaveBeenCalledWith('/Users/tester/.opencli/xiaoyuzhou.json', expect.stringContaining('"access_token": "new-access"'), 'utf-8');
+        const credentialDir = path.join('/Users/tester', '.opencli');
+        expect(mockMkdirSync).toHaveBeenCalledWith(credentialDir, { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.join(credentialDir, 'xiaoyuzhou.json'), expect.stringContaining('"access_token": "new-access"'), 'utf-8');
     });
 
     it('retries once on 401 using refreshed credentials', async () => {

--- a/clis/xiaoyuzhou/download.test.js
+++ b/clis/xiaoyuzhou/download.test.js
@@ -35,10 +35,6 @@ await import('./download.js');
 
 let cmd;
 
-function toPosixPath(value) {
-    return value.replaceAll(path.sep, '/');
-}
-
 beforeAll(() => {
     cmd = getRegistry().get('xiaoyuzhou/download');
     expect(cmd?.func).toBeTypeOf('function');
@@ -77,9 +73,10 @@ describe('xiaoyuzhou download', () => {
             query: { eid: 'ep123' },
             credentials: {},
         });
-        expect(toPosixPath(mockMkdirSync.mock.calls[0][0])).toBe('/tmp/xiaoyuzhou-test/ep123');
-        expect(mockMkdirSync.mock.calls[0][1]).toEqual({ recursive: true });
-        expect(mockHttpDownload).toHaveBeenCalledWith('https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc', expect.stringContaining('/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3'), {
+        const outputDir = path.join('/tmp/xiaoyuzhou-test', 'ep123');
+        const outputFile = path.join(outputDir, 'ep123_Hello_World.mp3');
+        expect(mockMkdirSync).toHaveBeenCalledWith(outputDir, { recursive: true });
+        expect(mockHttpDownload).toHaveBeenCalledWith('https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc', outputFile, {
             timeout: 60000,
         });
         expect(result).toEqual([{
@@ -87,7 +84,7 @@ describe('xiaoyuzhou download', () => {
                 podcast: 'OpenCLI FM',
                 status: 'success',
                 size: '1234 B',
-                file: '/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3',
+                file: outputFile,
             }]);
     });
 
@@ -112,7 +109,7 @@ describe('xiaoyuzhou download', () => {
         });
 
         expect(mockHttpDownload.mock.calls[0][1]).toContain('ep456_Lossless_Episode.m4a');
-        expect(result[0].file).toBe('/tmp/xiaoyuzhou-test/ep456/ep456_Lossless_Episode.m4a');
+        expect(result[0].file).toBe(path.join('/tmp/xiaoyuzhou-test', 'ep456', 'ep456_Lossless_Episode.m4a'));
     });
 
     it('throws when media.source.url is missing', async () => {

--- a/clis/xiaoyuzhou/transcript.test.js
+++ b/clis/xiaoyuzhou/transcript.test.js
@@ -29,10 +29,6 @@ await import('./transcript.js');
 
 let cmd;
 
-function toPosixPath(value) {
-    return value.replaceAll(path.sep, '/');
-}
-
 beforeAll(() => {
     cmd = getRegistry().get('xiaoyuzhou/transcript');
     expect(cmd?.func).toBeTypeOf('function');
@@ -82,16 +78,19 @@ describe('xiaoyuzhou transcript', () => {
             body: { eid: 'ep123', mediaId: 'media-123' },
             credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
         });
-        expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep123', { recursive: true });
-        expect(mockWriteFileSync).toHaveBeenNthCalledWith(1, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json', expect.any(String), 'utf-8');
-        expect(mockWriteFileSync).toHaveBeenNthCalledWith(2, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt', 'hello\nworld', 'utf-8');
+        const outputDir = path.join('/tmp/xiaoyuzhou-transcripts', 'ep123');
+        const jsonFile = path.join(outputDir, 'transcript.json');
+        const textFile = path.join(outputDir, 'transcript.txt');
+        expect(mockMkdirSync).toHaveBeenCalledWith(outputDir, { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(1, jsonFile, expect.any(String), 'utf-8');
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(2, textFile, 'hello\nworld', 'utf-8');
         expect(result).toEqual([{
                 title: 'Transcript Episode',
                 podcast: 'OpenCLI FM',
                 status: 'success',
                 segments: '2',
-                json_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json',
-                text_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt',
+                json_file: jsonFile,
+                text_file: textFile,
             }]);
     });
 
@@ -120,7 +119,7 @@ describe('xiaoyuzhou transcript', () => {
         });
         expect(mockRequestJson.mock.calls[1][1].body.mediaId).toBe('media-456');
         expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-        expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep456/transcript.txt', 'hello', 'utf-8');
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.join('/tmp/xiaoyuzhou-transcripts', 'ep456', 'transcript.txt'), 'hello', 'utf-8');
     });
 
     it('throws when transcript url is missing', async () => {


### PR DESCRIPTION
## Description

The adapter test project currently runs only on Ubuntu and its workflow
comment says OS differences do not affect the result. On Windows 11 at current
`main` commit `a80e5a3d58aff9f5908215c1f265a97aa9d9fb4f`, the unmodified suite completed
with:

```text
Test Files  8 failed | 468 passed (476)
Tests       11 failed | 5001 passed (5012)
```

These are test portability failures, not 11 production adapter defects:

- path assertions in Instagram, Suno, Twitter, and Xiaoyuzhou assumed POSIX
  separators;
- one Instagram test tried to create a filename containing `?`, which Windows
  cannot represent.

This patch makes those assertions use native path semantics and adds
`windows-latest` to the existing adapter job. The earlier three-OS adapter
matrix from #402 was slimmed to Ubuntu in #525; this change does not restore
that full matrix. It adds one Windows job only on push, schedule, and manual
dispatch, so the current #1522 fast-PR boundary is unchanged.

Related issue: none found

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests where needed
- [x] I included the exact before/after output below

### Documentation (if adding/modifying an adapter)

Not applicable: no adapter command or runtime behavior changes.

## Screenshots / Output

Windows 11 build 26200, Node 22.23.1:

```text
focused changed tests: 87 passed, 1 skipped
full adapter project:  5011 passed, 1 skipped
typecheck:             passed
build:                 passed (1301 manifest entries)
git diff --check:      passed
```

I also applied the mail patch to a second clean worktree at the locked base and
reran install, build, typecheck, workflow parsing, and all adapter tests. It
produced the same `5011 passed, 1 skipped` result.

The one skip is the POSIX-only filename case containing `?`. The default full
repository test command still has nine unrelated `src/plugin.test.ts`
directory-symlink `EPERM` failures on this non-privileged Windows host; this
patch does not touch the unit project or claim to resolve that capability
boundary. The bounded result was `6380 passed, 8 skipped`.

## Boundaries

- no production adapter code changed
- no dependency or generated manifest change
- no live account, cookie, upload, or publication test was used
- no pull-request CI matrix expansion

## AI assistance

Codex helped isolate the Windows failure family, prepare the patch, and run
the reported commands in my local environment. I take responsibility for the
proposed change and follow-up.
