### PR TITLE
fix(browser): recover stale page before evaluate

### DIFF
--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -93,6 +93,45 @@ describe('Page.evaluate', () => {
     expect(sendCommandMock).toHaveBeenCalledTimes(2);
   });
 
+  it('rebinds before retrying when the active page identity goes stale', async () => {
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/jobs' }, page: 'stale-page' })
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/jobs' }, page: 'fresh-page' });
+    sendCommandMock
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error('Page not found: stale-page — stale page identity'))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(42);
+
+    const page = new Page('site:example', undefined, undefined, undefined, 'adapter', 'persistent');
+    await page.goto('https://example.com/jobs');
+
+    await expect(page.evaluate('21 + 21')).resolves.toBe(42);
+    expect(page.getActivePage()).toBe('fresh-page');
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(2);
+    expect(sendCommandFullMock.mock.calls[1]).toEqual([
+      'navigate',
+      expect.not.objectContaining({ page: expect.anything() }),
+    ]);
+    expect(sendCommandMock).toHaveBeenLastCalledWith('exec', expect.objectContaining({
+      code: '21 + 21',
+      page: 'fresh-page',
+    }));
+  });
+
+  it('does not guess a replacement for an explicitly selected stale page', async () => {
+    sendCommandMock.mockRejectedValueOnce(
+      new Error('Page not found: selected-page — stale page identity'),
+    );
+
+    const page = new Page('default');
+    page.setActivePage('selected-page');
+
+    await expect(page.evaluate('21 + 21')).rejects.toThrow('stale page identity');
+    expect(sendCommandFullMock).not.toHaveBeenCalled();
+    expect(sendCommandMock).toHaveBeenCalledTimes(1);
+  });
+
   it('serializes function-form evaluate calls with JSON args', async () => {
     sendCommandMock.mockResolvedValueOnce('/opencli');
 

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -362,6 +362,29 @@ describe('Page active target tracking', () => {
     expect(retryCall[1]).not.toHaveProperty('page');
   });
 
+  it('rebinds when the settle retry exposes a stale page identity', async () => {
+    sendCommandFullMock
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/jobs' }, page: 'stale-page' })
+      .mockResolvedValueOnce({ data: { url: 'https://example.com/jobs' }, page: 'fresh-page' });
+    sendCommandMock
+      .mockRejectedValueOnce(new Error('Inspected target navigated or closed'))
+      .mockRejectedValueOnce(new Error('Page not found: stale-page — stale page identity'))
+      .mockResolvedValueOnce(null);
+
+    const page = new Page('site:boss', undefined, undefined, undefined, 'adapter', 'persistent');
+
+    await expect(page.goto('https://example.com/jobs')).resolves.toBeUndefined();
+    expect(page.getActivePage()).toBe('fresh-page');
+    expect(sendCommandFullMock).toHaveBeenCalledTimes(2);
+    expect(sendCommandFullMock.mock.calls[1]).toEqual([
+      'navigate',
+      expect.not.objectContaining({ page: expect.anything() }),
+    ]);
+    expect(sendCommandMock).toHaveBeenLastCalledWith('exec', expect.objectContaining({
+      page: 'fresh-page',
+    }));
+  });
+
   it('retries on a bare "Page not found:" error without the stale-identity suffix', async () => {
     // Under concurrent adapter calls the extension can reject with just
     // "Page not found: <id>" (no "— stale page identity" suffix) when the cached

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -122,9 +122,26 @@ export class Page extends BasePage {
         code: combinedCode,
         ...this._cmdOpts(),
       };
+      const recoverStalePageIdentity = async (err: unknown): Promise<boolean> => {
+        if (!isStalePageIdentityError(err) || this._page === undefined) return false;
+
+        this._page = undefined;
+        const rebound = await sendCommandFull('navigate', {
+          url,
+          ...this._cmdOpts(),
+        });
+        if (rebound.page) this._page = rebound.page;
+        this._lastUrl = url;
+        await sendCommand('exec', {
+          code: combinedCode,
+          ...this._cmdOpts(),
+        });
+        return true;
+      };
       try {
         await sendCommand('exec', combinedOpts);
       } catch (err) {
+        if (await recoverStalePageIdentity(err)) return;
         const advice = classifyBrowserError(err);
         // Only settle-retry on target navigation (SPA client-side redirects).
         // Extension/daemon errors are already retried by sendCommandRaw —
@@ -134,6 +151,7 @@ export class Page extends BasePage {
           await new Promise((r) => setTimeout(r, advice.delayMs));
           await sendCommand('exec', combinedOpts);
         } catch (retryErr) {
+          if (await recoverStalePageIdentity(retryErr)) return;
           if (classifyBrowserError(retryErr).kind !== 'target-navigation') throw retryErr;
         }
       }

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -29,8 +29,8 @@ function isUnsupportedNetworkCaptureError(err: unknown): boolean {
 // The extension throws "Page not found: <id> — stale page identity" when our cached
 // `_page` targetId no longer maps to a live tab — e.g. the user closed the automation
 // window, or a long-running script left the cache pointing at an evicted target.
-// Detect that signature so goto() can drop the stale id and let resolveTab fall back
-// to the session lease (or create a fresh tab).
+// Detect that signature so page-scoped operations can drop the stale id and let
+// resolveTab fall back to the session lease (or create a fresh tab).
 function isStalePageIdentityError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   return message.includes('stale page identity') || /^Page not found:\s*\S+\s*$/.test(message);
@@ -177,6 +177,15 @@ export class Page extends BasePage {
     try {
       return await sendCommand('exec', { code, ...this._cmdOpts() });
     } catch (err) {
+      // resolveTabId rejects a stale target before page code can run, so one retry is
+      // safe. Revisit the last known URL without the dead identity first; retrying the
+      // same exec immediately would only send the stale target again.
+      if (isStalePageIdentityError(err) && this._page !== undefined && this._lastUrl !== null) {
+        const lastUrl = this._lastUrl;
+        this._page = undefined;
+        await this.goto(lastUrl);
+        return sendCommand('exec', { code, ...this._cmdOpts() });
+      }
       const advice = classifyBrowserError(err);
       if (advice.kind !== 'target-navigation') throw err;
       await new Promise((resolve) => setTimeout(resolve, advice.delayMs));


### PR DESCRIPTION
## Summary

- recover a stale cached page identity when it fails immediately before `Page.evaluate()`
- rebind through the last known URL without the dead target before retrying once
- keep explicitly selected pages fail-closed when no trustworthy URL is available

## Root cause

The Browser Bridge can return a page identity from navigation that is evicted before the adapter's next evaluate call. The extension rejects that identity in `resolveTabId()` before any page code runs, but `Page.evaluate()` only retried target-navigation errors and kept resending the stale target. Adapters then surfaced a generic command execution failure even though the failure was recoverable at the page lifecycle boundary.

`Page.goto()` already had equivalent stale-identity recovery for later navigations. This change closes the missing evaluate path without adding adapter-specific retry logic.

## Impact

Cookie-backed adapters can recover when a page target becomes stale between navigation and their first API evaluation. Other evaluate failures remain unchanged, and caller-selected tabs without a known URL are never replaced implicitly.

## Validation

- `npm run typecheck`
- `npm run build`
- `npx vitest run --project unit src/browser` — 28 files, 427 tests passed
- focused stale-page replay — failed before the fix and passed twice after it

The full sandbox suite reached 6,546 passing tests; its remaining 40 failures were unrelated `EPERM` writes to the real user home, so they were not retried against live user configuration.
