### PR TITLE
fix(chatgpt): stop reporting an unfinished image as saved

### DIFF
--- a/clis/chatgpt/image.js
+++ b/clis/chatgpt/image.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { saveBase64ToFile } from '@jackwener/opencli/utils';
-import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import { clearChatGPTDraft, getChatGPTVisibleImageUrls, navigateToProject, normalizeBooleanFlag, prepareChatGPTImagePaths, sendChatGPTMessage, unwrapEvaluateResult, waitForChatGPTImages, getChatGPTImageAssets, uploadChatGPTImages } from './utils.js';
 
 const CHATGPT_DOMAIN = 'chatgpt.com';
@@ -134,11 +134,14 @@ export const imageCommand = cli({
             convUrl = await currentChatGPTLink(page);
         }
 
-        const urls = await waitForChatGPTImages(page, beforeUrls, timeout, convUrl);
+        const { urls, settled } = await waitForChatGPTImages(page, beforeUrls, timeout, convUrl);
         const link = convUrl;
 
         if (!urls.length) {
             throw new EmptyResultError('chatgpt image', `No generated images were detected before timeout. Open ${link} and verify whether ChatGPT finished generating the image.`);
+        }
+        if (!settled) {
+            throw new TimeoutError('chatgpt image', timeout, `The image was still rendering when the timeout hit. Open ${link} to see it, or re-run with a higher --timeout.`);
         }
 
         if (skipDownload) {

--- a/clis/chatgpt/image.test.js
+++ b/clis/chatgpt/image.test.js
@@ -59,7 +59,7 @@ beforeEach(() => {
     mocks.sendChatGPTMessage.mockReset().mockResolvedValue(true);
     mocks.uploadChatGPTImages.mockReset().mockResolvedValue({ ok: true });
     mocks.navigateToProject.mockReset().mockResolvedValue(undefined);
-    mocks.waitForChatGPTImages.mockReset().mockResolvedValue(['https://images.example/generated.png']);
+    mocks.waitForChatGPTImages.mockReset().mockResolvedValue({ urls: ['https://images.example/generated.png'], settled: true });
     mocks.getChatGPTImageAssets.mockReset().mockResolvedValue([{
         url: 'https://images.example/generated.png',
         dataUrl: 'data:image/png;base64,aGVsbG8=',
@@ -177,7 +177,7 @@ describe('chatgpt image failure contracts', () => {
     });
 
     it('fails fast when image generation detection finds no new images', async () => {
-        mocks.waitForChatGPTImages.mockResolvedValue([]);
+        mocks.waitForChatGPTImages.mockResolvedValue({ urls: [], settled: false });
 
         await expect(imageCommand.func(createPage(), {
             prompt: 'cat',
@@ -189,6 +189,21 @@ describe('chatgpt image failure contracts', () => {
             message: expect.stringContaining('chatgpt image returned no data'),
             hint: expect.stringContaining('No generated images were detected'),
         });
+    });
+
+    it('does not report an unfinished image as saved', async () => {
+        mocks.waitForChatGPTImages.mockResolvedValue({ urls: ['https://images.example/partial.png'], settled: false });
+
+        await expect(imageCommand.func(createPage(), {
+            prompt: 'cat',
+            op: '',
+            sd: false,
+            timeout: 240,
+        })).rejects.toMatchObject({
+            code: 'TIMEOUT',
+            hint: expect.stringContaining('still rendering'),
+        });
+        expect(mocks.getChatGPTImageAssets).not.toHaveBeenCalled();
     });
 
     it('fails fast when generated image assets cannot be exported', async () => {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2645,7 +2645,9 @@ export async function getChatGPTVisibleImageUrls(page) {
 }
 
 /**
- * Wait for new images to appear after sending a prompt.
+ * Wait for new images to appear after sending a prompt. Returns `settled: false`
+ * when the polls ran out before the image list stopped changing, so a still
+ * rendering image is not mistaken for a finished one.
  */
 export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, convUrl) {
     const beforeSet = new Set(beforeUrls);
@@ -2689,11 +2691,13 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
             stableCount = 1;
         }
 
-        if (stableCount >= 2 || i === maxPolls - 1) {
-            return lastUrls;
+        if (stableCount >= 2) {
+            return { urls: lastUrls, settled: true };
         }
     }
-    return lastUrls;
+    // Polls ran out. `lastUrls` may hold an image that is still rendering, so the
+    // caller must not present it as a finished result.
+    return { urls: lastUrls, settled: false };
 }
 
 /**

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -64,7 +64,7 @@ describe('chatgpt image wait contract', () => {
             generating: [true, true, true, true, true, true],
         });
 
-        await expect(waitForChatGPTImages(page, [], 18, convUrl)).resolves.toEqual([]);
+        await expect(waitForChatGPTImages(page, [], 18, convUrl)).resolves.toEqual({ urls: [], settled: false });
         expect(page.goto).not.toHaveBeenCalled();
     });
 
@@ -76,10 +76,46 @@ describe('chatgpt image wait contract', () => {
             imageUrls: [['https://cdn.openai.com/generated/demo.png']],
         });
 
-        await expect(waitForChatGPTImages(page, [], 3, convUrl)).resolves.toEqual([
-            'https://cdn.openai.com/generated/demo.png',
-        ]);
+        await expect(waitForChatGPTImages(page, [], 3, convUrl)).resolves.toEqual({
+            urls: ['https://cdn.openai.com/generated/demo.png'],
+            settled: false,
+        });
         expect(page.goto).toHaveBeenCalledWith(convUrl);
+    });
+
+    it('settles once the image list repeats', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false, false, false],
+            imageUrls: [
+                ['https://cdn.openai.com/generated/final.png'],
+                ['https://cdn.openai.com/generated/final.png'],
+            ],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 30, convUrl)).resolves.toEqual({
+            urls: ['https://cdn.openai.com/generated/final.png'],
+            settled: true,
+        });
+    });
+
+    it('reports settled:false when the image list is still changing at timeout', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false, false, false],
+            imageUrls: [
+                ['https://cdn.openai.com/generated/partial-1.png'],
+                ['https://cdn.openai.com/generated/partial-2.png'],
+                ['https://cdn.openai.com/generated/partial-3.png'],
+            ],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).resolves.toEqual({
+            urls: ['https://cdn.openai.com/generated/partial-3.png'],
+            settled: false,
+        });
     });
 
     it('treats query and hash variants as the same conversation', () => {


### PR DESCRIPTION
## Description

`waitForChatGPTImages` returned its collected URLs on the final poll whether or not the image list had stopped changing (`stableCount >= 2 || i === maxPolls - 1`). `image.js` only errored when that list was empty, so a run that timed out mid-generation still downloaded whatever was on screen and printed `✅ saved`.

The wait now reports whether it settled. Stable list, `settled: true`, unchanged behaviour. Polls exhausted while the list was still changing, `settled: false`, and the command raises `TimeoutError` instead of saving. Empty list still raises `EmptyResultError` as before.

`TimeoutError` exits TEMPFAIL, which tells a caller to retry with a higher `--timeout` rather than treating the run as done.

Related issue: Closes #1898.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Normal run is unchanged, and the file is a real 1 MB PNG:

```
$ opencli chatgpt image "a single red cube on a plain white background" --op ./out
status: ✅ saved
file: 📁 ./out/chatgpt_1785767056743.png
link: 🔗 https://chatgpt.com/c/6a70a469-355c-83e9-926c-50c0dc384b9b
```

A run that times out before any image appears is unchanged too:

```
$ opencli chatgpt image "a red cube" --timeout 12
error:
  code: EMPTY_RESULT
  message: chatgpt image returned no data
```

One note on verification: I could not reproduce the partial-render window live on my account, since the image only enters the DOM once it is essentially complete. The path is covered by unit tests instead, and `does not report an unfinished image as saved` in `clis/chatgpt/image.test.js` fails on `main`.

`clis/chatgpt` 174 / 174. Typecheck, both lint gates and doc-coverage pass. `cli-manifest.json` untouched.
