### PR TITLE
docs: add opencli-plugin-texpage to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ opencli plugin uninstall my-tool
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | JS | Multi-platform trending aggregator |
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | JS | 稀土掘金 (Juejin) hot articles |
 | [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | JS | VK (VKontakte) wall, feed, and search |
+| [opencli-plugin-texpage](https://github.com/dull-bird/opencli-plugin-texpage) | JS | TeXPage online LaTeX editor: projects, file read/write, compile, PDF download |
 
 See [Plugins Guide](./docs/guide/plugins.md) for creating your own plugin.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -315,6 +315,7 @@ opencli plugin uninstall my-tool                            # 卸载
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | JS | 多平台热榜聚合 |
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | JS | 稀土掘金热门文章 |
 | [opencli-plugin-vk](https://github.com/flobo3/opencli-plugin-vk) | JS | VK (VKontakte) 动态、信息流和搜索 |
+| [opencli-plugin-texpage](https://github.com/dull-bird/opencli-plugin-texpage) | JS | TeXPage 在线 LaTeX 编辑器：项目管理、文件读写、编译、PDF 下载 |
 
 详见 [插件指南](./docs/zh/guide/plugins.md) 了解如何创建自己的插件。
 

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -209,6 +209,7 @@ On startup, if both `my-command.ts` and `my-command.js` exist, the `.js` version
 | [opencli-plugin-hot-digest](https://github.com/ByteYue/opencli-plugin-hot-digest) | TS | Multi-platform trending aggregator (zhihu, weibo, bilibili, v2ex, stackoverflow, reddit, linux-do) |
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | TS | 稀土掘金 (Juejin) hot articles, categories, and article feed |
 | [opencli-plugin-rubysec](https://github.com/nullptrKey/opencli-plugin-rubysec) | TS | RubySec advisory archive and advisory article reader |
+| [opencli-plugin-texpage](https://github.com/dull-bird/opencli-plugin-texpage) | TS | TeXPage online LaTeX editor: projects, file read/write, compile, PDF download |
 
 ## Troubleshooting
 

--- a/docs/zh/guide/plugins.md
+++ b/docs/zh/guide/plugins.md
@@ -177,6 +177,7 @@ cli({
 - `opencli-plugin-hot-digest`：多平台热点聚合（zhihu、weibo、bilibili、v2ex、stackoverflow、reddit、linux-do）
 - `opencli-plugin-juejin`：稀土掘金热榜、分类和文章流
 - `opencli-plugin-rubysec`：RubySec 漏洞归档与单篇漏洞文章读取
+- `opencli-plugin-texpage`：TeXPage 在线 LaTeX 编辑器：项目列表、文件读写、编译、PDF 下载
 
 ## 排查问题
 


### PR DESCRIPTION
Adds [opencli-plugin-texpage](https://github.com/dull-bird/opencli-plugin-texpage) to the community plugin lists (EN/ZH README + plugins guide).

**What it does**: adapter for [TeXPage](https://www.texpage.com) (Overleaf-like online LaTeX editor, no public API):
- `texpage list / files / read` — project & file browsing via the HTTP JSON API (cookie auth)
- `texpage write` — full-content file replace through the site's CRDT socket.io channel (splice ops), verified by read-back; uses a fresh random CRDT site id per write to avoid colliding with open editor sessions
- `texpage compile` — headless compile via the socket RPC bridge, parses the log for LaTeX errors/warnings
- `texpage download` — compiled PDF or source zip

All six commands verified end-to-end against a live account (two projects, error cases, concurrent-editor scenario). MIT licensed.