### PR TITLE
fix(codex): select slash-command picker options from send

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -8059,6 +8059,12 @@
         "help": "Text, command (e.g. /review), or skill (e.g. $imagegen)"
       },
       {
+        "name": "pick",
+        "type": "str",
+        "required": false,
+        "help": "Picker option label to select when a slash command opens the picker (e.g. \"Review Agent\")"
+      },
+      {
         "name": "project",
         "type": "str",
         "required": false,

--- a/clis/codex/extract-diff.js
+++ b/clis/codex/extract-diff.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
 export const extractDiffCommand = cli({
     site: 'codex',
     name: 'extract-diff',
@@ -10,7 +11,7 @@ export const extractDiffCommand = cli({
     browser: true,
     columns: ['File', 'Diff'],
     func: async (page) => {
-        const diffs = await page.evaluate(`
+        const diffs = unwrapEvaluateResult(await page.evaluate(`
       (function() {
         const results = [];
         // Assuming diffs are rendered with standard diff classes or monaco difference editors
@@ -37,7 +38,10 @@ export const extractDiffCommand = cli({
         
         return results;
       })()
-    `);
+    `));
+        if (!Array.isArray(diffs)) {
+            throw new CommandExecutionError('Codex extract-diff returned an invalid payload.');
+        }
         if (diffs.length === 0) {
             throw new EmptyResultError('codex extract-diff', 'No Codex diffs were visible. Run opencli codex send "/review" --pick "Review Agent" and retry.');
         }

--- a/clis/codex/extract-diff.js
+++ b/clis/codex/extract-diff.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 export const extractDiffCommand = cli({
     site: 'codex',
     name: 'extract-diff',
@@ -38,7 +39,7 @@ export const extractDiffCommand = cli({
       })()
     `);
         if (diffs.length === 0) {
-            return [{ File: 'No diffs found', Diff: 'Try running opencli codex send "/review" first' }];
+            throw new EmptyResultError('codex extract-diff', 'No Codex diffs were visible. Run opencli codex send "/review" --pick "Review Agent" and retry.');
         }
         return diffs;
     },

--- a/clis/codex/send.js
+++ b/clis/codex/send.js
@@ -118,7 +118,7 @@ export const sendCommand = cli({
             throw new ArgumentError('--pick label cannot be empty');
         }
         const selected = await openCodexConversation(page, kwargs);
-        const injected = await page.evaluate(`
+        const injected = unwrapEvaluateResult(await page.evaluate(`
       (function(text) {
         const composer = (${findCodexComposerElement.toString()})();
         if (!composer) return false;
@@ -127,7 +127,7 @@ export const sendCommand = cli({
         document.execCommand('insertText', false, text);
         return true;
       })(${JSON.stringify(textToInsert)})
-    `);
+    `));
         if (!injected)
             throw selectorError('Codex Composer input element');
         // Wait for the UI to register the input

--- a/clis/codex/send.js
+++ b/clis/codex/send.js
@@ -1,6 +1,102 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { selectorError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
 import { conversationSelectionArgs, openCodexConversation } from './sidebar.js';
+
+const PICKER_ITEM_SELECTOR = '[data-list-navigation-item="true"]';
+
+export function findUniquePickerOption(options, rawLabel) {
+    const wanted = String(rawLabel ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+    if (!wanted) {
+        throw new ArgumentError('--pick label cannot be empty');
+    }
+    const normalized = options.map((option, index) => ({
+        index,
+        title: String(option.title ?? ''),
+        normalizedTitle: String(option.title ?? '').replace(/\s+/g, ' ').trim().toLowerCase(),
+        normalizedText: String(option.text ?? option.title ?? '').replace(/\s+/g, ' ').trim().toLowerCase(),
+    }));
+    const exact = normalized.filter(item => item.normalizedTitle === wanted);
+    if (exact.length === 1) {
+        return exact[0];
+    }
+    if (exact.length > 1) {
+        throw new CommandExecutionError(`Picker option "${rawLabel}" is ambiguous.`, `Matches: ${exact.map(item => item.title).join(', ')}`);
+    }
+    const partial = normalized.filter(item => item.normalizedText.includes(wanted));
+    if (partial.length === 1) {
+        return partial[0];
+    }
+    if (partial.length > 1) {
+        throw new CommandExecutionError(`Picker option "${rawLabel}" is ambiguous.`, `Matches: ${partial.map(item => item.title).join(', ')}`);
+    }
+    return null;
+}
+
+function normalizeChipText(value) {
+    return String(value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+export function chipMatchesLabel(chip, label) {
+    const wanted = normalizeChipText(label);
+    if (!wanted) {
+        return false;
+    }
+    return [chip.name, chip.display].some((value) => {
+        const candidate = normalizeChipText(value);
+        return candidate !== '' && (candidate.includes(wanted) || wanted.includes(candidate));
+    });
+}
+
+function describeComposerState(state) {
+    return `text=${JSON.stringify(state.text)} chips=${JSON.stringify(state.chips.map(chip => chip.display || chip.name))}`;
+}
+
+export function findCodexComposerElement(doc = document) {
+    let composer = doc.querySelector('textarea, [contenteditable="true"]');
+    const editables = Array.from(doc.querySelectorAll('[contenteditable="true"]'));
+    if (editables.length > 0) {
+        composer = editables[editables.length - 1];
+    }
+    return composer;
+}
+
+async function readComposerState(page) {
+    const state = unwrapEvaluateResult(await page.evaluate(`
+      (function() {
+        const injected = (${findCodexComposerElement.toString()})();
+        if (!injected) return null;
+        // Verification must read the element injection wrote into (the #1991
+        // bug class); the tagged composer counts only when it wraps it.
+        const composer = injected.closest('[data-codex-composer="true"]') || injected;
+        const chips = Array.from(composer.querySelectorAll('[skill-mention-name]')).map((chip) => ({
+          name: chip.getAttribute('skill-mention-name') || '',
+          display: chip.getAttribute('skill-mention-display-name') || '',
+        }));
+        const clone = composer.cloneNode(true);
+        clone.querySelectorAll('[skill-mention-name]').forEach((chip) => chip.remove());
+        return {
+          text: (composer.textContent || '').trim(),
+          nonChipText: (clone.textContent || '').trim(),
+          chips,
+        };
+      })()
+    `));
+    if (!state) {
+        throw selectorError('Codex Composer input element');
+    }
+    return state;
+}
+
+async function pollComposerState(page) {
+    let state = await readComposerState(page);
+    for (let attempt = 0; attempt < 5 && state.text; attempt += 1) {
+        await page.wait(0.25);
+        state = await readComposerState(page);
+    }
+    return state;
+}
+
 export const sendCommand = cli({
     site: 'codex',
     name: 'send',
@@ -11,21 +107,20 @@ export const sendCommand = cli({
     browser: true,
     args: [
         { name: 'text', required: true, positional: true, help: 'Text, command (e.g. /review), or skill (e.g. $imagegen)' },
+        { name: 'pick', required: false, help: 'Picker option label to select when a slash command opens the picker (e.g. "Review Agent")' },
         ...conversationSelectionArgs,
     ],
     columns: ['Status', 'Project', 'Conversation', 'InjectedText'],
     func: async (page, kwargs) => {
         const textToInsert = kwargs.text;
+        const pick = String(kwargs.pick ?? '').trim();
+        if (kwargs.pick != null && !pick) {
+            throw new ArgumentError('--pick label cannot be empty');
+        }
         const selected = await openCodexConversation(page, kwargs);
         const injected = await page.evaluate(`
       (function(text) {
-        let composer = document.querySelector('textarea, [contenteditable="true"]');
-        
-        const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'));
-        if (editables.length > 0) {
-           composer = editables[editables.length - 1];
-        }
-
+        const composer = (${findCodexComposerElement.toString()})();
         if (!composer) return false;
 
         composer.focus();
@@ -37,8 +132,105 @@ export const sendCommand = cli({
             throw selectorError('Codex Composer input element');
         // Wait for the UI to register the input
         await page.wait(0.5);
-        // Simulate Enter key to submit
+        let picked = null;
+        if (pick) {
+            const options = unwrapEvaluateResult(await page.evaluate(`(async () => {
+      const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+      let items = [];
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        items = Array.from(document.querySelectorAll('${PICKER_ITEM_SELECTOR}'))
+          .filter((it) => it instanceof HTMLElement && it.offsetParent);
+        if (items.length) break;
+        await wait(75);
+      }
+      // Picker titles are split into per-character spans for match
+      // highlighting, so read the leading truncate div for the title and the
+      // concatenated textContent (title plus description) for substrings.
+      return items.map((el) => {
+        const text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+        const lead = el.querySelector('[class*="truncate"]');
+        return { title: lead ? (lead.textContent || '').replace(/\\s+/g, ' ').trim() : text, text };
+      });
+    })()`));
+            if (!Array.isArray(options) || options.length === 0) {
+                throw new CommandExecutionError('Codex picker did not open after typing the command.', 'Check that the text opens a picker, or drop --pick.');
+            }
+            picked = findUniquePickerOption(options, pick);
+            if (!picked) {
+                throw new CommandExecutionError('No picker option matched.', `wanted=${pick} available=${JSON.stringify(options.map((option) => option.title))}`);
+            }
+            const clicked = unwrapEvaluateResult(await page.evaluate(`(() => {
+      const items = Array.from(document.querySelectorAll('${PICKER_ITEM_SELECTOR}'))
+        .filter((it) => it instanceof HTMLElement && it.offsetParent);
+      const target = items[${picked.index}];
+      if (!target) return false;
+      const rect = target.getBoundingClientRect();
+      const init = {
+        bubbles: true, cancelable: true, button: 0, buttons: 1,
+        clientX: Math.round(rect.left + rect.width / 2),
+        clientY: Math.round(rect.top + rect.height / 2),
+      };
+      // The picker only responds to the full pointer chain, and deferring it
+      // keeps the eval response ahead of the re-render that closes the picker.
+      Promise.resolve().then(() => {
+        try {
+          target.dispatchEvent(new PointerEvent('pointerdown', { ...init, pointerType: 'mouse' }));
+          target.dispatchEvent(new MouseEvent('mousedown', init));
+          target.dispatchEvent(new PointerEvent('pointerup', { ...init, pointerType: 'mouse' }));
+          target.dispatchEvent(new MouseEvent('mouseup', init));
+          target.dispatchEvent(new MouseEvent('click', init));
+        } catch {}
+      });
+      return true;
+    })()`));
+            if (clicked !== true) {
+                throw new CommandExecutionError('Codex picker option disappeared before it could be clicked.', `wanted=${picked.title}`);
+            }
+            // The click above is deferred, so verify it landed: the picker must
+            // close and the composer must hold a chip for the picked option.
+            let applied = null;
+            for (let attempt = 0; attempt < 20; attempt += 1) {
+                const state = await readComposerState(page);
+                const pickerOpen = unwrapEvaluateResult(await page.evaluate(`Array.from(document.querySelectorAll('${PICKER_ITEM_SELECTOR}')).some((it) => it instanceof HTMLElement && !!it.offsetParent)`)) === true;
+                if (!pickerOpen && state.chips.some((chip) => chipMatchesLabel(chip, picked.title))) {
+                    applied = state;
+                    break;
+                }
+                applied = state;
+                await page.wait(0.1);
+            }
+            if (!applied || !applied.chips.some((chip) => chipMatchesLabel(chip, picked.title))) {
+                throw new CommandExecutionError(
+                    'Codex picker selection did not reach the composer.',
+                    `expected=${picked.title} ${describeComposerState(applied ?? { text: '', chips: [] })}`,
+                );
+            }
+        }
         await page.pressKey('Enter');
+        let state = await pollComposerState(page);
+        if (state.text) {
+            // The picker consumes Enter to insert the highlighted entry, so a
+            // still-loaded composer is either the untouched draft or the chip
+            // the picker resolved. Anything else was rewritten: never submit.
+            const slashToken = /^\/\S+$/.test(textToInsert) ? textToInsert.slice(1) : '';
+            const chipLabel = picked ? picked.title : slashToken;
+            const unchangedDraft = state.chips.length === 0 && state.text === String(textToInsert).trim();
+            const pickerResolvedCommand = chipLabel !== ''
+                && state.chips.length === 1
+                && state.nonChipText === ''
+                && chipMatchesLabel(state.chips[0], chipLabel);
+            if (!unchangedDraft && !pickerResolvedCommand) {
+                throw new CommandExecutionError(
+                    'Codex send was not submitted.',
+                    `The composer now holds ${describeComposerState(state)}. Re-run with --pick <label> or press Escape in Codex first.`,
+                );
+            }
+            await page.pressKey('Enter');
+            state = await pollComposerState(page);
+            if (state.text) {
+                throw new CommandExecutionError('Codex send was not verified.', `The composer still holds an unsent draft: ${describeComposerState(state)}`);
+            }
+        }
         return [
             {
                 Status: 'Success',

--- a/clis/codex/sidebar.test.js
+++ b/clis/codex/sidebar.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { askCommand } from './ask.js';
+import { extractDiffCommand } from './extract-diff.js';
 import { historyCommand } from './history.js';
 import { projectsCommand } from './projects.js';
 import {
@@ -18,6 +19,7 @@ import {
     findUniqueModelOption,
     modelSelectionVerified,
 } from './model.js';
+import { findCodexComposerElement, findUniquePickerOption, sendCommand } from './send.js';
 
 class FakeElement {
     constructor(tagName = 'div', attrs = {}, children = [], text = '') {
@@ -376,6 +378,14 @@ describe('codex sidebar commands', () => {
         await expect(historyCommand.func(page, {})).rejects.toBeInstanceOf(EmptyResultError);
     });
 
+    it('extract-diff fails empty result instead of returning a sentinel row', async () => {
+        const page = {
+            evaluate: async () => [],
+        };
+
+        await expect(extractDiffCommand.func(page)).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
     it('ask rejects invalid timeout instead of falling back to the default', async () => {
         const page = {
             evaluate: async () => 0,
@@ -384,5 +394,258 @@ describe('codex sidebar commands', () => {
         await expect(askCommand.func(page, { text: 'hello', timeout: 'bogus' })).rejects.toBeInstanceOf(ArgumentError);
         await expect(askCommand.func(page, { text: 'hello', timeout: '0' })).rejects.toBeInstanceOf(ArgumentError);
         await expect(askCommand.func(page, { text: 'hello', timeout: '1.5' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+});
+
+describe('codex send picker', () => {
+    it('matches picker options without allowing ambiguous substrings', () => {
+        const options = [
+            { title: 'Review Agent', text: 'Review AgentFind actionable bugs in code changes' },
+            { title: 'Explore Agent', text: 'Explore AgentAnswer questions about the codebase' },
+            { title: 'Agent Builder', text: 'Agent BuilderBuild a custom agent skill' },
+        ];
+
+        expect(findUniquePickerOption(options, 'review agent')).toMatchObject({ title: 'Review Agent', index: 0 });
+        expect(findUniquePickerOption(options, 'actionable bugs')).toMatchObject({ title: 'Review Agent', index: 0 });
+        expect(findUniquePickerOption(options, 'missing option')).toBeNull();
+        expect(() => findUniquePickerOption(options, 'agent')).toThrowError(CommandExecutionError);
+        expect(() => findUniquePickerOption(options, '')).toThrowError(ArgumentError);
+    });
+
+    it('send presses Enter again when the picker resolved the slash command to a chip', async () => {
+        const chipState = { text: '$review-agent', nonChipText: '', chips: [{ name: 'review-agent', display: 'Review Agent' }] };
+        const clearedState = { text: '', nonChipText: '', chips: [] };
+        let injectionDone = false;
+        let enters = 0;
+        const pressed = [];
+        const page = {
+            evaluate: async () => {
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return enters >= 2 ? clearedState : chipState;
+            },
+            wait: async () => {},
+            pressKey: async (key) => {
+                pressed.push(key);
+                enters += 1;
+            },
+        };
+
+        const rows = await sendCommand.func(page, { text: '/review' });
+
+        expect(rows).toEqual([expect.objectContaining({ Status: 'Success', InjectedText: '/review' })]);
+        expect(pressed).toEqual(['Enter', 'Enter']);
+    });
+
+    it('send throws instead of submitting when the composer was rewritten to something else', async () => {
+        const mismatch = { text: '$deep-dive', nonChipText: '', chips: [{ name: 'deep-dive', display: 'Deep Dive' }] };
+        let injectionDone = false;
+        const pressed = [];
+        const page = {
+            evaluate: async () => {
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return mismatch;
+            },
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        await expect(sendCommand.func(page, { text: '/review' })).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(pressed).toEqual(['Enter']);
+    });
+
+    it('send retries once when the keypress did not register and then fails typed', async () => {
+        const stuck = { text: '/review', nonChipText: '/review', chips: [] };
+        let injectionDone = false;
+        const pressed = [];
+        const page = {
+            evaluate: async () => {
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return stuck;
+            },
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        await expect(sendCommand.func(page, { text: '/review' })).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(pressed).toEqual(['Enter', 'Enter']);
+    });
+
+    it('send fails typed when the composer selector cannot be verified', async () => {
+        let injectionDone = false;
+        const page = {
+            evaluate: async () => {
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return null;
+            },
+            wait: async () => {},
+            pressKey: async () => {},
+        };
+
+        await expect(sendCommand.func(page, { text: 'hello' })).rejects.toMatchObject({ code: 'SELECTOR' });
+    });
+
+    it('send submits plain text with a single Enter when no picker appears', async () => {
+        const cleared = { text: '', nonChipText: '', chips: [] };
+        const calls = [];
+        let injectionDone = false;
+        const pressed = [];
+        const page = {
+            evaluate: async () => {
+                calls.push('evaluate');
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return cleared;
+            },
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        const rows = await sendCommand.func(page, { text: 'hello' });
+
+        expect(rows).toEqual([expect.objectContaining({ Status: 'Success', InjectedText: 'hello' })]);
+        expect(pressed).toEqual(['Enter']);
+        expect(calls).toHaveLength(2);
+    });
+
+    it('send anchors injection and post-submit verification to the same composer element', async () => {
+        const scripts = [];
+        let injectionDone = false;
+        const page = {
+            evaluate: async (script) => {
+                scripts.push(String(script));
+                if (!injectionDone) {
+                    injectionDone = true;
+                    return true;
+                }
+                return { text: '', nonChipText: '', chips: [] };
+            },
+            wait: async () => {},
+            pressKey: async () => {},
+        };
+
+        await sendCommand.func(page, { text: 'hello' });
+
+        expect(scripts).toHaveLength(2);
+        for (const script of scripts) {
+            expect(script).toContain(findCodexComposerElement.toString());
+        }
+    });
+
+    it('send clicks the matched picker item and verifies the chip before submitting', async () => {
+        const responses = [
+            true, // inject text
+            [{ title: 'Review Agent', text: 'Review AgentFind actionable bugs in code changes' }], // picker options
+            true, // click dispatched
+            { text: '$review-agent', nonChipText: '', chips: [{ name: 'review-agent', display: 'Review Agent' }] }, // chip landed
+            false, // picker closed
+            { text: '', nonChipText: '', chips: [] }, // composer cleared after Enter
+        ];
+        const pressed = [];
+        const page = {
+            evaluate: async () => responses.shift(),
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        const rows = await sendCommand.func(page, { text: '/review', pick: 'Review Agent' });
+
+        expect(rows).toEqual([expect.objectContaining({ Status: 'Success', InjectedText: '/review' })]);
+        expect(pressed).toEqual(['Enter']);
+        expect(responses).toHaveLength(0);
+    });
+
+    it('send retries Enter when the picked chip does not echo the slash token', async () => {
+        const chipState = { text: '$agent-builder', nonChipText: '', chips: [{ name: 'agent-builder', display: 'Agent Builder' }] };
+        const responses = [
+            true, // inject text
+            [{ title: 'Agent Builder', text: 'Agent BuilderBuild a custom agent skill' }], // picker options
+            true, // click dispatched
+            chipState, // chip landed
+            false, // picker closed
+            ...Array.from({ length: 6 }, () => chipState), // first Enter left the chip in place
+            { text: '', nonChipText: '', chips: [] }, // composer cleared after the retry Enter
+        ];
+        const pressed = [];
+        const page = {
+            evaluate: async () => responses.shift(),
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        const rows = await sendCommand.func(page, { text: '/skills', pick: 'Agent Builder' });
+
+        expect(rows).toEqual([expect.objectContaining({ Status: 'Success', InjectedText: '/skills' })]);
+        expect(pressed).toEqual(['Enter', 'Enter']);
+        expect(responses).toHaveLength(0);
+    });
+
+    it('send fails typed when the picker click did not insert the picked chip', async () => {
+        const stuck = { text: '/review', nonChipText: '/review', chips: [] };
+        const responses = [
+            true, // inject text
+            [{ title: 'Review Agent', text: 'Review AgentFind actionable bugs in code changes' }], // picker options
+            true, // click dispatched
+            ...Array.from({ length: 20 }, () => [stuck, false]).flat(), // chip never lands, picker closed
+        ];
+        const pressed = [];
+        const page = {
+            evaluate: async () => responses.shift(),
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        await expect(sendCommand.func(page, { text: '/review', pick: 'Review Agent' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'Codex picker selection did not reach the composer.',
+        });
+        expect(pressed).toEqual([]);
+        expect(responses).toHaveLength(0);
+    });
+
+    it('send surfaces picker candidates when --pick is ambiguous', async () => {
+        const responses = [
+            true, // inject text
+            [
+                { title: 'Review Agent', text: 'Review AgentFind actionable bugs in code changes' },
+                { title: 'Explore Agent', text: 'Explore AgentAnswer questions about the codebase' },
+            ], // picker options
+        ];
+        const pressed = [];
+        const page = {
+            evaluate: async () => responses.shift(),
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        await expect(sendCommand.func(page, { text: '/review', pick: 'agent' })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'Picker option "agent" is ambiguous.',
+        });
+        expect(pressed).toEqual([]);
+        expect(responses).toHaveLength(0);
+    });
+
+    it('send rejects a --pick label that trims to empty', async () => {
+        const page = {
+            evaluate: async () => true,
+            wait: async () => {},
+            pressKey: async () => {},
+        };
+
+        await expect(sendCommand.func(page, { text: '/review', pick: '   ' })).rejects.toBeInstanceOf(ArgumentError);
     });
 });

--- a/clis/codex/sidebar.test.js
+++ b/clis/codex/sidebar.test.js
@@ -386,6 +386,14 @@ describe('codex sidebar commands', () => {
         await expect(extractDiffCommand.func(page)).rejects.toBeInstanceOf(EmptyResultError);
     });
 
+    it('extract-diff unwraps Browser Bridge envelopes before checking empty results', async () => {
+        const page = {
+            evaluate: async () => ({ session: 'codex', data: [] }),
+        };
+
+        await expect(extractDiffCommand.func(page)).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
     it('ask rejects invalid timeout instead of falling back to the default', async () => {
         const page = {
             evaluate: async () => 0,
@@ -494,6 +502,18 @@ describe('codex send picker', () => {
         };
 
         await expect(sendCommand.func(page, { text: 'hello' })).rejects.toMatchObject({ code: 'SELECTOR' });
+    });
+
+    it('send unwraps Browser Bridge envelopes before trusting injection success', async () => {
+        const pressed = [];
+        const page = {
+            evaluate: async () => ({ session: 'codex', data: false }),
+            wait: async () => {},
+            pressKey: async (key) => { pressed.push(key); },
+        };
+
+        await expect(sendCommand.func(page, { text: 'hello' })).rejects.toMatchObject({ code: 'SELECTOR' });
+        expect(pressed).toEqual([]);
     });
 
     it('send submits plain text with a single Enter when no picker appears', async () => {

--- a/docs/adapters/desktop/codex.md
+++ b/docs/adapters/desktop/codex.md
@@ -27,7 +27,7 @@ export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9238"
 ### Agent Manipulation
 - `opencli codex new`: Simulates `Cmd+N` to start a completely fresh and isolated Git Worktree thread context.
 - `opencli codex send "message"`: Robustly finds the active Thread Composer and injects your text.
-  - *Pro-tip*: You can trigger internal shortcuts, e.g., `opencli codex send "/review"`.
+  - *Pro-tip*: You can trigger internal shortcuts and resolve the skills picker they open in one shot, e.g., `opencli codex send "/review" --pick "Review Agent"`.
 - `opencli codex ask "message"`: Send + wait + read in one shot.
 - `opencli codex read`: Extracts the entire current thread history and AI reasoning logs.
 - `opencli codex projects`: List visible sidebar projects and conversations.


### PR DESCRIPTION
## Description

`codex send "/review"` reported Success while nothing was sent. The slash picker consumes the Enter that `send` fires: on current Codex builds it inserts the highlighted entry as a skill-mention chip and the message stays behind as an unsent draft, so `extract-diff` finds nothing (#1991).

`send` now verifies submission: after Enter it polls the composer and reports Success only once the draft has left; a chip matching the typed token, or the verified `--pick` label, is submitted with a second Enter; any other rewrite of the draft raises `CommandExecutionError` naming what the composer holds. The new `--pick <label>` matches the picker options in Node, clicks the entry by index, and verifies the chip landed before submitting. Injection and the post-submit check share one composer-selection function, so verification cannot pass against a different element than the one written into. `extract-diff`'s empty case now raises `EmptyResultError` like its siblings; `codex ask` keeps the single-Enter exposure, left for a follow-up.

Related issue: Closes #1991

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Codex 26.727.51351 (Chromium 150.0.7871.182), live. Before: `send "/review"` returns `Status: Success` while the composer still holds the `$review-agent` mention chip as an unsent draft and the thread receives nothing. After:

```
$ opencli codex send "/review" --pick "Review Agent"
- Status: Success
  InjectedText: /review

$ opencli codex read
  Content: |-
    You said:
    Review Agent
```

Adapter tests 32 / 32; the two picker-failure tests assert the exact error messages, and disabling the chip verification, the picked-label guard, or the shared anchoring each fails a test (mutation-checked). Typecheck, both lint gates and doc coverage pass; `cli-manifest.json` gains only the `pick` arg hunk with no local paths.
