### PR TITLE
fix(codex): resolve the ChatGPT executable inside Codex.app

### DIFF
--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -8,8 +8,10 @@ Control the **OpenAI Codex Desktop App** headless or headfully via Chrome DevToo
 2. Launch it via the terminal and expose the remote debugging port:
    ```bash
    # macOS
-   /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9238
+   /Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238
    ```
+
+   > Depending on your installation, the executable might be named differently, e.g., `Codex` instead of `ChatGPT`.
 
 ## Setup
 

--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -8,10 +8,10 @@ Control the **OpenAI Codex Desktop App** headless or headfully via Chrome DevToo
 2. Launch it via the terminal and expose the remote debugging port:
    ```bash
    # macOS
-   /Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238
+   /Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238 --remote-allow-origins=*
    ```
 
-   > Depending on your installation, the executable might be named differently, e.g., `Codex` instead of `ChatGPT`.
+   > Depending on your installation, the executable might be named differently, e.g., `Codex` instead of `ChatGPT`. OpenCLI's auto-launch path tries `ChatGPT` first, then `Codex`.
 
 ## Setup
 

--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -13,6 +13,7 @@ describe('electron-apps registry', () => {
     const app = getElectronApp('codex');
     expect(app).toBeDefined();
     expect(app!.port).toBe(9238);
+    expect(app!.executableNames).toEqual(['ChatGPT', 'Codex']);
   });
 
   it('keeps builtin Electron app CDP ports unique and off the browser-bridge port', () => {

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -30,9 +30,7 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
   codex:         {
     port: 9238,
     processName: 'Codex',
-    // Codex ships from the ChatGPT desktop bundle, so the executable inside
-    // Codex.app is named ChatGPT on current builds.
-    executableNames: ['Codex', 'ChatGPT'],
+    executableNames: ['ChatGPT', 'Codex'],
     bundleId: 'com.openai.codex',
     displayName: 'Codex',
   },

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -27,7 +27,15 @@ export interface ElectronAppEntry {
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
   cursor:        { port: 9226, processName: 'Cursor',      bundleId: 'com.todesktop.runtime.Cursor',   displayName: 'Cursor' },
-  codex:         { port: 9238, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
+  codex:         {
+    port: 9238,
+    processName: 'Codex',
+    // Codex ships from the ChatGPT desktop bundle, so the executable inside
+    // Codex.app is named ChatGPT on current builds.
+    executableNames: ['Codex', 'ChatGPT'],
+    bundleId: 'com.openai.codex',
+    displayName: 'Codex',
+  },
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
   'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ElectronAppEntry } from './electron-apps.js';
+import { builtinApps, type ElectronAppEntry } from './electron-apps.js';
 import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
 
 interface MockChildProcess {
@@ -131,6 +131,13 @@ describe('resolveExecutableCandidates', () => {
     expect(resolveExecutableCandidates('/Applications/Antigravity.app', app)).toEqual([
       '/Applications/Antigravity.app/Contents/MacOS/Electron',
       '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
+    ]);
+  });
+
+  it('resolves the Codex bundle to both the legacy and current executable names', () => {
+    expect(resolveExecutableCandidates('/Applications/Codex.app', builtinApps.codex)).toEqual([
+      '/Applications/Codex.app/Contents/MacOS/Codex',
+      '/Applications/Codex.app/Contents/MacOS/ChatGPT',
     ]);
   });
 });

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { builtinApps, type ElectronAppEntry } from './electron-apps.js';
+import type { ElectronAppEntry } from './electron-apps.js';
 import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
 
 interface MockChildProcess {
@@ -131,13 +131,6 @@ describe('resolveExecutableCandidates', () => {
     expect(resolveExecutableCandidates('/Applications/Antigravity.app', app)).toEqual([
       '/Applications/Antigravity.app/Contents/MacOS/Electron',
       '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
-    ]);
-  });
-
-  it('resolves the Codex bundle to both the legacy and current executable names', () => {
-    expect(resolveExecutableCandidates('/Applications/Codex.app', builtinApps.codex)).toEqual([
-      '/Applications/Codex.app/Contents/MacOS/Codex',
-      '/Applications/Codex.app/Contents/MacOS/ChatGPT',
     ]);
   });
 });

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { ElectronAppEntry } from './electron-apps.js';
 import {
   detectAppProcess,
@@ -54,6 +57,7 @@ describe('probeCDP', () => {
 describe('detectProcess', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    cp.execFileSync.mockReset();
   });
 
   it('returns false when pgrep finds no process', () => {
@@ -76,6 +80,7 @@ describe('detectProcess', () => {
 describe('discoverAppPath', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    cp.execFileSync.mockReset();
   });
 
   it.skipIf(process.platform !== 'darwin')('returns path when osascript succeeds', () => {
@@ -90,6 +95,30 @@ describe('discoverAppPath', () => {
     });
     const result = discoverAppPath('NonExistent');
     expect(result).toBeNull();
+  });
+
+  it.skipIf(process.platform !== 'darwin')('uses bundle id Spotlight fallback when osascript cannot resolve the display name', () => {
+    cp.execFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('osascript timed out');
+      })
+      .mockReturnValueOnce('/Applications/ChatGPT.app\n');
+
+    const result = discoverAppPath('Codex', 'com.openai.codex');
+
+    expect(result).toBe('/Applications/ChatGPT.app');
+    expect(cp.execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'osascript',
+      ['-e', 'POSIX path of (path to application id "com.openai.codex")'],
+      { encoding: 'utf-8', stdio: 'pipe', timeout: 5_000 },
+    );
+    expect(cp.execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'mdfind',
+      ['kMDItemCFBundleIdentifier == "com.openai.codex"'],
+      { encoding: 'utf-8', stdio: 'pipe', timeout: 5_000 },
+    );
   });
 
   it.skipIf(process.platform === 'darwin')('returns null on non-darwin platform', () => {
@@ -149,6 +178,7 @@ describe('resolveExecutableCandidates', () => {
 describe('app-scoped process detection', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    cp.execFileSync.mockReset();
   });
 
   const codexApp: ElectronAppEntry = {
@@ -212,13 +242,31 @@ describe('app-scoped process detection', () => {
       ChatGPT: [{ pid: 201, command: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9236' }],
     });
 
-    expect(detectAppProcess('/Applications/Codex.app', codexApp)).toBe(false);
+    expect(detectAppProcess('/Applications/FakeCodex.app', codexApp)).toBe(false);
+  });
+
+  it('detects Codex when the app path is a symlink but ps reports the resolved executable path', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-launcher-'));
+    const realAppPath = path.join(tmp, 'ChatGPT.app');
+    const linkAppPath = path.join(tmp, 'Codex.app');
+    fs.mkdirSync(path.join(realAppPath, 'Contents', 'MacOS'), { recursive: true });
+    fs.symlinkSync(realAppPath, linkAppPath);
+    const resolvedAppPath = fs.realpathSync(linkAppPath);
+    mockProcessTable({
+      ChatGPT: [{ pid: 101, command: `${resolvedAppPath}/Contents/MacOS/ChatGPT --remote-debugging-port=9238` }],
+    });
+
+    try {
+      expect(detectAppProcess(linkAppPath, codexApp)).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('kills only executable pids scoped to the target app bundle', async () => {
     mockProcessTable({
       ChatGPT: [
-        { pid: 101, command: '/Applications/Codex.app/Contents/MacOS/ChatGPT' },
+        { pid: 101, command: '/Applications/FakeCodex.app/Contents/MacOS/ChatGPT' },
         { pid: 201, command: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT' },
       ],
     });
@@ -231,7 +279,7 @@ describe('app-scoped process detection', () => {
       return true;
     });
 
-    await killAppProcess('/Applications/Codex.app', codexApp);
+    await killAppProcess('/Applications/FakeCodex.app', codexApp);
 
     expect(killSpy).toHaveBeenCalledWith(101, 'SIGTERM');
     expect(killSpy).not.toHaveBeenCalledWith(201, 'SIGTERM');
@@ -339,7 +387,7 @@ describe('launchElectronApp', () => {
       });
 
     await expect(
-      launchElectronApp('/Applications/Codex.app', app, ['--remote-debugging-port=9238'], 'Codex'),
+      launchElectronApp('/Applications/MissingCodex.app', app, ['--remote-debugging-port=9238'], 'Codex'),
     ).rejects.toThrow('Could not launch Codex: no compatible executable found');
 
     expect(cp.spawn).toHaveBeenCalledTimes(2);

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ElectronAppEntry } from './electron-apps.js';
-import { detectProcess, discoverAppPath, electronLaunchArgs, launchDetachedApp, launchElectronApp, probeCDP, resolveExecutableCandidates } from './launcher.js';
+import {
+  detectAppProcess,
+  detectProcess,
+  discoverAppPath,
+  electronLaunchArgs,
+  findAppProcessPids,
+  killAppProcess,
+  launchDetachedApp,
+  launchElectronApp,
+  probeCDP,
+  resolveExecutableCandidates,
+} from './launcher.js';
 
 interface MockChildProcess {
   once: ReturnType<typeof vi.fn>;
@@ -135,6 +146,98 @@ describe('resolveExecutableCandidates', () => {
   });
 });
 
+describe('app-scoped process detection', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const codexApp: ElectronAppEntry = {
+    port: 9238,
+    processName: 'Codex',
+    executableNames: ['ChatGPT', 'Codex'],
+  };
+
+  function mockProcessTable(rows: Record<string, Array<{ pid: number; command: string }>>): void {
+    cp.execFileSync.mockImplementation((command, args) => {
+      const argv = args as string[];
+      if (command === 'pgrep') {
+        const processName = argv[1];
+        const pids = rows[processName]?.map((row) => row.pid) ?? [];
+        if (pids.length === 0) {
+          const err = new Error('exit 1') as Error & { status: number };
+          err.status = 1;
+          throw err;
+        }
+        return `${pids.join('\n')}\n`;
+      }
+
+      if (command === 'ps') {
+        const pid = Number.parseInt(argv[1], 10);
+        const row = Object.values(rows).flat().find((entry) => entry.pid === pid);
+        if (!row) throw new Error('process not found');
+        return `${row.command}\n`;
+      }
+
+      throw new Error(`unexpected command ${String(command)}`);
+    });
+  }
+
+  it('detects Codex when only the ChatGPT executable is running inside Codex.app', () => {
+    mockProcessTable({
+      ChatGPT: [{ pid: 101, command: '/Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238' }],
+    });
+
+    expect(detectAppProcess('/Applications/Codex.app', codexApp)).toBe(true);
+  });
+
+  it('detects Codex when only the legacy Codex executable is running', () => {
+    mockProcessTable({
+      Codex: [{ pid: 102, command: '/Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9238' }],
+    });
+
+    expect(detectAppProcess('/Applications/Codex.app', codexApp)).toBe(true);
+  });
+
+  it('returns both matching pids when both executable names are running in Codex.app', () => {
+    mockProcessTable({
+      ChatGPT: [{ pid: 101, command: '/Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238' }],
+      Codex: [{ pid: 102, command: '/Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9238' }],
+    });
+
+    expect(findAppProcessPids('/Applications/Codex.app', codexApp)).toEqual([101, 102]);
+  });
+
+  it('does not treat the separate ChatGPT desktop app as a running Codex process', () => {
+    mockProcessTable({
+      ChatGPT: [{ pid: 201, command: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9236' }],
+    });
+
+    expect(detectAppProcess('/Applications/Codex.app', codexApp)).toBe(false);
+  });
+
+  it('kills only executable pids scoped to the target app bundle', async () => {
+    mockProcessTable({
+      ChatGPT: [
+        { pid: 101, command: '/Applications/Codex.app/Contents/MacOS/ChatGPT' },
+        { pid: 201, command: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT' },
+      ],
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (signal === 0) {
+        const err = new Error('missing') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      }
+      return true;
+    });
+
+    await killAppProcess('/Applications/Codex.app', codexApp);
+
+    expect(killSpy).toHaveBeenCalledWith(101, 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(201, 'SIGTERM');
+  });
+});
+
 describe('electronLaunchArgs', () => {
   it('includes Chromium 142 WebSocket origin allow-list for auto-launched Electron apps', () => {
     expect(electronLaunchArgs(9234)).toEqual([
@@ -194,5 +297,51 @@ describe('launchElectronApp', () => {
       { detached: true, stdio: 'ignore' },
     );
     expect(secondChild.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall back to the next executable when the first candidate fails for a non-ENOENT reason', async () => {
+    const firstChild = createMockChildProcess();
+    const app: ElectronAppEntry = {
+      port: 9238,
+      processName: 'Codex',
+      executableNames: ['ChatGPT', 'Codex'],
+    };
+
+    cp.spawn.mockImplementationOnce(() => {
+      queueMicrotask(() => firstChild.emit('error', Object.assign(new Error('permission denied'), { code: 'EACCES' })));
+      return firstChild as unknown as ReturnType<typeof cp.spawn>;
+    });
+
+    await expect(
+      launchElectronApp('/Applications/Codex.app', app, ['--remote-debugging-port=9238'], 'Codex'),
+    ).rejects.toThrow('Failed to launch Codex');
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a typed all-candidates-missing error when every executable candidate is absent', async () => {
+    const firstChild = createMockChildProcess();
+    const secondChild = createMockChildProcess();
+    const app: ElectronAppEntry = {
+      port: 9238,
+      processName: 'Codex',
+      executableNames: ['ChatGPT', 'Codex'],
+    };
+
+    cp.spawn
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => firstChild.emit('error', Object.assign(new Error('missing ChatGPT'), { code: 'ENOENT' })));
+        return firstChild as unknown as ReturnType<typeof cp.spawn>;
+      })
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => secondChild.emit('error', Object.assign(new Error('missing Codex'), { code: 'ENOENT' })));
+        return secondChild as unknown as ReturnType<typeof cp.spawn>;
+      });
+
+    await expect(
+      launchElectronApp('/Applications/Codex.app', app, ['--remote-debugging-port=9238'], 'Codex'),
+    ).rejects.toThrow('Could not launch Codex: no compatible executable found');
+
+    expect(cp.spawn).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -10,6 +10,7 @@
  */
 
 import { execFileSync, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
 import { request as httpRequest } from 'node:http';
 import * as path from 'node:path';
 import type { ElectronAppEntry } from './electron-apps.js';
@@ -116,26 +117,80 @@ export async function killProcess(processName: string): Promise<void> {
 
 /**
  * Discover the app installation path on macOS.
- * Uses osascript to resolve the app name to a POSIX path.
+ * Uses Launch Services/Spotlight metadata to resolve the app to a POSIX path.
  * Returns null if the app is not installed.
  */
-export function discoverAppPath(displayName: string): string | null {
-  if (process.platform !== 'darwin') {
-    return null;
-  }
+export function discoverAppPath(displayName: string, bundleId?: string): string | null {
+  return discoverAppPathForEntry({ displayName, bundleId });
+}
 
+function normalizeAppPath(appPath: string): string {
+  return appPath.trim().replace(/\/$/, '');
+}
+
+function appleScriptString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function discoverAppPathByOsascript(nameOrBundleId: string, kind: 'name' | 'id'): string | null {
   try {
+    const appSpecifier = kind === 'id'
+      ? `id "${appleScriptString(nameOrBundleId)}"`
+      : `"${appleScriptString(nameOrBundleId)}"`;
     const result = execFileSync('osascript', [
-      '-e', `POSIX path of (path to application "${displayName}")`,
+      '-e', `POSIX path of (path to application ${appSpecifier})`,
     ], { encoding: 'utf-8', stdio: 'pipe', timeout: 5_000 });
-    return result.trim().replace(/\/$/, '');
+    const appPath = normalizeAppPath(result);
+    return appPath ? appPath : null;
   } catch {
     return null;
   }
 }
 
+function discoverAppPathByBundleId(bundleId: string): string | null {
+  if (!/^[A-Za-z0-9.-]+$/.test(bundleId)) return null;
+  try {
+    const result = execFileSync('mdfind', [
+      `kMDItemCFBundleIdentifier == "${bundleId}"`,
+    ], { encoding: 'utf-8', stdio: 'pipe', timeout: 5_000 });
+    const appPath = result
+      .split(/\r?\n/)
+      .map((line) => normalizeAppPath(line))
+      .find((line) => line.endsWith('.app'));
+    return appPath ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function discoverAppPathForEntry(app: Pick<ElectronAppEntry, 'displayName' | 'bundleId'> & { processName?: string }): string | null {
+  if (process.platform !== 'darwin') {
+    return null;
+  }
+
+  if (app.bundleId) {
+    const byBundleId = discoverAppPathByOsascript(app.bundleId, 'id') ?? discoverAppPathByBundleId(app.bundleId);
+    if (byBundleId) return byBundleId;
+  }
+
+  const label = app.displayName ?? app.processName;
+  return label ? discoverAppPathByOsascript(label, 'name') : null;
+}
+
 function resolveExecutable(appPath: string, processName: string): string {
   return `${appPath}/Contents/MacOS/${processName}`;
+}
+
+function resolveAppPathAliases(appPath: string): string[] {
+  const normalizedPath = normalizeAppPath(appPath);
+  const aliases = [normalizedPath];
+  try {
+    const realPath = normalizeAppPath(fs.realpathSync(normalizedPath));
+    if (realPath && !aliases.includes(realPath)) aliases.push(realPath);
+  } catch {
+    // If realpath is unavailable, the original app path is still the best evidence.
+  }
+  return aliases;
 }
 
 function isMissingExecutableError(err: unknown, label: string): boolean {
@@ -145,7 +200,14 @@ function isMissingExecutableError(err: unknown, label: string): boolean {
 
 export function resolveExecutableCandidates(appPath: string, app: ElectronAppEntry): string[] {
   const executableNames = app.executableNames?.length ? app.executableNames : [app.processName];
-  return [...new Set(executableNames)].map((name) => resolveExecutable(appPath, name));
+  const appPaths = resolveAppPathAliases(appPath);
+  const candidates = [];
+  for (const name of new Set(executableNames)) {
+    for (const candidateAppPath of appPaths) {
+      candidates.push(resolveExecutable(candidateAppPath, name));
+    }
+  }
+  return candidates;
 }
 
 export function findAppProcessPids(appPath: string, app: ElectronAppEntry): number[] {
@@ -325,7 +387,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
   }
 
   // Step 3: Discover path
-  const appPath = discoverAppPath(label);
+  const appPath = discoverAppPathForEntry(app);
   if (!appPath) {
     throw new CommandExecutionError(
       `Could not find ${label} on this machine.`,

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -23,6 +23,13 @@ const POLL_TIMEOUT_MS = 15_000;
 const PROBE_TIMEOUT_MS = 2_000;
 const KILL_GRACE_MS = 3_000;
 
+function parsePgrepOutput(output: string): number[] {
+  return output
+    .split(/\s+/)
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isInteger(value) && value > 0);
+}
+
 /**
  * Probe whether a CDP endpoint is listening on the given port.
  * Returns true if http://127.0.0.1:{port}/json responds successfully.
@@ -48,11 +55,38 @@ export function probeCDP(port: number, timeoutMs: number = PROBE_TIMEOUT_MS): Pr
  */
 export function detectProcess(processName: string): boolean {
   if (process.platform === 'win32') return false; // pgrep not available on Windows
+  return findProcessPids(processName).length > 0;
+}
+
+function findProcessPids(processName: string): number[] {
   try {
-    execFileSync('pgrep', ['-x', processName], { encoding: 'utf-8', stdio: 'pipe' });
-    return true;
+    const output = execFileSync('pgrep', ['-x', processName], { encoding: 'utf-8', stdio: 'pipe' });
+    return parsePgrepOutput(output);
   } catch {
-    return false;
+    return [];
+  }
+}
+
+function readProcessCommand(pid: number): string | null {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf-8', stdio: 'pipe' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function commandStartsWithExecutable(command: string, executable: string): boolean {
+  if (!command.startsWith(executable)) return false;
+  const next = command.charAt(executable.length);
+  return next === '' || /\s/.test(next);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
   }
 }
 
@@ -112,6 +146,60 @@ function isMissingExecutableError(err: unknown, label: string): boolean {
 export function resolveExecutableCandidates(appPath: string, app: ElectronAppEntry): string[] {
   const executableNames = app.executableNames?.length ? app.executableNames : [app.processName];
   return [...new Set(executableNames)].map((name) => resolveExecutable(appPath, name));
+}
+
+export function findAppProcessPids(appPath: string, app: ElectronAppEntry): number[] {
+  if (process.platform === 'win32') return [];
+
+  const executables = resolveExecutableCandidates(appPath, app);
+  const candidatesByName = new Map<string, string[]>();
+  for (const executable of executables) {
+    const name = path.basename(executable);
+    candidatesByName.set(name, [...(candidatesByName.get(name) ?? []), executable]);
+  }
+
+  const matched = new Set<number>();
+  for (const [processName, candidates] of candidatesByName) {
+    for (const pid of findProcessPids(processName)) {
+      const command = readProcessCommand(pid);
+      if (command && candidates.some((candidate) => commandStartsWithExecutable(command, candidate))) {
+        matched.add(pid);
+      }
+    }
+  }
+
+  return [...matched];
+}
+
+export function detectAppProcess(appPath: string, app: ElectronAppEntry): boolean {
+  return findAppProcessPids(appPath, app).length > 0;
+}
+
+export async function killAppProcess(appPath: string, app: ElectronAppEntry): Promise<void> {
+  if (process.platform === 'win32') return;
+
+  for (const pid of findAppProcessPids(appPath, app)) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Process may have already exited.
+    }
+  }
+
+  const deadline = Date.now() + KILL_GRACE_MS;
+  while (Date.now() < deadline) {
+    const livePids = findAppProcessPids(appPath, app).filter(processIsAlive);
+    if (livePids.length === 0) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  for (const pid of findAppProcessPids(appPath, app)) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // Ignore.
+    }
+  }
 }
 
 export async function launchDetachedApp(executable: string, args: string[], label: string): Promise<void> {
@@ -236,7 +324,16 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
     );
   }
 
-  const isRunning = detectProcess(processName);
+  // Step 3: Discover path
+  const appPath = discoverAppPath(label);
+  if (!appPath) {
+    throw new CommandExecutionError(
+      `Could not find ${label} on this machine.`,
+      `Install ${label} or register a custom path in ~/.opencli/apps.yaml`,
+    );
+  }
+
+  const isRunning = detectAppProcess(appPath, app);
   if (isRunning) {
     log.debug(`[launcher] ${label} is running but CDP not available`);
     const confirmed = await confirmPrompt(
@@ -250,16 +347,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
       );
     }
     process.stderr.write(`  Restarting ${label}...\n`);
-    await killProcess(processName);
-  }
-
-  // Step 3: Discover path
-  const appPath = discoverAppPath(label);
-  if (!appPath) {
-    throw new CommandExecutionError(
-      `Could not find ${label} on this machine.`,
-      `Install ${label} or register a custom path in ~/.opencli/apps.yaml`,
-    );
+    await killAppProcess(appPath, app);
   }
 
   // Step 4: Launch


### PR DESCRIPTION
## Description

The launcher resolves an Electron app's executable as `<App>.app/Contents/MacOS/<processName>`, and the `codex` entry declared only `processName: 'Codex'`. Current Codex builds ship an executable named `ChatGPT` inside `Codex.app`, so every `codex` command failed with `executable not found` before it could connect. `ElectronAppEntry` already carries `executableNames` for this, as `antigravity` and `qoder` use; `codex` now lists `ChatGPT` ahead of the `Codex` fallback, and the manual launch step in `docs/adapters/desktop/codex.md` gets the same path.

Two conditions stay open in the shared launcher (#2231): `processName` must stay `Codex` so `pkill -x` cannot hit the `chatgpt-app` entry, and the auto-launched process does not retain `--remote-debugging-port`.

Related issue: #2231. Only the executable-name condition is addressed here, so it stays open.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Codex 26.727.51351 (Chromium 150.0.7871.182), bundle identifier `com.openai.codex`, single executable `ChatGPT`.

Before:

```
$ opencli codex status
error:
  code: COMMAND_EXEC
  message: 'Could not launch Codex: executable not found at /Applications/Codex.app/Contents/MacOS/Codex'
```

After, the first candidate resolves and the app starts:

```
$ OPENCLI_VERBOSE=1 opencli codex status
[verbose] [launcher] Launching: /Applications/Codex.app/Contents/MacOS/ChatGPT --remote-debugging-port=9238 --remote-allow-origins=*
```

With the app started from a shell so the port stays open (the auto-launched process does not retain it, #2231), the adapter connects:

```
$ opencli codex status
- Status: Connected
  Url: app://-/index.html?initialRoute=%2Favatar-overlay
  Title: Codex
```

`src/electron-apps.test.ts` and `src/launcher.test.ts` 22 / 22; the codex entry case fails if `src/electron-apps.ts` is reverted. Typecheck, both lint gates and doc-coverage pass. `cli-manifest.json` untouched.
