### PR TITLE
feat(args): support single-letter short option aliases in the Arg schema (#1970)

### DIFF
--- a/src/arg-short.ts
+++ b/src/arg-short.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared resolution for adapter-declared single-letter short option aliases.
+ *
+ * Used by BOTH the Commander registration (`commanderAdapter`) and the argv
+ * pre-processor (`cli-argv-preprocess`) so the two layers agree exactly on which
+ * shorts are live — otherwise a short the pre-processor doesn't recognize gets
+ * mis-escaped as a positional and never reaches Commander. Kept dependency-free
+ * so the pre-processor's lazy import stays cheap.
+ */
+
+/** Short flags reserved by the base options: -f/--format, -v/--verbose, -h/--help. */
+export const RESERVED_ARG_SHORTS: readonly string[] = ['f', 'v', 'h'];
+
+/**
+ * Resolve an arg's declared short alias to a single letter that is safe to
+ * register, or undefined when it can't be. Rejects anything that isn't a single
+ * ASCII letter and anything already claimed (seed `used` with
+ * `RESERVED_ARG_SHORTS`). A claimed short is added to `used`, so the first
+ * declaration in a command wins and a later duplicate degrades to long-only
+ * rather than making Commander throw on a duplicate flag.
+ */
+export function resolveArgShort(short: string | undefined, used: Set<string>): string | undefined {
+  if (typeof short !== 'string') return undefined;
+  const s = short.trim();
+  if (!/^[A-Za-z]$/.test(s)) return undefined;
+  if (used.has(s)) return undefined;
+  used.add(s);
+  return s;
+}

--- a/src/build-manifest.ts
+++ b/src/build-manifest.ts
@@ -76,6 +76,7 @@ export interface BuildManifestArgs {
 function toManifestArgs(args: CliCommand['args']): ManifestEntry['args'] {
   return args.map(arg => ({
     name: arg.name,
+    short: (typeof arg.short === 'string' && arg.short.trim()) ? arg.short.trim() : undefined,
     type: arg.type ?? 'str',
     default: arg.default,
     required: !!arg.required,

--- a/src/cli-argv-preprocess.test.ts
+++ b/src/cli-argv-preprocess.test.ts
@@ -247,7 +247,7 @@ import { escapeLeadingDashPositional } from './cli-argv-preprocess.js';
 
 describe('escapeLeadingDashPositional', () => {
   const manifest = [
-    { site: 'boss', name: 'detail', browser: true, args: [{ name: 'security-id', positional: true, required: true }, { name: 'retry', positional: false, valueRequired: true }] },
+    { site: 'boss', name: 'detail', browser: true, args: [{ name: 'security-id', positional: true, required: true }, { name: 'retry', positional: false, valueRequired: true }, { name: 'limit', short: 'l', positional: false, valueRequired: true }, { name: 'sort', short: 's', positional: false }] },
     { site: 'boss', name: 'search', args: [{ name: 'query', positional: true, required: false }, { name: 'limit', positional: false }] },
     { site: 'twitter', name: 'follow', args: [{ name: 'username', positional: true, required: true }] },
     { site: 'twitter', name: 'lists', args: [{ name: 'limit', positional: false }] },
@@ -275,9 +275,58 @@ describe('escapeLeadingDashPositional', () => {
       .toEqual(['boss', 'detail', '--format', 'json', '--trace=on', '--', '-xyz']);
   });
 
+  it('recognizes an adapter short alias (-l) as a known option, not part of the dash-leading positional', () => {
+    // -l is the short for --limit; without short-awareness the preprocessor would
+    // mis-escape it. Both orders must hoist `-l 10` ahead of the escaped positional.
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-l', '10'], manifest))
+      .toEqual(['boss', 'detail', '-l', '10', '--', '-xyz']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-l', '10', '-xyz'], manifest))
+      .toEqual(['boss', 'detail', '-l', '10', '--', '-xyz']);
+  });
+
+  it('recognizes attached short values (-l10 / -sdesc) for both required and optional shorts', () => {
+    // -l is value-required, -s is value-optional; Commander accepts `-l10` / `-sdesc`
+    // for both, so the preprocessor must consume the whole attached token, not split it.
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-l10'], manifest))
+      .toEqual(['boss', 'detail', '-l10', '--', '-xyz']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-sdesc', '-xyz'], manifest))
+      .toEqual(['boss', 'detail', '-sdesc', '--', '-xyz']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '-sdesc'], manifest))
+      .toEqual(['boss', 'detail', '-sdesc', '--', '-xyz']);
+  });
+
   it('keeps adapter and browser options parseable when they follow the positional', () => {
     expect(escapeLeadingDashPositional(['boss', 'detail', '-xyz', '--retry', '2', '--window', 'foreground'], manifest))
       .toEqual(['boss', 'detail', '--retry', '2', '--window', 'foreground', '--', '-xyz']);
+  });
+
+  it('consumes an attached value on an optional-value short, not just a required one', () => {
+    // Commander accepts `-sfoo` for `-s, --sort [value]` exactly as it accepts
+    // `-l10` for `-l, --limit <value>`. consumeKnownOption once honoured the
+    // attached form only for 'required', so an optional short with an attached
+    // value became the dash-leading positional (short-first) or was pushed past
+    // `--` and read as a positional (short-last).
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-sdate', '-abc123'], manifest))
+      .toEqual(['boss', 'detail', '-sdate', '--', '-abc123']);
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-abc123', '-sdate'], manifest))
+      .toEqual(['boss', 'detail', '-sdate', '--', '-abc123']);
+    // The separated form of the same optional short keeps working.
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-abc123', '-s', 'date'], manifest))
+      .toEqual(['boss', 'detail', '-s', 'date', '--', '-abc123']);
+  });
+
+  it('does not let an adapter short shadow a reserved global short', () => {
+    // `shadow` declares short 'f', which resolveArgShort refuses because -f is
+    // reserved for --format. -f must keep consuming its own value, not be
+    // re-typed by the adapter arg.
+    const withShadow = [
+      { site: 'boss', name: 'detail', browser: true, args: [
+        { name: 'security-id', positional: true, required: true },
+        { name: 'shadow', short: 'f', positional: false },
+      ] },
+    ];
+    expect(escapeLeadingDashPositional(['boss', 'detail', '-abc123', '-f', 'json'], withShadow))
+      .toEqual(['boss', 'detail', '-f', 'json', '--', '-abc123']);
   });
 
   it('protects negative numeric positionals too', () => {

--- a/src/cli-argv-preprocess.ts
+++ b/src/cli-argv-preprocess.ts
@@ -6,6 +6,7 @@
  * The user-facing form is positional; the internal form uses --session. Help text
  * for the `browser` command is overridden to advertise the positional form.
  */
+import { RESERVED_ARG_SHORTS, resolveArgShort } from './arg-short.js';
 
 /**
  * Browser subcommand names. If `<session>` would collide with one of these,
@@ -171,7 +172,7 @@ export class BrowserSessionArgvError extends Error {
 export interface DashPositionalManifestEntry {
   site: string;
   name: string;
-  args?: Array<{ name: string; positional?: boolean; required?: boolean; valueRequired?: boolean; default?: unknown }>;
+  args?: Array<{ name: string; short?: string; positional?: boolean; required?: boolean; valueRequired?: boolean; default?: unknown }>;
   browser?: boolean;
 }
 
@@ -193,11 +194,19 @@ function knownCommandOptions(cmd: DashPositionalManifestEntry): Map<string, Opti
     options.set('--site-session', 'required');
     options.set('--keep-tab', 'required');
   }
+  // Seed with the reserved shorts (-f/-v/-h above) so an arg's `short` resolves
+  // identically to commanderAdapter — otherwise the pre-processor would treat a
+  // short it doesn't recognize as a dash-leading positional and never hand it to
+  // Commander.
+  const usedShorts = new Set(RESERVED_ARG_SHORTS);
   for (const arg of cmd.args ?? []) {
     if (arg.positional) continue;
     // Keep in sync with commanderAdapter.ts:
     // required/valueRequired -> `<value>`; otherwise -> `[value]`.
-    options.set(`--${arg.name}`, arg.required || arg.valueRequired ? 'required' : 'optional');
+    const mode: OptionValueMode = arg.required || arg.valueRequired ? 'required' : 'optional';
+    options.set(`--${arg.name}`, mode);
+    const short = resolveArgShort(arg.short, usedShorts);
+    if (short) options.set(`-${short}`, mode);
   }
   return options;
 }
@@ -211,7 +220,10 @@ function consumeKnownOption(argv: readonly string[], index: number, options: Rea
   if (!mode && eq === -1 && token.startsWith('-') && !token.startsWith('--') && token.length > 2) {
     const shortKey = token.slice(0, 2);
     const shortMode = options.get(shortKey);
-    if (shortMode === 'required') {
+    // Attached short value like `-l10`: Commander accepts it for both value-taking
+    // modes (`-l <value>` and `-l [value]`), so consume the whole token as one
+    // option for either — not just `required`.
+    if (shortMode === 'required' || shortMode === 'optional') {
       return { values: [token], nextIndex: index + 1 };
     }
   }

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -21,6 +21,7 @@ vi.mock('./output.js', () => ({
 }));
 
 import { registerCommandToProgram } from './commanderAdapter.js';
+import { resolveArgShort } from './arg-short.js';
 
 describe('commanderAdapter arg passing', () => {
   const cmd: CliCommand = {
@@ -108,6 +109,99 @@ describe('commanderAdapter arg passing', () => {
 
     // prepareCommandArgs validates bools before dispatch; executeCommand should not be reached
     expect(mockExecuteCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveArgShort', () => {
+  it('accepts a single ASCII letter and claims it', () => {
+    const used = new Set<string>();
+    expect(resolveArgShort('l', used)).toBe('l');
+    expect(used.has('l')).toBe(true);
+  });
+
+  it('rejects reserved global shorts, duplicates, and non-single-letter values', () => {
+    const used = new Set(['f', 'v', 'h']); // as seeded per command
+    expect(resolveArgShort('f', used)).toBeUndefined(); // reserved -f/--format
+    expect(resolveArgShort('v', used)).toBeUndefined(); // reserved -v/--verbose
+    expect(resolveArgShort('lo', used)).toBeUndefined(); // multi-char
+    expect(resolveArgShort('1', used)).toBeUndefined(); // not a letter
+    expect(resolveArgShort('', used)).toBeUndefined();
+    expect(resolveArgShort(undefined, used)).toBeUndefined();
+    // first declaration wins; a later duplicate degrades to long-only
+    expect(resolveArgShort('x', used)).toBe('x');
+    expect(resolveArgShort('x', used)).toBeUndefined();
+    // case-sensitive: -F is distinct from the reserved -f
+    expect(resolveArgShort('F', used)).toBe('F');
+  });
+});
+
+describe('commanderAdapter short option aliases', () => {
+  const cmd: CliCommand = {
+    site: 'demo',
+    name: 'list', access: 'read',
+    description: 'List things',
+    browser: false,
+    args: [
+      { name: 'limit', short: 'l', type: 'int', default: 20, help: 'Max items' },
+      { name: 'output', short: 'o', type: 'str', help: 'Output file' },
+    ],
+    func: vi.fn(),
+  };
+
+  beforeEach(() => {
+    mockExecuteCommand.mockReset();
+    mockExecuteCommand.mockResolvedValue([]);
+    mockRenderOutput.mockReset();
+    process.exitCode = undefined;
+  });
+
+  it('populates the canonical kwargs key from the short form', async () => {
+    const program = new Command();
+    registerCommandToProgram(program.command('demo'), cmd);
+    await program.parseAsync(['node', 'opencli', 'demo', 'list', '-l', '10', '-o', 'out.json']);
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(Number(kwargs.limit)).toBe(10); // int arg is coerced; short and long agree on the value
+    expect(kwargs.output).toBe('out.json');
+  });
+
+  it('populates the same key from the long form', async () => {
+    const program = new Command();
+    registerCommandToProgram(program.command('demo'), cmd);
+    await program.parseAsync(['node', 'opencli', 'demo', 'list', '--limit', '10', '--output', 'out.json']);
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(Number(kwargs.limit)).toBe(10); // int arg is coerced; short and long agree on the value
+    expect(kwargs.output).toBe('out.json');
+  });
+
+  it('skips a short that collides with a reserved flag without breaking registration or -f', async () => {
+    const clashCmd: CliCommand = {
+      site: 'demo', name: 'run', access: 'read', description: 'Run', browser: false,
+      args: [{ name: 'foo', short: 'f', type: 'str', help: 'Foo' }], // 'f' is reserved by --format
+      func: vi.fn(),
+    };
+    const program = new Command();
+    // Registration must not throw on the reserved-short collision.
+    expect(() => registerCommandToProgram(program.command('demo'), clashCmd)).not.toThrow();
+    await program.parseAsync(['node', 'opencli', 'demo', 'run', '--foo', 'bar', '-f', 'json']);
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs.foo).toBe('bar'); // long form still works; -f stayed with --format
+  });
+
+  it('gives the short to the first arg and degrades a duplicate to long-only', async () => {
+    const dupCmd: CliCommand = {
+      site: 'demo', name: 'dup', access: 'read', description: 'Dup', browser: false,
+      args: [
+        { name: 'aa', short: 'x', type: 'str', help: 'A' },
+        { name: 'bb', short: 'x', type: 'str', help: 'B' },
+      ],
+      func: vi.fn(),
+    };
+    const program = new Command();
+    expect(() => registerCommandToProgram(program.command('demo'), dupCmd)).not.toThrow();
+    await program.parseAsync(['node', 'opencli', 'demo', 'dup', '-x', '1', '--bb', '2']);
+    const kwargs = mockExecuteCommand.mock.calls[0][1];
+    expect(kwargs.aa).toBe('1'); // -x bound to the first declaration
+    expect(kwargs.bb).toBe('2'); // second still reachable via its long flag
   });
 });
 

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -11,6 +11,7 @@
  */
 
 import { Command } from 'commander';
+import { RESERVED_ARG_SHORTS, resolveArgShort } from './arg-short.js';
 import { log } from './logger.js';
 import yaml from 'js-yaml';
 import { type CliCommand, fullName, getRegistry } from './registry.js';
@@ -42,6 +43,10 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   const subCmd = siteCmd.command(cmd.name).description(formatSiteCommandDescription(cmd));
   if (cmd.aliases?.length) subCmd.aliases(cmd.aliases);
 
+  // Reserve the global short flags this subcommand adds below (-f/--format,
+  // -v/--verbose) plus Commander's built-in -h/--help, so an adapter's `short`
+  // can never clobber them — Commander throws on a duplicate flag.
+  const usedShorts = new Set(RESERVED_ARG_SHORTS);
   // Register positional args first, then named options
   const positionalArgs: typeof cmd.args = [];
   for (const arg of cmd.args) {
@@ -51,7 +56,11 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
       positionalArgs.push(arg);
     } else {
       const expectsValue = arg.required || arg.valueRequired;
-      const flag = expectsValue ? `--${arg.name} <value>` : `--${arg.name} [value]`;
+      const short = resolveArgShort(arg.short, usedShorts);
+      const longSpec = expectsValue ? `--${arg.name} <value>` : `--${arg.name} [value]`;
+      // Commander maps both -x and --name to the same long-name key, so short
+      // aliases populate the canonical kwargs.<name> with no extra wiring.
+      const flag = short ? `-${short}, ${longSpec}` : longSpec;
       if (arg.required) subCmd.requiredOption(flag, arg.help ?? '');
       else if (arg.default != null) subCmd.option(flag, arg.help ?? '', String(arg.default));
       else subCmd.option(flag, arg.help ?? '');

--- a/src/manifest-types.ts
+++ b/src/manifest-types.ts
@@ -19,6 +19,8 @@ export interface ManifestEntry {
   browser: boolean;
   args: Array<{
     name: string;
+    /** Single-letter short alias for a named option (e.g. 'l' → -l); see registry Arg.short. */
+    short?: string;
     type?: string;
     default?: unknown;
     required?: boolean;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,6 +14,14 @@ export enum Strategy {
 
 export interface Arg {
   name: string;
+  /**
+   * Optional single-letter short alias for a named (non-positional) option, e.g.
+   * `short: 'l'` exposes `-l` alongside `--<name>`. Both forms populate the same
+   * canonical `kwargs.<name>` key. Ignored for positional args, and skipped when
+   * it is not a single ASCII letter, collides with a reserved global flag
+   * (`-f`/`-v`/`-h`), or duplicates another arg's short in the same command.
+   */
+  short?: string;
   type?: string;
   default?: unknown;
   required?: boolean;


### PR DESCRIPTION
Closes #1970.

Adapters/plugins can declare a single-letter short alias on a named arg:

```js
args: [
  { name: 'limit',  short: 'l', type: 'int', default: 20 },
  { name: 'output', short: 'o' },
]
```

```bash
opencli some-site list --limit 10 --output r.json
opencli some-site list -l 10 -o r.json          # same canonical kwargs.limit / kwargs.output
```

## What changed

- **`Arg.short?`** added to the runtime type (`registry.ts`), the manifest arg shape (`manifest-types.ts`), and carried through manifest generation (`build-manifest.ts`). It's emitted only when non-empty, so **manifests of adapters that don't use it are unchanged** (zero churn until adopted).
- **New shared `src/arg-short.ts`** — `resolveArgShort` + `RESERVED_ARG_SHORTS` — the single source of truth for the rules: a single ASCII letter, not a reserved global short (`-f`/`-v`/`-h`), first-declaration-wins dedup. Both the Commander registration and the argv pre-processor use it so they agree on exactly which shorts are live.
- **`commanderAdapter.ts`** builds `-<short>, --<name> <value>` and skips an invalid/colliding short (degrades to long-only rather than making Commander throw on a duplicate flag). Positional args ignore `short`.
- **`cli-argv-preprocess.ts`** learns the shorts too, so a `-l` on a command that has a dash-leading positional isn't mis-escaped as the positional; attached values (`-l10`, `-sdesc`) are consumed for both value-required and value-optional shorts.

## Design choices flagged for your preference

- Field name `short` (matches the issue's proposal); reserved shorts limited to `f`/`v`/`h` at the subcommand scope (`-V/--version` lives on the root command, a different scope); invalid/duplicate shorts degrade silently to long-only. Happy to adjust any of these.

## Tests

```
npx vitest run src/commanderAdapter.test.ts src/cli-argv-preprocess.test.ts   # 62 passed
npm run typecheck            # clean
npm run check:typed-error-lint / check:silent-column-drop   # new=0
```

Offline coverage: the resolver (letter/reserved/dup), short↔long parity, reserved & duplicate collisions not breaking registration, and the pre-processor's dash-leading-positional interaction (separate + attached values, both orders). No manifest churn (`npm run build` leaves `cli-manifest.json` unchanged).

(The 6 pre-existing `cli.test.ts > browser tab targeting` failures in a daemon-less env are unrelated to this change.)