### PR TITLE
fix: preserve complete Nowcoder and Xiaohongshu source metadata

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -26357,8 +26357,12 @@
       }
     ],
     "columns": [
+      "id",
+      "url",
       "title",
       "author",
+      "author_id",
+      "author_url",
       "school",
       "content",
       "likes",
@@ -26400,11 +26404,14 @@
       "rank",
       "title",
       "author",
+      "author_id",
+      "author_url",
       "school",
       "likes",
       "comments",
       "views",
-      "id"
+      "id",
+      "url"
     ],
     "type": "js",
     "modulePath": "nowcoder/experience.js",
@@ -26732,9 +26739,12 @@
       "rank",
       "title",
       "author",
+      "author_id",
+      "author_url",
       "school",
       "content",
-      "id"
+      "id",
+      "url"
     ],
     "type": "js",
     "modulePath": "nowcoder/search.js",
@@ -44755,8 +44765,11 @@
       "rank",
       "title",
       "author",
+      "author_id",
+      "author_url",
       "likes",
       "published_at",
+      "published_at_source",
       "url"
     ],
     "type": "js",

--- a/clis/nowcoder/detail.js
+++ b/clis/nowcoder/detail.js
@@ -1,4 +1,5 @@
 import { cli } from '@jackwener/opencli/registry';
+import { projectNowcoderDetail } from './output.js';
 
 cli({
     site: 'nowcoder',
@@ -9,16 +10,16 @@ cli({
     args: [
         { name: 'id', positional: true, required: true, help: 'Post ID, UUID, or URL' },
     ],
-    columns: ['title', 'author', 'school', 'content', 'likes', 'comments', 'views', 'time', 'location'],
+    columns: ['id', 'url', 'title', 'author', 'author_id', 'author_url', 'school', 'content', 'likes', 'comments', 'views', 'time', 'location'],
     pipeline: [
         { navigate: 'https://www.nowcoder.com' },
         { evaluate: `(async () => {
-  const raw = \${{ args.id | json }};
+  const raw = String(\${{ args.id | json }});
   const base = 'https://gw-c.nowcoder.com';
-  const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').trim();
+  const projectDetail = ${projectNowcoderDetail.toString()};
 
   let id = raw;
-  const urlMatch = raw.match(/discuss\\/(\\d+)/);
+  const urlMatch = raw.match(/discuss\\/([^/?#]+)/);
   if (urlMatch) id = urlMatch[1];
 
   let data = null;
@@ -43,19 +44,7 @@ cli({
 
   if (!data) throw new Error('Post not found: ' + id);
 
-  const user = data.userBrief || {};
-  const freq = data.frequencyData || {};
-  return [{
-    title: data.title || '(untitled)',
-    author: user.nickname || '',
-    school: user.educationInfo || '',
-    content: strip(data.content || '').substring(0, 500),
-    likes: freq.likeCnt || 0,
-    comments: freq.commentCnt || freq.totalCommentCnt || 0,
-    views: freq.viewCnt || 0,
-    time: data.createdAt ? new Date(data.createdAt).toISOString().slice(0, 19) : '',
-    location: data.ip4Location || '',
-  }];
+  return [projectDetail(data, id)];
 })()
 ` },
     ],

--- a/clis/nowcoder/experience.js
+++ b/clis/nowcoder/experience.js
@@ -1,4 +1,5 @@
 import { cli } from '@jackwener/opencli/registry';
+import { projectNowcoderExperienceItem } from './output.js';
 
 cli({
     site: 'nowcoder',
@@ -10,25 +11,17 @@ cli({
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
         { name: 'limit', type: 'int', default: 15, help: 'Number of items' },
     ],
-    columns: ['rank', 'title', 'author', 'school', 'likes', 'comments', 'views', 'id'],
+    columns: ['rank', 'title', 'author', 'author_id', 'author_url', 'school', 'likes', 'comments', 'views', 'id', 'url'],
     pipeline: [
         { navigate: 'https://www.nowcoder.com' },
         { evaluate: `(async () => {
   const page = \${{ args.page }};
   const limit = \${{ args.limit }};
+  const projectItem = ${projectNowcoderExperienceItem.toString()};
   const r = await fetch('https://gw-c.nowcoder.com/api/sparta/home/tab/content?tabId=818&categoryType=1&pageNo=' + page + '&pageSize=' + limit, {credentials: 'include'});
   const d = await r.json();
   if (!d.success) throw new Error(d.msg || 'API failed');
-  return (d.data?.records || []).map((item, i) => ({
-    rank: i + 1,
-    title: item.contentData?.title || '',
-    author: item.userBrief?.nickname || '',
-    school: item.userBrief?.educationInfo || '',
-    likes: item.frequencyData?.likeCnt || 0,
-    comments: item.frequencyData?.commentCnt || 0,
-    views: item.frequencyData?.viewCnt || 0,
-    id: item.contentData?.uuid || item.contentData?.id || item.contentId || '',
-  }));
+  return (d.data?.records || []).map(projectItem);
 })()
 ` },
         { filter: 'item.title' },

--- a/clis/nowcoder/output.js
+++ b/clis/nowcoder/output.js
@@ -1,0 +1,95 @@
+/** Self-contained projector: serialized into the browser evaluation context. */
+export function projectNowcoderDetail(data, requestedId = '') {
+    const toString = (value) => value == null ? '' : String(value).trim();
+    const user = data?.userBrief || {};
+    const frequency = data?.frequencyData || {};
+    const authorId = toString(user.userId || user.user_id || user.id || user.uid);
+    const id = toString(data?.uuid || data?.contentData?.uuid || data?.contentId || data?.id || requestedId);
+    const html = toString(data?.content);
+    const content = html
+        .replace(/<\s*br\s*\/?>/gi, '\n')
+        .replace(/<\/(?:p|div|li)>/gi, '\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+    let time = '';
+    if (data?.createdAt != null && data.createdAt !== '') {
+        const date = new Date(data.createdAt);
+        if (!Number.isNaN(date.getTime()))
+            time = date.toISOString();
+    }
+    return {
+        id,
+        url: id ? `https://www.nowcoder.com/discuss/${encodeURIComponent(id)}` : '',
+        title: toString(data?.title) || '(untitled)',
+        author: toString(user.nickname),
+        author_id: authorId,
+        author_url: authorId ? `https://www.nowcoder.com/users/${encodeURIComponent(authorId)}` : '',
+        school: toString(user.educationInfo),
+        content,
+        likes: frequency.likeCnt || 0,
+        comments: frequency.commentCnt || frequency.totalCommentCnt || 0,
+        views: frequency.viewCnt || 0,
+        time,
+        location: toString(data?.ip4Location),
+    };
+}
+
+/** Self-contained projector: serialized into the browser evaluation context. */
+export function projectNowcoderSearchItem(item, index) {
+    const toString = (value) => value == null ? '' : String(value).trim();
+    const strip = (html) => toString(html)
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&nbsp;/g, ' ')
+        .trim();
+    const data = item?.data || {};
+    const moment = data.momentData || {};
+    const contentData = data.contentData || {};
+    const user = data.userBrief || {};
+    const id = toString(moment.uuid || contentData.uuid || data.contentId || moment.id || contentData.id);
+    const authorId = toString(user.userId || user.user_id || user.id || user.uid);
+    return {
+        rank: index + 1,
+        title: toString(moment.title || contentData.title || user.nickname),
+        author: toString(user.nickname),
+        author_id: authorId,
+        author_url: authorId ? `https://www.nowcoder.com/users/${encodeURIComponent(authorId)}` : '',
+        school: toString(user.educationInfo),
+        content: strip(moment.content || contentData.content),
+        id,
+        url: id ? `https://www.nowcoder.com/discuss/${encodeURIComponent(id)}` : '',
+    };
+}
+
+/** Self-contained projector: serialized into the browser evaluation context. */
+export function projectNowcoderExperienceItem(item, index) {
+    const toString = (value) => value == null ? '' : String(value).trim();
+    const user = item?.userBrief || {};
+    const content = item?.contentData || {};
+    const frequency = item?.frequencyData || {};
+    const id = toString(content.uuid || content.id || item?.contentId);
+    const authorId = toString(user.userId || user.user_id || user.id || user.uid);
+    return {
+        rank: index + 1,
+        title: toString(content.title),
+        author: toString(user.nickname),
+        author_id: authorId,
+        author_url: authorId ? `https://www.nowcoder.com/users/${encodeURIComponent(authorId)}` : '',
+        school: toString(user.educationInfo),
+        likes: frequency.likeCnt || 0,
+        comments: frequency.commentCnt || 0,
+        views: frequency.viewCnt || 0,
+        id,
+        url: id ? `https://www.nowcoder.com/discuss/${encodeURIComponent(id)}` : '',
+    };
+}

--- a/clis/nowcoder/output.test.js
+++ b/clis/nowcoder/output.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { projectNowcoderDetail, projectNowcoderExperienceItem, projectNowcoderSearchItem } from './output.js';
+import './detail.js';
+import './experience.js';
+import './search.js';
+
+describe('Nowcoder lossless output projection', () => {
+    it('keeps the complete detail body, stable identity, canonical URL, and timezone', () => {
+        const longBody = `${'面试题'.repeat(220)}<br>最终结果`;
+        const result = projectNowcoderDetail({
+            uuid: 'post-uuid-1',
+            title: '长面经',
+            content: `<p>${longBody}</p>`,
+            createdAt: '2026-01-01T12:00:00+08:00',
+            userBrief: {
+                userId: 'author-123',
+                nickname: '牛客用户',
+                educationInfo: '示例大学',
+            },
+            frequencyData: { likeCnt: 4, commentCnt: 3, viewCnt: 20 },
+        });
+
+        expect(result.content.length).toBeGreaterThan(500);
+        expect(result.content).toContain('最终结果');
+        expect(result).toMatchObject({
+            id: 'post-uuid-1',
+            url: 'https://www.nowcoder.com/discuss/post-uuid-1',
+            author_id: 'author-123',
+            author_url: 'https://www.nowcoder.com/users/author-123',
+            time: '2026-01-01T04:00:00.000Z',
+        });
+    });
+
+    it('adds stable author and post URLs to search output', () => {
+        expect(projectNowcoderSearchItem({
+            data: {
+                momentData: { uuid: 'moment-1', title: '搜索结果', content: '<b>正文</b>' },
+                userBrief: { userId: 42, nickname: 'Alice' },
+            },
+        }, 0)).toMatchObject({
+            rank: 1,
+            id: 'moment-1',
+            url: 'https://www.nowcoder.com/discuss/moment-1',
+            author_id: '42',
+            author_url: 'https://www.nowcoder.com/users/42',
+            content: '正文',
+        });
+    });
+
+    it('adds stable author and post URLs to experience output', () => {
+        expect(projectNowcoderExperienceItem({
+            contentData: { uuid: 'experience-1', title: '一面复盘' },
+            userBrief: { userId: 'user-7', nickname: 'Bob' },
+            frequencyData: { likeCnt: 1, commentCnt: 2, viewCnt: 3 },
+        }, 2)).toMatchObject({
+            rank: 3,
+            id: 'experience-1',
+            url: 'https://www.nowcoder.com/discuss/experience-1',
+            author_id: 'user-7',
+            author_url: 'https://www.nowcoder.com/users/user-7',
+        });
+    });
+
+    it('declares every identity field in the command columns', () => {
+        for (const name of ['detail', 'search', 'experience']) {
+            const columns = getRegistry().get(`nowcoder/${name}`)?.columns || [];
+            expect(columns).toEqual(expect.arrayContaining(['id', 'url', 'author_id', 'author_url']));
+        }
+    });
+});

--- a/clis/nowcoder/search.js
+++ b/clis/nowcoder/search.js
@@ -1,4 +1,5 @@
 import { cli } from '@jackwener/opencli/registry';
+import { projectNowcoderSearchItem } from './output.js';
 
 cli({
     site: 'nowcoder',
@@ -11,14 +12,14 @@ cli({
         { name: 'type', type: 'str', default: 'all', help: 'Search type (all/post/question/user/job)' },
         { name: 'limit', type: 'int', default: 10, help: 'Number of results' },
     ],
-    columns: ['rank', 'title', 'author', 'school', 'content', 'id'],
+    columns: ['rank', 'title', 'author', 'author_id', 'author_url', 'school', 'content', 'id', 'url'],
     pipeline: [
         { navigate: 'https://www.nowcoder.com' },
         { evaluate: `(async () => {
   const query = \${{ args.query | json }};
   const type = \${{ args.type | json }};
   const limit = \${{ args.limit }};
-  const strip = (html) => (html || '').replace(/<[^>]+>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ').trim();
+  const projectItem = ${projectNowcoderSearchItem.toString()};
   const r = await fetch('https://gw-c.nowcoder.com/api/sparta/pc/search', {
     method: 'POST',
     credentials: 'include',
@@ -27,22 +28,7 @@ cli({
   });
   const d = await r.json();
   if (!d.success) throw new Error(d.msg || 'search failed');
-  return (d.data?.records || []).map((item, i) => {
-    const data = item.data || {};
-    const moment = data.momentData || {};
-    const contentData = data.contentData || {};
-    const user = data.userBrief || {};
-    const uuid = moment.uuid || contentData.uuid || '';
-    const id = data.contentId || '';
-    return {
-      rank: i + 1,
-      title: moment.title || contentData.title || user.nickname || '',
-      author: user.nickname || '',
-      school: user.educationInfo || '',
-      content: strip(moment.content || contentData.content || ''),
-      id: uuid || id,
-    };
-  }).filter(r => r.title);
+  return (d.data?.records || []).map(projectItem).filter(r => r.title);
 })()
 ` },
         { limit: '${{ args.limit }}' },

--- a/clis/xiaohongshu/note.js
+++ b/clis/xiaohongshu/note.js
@@ -10,12 +10,18 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CliError, EmptyResultError } from '@jackwener/opencli/errors';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
 /**
- * Host-agnostic IIFE that scrapes note title / author / counts / tags from a
- * rendered note detail page. Exported so the rednote adapter can reuse the
- * exact same selector set without copying it.
+ * Host-agnostic IIFE that scrapes note content plus stable identity, publish
+ * time, and ordered media from the rendered page and its hydration state.
+ * Exported so the rednote adapter can reuse the same selector set.
  */
-export const NOTE_EXTRACT_JS = `
+export function buildNoteExtractJs(requestedNoteId = '', webHost = 'www.xiaohongshu.com') {
+    const encodedNoteId = JSON.stringify(String(requestedNoteId || ''));
+    const encodedWebHost = JSON.stringify(String(webHost || 'www.xiaohongshu.com'));
+    return `
       (() => {
+        const requestedNoteId = ${encodedNoteId}
+        const configuredWebHost = ${encodedWebHost}
+        const activeWebHost = location.hostname.endsWith('rednote.com') ? 'www.rednote.com' : configuredWebHost
         const bodyText = document.body?.innerText || ''
         const loginWall = /登录后查看|请登录/.test(bodyText)
         const notFound = /页面不见了|笔记不存在|无法浏览/.test(bodyText)
@@ -23,29 +29,176 @@ export const NOTE_EXTRACT_JS = `
           || /website-login\\/error|error_code=300017|error_code=300031/.test(location.href)
 
         const clean = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim()
+        const cleanValue = (value) => value == null ? '' : String(value).trim()
+        const pathMatch = (location.pathname || '').match(
+          /\\/(?:explore|note|search_result|discovery\\/item)\\/([a-f0-9]+)|\\/user\\/profile\\/[^/?#]+\\/([a-f0-9]+)/i
+        )
+        const noteId = pathMatch?.[1] || pathMatch?.[2] || requestedNoteId
+        const canonicalUrl = noteId ? 'https://' + activeWebHost + '/explore/' + encodeURIComponent(noteId) : ''
+
+        const getStructuredNote = () => {
+          const state = window.__INITIAL_STATE__
+          const noteData = state?.note?.noteDetailMap || state?.note?.note || {}
+          if (!noteData || typeof noteData !== 'object') return null
+          for (const id of [...new Set([noteId, requestedNoteId].filter(Boolean))]) {
+            const entry = noteData[id]
+            const note = entry?.note || entry
+            if (note && typeof note === 'object') return note
+          }
+          const keys = Object.keys(noteData)
+          if (keys.length === 1) {
+            const entry = noteData[keys[0]]
+            const note = entry?.note || entry
+            if (note && typeof note === 'object') return note
+          }
+          return null
+        }
+        const note = getStructuredNote()
 
         const title = clean(document.querySelector('#detail-title, .title'))
+          || cleanValue(note?.title ?? note?.displayTitle ?? note?.display_title)
         const desc = clean(document.querySelector('#detail-desc, .desc, .note-text'))
+          || cleanValue(note?.desc ?? note?.content)
+        const authorLink = document.querySelector(
+          '.author-wrapper a[href*="/user/profile/"], a.username[href*="/user/profile/"], a[href*="/user/profile/"]'
+        )
+        const authorHref = authorLink?.getAttribute('href') || ''
+        const authorPath = authorHref.match(/\\/user\\/profile\\/([^/?#]+)/)
+        const structuredUser = note?.user || note?.userInfo || note?.user_info || {}
+        const authorId = cleanValue(
+          structuredUser.userId ?? structuredUser.user_id ?? structuredUser.id ?? note?.userId ?? authorPath?.[1]
+        )
         const author = clean(document.querySelector('.username, .author-wrapper .name'))
-        // Scope to .interact-container — the post's main interaction bar.
-        // Without scoping, .like-wrapper / .chat-wrapper also match each
-        // comment's like/reply buttons in the comment section, and
-        // querySelector returns the FIRST match (a comment's count, not the
-        // post's). The post's true counts live inside .interact-container.
+          || cleanValue(structuredUser.nickname ?? structuredUser.nickName ?? structuredUser.name)
+        const authorUrl = authorId
+          ? 'https://' + activeWebHost + '/user/profile/' + encodeURIComponent(authorId)
+          : ''
+
+        // Scope to .interact-container so comment action counts are never
+        // mistaken for the note's top-level engagement counts.
         const likes = clean(document.querySelector('.interact-container .like-wrapper .count'))
         const collects = clean(document.querySelector('.interact-container .collect-wrapper .count'))
         const comments = clean(document.querySelector('.interact-container .chat-wrapper .count'))
 
-        // Try to extract tags/topics
         const tags = []
+        const seenTags = new Set()
+        const pushTag = (value) => {
+          const tag = cleanValue(value)
+          if (tag && !seenTags.has(tag)) {
+            seenTags.add(tag)
+            tags.push(tag)
+          }
+        }
         document.querySelectorAll('#detail-desc a.tag, #detail-desc a[href*="search_result"]').forEach(el => {
-          const t = (el.textContent || '').trim()
-          if (t) tags.push(t)
+          pushTag(el.textContent)
         })
+        for (const tag of Array.isArray(note?.tagList) ? note.tagList : []) {
+          pushTag(tag?.name ?? tag?.title ?? tag)
+        }
 
-        return { pageUrl: location.href, securityBlock, loginWall, notFound, title, desc, author, likes, collects, comments, tags }
+        const normalizePublishedAt = (value) => {
+          if (value == null || value === '') return ''
+          let candidate = value
+          if (typeof candidate === 'string' && /^\\d+$/.test(candidate.trim())) candidate = Number(candidate)
+          if (typeof candidate === 'number') {
+            if (!Number.isFinite(candidate) || candidate <= 0) return ''
+            if (candidate < 1e12) candidate *= 1000
+          }
+          const date = new Date(candidate)
+          return Number.isNaN(date.getTime()) ? '' : date.toISOString()
+        }
+        const publishedAt = normalizePublishedAt(
+          note?.time ?? note?.publishTime ?? note?.publish_time ?? note?.createdAt ?? note?.createTime
+        )
+
+        const media = []
+        const seenMedia = new Set()
+        const normalizeMediaUrl = (value) => {
+          const raw = cleanValue(value)
+          if (!raw || raw.startsWith('blob:')) return ''
+          if (raw.startsWith('//')) return 'https:' + raw
+          try { return new URL(raw, location.href).href } catch { return '' }
+        }
+        const pushMedia = (type, value) => {
+          const url = normalizeMediaUrl(value)
+          if (!url) return
+          const key = type + ':' + url
+          if (seenMedia.has(key)) return
+          seenMedia.add(key)
+          media.push({ type, url })
+        }
+
+        let structuredVideoUsed = false
+        const video = note?.video
+        if (video) {
+          const directVideo = video.url || video.originVideoKey || video.consumer?.originVideoKey
+          if (directVideo) {
+            pushMedia('video', /^https?:/.test(directVideo) ? directVideo : 'https://sns-video-bd.xhscdn.com/' + directVideo)
+            structuredVideoUsed = true
+          }
+          const streams = video.media?.stream?.h264 || []
+          for (const stream of streams) {
+            if (stream?.masterUrl) {
+              pushMedia('video', stream.masterUrl)
+              structuredVideoUsed = true
+            }
+          }
+        }
+        if (!structuredVideoUsed) {
+          document.querySelectorAll('video source, video[src], .player video, .video-player video').forEach(el => {
+            pushMedia('video', el.src || el.getAttribute('src'))
+          })
+        }
+
+        let structuredImagesUsed = false
+        const imageList = Array.isArray(note?.imageList) ? note.imageList : []
+        for (const image of imageList) {
+          const candidate = image?.urlDefault || image?.urlPre || image?.url
+            || image?.infoList?.find(item => item?.imageScene === 'WB_DFT')?.url
+            || image?.infoList?.[0]?.url
+          if (candidate) {
+            pushMedia('image', candidate)
+            structuredImagesUsed = true
+          }
+        }
+        if (!structuredImagesUsed) {
+          const selectors = [
+            '.swiper-slide img', '.carousel-image img', '.note-slider img',
+            '.note-image img', '.image-wrapper img',
+            '#noteContainer .media-container img[src*="xhscdn"]',
+            'img[src*="ci.xiaohongshu.com"]'
+          ]
+          for (const selector of selectors) {
+            document.querySelectorAll(selector).forEach(img => {
+              pushMedia('image', img.src || img.getAttribute('data-src'))
+            })
+          }
+        }
+
+        return {
+          pageUrl: location.href,
+          securityBlock,
+          loginWall,
+          notFound,
+          id: noteId,
+          url: canonicalUrl,
+          title,
+          desc,
+          author,
+          author_id: authorId,
+          author_url: authorUrl,
+          published_at: publishedAt,
+          published_at_source: publishedAt ? 'initial_state' : '',
+          likes,
+          collects,
+          comments,
+          tags,
+          media,
+        }
       })()
     `;
+}
+export const NOTE_EXTRACT_JS = buildNoteExtractJs();
 export const command = cli({
     site: 'xiaohongshu',
     name: 'note',
@@ -64,7 +217,7 @@ export const command = cli({
         const url = buildNoteUrl(raw, { commandName: 'xiaohongshu note' });
         await page.goto(url);
         await page.wait({ time: 2 + Math.random() * 3 });
-        const data = await page.evaluate(NOTE_EXTRACT_JS);
+        const data = await page.evaluate(buildNoteExtractJs(noteId));
         if (!data || typeof data !== 'object') {
             throw new EmptyResultError('xiaohongshu/note', 'Unexpected evaluate response');
         }
@@ -89,12 +242,19 @@ export const command = cli({
             throw new EmptyResultError('xiaohongshu/note', 'The note page loaded without visible content. The note may be deleted or restricted.');
         }
         const rows = [
+            { field: 'id', value: d.id || noteId },
+            { field: 'url', value: d.url || `https://www.xiaohongshu.com/explore/${encodeURIComponent(noteId)}` },
             { field: 'title', value: d.title || '' },
             { field: 'author', value: d.author || '' },
+            { field: 'author_id', value: d.author_id || '' },
+            { field: 'author_url', value: d.author_url || '' },
+            { field: 'published_at', value: d.published_at || '' },
+            { field: 'published_at_source', value: d.published_at_source || '' },
             { field: 'content', value: d.desc || '' },
             { field: 'likes', value: numOrZero(d.likes || '') },
             { field: 'collects', value: numOrZero(d.collects || '') },
             { field: 'comments', value: numOrZero(d.comments || '') },
+            { field: 'media', value: Array.isArray(d.media) ? d.media : [] },
         ];
         if (d.tags?.length) {
             rows.push({ field: 'tags', value: d.tags.join(', ') });

--- a/clis/xiaohongshu/note.test.js
+++ b/clis/xiaohongshu/note.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { JSDOM } from 'jsdom';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
-import './note.js';
+import { buildNoteExtractJs } from './note.js';
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -74,21 +75,41 @@ describe('xiaohongshu note', () => {
             title: '尚界Z7实车体验',
             desc: '今天去看了实车，外观很帅',
             author: '小红薯用户',
+            id: '69c131c9000000002800be4c',
+            url: 'https://www.xiaohongshu.com/explore/69c131c9000000002800be4c',
+            author_id: 'author-123',
+            author_url: 'https://www.xiaohongshu.com/user/profile/author-123',
+            published_at: '2026-03-18T12:01:00.000Z',
+            published_at_source: 'initial_state',
             likes: '257',
             collects: '98',
             comments: '45',
             tags: ['#尚界Z7', '#鸿蒙智行'],
+            media: [
+                { type: 'image', url: 'https://sns-img-bd.xhscdn.com/cover.jpg' },
+                { type: 'image', url: 'https://sns-img-bd.xhscdn.com/second.jpg' },
+            ],
         });
         const signedUrl = 'https://www.xiaohongshu.com/search_result/69c131c9000000002800be4c?xsec_token=abc';
         const result = (await command.func(page, { 'note-id': signedUrl }));
         expect(page.goto.mock.calls[0][0]).toBe(signedUrl);
         expect(result).toEqual([
+            { field: 'id', value: '69c131c9000000002800be4c' },
+            { field: 'url', value: 'https://www.xiaohongshu.com/explore/69c131c9000000002800be4c' },
             { field: 'title', value: '尚界Z7实车体验' },
             { field: 'author', value: '小红薯用户' },
+            { field: 'author_id', value: 'author-123' },
+            { field: 'author_url', value: 'https://www.xiaohongshu.com/user/profile/author-123' },
+            { field: 'published_at', value: '2026-03-18T12:01:00.000Z' },
+            { field: 'published_at_source', value: 'initial_state' },
             { field: 'content', value: '今天去看了实车，外观很帅' },
             { field: 'likes', value: '257' },
             { field: 'collects', value: '98' },
             { field: 'comments', value: '45' },
+            { field: 'media', value: [
+                    { type: 'image', url: 'https://sns-img-bd.xhscdn.com/cover.jpg' },
+                    { type: 'image', url: 'https://sns-img-bd.xhscdn.com/second.jpg' },
+                ] },
             { field: 'tags', value: '#尚界Z7, #鸿蒙智行' },
         ]);
     });
@@ -244,6 +265,56 @@ describe('xiaohongshu note', () => {
             'note-id': 'https://www.xiaohongshu.com/search_result/abc123?xsec_token=tok',
         }));
         expect(result.find((r) => r.field === 'tags')).toBeUndefined();
-        expect(result).toHaveLength(6);
+        expect(result).toHaveLength(13);
+    });
+});
+
+describe('buildNoteExtractJs metadata extraction', () => {
+    it('preserves stable identity, precise time, and structured media order', () => {
+        const noteId = '69c131c9000000002800be4c';
+        const dom = new JSDOM(`<!doctype html><html><body>
+          <div id="detail-title">结构化笔记</div>
+          <div id="detail-desc">完整正文</div>
+          <div class="author-wrapper"><a href="/user/profile/dom-author"><span class="name">DOM 作者</span></a></div>
+          <div class="interact-container">
+            <div class="like-wrapper"><span class="count">11</span></div>
+            <div class="collect-wrapper"><span class="count">12</span></div>
+            <div class="chat-wrapper"><span class="count">13</span></div>
+          </div>
+        </body></html>`, {
+            url: `https://www.xiaohongshu.com/search_result/${noteId}?xsec_token=abc`,
+            runScripts: 'outside-only',
+        });
+        dom.window.__INITIAL_STATE__ = {
+            note: {
+                noteDetailMap: {
+                    [noteId]: {
+                        note: {
+                            time: Date.parse('2026-03-18T20:01:00+08:00'),
+                            user: { userId: 'stable-author', nickname: '结构化作者' },
+                            imageList: [
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/cover.jpg' },
+                                { urlDefault: 'https://sns-img-bd.xhscdn.com/second.jpg' },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = dom.window.eval(buildNoteExtractJs(noteId));
+
+        expect(result).toMatchObject({
+            id: noteId,
+            url: `https://www.xiaohongshu.com/explore/${noteId}`,
+            author_id: 'stable-author',
+            author_url: 'https://www.xiaohongshu.com/user/profile/stable-author',
+            published_at: '2026-03-18T12:01:00.000Z',
+            published_at_source: 'initial_state',
+        });
+        expect(result.media).toEqual([
+            { type: 'image', url: 'https://sns-img-bd.xhscdn.com/cover.jpg' },
+            { type: 'image', url: 'https://sns-img-bd.xhscdn.com/second.jpg' },
+        ]);
     });
 });

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -55,6 +55,17 @@ export function noteIdToDate(url) {
     // Offset by UTC+8 (China Standard Time) so the date matches what XHS users see
     return new Date((ts + 8 * 3600) * 1000).toISOString().slice(0, 10);
 }
+export function xhsProfileIdFromUrl(url) {
+    if (!url)
+        return '';
+    try {
+        const parsed = new URL(url, 'https://www.xiaohongshu.com');
+        return parsed.pathname.match(/^\/user\/profile\/([^/?#]+)/)?.[1] || '';
+    }
+    catch {
+        return '';
+    }
+}
 export function stripXhsAuthorDateSuffix(value) {
     const text = (value || '').replace(/\s+/g, ' ').trim();
     const stripped = text.replace(/\s*(?:\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2})$/u, '').trim();
@@ -279,7 +290,7 @@ export const command = cli({
         { name: 'query', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     ],
-    columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
+    columns: ['rank', 'title', 'author', 'author_id', 'author_url', 'likes', 'published_at', 'published_at_source', 'url'],
     func: async (page, kwargs) => {
         const limit = parseLimit(kwargs.limit);
         const keyword = encodeURIComponent(kwargs.query);
@@ -318,11 +329,16 @@ export const command = cli({
         return data
             .filter((item) => item.title)
             .slice(0, limit)
-            .map((item, i) => ({
-            rank: i + 1,
-            ...item,
-            published_at: noteIdToDate(item.url),
-        }));
+            .map((item, i) => {
+            const publishedAt = noteIdToDate(item.url);
+            return {
+                rank: i + 1,
+                ...item,
+                author_id: xhsProfileIdFromUrl(item.author_url),
+                published_at: publishedAt,
+                published_at_source: publishedAt ? 'note_id' : '',
+            };
+        });
     },
 });
 export const __test__ = {

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { JSDOM } from 'jsdom';
-import { __test__, buildScrollUntilJs, noteIdToDate, unwrapEvaluateResult } from './search.js';
+import { __test__, buildScrollUntilJs, noteIdToDate, unwrapEvaluateResult, xhsProfileIdFromUrl } from './search.js';
 
 function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100 });
@@ -97,12 +97,19 @@ describe('xiaohongshu search', () => {
                 rank: 1,
                 title: '某鱼买FSD被坑了4万',
                 author: '随风',
+                author_id: '635a9c720000000018028b40',
+                author_url: authorUrl,
                 likes: '261',
                 published_at: '2025-10-10',
+                published_at_source: 'note_id',
                 url: detailUrl,
-                author_url: authorUrl,
             },
         ]);
+        expect(cmd.columns).toEqual(expect.arrayContaining([
+            'author_id',
+            'author_url',
+            'published_at_source',
+        ]));
     });
     it('fails typed instead of silently returning [] for malformed extraction payloads', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
@@ -216,6 +223,7 @@ describe('xiaohongshu search', () => {
         expect(result[0]).toMatchObject({
             title: '数字作者测试',
             author: '数字3天前端',
+            author_id: 'author123',
             likes: '8',
             author_url: 'https://www.xiaohongshu.com/user/profile/author123',
         });
@@ -295,6 +303,15 @@ describe('noteIdToDate (ObjectID timestamp parsing)', () => {
     it('returns empty string when timestamp is out of range', () => {
         // All zeros → ts = 0
         expect(noteIdToDate('https://www.xiaohongshu.com/search_result/000000000000000000000000')).toBe('');
+    });
+});
+describe('xhsProfileIdFromUrl', () => {
+    it('extracts a stable author id from absolute and relative profile URLs', () => {
+        expect(xhsProfileIdFromUrl('https://www.xiaohongshu.com/user/profile/author123?xsec_token=abc')).toBe('author123');
+        expect(xhsProfileIdFromUrl('/user/profile/635a9c720000000018028b40')).toBe('635a9c720000000018028b40');
+    });
+    it('returns empty for non-profile URLs', () => {
+        expect(xhsProfileIdFromUrl('https://www.xiaohongshu.com/explore/note123')).toBe('');
     });
 });
 describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {


### PR DESCRIPTION
## Summary

- preserve the complete cleaned body and full ISO timestamp in `nowcoder detail`
- add stable post IDs/URLs and author IDs/profile URLs to Nowcoder detail, search, and experience output
- expose Xiaohongshu search author identity and mark ObjectID-derived publish dates with `published_at_source: "note_id"`
- enrich `xiaohongshu note` with canonical identity, structured publish time, and ordered image/video metadata from hydration state
- regenerate the CLI manifest and add focused regression coverage

## Root cause

The adapters either truncated values in their final projection or computed/extracted metadata that was omitted from the declared output columns. Xiaohongshu note detail also limited its projection to visible text and engagement DOM nodes instead of using the already-present structured note state.

## Impact

Long Nowcoder interview posts can now be archived without silent truncation, returned records are self-contained and joinable by stable author identity, and Xiaohongshu consumers can distinguish inferred search dates from precise structured timestamps while preserving note media order.

No synthetic comment IDs or reply relationships are introduced.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm test` — 587 test files passed; 6,591 tests passed and 1 skipped on the upstream-based branch
- focused metadata regressions — 58 tests passed

Closes #2215

Detailed original report: [aolast/OpenCLI#1](https://github.com/aolast/OpenCLI/issues/1)
