### PR TITLE
fix(discord-app): extract guild ids from navigation items

### DIFF
--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -12,6 +12,7 @@ import './threads.js';
 import {
     buildDiscordChannelUrl,
     buildListChannelsScript,
+    buildListServersScript,
     buildListThreadsScript,
     listDiscordChannels,
     listDiscordServers,
@@ -109,6 +110,62 @@ describe('discord-app DOM extraction scripts', () => {
                 url: 'https://discord.com/channels/111/444',
             },
         ]);
+    });
+
+    it('lists servers from current guild navigation items without channel links', () => {
+        const rows = runDomScript(`
+          <nav>
+            <div class="listItem_home" data-list-item-id="guildsnav___home" aria-label="Direct Messages"></div>
+            <div class="listItem_server">
+              <svg>
+                <foreignObject>
+                  <div data-dnd-name="OpenCLI">
+                    <div data-list-item-id="guildsnav___111" role="treeitem">
+                      <span>OpenCLI</span>
+                    </div>
+                  </div>
+                </foreignObject>
+              </svg>
+            </div>
+            <div class="listItem_server">
+              <div data-list-item-id="guildsnav___222" role="treeitem" aria-label="Agent Lab"></div>
+            </div>
+            <div class="listItem_add" data-list-item-id="guildsnav___create-join-a-guild" aria-label="Add a Server"></div>
+            <div class="listItem_discover" data-list-item-id="guildsnav___guild-discovery" aria-label="Discover"></div>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([
+            {
+                Index: 1,
+                Server: 'OpenCLI',
+                guild_id: '111',
+                url: 'https://discord.com/channels/111',
+            },
+            {
+                Index: 2,
+                Server: 'Agent Lab',
+                guild_id: '222',
+                url: 'https://discord.com/channels/222',
+            },
+        ]);
+    });
+
+    it('keeps supporting legacy guild channel links', () => {
+        const rows = runDomScript(`
+          <nav>
+            <div class="listItem_server">
+              <a href="/channels/333" aria-label="Legacy Guild"></a>
+            </div>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([{
+            Index: 1,
+            Server: 'Legacy Guild',
+            guild_id: '333',
+            url: 'https://discord.com/channels/333',
+        }]);
     });
 
     it('lists visible forum/thread cards with thread ids', () => {

--- a/clis/discord-app/commands.test.js
+++ b/clis/discord-app/commands.test.js
@@ -151,6 +151,89 @@ describe('discord-app DOM extraction scripts', () => {
         ]);
     });
 
+    it('rejects non-numeric guild navigation sentinels and channel/thread-shaped ids', () => {
+        const rows = runDomScript(`
+          <nav>
+            <div data-list-item-id="guildsnav___home" aria-label="Direct Messages"></div>
+            <div data-list-item-id="guildsnav___create-join-a-guild" aria-label="Add a Server"></div>
+            <div data-list-item-id="guildsnav___guild-discovery" aria-label="Discover"></div>
+            <div data-list-item-id="guildsnav___folder-111" aria-label="Folder"></div>
+            <div data-list-item-id="guildsnav___333/444" aria-label="Channel Item"></div>
+            <div data-list-item-id="guildsnav___555/666/777" aria-label="Thread Item"></div>
+            <div data-list-item-id="guildsnav___222" aria-label="Valid Guild"></div>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([{
+            Index: 1,
+            Server: 'Valid Guild',
+            guild_id: '222',
+            url: 'https://discord.com/channels/222',
+        }]);
+    });
+
+    it('does not pair a guild id with a broad ancestor or neighboring guild name', () => {
+        const rows = runDomScript(`
+          <nav>
+            <div data-dnd-name="Shared Wrong Wrapper">
+              <div data-list-item-id="guildsnav___111" role="treeitem" aria-label="Alpha Guild"></div>
+              <div data-list-item-id="guildsnav___222" role="treeitem">
+                <img alt="Beta Guild">
+              </div>
+              <div data-list-item-id="guildsnav___333" role="treeitem"></div>
+            </div>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([
+            {
+                Index: 1,
+                Server: 'Alpha Guild',
+                guild_id: '111',
+                url: 'https://discord.com/channels/111',
+            },
+            {
+                Index: 2,
+                Server: 'Beta Guild',
+                guild_id: '222',
+                url: 'https://discord.com/channels/222',
+            },
+        ]);
+    });
+
+    it('uses a narrow owned wrapper name only when it owns exactly one guild item', () => {
+        const rows = runDomScript(`
+          <nav>
+            <div data-dnd-name="Owned Guild">
+              <svg>
+                <foreignObject>
+                  <div data-list-item-id="guildsnav___111" role="treeitem"></div>
+                </foreignObject>
+              </svg>
+            </div>
+            <div data-dnd-name="Crowded Wrapper">
+              <div data-list-item-id="guildsnav___222" role="treeitem"></div>
+              <div data-list-item-id="guildsnav___333" role="treeitem" aria-label="Explicit Neighbor"></div>
+            </div>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([
+            {
+                Index: 1,
+                Server: 'Owned Guild',
+                guild_id: '111',
+                url: 'https://discord.com/channels/111',
+            },
+            {
+                Index: 2,
+                Server: 'Explicit Neighbor',
+                guild_id: '333',
+                url: 'https://discord.com/channels/333',
+            },
+        ]);
+    });
+
     it('keeps supporting legacy guild channel links', () => {
         const rows = runDomScript(`
           <nav>
@@ -165,6 +248,25 @@ describe('discord-app DOM extraction scripts', () => {
             Server: 'Legacy Guild',
             guild_id: '333',
             url: 'https://discord.com/channels/333',
+        }]);
+    });
+
+    it('keeps legacy guild link fallback strict to Discord guild roots', () => {
+        const rows = runDomScript(`
+          <nav>
+            <a href="https://example.com/channels/111" aria-label="Off Domain"></a>
+            <a href="https://discord.com/channels/@me" aria-label="Direct Messages"></a>
+            <a href="https://discord.com/channels/222/333" aria-label="Channel Link"></a>
+            <a href="https://discord.com/channels/444/555/666" aria-label="Thread Link"></a>
+            <a href="https://canary.discord.com/channels/777" title="Canary Guild"></a>
+          </nav>
+        `, buildListServersScript());
+
+        expect(rows).toEqual([{
+            Index: 1,
+            Server: 'Canary Guild',
+            guild_id: '777',
+            url: 'https://discord.com/channels/777',
         }]);
     });
 
@@ -247,6 +349,37 @@ describe('discord-app search', () => {
 });
 
 describe('discord-app list row validation', () => {
+    it('unwraps Browser Bridge envelopes for server rows', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue({
+                session: 'site:discord-app',
+                data: [{ Server: 'OpenCLI', guild_id: '111', url: 'https://discord.com/channels/111' }],
+            }),
+        };
+
+        await expect(listDiscordServers(page)).resolves.toEqual([
+            { Server: 'OpenCLI', guild_id: '111', url: 'https://discord.com/channels/111' },
+        ]);
+    });
+
+    it('returns a valid empty helper result but servers command maps it to EmptyResultError', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue({ session: 'site:discord-app', data: [] }),
+        };
+        const cmd = getRegistry().get('discord-app/servers');
+
+        await expect(listDiscordServers(page)).resolves.toEqual([]);
+        await expect(cmd.func(page, {})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('typed-fails malformed server browser output', async () => {
+        const page = {
+            evaluate: vi.fn().mockResolvedValue({ session: 'site:discord-app', data: { rows: [] } }),
+        };
+
+        await expect(listDiscordServers(page)).rejects.toThrow(CommandExecutionError);
+    });
+
     it('typed-fails channel rows missing stable channel identity', async () => {
         const page = {
             evaluate: vi.fn().mockResolvedValue([{ Channel: 'general', guild_id: '111', url: 'https://discord.com/channels/111/222' }]),

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -196,59 +196,76 @@ export function buildListChannelsScript() {
 export function buildListServersScript() {
     return `
       (function __opencliDiscordListServers() {
+        var DISCORD_HOSTS = new Set(['discord.com', 'canary.discord.com', 'ptb.discord.com']);
+        var GUILD_NAV_RE = /^guildsnav___(\\d+)$/;
+
         function parseGuildId(raw) {
           try {
             var url = new URL(raw, 'https://discord.com');
+            if (!DISCORD_HOSTS.has(url.hostname)) return '';
             var parts = url.pathname.split('/').filter(Boolean);
-            if (parts[0] !== 'channels' || parts.length !== 2 || !parts[1] || parts[1] === '@me') return '';
+            if (parts[0] !== 'channels' || parts.length !== 2 || !/^\\d+$/.test(parts[1] || '')) return '';
             return parts[1];
           } catch (_) {
             return '';
           }
         }
 
-        function guildItemOf(item) {
-          if (!item || !item.matches) return null;
-          if (item.matches('[data-list-item-id*="guildsnav___"]')) return item;
-          return item.closest('[data-list-item-id*="guildsnav___"]')
-            || item.querySelector('[data-list-item-id*="guildsnav___"]');
-        }
-
-        function parseGuildItemId(item) {
-          var guildItem = guildItemOf(item);
-          var listItemId = guildItem ? guildItem.getAttribute('data-list-item-id') || '' : '';
-          var match = listItemId.match(/^guildsnav___(\\d+)$/);
+        function guildIdFromNavItem(item) {
+          if (!item || !item.getAttribute) return '';
+          var match = String(item.getAttribute('data-list-item-id') || '').match(GUILD_NAV_RE);
           return match ? match[1] : '';
         }
 
-        var rows = [];
-        var seen = new Set();
-        var items = Array.from(document.querySelectorAll('a[href^="/channels/"], [data-list-item-id*="guildsnav___"], [class*="listItem_"]'));
-        items.forEach(function(item) {
-          var guildItem = guildItemOf(item);
-          var link = item.matches && item.matches('a[href^="/channels/"]') ? item : item.querySelector && item.querySelector('a[href^="/channels/"]');
-          var href = link ? link.getAttribute('href') || '' : '';
-          var guildId = parseGuildItemId(item) || parseGuildId(href);
-          if (!guildId || seen.has(guildId)) return;
+        function narrowOwnedWrapper(item) {
+          if (!item || !item.closest) return null;
+          var wrapper = item.closest('[data-dnd-name]');
+          if (!wrapper || !wrapper.contains(item)) return null;
+          var ownedGuildItems = Array.from(wrapper.querySelectorAll('[data-list-item-id^="guildsnav___"]'))
+            .filter(function(el) { return GUILD_NAV_RE.test(String(el.getAttribute('data-list-item-id') || '')); });
+          return ownedGuildItems.length === 1 && ownedGuildItems[0] === item ? wrapper : null;
+        }
 
-          var named = (guildItem && guildItem.matches('[data-dnd-name]') ? guildItem : null)
-            || (guildItem && guildItem.querySelector('[data-dnd-name]'))
-            || (item.querySelector && item.querySelector('[data-dnd-name]'));
-          var name = named ? named.getAttribute('data-dnd-name') : '';
-          if (!name && guildItem) name = guildItem.getAttribute('aria-label') || '';
-          if (!name && guildItem) {
-            var labelled = guildItem.querySelector('[role="treeitem"][aria-label]');
-            name = labelled ? labelled.getAttribute('aria-label') || '' : '';
+        function firstAttr(nodes, attr) {
+          for (var i = 0; i < nodes.length; i++) {
+            if (!nodes[i] || !nodes[i].getAttribute) continue;
+            var value = String(nodes[i].getAttribute(attr) || '').replace(/\\s+/g, ' ').trim();
+            if (value) return value;
           }
-          if (!name && guildItem) {
-            var image = guildItem.querySelector('img[alt]');
-            name = image ? image.getAttribute('alt') || '' : '';
-          }
-          if (!name) name = item.getAttribute && item.getAttribute('aria-label') || '';
-          if (!name && link) name = link.getAttribute('aria-label') || link.getAttribute('title') || '';
-          name = String(name || '').replace(/\\s+/g, ' ').trim();
-          if (!name || /^direct messages$/i.test(name)) return;
+          return '';
+        }
 
+        function guildNameFromNavItem(item) {
+          var wrapper = narrowOwnedWrapper(item);
+
+          var name = firstAttr([item], 'data-dnd-name') || firstAttr([item], 'aria-label') || firstAttr([item], 'title');
+          if (name) return name;
+
+          var labelled = item.matches('[role="treeitem"][aria-label]') ? item : item.querySelector('[role="treeitem"][aria-label]');
+          name = firstAttr([labelled], 'aria-label');
+          if (name) return name;
+
+          var image = item.querySelector('img[alt]');
+          name = firstAttr([image], 'alt');
+          if (name) return name;
+
+          if (wrapper) {
+            name = firstAttr([wrapper], 'data-dnd-name') || firstAttr([wrapper], 'aria-label') || firstAttr([wrapper], 'title');
+            if (name) return name;
+          }
+
+          var text = String(item.textContent || '').replace(/\\s+/g, ' ').trim();
+          return text;
+        }
+
+        function normalizeName(name) {
+          return String(name || '').replace(/\\s+/g, ' ').trim();
+        }
+
+        function pushRow(rows, seen, guildId, name) {
+          guildId = String(guildId || '').trim();
+          name = normalizeName(name);
+          if (!/^\\d+$/.test(guildId) || seen.has(guildId) || !name || /^direct messages$/i.test(name)) return;
           rows.push({
             Index: rows.length + 1,
             Server: name.slice(0, 80),
@@ -256,6 +273,22 @@ export function buildListServersScript() {
             url: 'https://discord.com/channels/' + guildId
           });
           seen.add(guildId);
+        }
+
+        var rows = [];
+        var seen = new Set();
+        var navItems = Array.from(document.querySelectorAll('[data-list-item-id^="guildsnav___"]'))
+          .filter(function(item) { return guildIdFromNavItem(item); });
+        navItems.forEach(function(item) {
+          pushRow(rows, seen, guildIdFromNavItem(item), guildNameFromNavItem(item));
+        });
+
+        var legacyLinks = Array.from(document.querySelectorAll('a[href*="/channels/"]'));
+        legacyLinks.forEach(function(link) {
+          var guildId = parseGuildId(link.getAttribute('href') || '');
+          if (!guildId || seen.has(guildId)) return;
+          var name = link.getAttribute('aria-label') || link.getAttribute('title') || link.textContent || '';
+          pushRow(rows, seen, guildId, name);
         });
 
         return rows;

--- a/clis/discord-app/utils.js
+++ b/clis/discord-app/utils.js
@@ -207,17 +207,43 @@ export function buildListServersScript() {
           }
         }
 
+        function guildItemOf(item) {
+          if (!item || !item.matches) return null;
+          if (item.matches('[data-list-item-id*="guildsnav___"]')) return item;
+          return item.closest('[data-list-item-id*="guildsnav___"]')
+            || item.querySelector('[data-list-item-id*="guildsnav___"]');
+        }
+
+        function parseGuildItemId(item) {
+          var guildItem = guildItemOf(item);
+          var listItemId = guildItem ? guildItem.getAttribute('data-list-item-id') || '' : '';
+          var match = listItemId.match(/^guildsnav___(\\d+)$/);
+          return match ? match[1] : '';
+        }
+
         var rows = [];
         var seen = new Set();
         var items = Array.from(document.querySelectorAll('a[href^="/channels/"], [data-list-item-id*="guildsnav___"], [class*="listItem_"]'));
         items.forEach(function(item) {
+          var guildItem = guildItemOf(item);
           var link = item.matches && item.matches('a[href^="/channels/"]') ? item : item.querySelector && item.querySelector('a[href^="/channels/"]');
           var href = link ? link.getAttribute('href') || '' : '';
-          var guildId = parseGuildId(href);
+          var guildId = parseGuildItemId(item) || parseGuildId(href);
           if (!guildId || seen.has(guildId)) return;
 
-          var named = item.querySelector && item.querySelector('[data-dnd-name]');
+          var named = (guildItem && guildItem.matches('[data-dnd-name]') ? guildItem : null)
+            || (guildItem && guildItem.querySelector('[data-dnd-name]'))
+            || (item.querySelector && item.querySelector('[data-dnd-name]'));
           var name = named ? named.getAttribute('data-dnd-name') : '';
+          if (!name && guildItem) name = guildItem.getAttribute('aria-label') || '';
+          if (!name && guildItem) {
+            var labelled = guildItem.querySelector('[role="treeitem"][aria-label]');
+            name = labelled ? labelled.getAttribute('aria-label') || '' : '';
+          }
+          if (!name && guildItem) {
+            var image = guildItem.querySelector('img[alt]');
+            name = image ? image.getAttribute('alt') || '' : '';
+          }
           if (!name) name = item.getAttribute && item.getAttribute('aria-label') || '';
           if (!name && link) name = link.getAttribute('aria-label') || link.getAttribute('title') || '';
           name = String(name || '').replace(/\\s+/g, ' ').trim();


### PR DESCRIPTION
## Description

Fix `opencli discord-app servers` returning `EMPTY_RESULT` with the current Discord guild navigation DOM.

Discord no longer renders an inner `<a href="/channels/...">` inside each guild item. The scraper now extracts numeric guild IDs from `data-list-item-id="guildsnav___<id>"`, while retaining the legacy channel-link fallback for older Discord versions.

The change also ignores non-guild navigation entries such as Direct Messages, Add a Server, and Discover, and adds regression coverage for both DOM structures.

Related issue: #2058

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

The documentation checklist is not applicable because this fixes an existing command without changing its arguments, failure handling, documentation surface, or discoverability.

## Screenshots / Output

Validated against Discord Desktop 0.0.406 over CDP. The live guild node had a numeric `guildsnav___<id>` identifier and no inner channel anchor.

```json
[
  {
    "Index": 1,
    "Server": "OpenCLI-2058-Test",
    "guild_id": "1534046145607634974",
    "url": "https://discord.com/channels/1534046145607634974"
  }
]
```

Checks:

- `npx vitest run --project adapter clis/discord-app/commands.test.js` — 23 passed
- `npm run typecheck` — passed
- `npm test` — 586 test files passed, 6,586 tests passed, 1 skipped

Fixes #2058
