### PR TITLE
fix(discovery): warn when yaml adapters are skipped instead of dropping them silently

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -29,6 +29,7 @@ export const PLUGINS_DIR = path.join(USER_OPENCLI_DIR, 'plugins');
 const PLUGIN_MODULE_PATTERN = /\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/;
 const YAML_ADAPTER_EXT_RE = /\.ya?ml$/i;
 const warnedYamlAdapterPaths = new Set<string>();
+const cliModuleLoadResults = new Map<string, Promise<boolean>>();
 
 function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
   if (!rawStrategy) return fallback;
@@ -309,7 +310,7 @@ async function hasUsableJsReplacement(
 
   const jsPath = path.resolve(dir, jsFile);
   if (manifestFiles) return manifestFiles.has(jsPath);
-  return isCliModule(jsPath);
+  return loadCliModule(jsPath);
 }
 
 async function isLikelyYamlAdapter(filePath: string, pluginMode: boolean): Promise<boolean> {
@@ -345,6 +346,35 @@ async function stableWarningKey(filePath: string): Promise<string> {
   } catch {
     return path.resolve(filePath);
   }
+}
+
+async function cliModuleCacheKey(filePath: string): Promise<string> {
+  const resolved = await stableWarningKey(filePath);
+  try {
+    const stat = await fs.promises.stat(filePath);
+    return `${resolved}:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return resolved;
+  }
+}
+
+async function loadCliModule(filePath: string): Promise<boolean> {
+  const key = await cliModuleCacheKey(filePath);
+  let result = cliModuleLoadResults.get(key);
+  if (!result) {
+    result = (async () => {
+      if (!(await isCliModule(filePath))) return false;
+      try {
+        await import(pathToFileURL(filePath).href);
+        return true;
+      } catch (err) {
+        log.warn(`Failed to load module ${filePath}: ${getErrorMessage(err)}`);
+        return false;
+      }
+    })();
+    cliModuleLoadResults.set(key, result);
+  }
+  return result;
 }
 
 async function isCliModule(filePath: string): Promise<boolean> {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -150,6 +150,22 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
 }
 
 /**
+ * v1.7.0 stopped loading `.yaml` adapters and promised a deprecation warning
+ * that was never wired up, so a directory of them drops out of `opencli list`
+ * with no diagnostic at all. Warn once per directory rather than once per file,
+ * because these directories routinely hold hundreds of adapters and `warn` is
+ * unconditional.
+ */
+function warnIgnoredYamlAdapters(dir: string, files: string[]): void {
+  const ignored = files.filter((file) => file.endsWith('.yaml') || file.endsWith('.yml'));
+  if (ignored.length === 0) return;
+  log.warn(
+    `Ignoring ${ignored.length} YAML adapter${ignored.length === 1 ? '' : 's'} in ${dir}: `
+    + '.yaml adapters are no longer loaded. Convert them to .js with the cli() API.',
+  );
+}
+
+/**
  * Fallback: traditional filesystem scan (used during development with tsx).
  */
 async function discoverClisFromFs(dir: string): Promise<void> {
@@ -162,6 +178,7 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       const site = entry.name;
       const siteDir = path.join(dir, site);
       const files = await fs.promises.readdir(siteDir);
+      warnIgnoredYamlAdapters(siteDir, files);
       await Promise.all(files.map(async (file) => {
         const filePath = path.join(siteDir, file);
         if (file.endsWith('.yaml') || file.endsWith('.yml')) {
@@ -203,6 +220,7 @@ export async function discoverPlugins(): Promise<void> {
  */
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
   const files = await fs.promises.readdir(dir);
+  warnIgnoredYamlAdapters(dir, files);
   const fileSet = new Set(files);
   await Promise.all(files.map(async (file) => {
     const filePath = path.join(dir, file);

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -150,22 +150,6 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
 }
 
 /**
- * v1.7.0 stopped loading `.yaml` adapters and promised a deprecation warning
- * that was never wired up, so a directory of them drops out of `opencli list`
- * with no diagnostic at all. Warn once per directory rather than once per file,
- * because these directories routinely hold hundreds of adapters and `warn` is
- * unconditional.
- */
-function warnIgnoredYamlAdapters(dir: string, files: string[]): void {
-  const ignored = files.filter((file) => file.endsWith('.yaml') || file.endsWith('.yml'));
-  if (ignored.length === 0) return;
-  log.warn(
-    `Ignoring ${ignored.length} YAML adapter${ignored.length === 1 ? '' : 's'} in ${dir}: `
-    + '.yaml adapters are no longer loaded. Convert them to .js with the cli() API.',
-  );
-}
-
-/**
  * Fallback: traditional filesystem scan (used during development with tsx).
  */
 async function discoverClisFromFs(dir: string): Promise<void> {
@@ -178,7 +162,7 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       const site = entry.name;
       const siteDir = path.join(dir, site);
       const files = await fs.promises.readdir(siteDir);
-      warnIgnoredYamlAdapters(siteDir, files);
+      warnIgnoredYamlAdapters(siteDir, new Set(files));
       await Promise.all(files.map(async (file) => {
         const filePath = path.join(siteDir, file);
         if (file.endsWith('.yaml') || file.endsWith('.yml')) {
@@ -220,8 +204,8 @@ export async function discoverPlugins(): Promise<void> {
  */
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
   const files = await fs.promises.readdir(dir);
-  warnIgnoredYamlAdapters(dir, files);
   const fileSet = new Set(files);
+  warnIgnoredYamlAdapters(dir, fileSet);
   await Promise.all(files.map(async (file) => {
     const filePath = path.join(dir, file);
     if (file.endsWith('.yaml') || file.endsWith('.yml')) {
@@ -246,6 +230,17 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
       );
     }
   }));
+}
+
+/**
+ * Warn once per directory for `.yaml` adapters that are skipped without a `.js`
+ * replacement beside them, so a directory of them cannot vanish silently.
+ */
+function warnIgnoredYamlAdapters(dir: string, files: Set<string>): void {
+  const ignored = [...files].filter((file) => (file.endsWith('.yaml') || file.endsWith('.yml'))
+    && !files.has(file.replace(/\.ya?ml$/, '.js')));
+  if (ignored.length === 0) return;
+  log.warn(`Ignoring ${ignored.length} YAML adapter${ignored.length === 1 ? '' : 's'} in ${dir} — .yaml adapters are no longer loaded. Convert them to .js with the cli() API.`);
 }
 
 async function isCliModule(filePath: string): Promise<boolean> {

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import yaml from 'js-yaml';
 import { type InternalCliCommand, Strategy, registerCommand } from './registry.js';
 import { getErrorMessage } from './errors.js';
 import { log } from './logger.js';
@@ -26,6 +27,8 @@ export const USER_CLIS_DIR = path.join(USER_OPENCLI_DIR, 'clis');
 export const PLUGINS_DIR = path.join(USER_OPENCLI_DIR, 'plugins');
 /** Matches files that register commands via cli() or lifecycle hooks */
 const PLUGIN_MODULE_PATTERN = /\b(?:cli|registerSiteAuthCommands|onStartup|onBeforeExecute|onAfterExecute)\s*\(/;
+const YAML_ADAPTER_EXT_RE = /\.ya?ml$/i;
+const warnedYamlAdapterPaths = new Set<string>();
 
 function parseStrategy(rawStrategy: string | undefined, fallback: Strategy = Strategy.COOKIE): Strategy {
   if (!rawStrategy) return fallback;
@@ -99,7 +102,10 @@ export async function discoverClis(...dirs: string[]): Promise<void> {
     try {
       await fs.promises.access(manifestPath);
       const loaded = await loadFromManifest(manifestPath, dir);
-      if (loaded) continue; // Skip filesystem scan only when manifest is usable
+      if (loaded) {
+        await warnIgnoredYamlAdaptersInCliRoot(dir, loaded.manifestFiles);
+        continue; // Skip filesystem scan only when manifest is usable
+      }
     } catch {
       // Fall through to filesystem scan
     }
@@ -111,13 +117,16 @@ export async function discoverClis(...dirs: string[]): Promise<void> {
  * Fast-path: register commands from pre-compiled manifest.
  * TS modules are deferred — loaded lazily on first execution.
  */
-async function loadFromManifest(manifestPath: string, clisDir: string): Promise<boolean> {
+async function loadFromManifest(manifestPath: string, clisDir: string): Promise<{ manifestFiles: Set<string> } | null> {
   try {
     const raw = await fs.promises.readFile(manifestPath, 'utf-8');
     const manifest = JSON.parse(raw) as ManifestEntry[];
+    const manifestFiles = new Set<string>();
     for (const entry of manifest) {
       if (!entry.modulePath) continue;
       const modulePath = path.resolve(clisDir, entry.modulePath);
+      manifestFiles.add(modulePath);
+      if (entry.sourceFile) manifestFiles.add(path.resolve(clisDir, entry.sourceFile));
       const cmd: InternalCliCommand = {
         site: entry.site,
         name: entry.name,
@@ -142,10 +151,10 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
       // normalizeCommand inside registerCommand handles strategy → browser/navigateBefore
       registerCommand(cmd);
     }
-    return true;
+    return { manifestFiles };
   } catch (err) {
     log.warn(`Failed to load manifest ${manifestPath}: ${getErrorMessage(err)}`);
-    return false;
+    return null;
   }
 }
 
@@ -155,6 +164,7 @@ async function loadFromManifest(manifestPath: string, clisDir: string): Promise<
 async function discoverClisFromFs(dir: string): Promise<void> {
   try { await fs.promises.access(dir); } catch { return; }
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  await warnIgnoredYamlAdaptersInCliRoot(dir);
   
   const sitePromises = entries
     .filter(entry => entry.isDirectory())
@@ -162,10 +172,9 @@ async function discoverClisFromFs(dir: string): Promise<void> {
       const site = entry.name;
       const siteDir = path.join(dir, site);
       const files = await fs.promises.readdir(siteDir);
-      warnIgnoredYamlAdapters(siteDir, new Set(files));
       await Promise.all(files.map(async (file) => {
         const filePath = path.join(siteDir, file);
-        if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+        if (isYamlAdapterFile(file)) {
           return;
         }
         if (file.endsWith('.ts') && !file.endsWith('.d.ts') && !file.endsWith('.test.ts')) {
@@ -190,10 +199,19 @@ async function discoverClisFromFs(dir: string): Promise<void> {
  */
 export async function discoverPlugins(): Promise<void> {
   try { await fs.promises.access(PLUGINS_DIR); } catch { return; }
-  const entries = await fs.promises.readdir(PLUGINS_DIR, { withFileTypes: true });
-  await Promise.all(entries.map(async (entry) => {
+  const entries = (await fs.promises.readdir(PLUGINS_DIR, { withFileTypes: true }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const discoverable: Array<{ entry: fs.Dirent; pluginDir: string }> = [];
+  for (const entry of entries) {
     const pluginDir = path.join(PLUGINS_DIR, entry.name);
-    if (!(await isDiscoverablePluginDir(entry, pluginDir))) return;
+    if (await isDiscoverablePluginDir(entry, pluginDir)) {
+      discoverable.push({ entry, pluginDir });
+    }
+  }
+  for (const { entry, pluginDir } of discoverable) {
+    await warnIgnoredYamlAdaptersInFlatDir(pluginDir, { owner: `plugin ${entry.name}`, pluginMode: true });
+  }
+  await Promise.all(discoverable.map(async ({ entry, pluginDir }) => {
     await discoverPluginDir(pluginDir, entry.name);
   }));
 }
@@ -205,10 +223,9 @@ export async function discoverPlugins(): Promise<void> {
 async function discoverPluginDir(dir: string, site: string): Promise<void> {
   const files = await fs.promises.readdir(dir);
   const fileSet = new Set(files);
-  warnIgnoredYamlAdapters(dir, fileSet);
   await Promise.all(files.map(async (file) => {
     const filePath = path.join(dir, file);
-    if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+    if (isYamlAdapterFile(file)) {
       return;
     }
     if (file.endsWith('.js') && !file.endsWith('.d.js')) {
@@ -232,15 +249,102 @@ async function discoverPluginDir(dir: string, site: string): Promise<void> {
   }));
 }
 
-/**
- * Warn once per directory for `.yaml` adapters that are skipped without a `.js`
- * replacement beside them, so a directory of them cannot vanish silently.
- */
-function warnIgnoredYamlAdapters(dir: string, files: Set<string>): void {
-  const ignored = [...files].filter((file) => (file.endsWith('.yaml') || file.endsWith('.yml'))
-    && !files.has(file.replace(/\.ya?ml$/, '.js')));
+async function warnIgnoredYamlAdaptersInCliRoot(dir: string, manifestFiles?: Set<string>): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries.filter((candidate) => candidate.isDirectory()).sort((a, b) => a.name.localeCompare(b.name))) {
+    const siteDir = path.join(dir, entry.name);
+    await warnIgnoredYamlAdaptersInFlatDir(siteDir, { owner: `site ${entry.name}`, manifestFiles });
+  }
+}
+
+async function warnIgnoredYamlAdaptersInFlatDir(
+  dir: string,
+  options: { owner: string; manifestFiles?: Set<string>; pluginMode?: boolean },
+): Promise<void> {
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(dir);
+  } catch (err) {
+    log.warn(`Could not inspect YAML adapters for ${options.owner}: ${getErrorMessage(err)}`);
+    return;
+  }
+
+  const fileSet = new Set(files);
+  const ignored: string[] = [];
+  for (const file of files.filter(isYamlAdapterFile).sort()) {
+    const filePath = path.join(dir, file);
+    if (!(await isLikelyYamlAdapter(filePath, options.pluginMode === true))) continue;
+    if (await hasUsableJsReplacement(dir, file, fileSet, options.manifestFiles)) continue;
+    const warningKey = await stableWarningKey(filePath);
+    if (warnedYamlAdapterPaths.has(warningKey)) continue;
+    warnedYamlAdapterPaths.add(warningKey);
+    ignored.push(file);
+  }
+
   if (ignored.length === 0) return;
-  log.warn(`Ignoring ${ignored.length} YAML adapter${ignored.length === 1 ? '' : 's'} in ${dir} — .yaml adapters are no longer loaded. Convert them to .js with the cli() API.`);
+  log.warn(
+    `Ignoring ${ignored.length} YAML adapter${ignored.length === 1 ? '' : 's'} for ${options.owner}: `
+    + `${ignored.join(', ')}. .yaml/.yml adapters are no longer loaded; convert them to .js with the cli() API.`,
+  );
+}
+
+function isYamlAdapterFile(file: string): boolean {
+  return YAML_ADAPTER_EXT_RE.test(file);
+}
+
+async function hasUsableJsReplacement(
+  dir: string,
+  yamlFile: string,
+  fileSet: Set<string>,
+  manifestFiles?: Set<string>,
+): Promise<boolean> {
+  const jsFile = yamlFile.replace(YAML_ADAPTER_EXT_RE, '.js');
+  if (!fileSet.has(jsFile)) return false;
+
+  const jsPath = path.resolve(dir, jsFile);
+  if (manifestFiles) return manifestFiles.has(jsPath);
+  return isCliModule(jsPath);
+}
+
+async function isLikelyYamlAdapter(filePath: string, pluginMode: boolean): Promise<boolean> {
+  let source: string;
+  try {
+    source = await fs.promises.readFile(filePath, 'utf-8');
+  } catch {
+    return !pluginMode;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(source);
+  } catch {
+    return !pluginMode;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.name !== 'string' || !record.name.trim()) return false;
+
+  const adapterKeys = [
+    'site', 'description', 'access', 'strategy', 'browser', 'domain',
+    'args', 'columns', 'pipeline', 'url', 'request', 'steps', 'extract',
+    'output', 'func', 'method', 'headers',
+  ];
+  return adapterKeys.some((key) => key in record);
+}
+
+async function stableWarningKey(filePath: string): Promise<string> {
+  try {
+    return await fs.promises.realpath(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
 }
 
 async function isCliModule(filePath: string): Promise<boolean> {

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -135,6 +135,28 @@ cli({
     }
   });
 
+  it('warns when the same-basename js replacement is not loadable', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-broken-js-'));
+    const siteDir = path.join(tempRoot, 'broken-replacement-site');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'broken.yaml'), 'name: broken\ndescription: broken command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'broken.js'), `
+import { cli } from '${pathToFileURL(path.join(process.cwd(), 'src', 'registry.ts')).href}';
+cli({
+`);
+
+      const { writes } = await captureStderr(() => discoverClis(tempRoot));
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('broken.yaml');
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('warns during valid-manifest fast path when yaml adapters are skipped', async () => {
     const tempBuildRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-manifest-'));
     const distDir = path.join(tempBuildRoot, 'dist');

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -76,6 +76,32 @@ cli({
     }
   });
 
+  it('stays silent for a yaml adapter that already has a .js replacement beside it', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-migrated-'));
+    const siteDir = path.join(tempRoot, 'migrated-site');
+    const writes: string[] = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'done.yaml'), 'name: done\n');
+      await fs.promises.writeFile(path.join(siteDir, 'done.js'), 'export const migrated = true;\n');
+      await fs.promises.writeFile(path.join(siteDir, 'pending.yml'), 'name: pending\n');
+
+      await discoverClis(tempRoot);
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('Ignoring 1 YAML adapter ');
+    } finally {
+      stderr.mockRestore();
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('stays silent for a site directory with no yaml adapters', async () => {
     const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-none-'));
     const siteDir = path.join(tempRoot, 'js-only-site');
@@ -250,8 +276,13 @@ strategy: public
 browser: false
 `);
     await fs.promises.symlink(symlinkTargetDir, symlinkPluginDir, dirSymlinkType);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    await discoverPlugins();
+    try {
+      await discoverPlugins();
+    } finally {
+      stderr.mockRestore();
+    }
 
     const cmd = getRegistry().get('__test-plugin-symlink__/hello');
     expect(cmd).toBeUndefined();

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -49,6 +49,55 @@ cli({
     }
   });
 
+  it('warns once per site directory that holds skipped yaml adapters', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-skip-'));
+    const siteDir = path.join(tempRoot, 'yaml-site');
+    const writes: string[] = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'one.yaml'), 'name: one\n');
+      await fs.promises.writeFile(path.join(siteDir, 'two.yml'), 'name: two\n');
+
+      await discoverClis(tempRoot);
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('Ignoring 2 YAML adapters');
+      expect(warnings[0]).toContain(siteDir);
+      expect(warnings[0]).toContain('cli() API');
+    } finally {
+      stderr.mockRestore();
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('stays silent for a site directory with no yaml adapters', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-none-'));
+    const siteDir = path.join(tempRoot, 'js-only-site');
+    const writes: string[] = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'notes.md'), '# notes\n');
+
+      await discoverClis(tempRoot);
+
+      expect(writes.filter((line) => line.includes('YAML adapter'))).toEqual([]);
+    } finally {
+      stderr.mockRestore();
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to filesystem discovery when the manifest is invalid', async () => {
     const tempBuildRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-manifest-fallback-'));
     const distDir = path.join(tempBuildRoot, 'dist');
@@ -166,12 +215,23 @@ description: Test plugin greeting
 strategy: public
 browser: false
 `);
+    const writes: string[] = [];
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
 
-    await discoverPlugins();
+    try {
+      await discoverPlugins();
+    } finally {
+      stderr.mockRestore();
+    }
 
     const registry = getRegistry();
     const cmd = registry.get('__test-plugin__/greeting');
     expect(cmd).toBeUndefined();
+    const warnings = writes.filter((line) => line.includes('YAML adapter') && line.includes(testPluginDir));
+    expect(warnings).toHaveLength(1);
   });
 
   it('handles non-existent plugins directory gracefully', async () => {

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -8,6 +8,19 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+async function captureStderr<T>(fn: () => Promise<T>): Promise<{ result: T; writes: string[] }> {
+  const writes: string[] = [];
+  const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  try {
+    return { result: await fn(), writes };
+  } finally {
+    stderr.mockRestore();
+  }
+}
+
 describe('discoverClis', () => {
   it('handles non-existent directories gracefully', async () => {
     // Should not throw for missing directories
@@ -52,26 +65,21 @@ cli({
   it('warns once per site directory that holds skipped yaml adapters', async () => {
     const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-skip-'));
     const siteDir = path.join(tempRoot, 'yaml-site');
-    const writes: string[] = [];
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-      writes.push(String(chunk));
-      return true;
-    });
 
     try {
       await fs.promises.mkdir(siteDir, { recursive: true });
-      await fs.promises.writeFile(path.join(siteDir, 'one.yaml'), 'name: one\n');
-      await fs.promises.writeFile(path.join(siteDir, 'two.yml'), 'name: two\n');
+      await fs.promises.writeFile(path.join(siteDir, 'one.yaml'), 'name: one\ndescription: one command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'two.yml'), 'name: two\ndescription: two command\nbrowser: false\n');
 
-      await discoverClis(tempRoot);
+      const { writes } = await captureStderr(() => discoverClis(tempRoot));
 
       const warnings = writes.filter((line) => line.includes('YAML adapter'));
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain('Ignoring 2 YAML adapters');
-      expect(warnings[0]).toContain(siteDir);
+      expect(warnings[0]).toContain('site yaml-site');
+      expect(warnings[0]).toContain('one.yaml, two.yml');
       expect(warnings[0]).toContain('cli() API');
     } finally {
-      stderr.mockRestore();
       await fs.promises.rm(tempRoot, { recursive: true, force: true });
     }
   });
@@ -79,25 +87,145 @@ cli({
   it('stays silent for a yaml adapter that already has a .js replacement beside it', async () => {
     const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-migrated-'));
     const siteDir = path.join(tempRoot, 'migrated-site');
-    const writes: string[] = [];
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-      writes.push(String(chunk));
-      return true;
-    });
 
     try {
       await fs.promises.mkdir(siteDir, { recursive: true });
-      await fs.promises.writeFile(path.join(siteDir, 'done.yaml'), 'name: done\n');
-      await fs.promises.writeFile(path.join(siteDir, 'done.js'), 'export const migrated = true;\n');
-      await fs.promises.writeFile(path.join(siteDir, 'pending.yml'), 'name: pending\n');
+      await fs.promises.writeFile(path.join(siteDir, 'done.yaml'), 'name: done\ndescription: migrated command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'done.js'), `
+import { cli, Strategy } from '${pathToFileURL(path.join(process.cwd(), 'src', 'registry.ts')).href}';
+cli({
+  site: 'migrated-site',
+  name: 'done', access: 'read',
+  description: 'migrated command',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  func: async () => [{ ok: true }],
+});
+`);
+      await fs.promises.writeFile(path.join(siteDir, 'pending.yml'), 'name: pending\ndescription: pending command\nbrowser: false\n');
 
-      await discoverClis(tempRoot);
+      const { writes } = await captureStderr(() => discoverClis(tempRoot));
 
       const warnings = writes.filter((line) => line.includes('YAML adapter'));
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain('Ignoring 1 YAML adapter ');
+      expect(warnings[0]).toContain('pending.yml');
+      expect(warnings[0]).not.toContain('done.yaml');
     } finally {
-      stderr.mockRestore();
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when the same-basename js replacement is not a CLI module', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-bad-js-'));
+    const siteDir = path.join(tempRoot, 'bad-replacement-site');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'ghost.yaml'), 'name: ghost\ndescription: ghost command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'ghost.js'), 'export const helper = true;\n');
+
+      const { writes } = await captureStderr(() => discoverClis(tempRoot));
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('ghost.yaml');
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('warns during valid-manifest fast path when yaml adapters are skipped', async () => {
+    const tempBuildRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-manifest-'));
+    const distDir = path.join(tempBuildRoot, 'dist');
+    const siteDir = path.join(distDir, 'manifest-site');
+    const manifestPath = path.join(tempBuildRoot, 'cli-manifest.json');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(manifestPath, '[]\n');
+      await fs.promises.writeFile(path.join(siteDir, 'lost.yaml'), 'name: lost\ndescription: lost command\nbrowser: false\n');
+
+      const { writes } = await captureStderr(() => discoverClis(distDir));
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('site manifest-site');
+      expect(warnings[0]).toContain('lost.yaml');
+    } finally {
+      await fs.promises.rm(tempBuildRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('trusts a same-basename js replacement only when it is present in the valid manifest', async () => {
+    const tempBuildRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-manifest-replacement-'));
+    const distDir = path.join(tempBuildRoot, 'dist');
+    const siteDir = path.join(distDir, 'manifest-replacement-site');
+    const manifestPath = path.join(tempBuildRoot, 'cli-manifest.json');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'done.yaml'), 'name: done\ndescription: done command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'done.js'), 'export const helper = true;\n');
+      await fs.promises.writeFile(path.join(siteDir, 'ghost.yaml'), 'name: ghost\ndescription: ghost command\nbrowser: false\n');
+      await fs.promises.writeFile(path.join(siteDir, 'ghost.js'), 'export const helper = true;\n');
+      await fs.promises.writeFile(manifestPath, `${JSON.stringify([{
+        site: 'manifest-replacement-site',
+        name: 'done',
+        access: 'read',
+        browser: false,
+        modulePath: 'manifest-replacement-site/done.js',
+        sourceFile: 'manifest-replacement-site/done.js',
+      }])}\n`);
+
+      const { writes } = await captureStderr(() => discoverClis(distDir));
+
+      const warnings = writes.filter((line) => line.includes('YAML adapter'));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('ghost.yaml');
+      expect(warnings[0]).not.toContain('done.yaml');
+    } finally {
+      await fs.promises.rm(tempBuildRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('does not repeat the same yaml warning across repeated discovery calls', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-repeat-'));
+    const siteDir = path.join(tempRoot, 'repeat-site');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'once.yaml'), 'name: once\ndescription: once command\nbrowser: false\n');
+
+      const { writes } = await captureStderr(async () => {
+        await discoverClis(tempRoot);
+        await discoverClis(tempRoot);
+      });
+
+      expect(writes.filter((line) => line.includes('YAML adapter'))).toHaveLength(1);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('still warns for a newly added skipped yaml adapter after an earlier discovery call', async () => {
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-repeat-new-'));
+    const siteDir = path.join(tempRoot, 'repeat-new-site');
+
+    try {
+      await fs.promises.mkdir(siteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(siteDir, 'first.yaml'), 'name: first\ndescription: first command\nbrowser: false\n');
+
+      const first = await captureStderr(() => discoverClis(tempRoot));
+      await fs.promises.writeFile(path.join(siteDir, 'second.yml'), 'name: second\ndescription: second command\nbrowser: false\n');
+      const second = await captureStderr(() => discoverClis(tempRoot));
+
+      expect(first.writes.filter((line) => line.includes('YAML adapter'))).toHaveLength(1);
+      const secondWarnings = second.writes.filter((line) => line.includes('YAML adapter'));
+      expect(secondWarnings).toHaveLength(1);
+      expect(secondWarnings[0]).toContain('second.yml');
+      expect(secondWarnings[0]).not.toContain('first.yaml');
+    } finally {
       await fs.promises.rm(tempRoot, { recursive: true, force: true });
     }
   });
@@ -105,21 +233,15 @@ cli({
   it('stays silent for a site directory with no yaml adapters', async () => {
     const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-yaml-none-'));
     const siteDir = path.join(tempRoot, 'js-only-site');
-    const writes: string[] = [];
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-      writes.push(String(chunk));
-      return true;
-    });
 
     try {
       await fs.promises.mkdir(siteDir, { recursive: true });
       await fs.promises.writeFile(path.join(siteDir, 'notes.md'), '# notes\n');
 
-      await discoverClis(tempRoot);
+      const { writes } = await captureStderr(() => discoverClis(tempRoot));
 
       expect(writes.filter((line) => line.includes('YAML adapter'))).toEqual([]);
     } finally {
-      stderr.mockRestore();
       await fs.promises.rm(tempRoot, { recursive: true, force: true });
     }
   });
@@ -241,23 +363,25 @@ description: Test plugin greeting
 strategy: public
 browser: false
 `);
-    const writes: string[] = [];
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-      writes.push(String(chunk));
-      return true;
-    });
+    await fs.promises.writeFile(path.join(testPluginDir, 'config.yaml'), `
+name: config
+version: 1
+`);
+    await fs.promises.writeFile(path.join(testPluginDir, 'data.yml'), `
+- just
+- data
+`);
 
-    try {
-      await discoverPlugins();
-    } finally {
-      stderr.mockRestore();
-    }
+    const { writes } = await captureStderr(() => discoverPlugins());
 
     const registry = getRegistry();
     const cmd = registry.get('__test-plugin__/greeting');
     expect(cmd).toBeUndefined();
-    const warnings = writes.filter((line) => line.includes('YAML adapter') && line.includes(testPluginDir));
+    const warnings = writes.filter((line) => line.includes('YAML adapter') && line.includes('plugin __test-plugin__'));
     expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('greeting.yaml');
+    expect(warnings[0]).not.toContain('config.yaml');
+    expect(warnings[0]).not.toContain('data.yml');
   });
 
   it('handles non-existent plugins directory gracefully', async () => {


### PR DESCRIPTION
## Description

The v1.7.0 notes say "A deprecation warning is emitted if `.yaml` files are detected." It never was. `src/discovery.ts` just returns on `.yaml` / `.yml`, so YAML adapters disappear from `opencli list` with no message at all. The `.ts` breaking change from the same release does warn, on the next line.

This adds that warning, in both scan paths. Once per directory with a count, not per file, since `log.warn` can't be silenced and one site can hold 100+ files. A `.yaml` with a matching `.js` beside it is skipped, so a migrated directory stays quiet.

Nothing about loading changes.

Related issue: #1519. Not closing it, since that issue asks for migration tooling and its author has a codemod to offer.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Two YAML adapters in `~/.opencli/clis/yamlprobe/`.

Before:

```
$ opencli list 2>&1 | grep -ci "yaml adapter"
0
$ opencli yamlprobe hello
error: unknown command 'yamlprobe'
```

After:

```
$ opencli list
⚠  Ignoring 2 YAML adapters in /Users/me/.opencli/clis/yamlprobe — .yaml adapters are no longer loaded. Convert them to .js with the cli() API.
```

Half-migrated directory (`done.yaml` + `done.js`, plus an unconverted `pending.yml`) counts only the one that is lost:

```
$ opencli list
⚠  Ignoring 1 YAML adapter in /Users/me/.opencli/clis/yamlprobe — ...
$ opencli yamlprobe done
- ok: true
```

`src/engine.test.ts` 20 / 20; three of the cases fail if `src/discovery.ts` is reverted. Typecheck, both lint gates and doc-coverage pass. `cli-manifest.json` untouched.
