### PR TITLE
fix(chatgpt): never save in-progress canvas frames as generated images

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2603,11 +2603,10 @@ export async function getChatGPTVisibleImageUrls(page) {
             }
 
             // Some ChatGPT image surfaces mount large transparent canvases as
-            // placeholders/overlays before the real backend image is ready. If
-            // those data URLs are accepted as generated assets, the adapter can
-            // save a blank transparent PNG while reporting success. Prefer real
-            // <img>/background URLs; only keep a canvas if it contains at least
-            // one non-transparent/non-white sampled pixel.
+            // placeholders/overlays before the real backend image is ready. The
+            // image wait no longer saves these (#1898), but it does treat a
+            // content-bearing one as "still rendering", so keep the sampling:
+            // it decides whether a deadline reports TIMEOUT or EMPTY_RESULT.
             for (const canvas of Array.from(document.querySelectorAll('canvas'))) {
                 if (!(canvas instanceof HTMLCanvasElement) || !isVisible(canvas) || isDecorative(canvas)) continue;
                 const width = canvas.width || canvas.getBoundingClientRect().width || 0;
@@ -2653,6 +2652,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     const maxPolls = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));
     let lastUrls = [];
     let stableCount = 0;
+    let stillRendering = false;
 
     for (let i = 0; i < maxPolls; i++) {
         await page.sleep(i === 0 ? 3 : pollIntervalSeconds);
@@ -2667,6 +2667,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
         }
 
         const generating = await isGenerating(page);
+        stillRendering = generating;
         if (generating) continue;
 
         if (convUrl && convUrl.includes('/c/') && i > 0 && i % 5 === 0) {
@@ -2677,7 +2678,15 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
             }
         }
 
-        const urls = (await getChatGPTVisibleImageUrls(page)).filter(url => !beforeSet.has(url));
+        const candidates = (await getChatGPTVisibleImageUrls(page)).filter(url => !beforeSet.has(url));
+        // Canvas snapshots surface as data: URLs and hold half-drawn frames
+        // while generation renders. A hidden page stops repainting the canvas,
+        // so a frozen partial frame stays byte-identical across polls and
+        // would pass the stability gate below as a finished image (#1898).
+        // Kept out of completion, they still mark the wait as rendering so a
+        // deadline reports TIMEOUT instead of EMPTY_RESULT.
+        const urls = candidates.filter(url => !url.startsWith('data:'));
+        stillRendering = urls.length === 0 && candidates.length > 0;
         if (urls.length === 0) continue;
 
         const key = urls.join('\n');
@@ -2692,6 +2701,15 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
         if (stableCount >= 2 || i === maxPolls - 1) {
             return lastUrls;
         }
+    }
+    // A deadline that lands while ChatGPT is visibly mid-generation is a
+    // temporary failure, not an empty conversation. Mirror the ask wait.
+    if (!lastUrls.length && stillRendering) {
+        throw new TimeoutError(
+            'chatgpt image',
+            timeoutSeconds,
+            'No finished image appeared before timeout. Re-run with a higher --timeout if it is still generating.',
+        );
     }
     return lastUrls;
 }

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2685,7 +2685,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
         // would pass the stability gate below as a finished image (#1898).
         // Kept out of completion, they still mark the wait as rendering so a
         // deadline reports TIMEOUT instead of EMPTY_RESULT.
-        const urls = candidates.filter(url => !url.startsWith('data:'));
+        const urls = candidates.filter(url => !/^data:/i.test(url));
         stillRendering = urls.length === 0 && candidates.length > 0;
         if (urls.length === 0) continue;
 

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -79,6 +79,17 @@ describe('chatgpt image wait contract', () => {
         await expect(waitForChatGPTImages(page, [], 9, convUrl)).rejects.toThrow(/chatgpt image timed out/);
     });
 
+    it('rejects data URL completion candidates case-insensitively', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            imageUrls: [['DATA:image/png;base64,halfdrawnframe']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).rejects.toThrow(/chatgpt image timed out/);
+    });
+
     it('keeps only backend-served URLs when a canvas frame renders alongside them', async () => {
         const convUrl = 'https://chatgpt.com/c/demo';
         const page = createPageMock({

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -64,8 +64,69 @@ describe('chatgpt image wait contract', () => {
             generating: [true, true, true, true, true, true],
         });
 
-        await expect(waitForChatGPTImages(page, [], 18, convUrl)).resolves.toEqual([]);
+        await expect(waitForChatGPTImages(page, [], 18, convUrl)).rejects.toThrow(/chatgpt image timed out/);
         expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('does not return a frozen canvas snapshot as a generated image', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            imageUrls: [['data:image/png;base64,halfdrawnframe']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).rejects.toThrow(/chatgpt image timed out/);
+    });
+
+    it('keeps only backend-served URLs when a canvas frame renders alongside them', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            imageUrls: [['data:image/png;base64,halfdrawnframe', 'https://cdn.openai.com/generated/demo.png']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).resolves.toEqual([
+            'https://cdn.openai.com/generated/demo.png',
+        ]);
+    });
+
+    it('drops the canvas frame from a deadline capture that also has a backend URL', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            imageUrls: [['data:image/png;base64,halfdrawnframe', 'https://cdn.openai.com/generated/demo.png']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 3, convUrl)).resolves.toEqual([
+            'https://cdn.openai.com/generated/demo.png',
+        ]);
+    });
+
+    it('returns the captured URLs when generation resumes until the deadline', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false, true],
+            imageUrls: [['https://cdn.openai.com/generated/demo.png']],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).resolves.toEqual([
+            'https://cdn.openai.com/generated/demo.png',
+        ]);
+    });
+
+    it('still resolves empty when the conversation finishes with no image', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            imageUrls: [[]],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).resolves.toEqual([]);
     });
 
     it('jumps back to the captured conversation when the page drifts away', async () => {


### PR DESCRIPTION
## Description

`chatgpt image` could report `✅ saved` for an image that never finished. `getChatGPTVisibleImageUrls` exports content-bearing canvases as `data:` URLs, and the canvas is the in-progress render surface. The #1802 pixel guard only rejects blank frames, and a hidden or stalled page stops repainting, so a half-drawn frame stays byte-identical across polls and passes the two-poll stability gate in `waitForChatGPTImages`.

The wait now keeps `data:` candidates out of completion and out of the returned set; every observed finished image is a backend `https` URL, so successful generations are unchanged. This supersedes the #1677 canvas save path: a conversation whose only visible image is a canvas ends in `TimeoutError`, and the #1802 sampling decides whether that deadline reports `TIMEOUT` (exit 75) or `EMPTY_RESULT` (exit 66), matching the `chatgpt ask` wait.

Related issue: Closes #1898

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Deadline landing mid-generation, previously `EMPTY_RESULT` with exit 66:

```
$ opencli chatgpt image "a colorful parrot perched on a branch against a dark blue night sky" --timeout 30
error:
  code: TIMEOUT
  message: chatgpt image timed out after 30s
  help: No finished image appeared before timeout. Re-run with a higher --timeout if it is still generating.
  exitCode: 75
```

Successful generation verified foreground and with the window hidden mid-generation, both saving the finished backend image:

```
$ opencli chatgpt image "Hard sci-fi cosmic battlefield, ..." --timeout 240
status: ✅ saved
file: 📁 ~/Pictures/chatgpt/chatgpt_1785829455580.png
link: 🔗 https://chatgpt.com/c/6a719815-ac30-83ee-863a-ab7d46454842
```

With `clis/chatgpt/utils.js` reverted to main the four behavior tests fail; full `clis/chatgpt` suite 158 / 158. Typecheck, typed-error lint, silent-column-drop and doc coverage pass. `cli-manifest.json` untouched.
