### PR TITLE
fix(doctor): use a windowless connectivity probe

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetDaemonHealth, mockConnect, mockClose, mockFindShadowedUserAdapters } = vi.hoisted(() => ({
+const {
+  mockGetDaemonHealth,
+  mockSendCommand,
+  mockSetDaemonCommandTimeoutSeconds,
+  mockFindShadowedUserAdapters,
+} = vi.hoisted(() => ({
   mockGetDaemonHealth: vi.fn(),
-  mockConnect: vi.fn(),
-  mockClose: vi.fn(),
+  mockSendCommand: vi.fn(),
+  mockSetDaemonCommandTimeoutSeconds: vi.fn(),
   mockFindShadowedUserAdapters: vi.fn(),
 }));
 
@@ -15,12 +20,14 @@ vi.mock('./browser/daemon-transport.js', async (importOriginal) => {
   };
 });
 
-vi.mock('./browser/index.js', () => ({
-  BrowserBridge: class {
-    connect = mockConnect;
-    close = mockClose;
-  },
-}));
+vi.mock('./browser/daemon-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./browser/daemon-client.js')>();
+  return {
+    ...actual,
+    sendCommand: mockSendCommand,
+    setDaemonCommandTimeoutSeconds: mockSetDaemonCommandTimeoutSeconds,
+  };
+});
 
 vi.mock('./adapter-shadow.js', async () => {
   const actual = await vi.importActual<typeof import('./adapter-shadow.js')>('./adapter-shadow.js');
@@ -38,12 +45,9 @@ describe('doctor report rendering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFindShadowedUserAdapters.mockReturnValue([]);
-    // Doctor always runs live connectivity. Tests that want connect to fail override.
-    mockConnect.mockResolvedValue({
-      evaluate: vi.fn().mockResolvedValue(2),
-      closeWindow: vi.fn().mockResolvedValue(undefined),
-    });
-    mockClose.mockResolvedValue(undefined);
+    // Doctor always runs a live daemon-to-extension command. Tests that want
+    // connectivity to fail override this result.
+    mockSendCommand.mockResolvedValue([]);
   });
 
   it('renders OK-style report when daemon and extension connected', () => {
@@ -168,7 +172,7 @@ describe('doctor report rendering', () => {
   });
 
   it('reports daemon not running when connectivity fails and daemon stays stopped', async () => {
-    mockConnect.mockRejectedValueOnce(new Error('Could not start daemon'));
+    mockSendCommand.mockRejectedValueOnce(new Error('Could not start daemon'));
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
 
     const report = await runBrowserDoctor();
@@ -265,24 +269,17 @@ describe('doctor report rendering', () => {
     ]));
   });
 
-  it('uses the fast default timeout for live connectivity checks', async () => {
-    let timeoutSeen: number | undefined;
-    const closeWindow = vi.fn().mockResolvedValue(undefined);
-    mockConnect.mockImplementationOnce(async (opts?: { timeout?: number; session?: string; surface?: string }) => {
-      timeoutSeen = opts?.timeout;
-      expect(opts?.session).toBe('__doctor__');
-      expect(opts?.surface).toBe('browser');
-      return {
-        evaluate: vi.fn().mockResolvedValue(2),
-        closeWindow,
-      };
-    });
+  it('uses a windowless extension command and the fast default timeout for live connectivity checks', async () => {
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { extensionConnected: true } });
 
     await runBrowserDoctor();
 
-    expect(timeoutSeen).toBe(8);
-    expect(closeWindow).toHaveBeenCalledTimes(1);
+    expect(mockSetDaemonCommandTimeoutSeconds.mock.calls).toEqual([[8], [null]]);
+    expect(mockSendCommand).toHaveBeenCalledWith('cookies', {
+      domain: 'opencli-probe.invalid',
+      session: '__doctor__',
+      surface: 'browser',
+    });
   });
 
   it('reports an issue when the extension is connected but does not report a version', async () => {
@@ -362,7 +359,7 @@ describe('doctor report rendering', () => {
     mockGetDaemonHealth.mockResolvedValue(status);
     // Real connectivity would fail in profile-required state; force it here so
     // the test exercises the profile-required issue path, not the flaky path.
-    mockConnect.mockRejectedValueOnce(new Error('profile required'));
+    mockSendCommand.mockRejectedValueOnce(new Error('profile required'));
 
     const report = await runBrowserDoctor();
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetDaemonHealth, mockConnect, mockClose, mockFindShadowedUserAdapters } = vi.hoisted(() => ({
+const {
+  mockGetDaemonHealth,
+  mockSendCommand,
+  mockSetDaemonCommandTimeoutSeconds,
+  mockFindShadowedUserAdapters,
+} = vi.hoisted(() => ({
   mockGetDaemonHealth: vi.fn(),
-  mockConnect: vi.fn(),
-  mockClose: vi.fn(),
+  mockSendCommand: vi.fn(),
+  mockSetDaemonCommandTimeoutSeconds: vi.fn(),
   mockFindShadowedUserAdapters: vi.fn(),
 }));
 
@@ -15,12 +20,14 @@ vi.mock('./browser/daemon-transport.js', async (importOriginal) => {
   };
 });
 
-vi.mock('./browser/index.js', () => ({
-  BrowserBridge: class {
-    connect = mockConnect;
-    close = mockClose;
-  },
-}));
+vi.mock('./browser/daemon-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./browser/daemon-client.js')>();
+  return {
+    ...actual,
+    sendCommand: mockSendCommand,
+    setDaemonCommandTimeoutSeconds: mockSetDaemonCommandTimeoutSeconds,
+  };
+});
 
 vi.mock('./adapter-shadow.js', async () => {
   const actual = await vi.importActual<typeof import('./adapter-shadow.js')>('./adapter-shadow.js');
@@ -38,12 +45,9 @@ describe('doctor report rendering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFindShadowedUserAdapters.mockReturnValue([]);
-    // Doctor always runs live connectivity. Tests that want connect to fail override.
-    mockConnect.mockResolvedValue({
-      evaluate: vi.fn().mockResolvedValue(2),
-      closeWindow: vi.fn().mockResolvedValue(undefined),
-    });
-    mockClose.mockResolvedValue(undefined);
+    // Doctor always runs a live daemon-to-extension command. Tests that want
+    // connectivity to fail override this result.
+    mockSendCommand.mockResolvedValue([]);
   });
 
   it('renders OK-style report when daemon and extension connected', () => {
@@ -168,7 +172,7 @@ describe('doctor report rendering', () => {
   });
 
   it('reports daemon not running when connectivity fails and daemon stays stopped', async () => {
-    mockConnect.mockRejectedValueOnce(new Error('Could not start daemon'));
+    mockSendCommand.mockRejectedValueOnce(new Error('Could not start daemon'));
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
 
     const report = await runBrowserDoctor();
@@ -239,24 +243,17 @@ describe('doctor report rendering', () => {
     ]));
   });
 
-  it('uses the fast default timeout for live connectivity checks', async () => {
-    let timeoutSeen: number | undefined;
-    const closeWindow = vi.fn().mockResolvedValue(undefined);
-    mockConnect.mockImplementationOnce(async (opts?: { timeout?: number; session?: string; surface?: string }) => {
-      timeoutSeen = opts?.timeout;
-      expect(opts?.session).toBe('__doctor__');
-      expect(opts?.surface).toBe('browser');
-      return {
-        evaluate: vi.fn().mockResolvedValue(2),
-        closeWindow,
-      };
-    });
+  it('uses a windowless extension command and the fast default timeout for live connectivity checks', async () => {
     mockGetDaemonHealth.mockResolvedValueOnce({ state: 'ready', status: { extensionConnected: true } });
 
     await runBrowserDoctor();
 
-    expect(timeoutSeen).toBe(8);
-    expect(closeWindow).toHaveBeenCalledTimes(1);
+    expect(mockSetDaemonCommandTimeoutSeconds.mock.calls).toEqual([[8], [null]]);
+    expect(mockSendCommand).toHaveBeenCalledWith('cookies', {
+      domain: 'opencli-probe.invalid',
+      session: '__doctor__',
+      surface: 'browser',
+    });
   });
 
   it('reports an issue when the extension is connected but does not report a version', async () => {
@@ -336,7 +333,7 @@ describe('doctor report rendering', () => {
     mockGetDaemonHealth.mockResolvedValue(status);
     // Real connectivity would fail in profile-required state; force it here so
     // the test exercises the profile-required issue path, not the flaky path.
-    mockConnect.mockRejectedValueOnce(new Error('profile required'));
+    mockSendCommand.mockRejectedValueOnce(new Error('profile required'));
 
     const report = await runBrowserDoctor();
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,8 +5,7 @@
  */
 
 import { DEFAULT_DAEMON_PORT } from './constants.js';
-import { BrowserBridge } from './browser/index.js';
-import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
+import { sendCommand, setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { getDaemonHealth } from './browser/daemon-transport.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
@@ -76,7 +75,8 @@ export type DoctorReport = {
 };
 
 /**
- * Test connectivity by attempting a real browser command.
+ * Test connectivity with a daemon-to-extension command that does not resolve a
+ * page or create a Browser Bridge container window.
  */
 export async function checkConnectivity(opts?: { timeout?: number }): Promise<ConnectivityResult> {
   const start = Date.now();
@@ -85,19 +85,11 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   // hung daemon/extension fails the check in seconds, not the default 120s.
   setDaemonCommandTimeoutSeconds(timeoutSeconds);
   try {
-    const bridge = new BrowserBridge();
-    const page = await bridge.connect({
-      timeout: timeoutSeconds,
+    await sendCommand('cookies', {
+      domain: 'opencli-probe.invalid',
       session: DOCTOR_SESSION,
       surface: 'browser',
     });
-    try {
-      // Try a simple eval to verify end-to-end connectivity.
-      await page.evaluate('1 + 1');
-      await page.closeWindow?.();
-    } finally {
-      await bridge.close();
-    }
     return { ok: true, durationMs: Date.now() - start };
   } catch (err) {
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
@@ -107,8 +99,8 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
 }
 
 export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<DoctorReport> {
-  // Live connectivity check is the core of doctor — it doubles as auto-start
-  // (bridge.connect spawns daemon) and validates end-to-end browser bridge health.
+  // Live connectivity is the core of doctor. The command transport doubles as
+  // daemon auto-start and validates end-to-end Browser Bridge health.
   const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle. Threads the

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,8 +5,7 @@
  */
 
 import { DEFAULT_DAEMON_PORT } from './constants.js';
-import { BrowserBridge } from './browser/index.js';
-import { setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
+import { sendCommand, setDaemonCommandTimeoutSeconds } from './browser/daemon-client.js';
 import { getDaemonHealth } from './browser/daemon-transport.js';
 import { getErrorMessage } from './errors.js';
 import { getRuntimeLabel } from './runtime-detect.js';
@@ -76,7 +75,8 @@ export type DoctorReport = {
 };
 
 /**
- * Test connectivity by attempting a real browser command.
+ * Test connectivity with a daemon-to-extension command that does not resolve a
+ * page or create a Browser Bridge container window.
  */
 export async function checkConnectivity(opts?: { timeout?: number }): Promise<ConnectivityResult> {
   const start = Date.now();
@@ -85,19 +85,11 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
   // hung daemon/extension fails the check in seconds, not the default 120s.
   setDaemonCommandTimeoutSeconds(timeoutSeconds);
   try {
-    const bridge = new BrowserBridge();
-    const page = await bridge.connect({
-      timeout: timeoutSeconds,
+    await sendCommand('cookies', {
+      domain: 'opencli-probe.invalid',
       session: DOCTOR_SESSION,
       surface: 'browser',
     });
-    try {
-      // Try a simple eval to verify end-to-end connectivity.
-      await page.evaluate('1 + 1');
-      await page.closeWindow?.();
-    } finally {
-      await bridge.close();
-    }
     return { ok: true, durationMs: Date.now() - start };
   } catch (err) {
     return { ok: false, error: getErrorMessage(err), durationMs: Date.now() - start };
@@ -107,8 +99,8 @@ export async function checkConnectivity(opts?: { timeout?: number }): Promise<Co
 }
 
 export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<DoctorReport> {
-  // Live connectivity check is the core of doctor — it doubles as auto-start
-  // (bridge.connect spawns daemon) and validates end-to-end browser bridge health.
+  // Live connectivity is the core of doctor. The command transport doubles as
+  // daemon auto-start and validates end-to-end Browser Bridge health.
   const connectivity = await checkConnectivity();
 
   // Single status read *after* connectivity side-effects settle.


### PR DESCRIPTION
## What

Use the existing windowless `cookies` command for the `opencli doctor` live connectivity probe instead of constructing a `BrowserBridge` page.

The probe uses the reserved `opencli-probe.invalid` domain and the existing `__doctor__` session, so it exercises daemon startup, profile routing, daemon-to-extension transport, and the extension response without reading site data or creating an automation window.

## Scope

This addresses the doctor-specific window side effect reported in #2202. It does not claim to solve the broader automation-container lifecycle or orphan-recovery questions in that issue, so #2202 should remain open after this PR merges.

A new protocol-level health action would require a coordinated extension upgrade. Reusing an existing windowless action keeps compatibility with supported extensions while removing the page/window side effect from doctor.

## Verification

Exact head `8c6aa559` rebuilt on main `50565efd` (including the preferred-profile health routing from #2262):

- `npx vitest run --project unit src/doctor.test.ts` — 19/19 passed
- `npm run typecheck` — passed
- `npm run build` — passed; manifest compiled 1331 entries
- `npm run check:silent-column-drop` — passed, no new violations
- `npm run check:typed-error-lint` — passed, no new violations
- `git diff --check` — passed

The final diff contains only `src/doctor.ts` and `src/doctor.test.ts`.