### PR TITLE
fix(weread-official): bump skill version to 1.0.4

### DIFF
--- a/clis/weread-official/utils.js
+++ b/clis/weread-official/utils.js
@@ -25,7 +25,7 @@ export const WEREAD_DOMAIN = 'weread.qq.com';
  * Skill version reported with every gateway request. Bump when official
  * `weread-skills.zip` ships a new SKILL.md `version:` line.
  */
-export const SKILL_VERSION = '1.0.3';
+export const SKILL_VERSION = '1.0.4';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 

--- a/docs/adapters/browser/weread-official.md
+++ b/docs/adapters/browser/weread-official.md
@@ -131,7 +131,7 @@ opencli weread-official book 3300045871 -f json
   export WEREAD_API_KEY=wrk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   ```
 
-- Skill version is pinned to `1.0.3` and reported with every request. When the gateway returns `upgrade_info`, pull the latest `weread-skills.zip` and bump `SKILL_VERSION` in `clis/weread-official/utils.js`.
+- Skill version is pinned to `1.0.4` and reported with every request. When the gateway returns `upgrade_info`, pull the latest `weread-skills.zip` and bump `SKILL_VERSION` in `clis/weread-official/utils.js`.
 
 ## Related
 


### PR DESCRIPTION
## Description

The WeRead official Agent Gateway now requires skill version `1.0.4`. Requests from the existing `1.0.3` client are rejected with `upgrade_info`, causing `weread-official search` to fail with `COMMAND_EXEC`.

This updates `SKILL_VERSION` to `1.0.4` and keeps the adapter documentation in sync. No command signatures, output columns, or error-handling behavior changed.

Closes #2213

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, the gateway rejected the adapter's `1.0.3` request with `upgrade_info`, surfaced by OpenCLI as `COMMAND_EXEC`.

After rebuilding with `1.0.4`, a live verification succeeded:

```console
$ node dist/src/main.js weread-official search "三体" --count 3 -f json
# Returned 3 matching books without COMMAND_EXEC.
```

Checks completed:

- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- Live `weread-official search` against the official Gateway
