### PR TITLE
feat(openrouter/credits): read total available credits balance

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -27813,6 +27813,25 @@
     "sourceFile": "openreview/venue.js"
   },
   {
+    "site": "openrouter",
+    "name": "credits",
+    "description": "Read the OpenRouter total available credits balance from the settings/credits page.",
+    "access": "read",
+    "domain": "openrouter.ai",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "totalAvailable",
+      "currency"
+    ],
+    "type": "js",
+    "modulePath": "openrouter/credits.js",
+    "sourceFile": "openrouter/credits.js",
+    "navigateBefore": true,
+    "siteSession": "persistent"
+  },
+  {
     "site": "osv",
     "name": "query",
     "description": "OSV.dev vulnerabilities affecting a package (optionally pinned to a version)",

--- a/clis/openrouter/credits.js
+++ b/clis/openrouter/credits.js
@@ -1,0 +1,71 @@
+// OpenRouter credits balance summary.
+// Reads the "Total available credits" balance from the settings/credits page.
+// The value is exposed as an aria-label on the balance card, so we extract it
+// from the DOM instead of relying on an undocumented internal API.
+
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+const OR_DOMAIN = 'openrouter.ai';
+const CREDITS_URL = 'https://openrouter.ai/settings/credits';
+
+// Runs in the browser via page.evaluate. Backslashes are doubled because this
+// string is interpolated into a template literal.
+const EVAL_JS = `
+    var el = document.querySelector('[aria-label^="Total available credits:"]');
+    var total = null;
+    var currency = null;
+
+    if (el) {
+        var label = el.getAttribute('aria-label') || '';
+        var m = label.match(/Total available credits:\\s*\\$?\\s*([\\d,.]+)/);
+        if (m) {
+            total = m[1].replace(/,/g, '');
+            currency = 'USD';
+        }
+    }
+
+    // Fallback: scan the balance card text for a currency amount
+    if (total === null && el) {
+        var text = el.innerText || '';
+        var tm = text.match(/([\\d,.]+)/);
+        if (tm) total = tm[1].replace(/,/g, '');
+    }
+
+    return { totalAvailable: total, currency: currency };
+`;
+
+cli({
+    site: 'openrouter',
+    name: 'credits',
+    access: 'read',
+    description: 'Read the OpenRouter total available credits balance from the settings/credits page.',
+    domain: OR_DOMAIN,
+    strategy: Strategy.COOKIE,
+    browser: true,
+    siteSession: 'persistent',
+    navigateBefore: true,
+    args: [],
+    columns: [
+        'totalAvailable',
+        'currency',
+    ],
+    func: async (page) => {
+        await page.goto(CREDITS_URL);
+        await page.wait(3);
+
+        const data = await page.evaluate(`(() => {${EVAL_JS}})()`);
+
+        if (!data || typeof data !== 'object' || Array.isArray(data)) {
+            throw new CommandExecutionError('openrouter credits returned malformed payload: expected object');
+        }
+        if (!data.totalAvailable) {
+            throw new CommandExecutionError('openrouter credits returned malformed payload: missing totalAvailable balance');
+        }
+
+        return [{
+            totalAvailable: String(data.totalAvailable),
+            currency: String(data.currency || 'USD'),
+        }];
+    },
+});


### PR DESCRIPTION
Add `opencli openrouter credits` command that reads the total available credits balance from https://openrouter.ai/settings/credits.

**Strategy:** `UI_SELECTOR` — the balance is exposed as a semantic `aria-label` (`Total available credits: $X.XX`) on the balance card. DOM extraction is more stable than an undocumented internal API (the public `/api/v1/credits` endpoint requires a management key, and the frontend has no separate credits JSON endpoint — the value is rendered client-side).

**Output columns:** `totalAvailable`, `currency`

```
$ opencli openrouter credits
- totalAvailable: '8.05'
  currency: USD
```

Tested locally — value matches the page ($8.05).