### PR TITLE
fix(instagram): like and unlike posts through the post page controls

### DIFF
--- a/clis/instagram/_shared/post-like.js
+++ b/clis/instagram/_shared/post-like.js
@@ -1,8 +1,10 @@
-import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 
 const INSTAGRAM_APP_ID = '936619743392459';
 const LIKE_LABELS = ['Like', '赞'];
 const UNLIKE_LABELS = ['Unlike', '取消赞'];
+const COMMENT_LABELS = ['Comment', '评论'];
+const SHARE_LABELS = ['Share', '分享'];
 
 function unwrapEvaluateResult(result) {
     return result && typeof result === 'object' && !Array.isArray(result) && 'data' in result && 'session' in result
@@ -14,31 +16,57 @@ function labelSelector(labels) {
     return labels.map((label) => `svg[aria-label="${label}"]`).join(', ');
 }
 
+function normalizeNumericId(value) {
+    const id = typeof value === 'number' ? String(value) : (typeof value === 'string' ? value.trim() : '');
+    return /^\d+$/.test(id) ? id : '';
+}
+
+function normalizeShortcode(value) {
+    const code = typeof value === 'string' ? value.trim() : '';
+    return /^[A-Za-z0-9_-]+$/.test(code) ? code : '';
+}
+
 export function buildReadPostsJs(username, count) {
     return `(async () => {
-  const res = await fetch(
-    'https://www.instagram.com/api/v1/feed/user/' + encodeURIComponent(${JSON.stringify(username)}) + '/username/?count=' + ${count},
-    { credentials: 'include', headers: { 'X-IG-App-ID': '${INSTAGRAM_APP_ID}' } }
-  );
+  let res;
+  try {
+    res = await fetch(
+      'https://www.instagram.com/api/v1/feed/user/' + encodeURIComponent(${JSON.stringify(username)}) + '/username/?count=' + ${count},
+      { credentials: 'include', headers: { 'X-IG-App-ID': '${INSTAGRAM_APP_ID}' } }
+    );
+  } catch (error) {
+    return { errorKind: 'fetch', message: error instanceof Error ? error.message : String(error) };
+  }
   if (!res.ok) return { error: res.status };
-  const items = (await res.json())?.items || [];
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return { errorKind: 'invalid-json' };
+  }
+  const items = Array.isArray(data?.items) ? data.items : null;
   return {
-    items: items.map((item) => ({
-      code: item.code || '',
-      caption: (item.caption?.text || '').substring(0, 60),
-      liked: !!item.has_liked,
+    ownerId: data?.user?.pk ?? data?.user?.id,
+    items: items && items.map((item) => ({
+      code: item?.code,
+      pk: item?.pk ?? item?.id,
+      caption: typeof item?.caption?.text === 'string' ? item.caption.text.substring(0, 60) : '',
+      liked: item?.has_liked,
     })),
   };
 })()`;
 }
 
 // Comment rows repeat the like labels on 16px icons, so only a 24px icon in a
-// sparse section/div[role="group"] is the post control (#2241).
+// sparse action bar with comment/share siblings is the post control (#2241).
 function buildFindControlJs(body) {
     return `(() => {
   const isActionBar = (icon) => {
     const bar = icon.closest('section, div[role="group"]');
-    return !!bar && bar.querySelectorAll('svg[aria-label]').length <= 8;
+    if (!bar || bar.querySelectorAll('svg[aria-label]').length > 8) return false;
+    const hasComment = !!bar.querySelector('${labelSelector(COMMENT_LABELS)}');
+    const hasShare = !!bar.querySelector('${labelSelector(SHARE_LABELS)}');
+    return hasComment || hasShare;
   };
   const control = Array.from(document.querySelectorAll('${labelSelector([...LIKE_LABELS, ...UNLIKE_LABELS])}'))
     .find((icon) => Math.round(icon.getBoundingClientRect().width) >= 24 && isActionBar(icon)) || null;
@@ -60,31 +88,85 @@ export function buildReadLikeStateJs(shouldLike) {
     return buildFindControlJs(`  return liked === ${shouldLike};`);
 }
 
+function readPostsError(feed, command, username) {
+    if (feed?.error === 401 || feed?.error === 403) {
+        return new AuthRequiredError('www.instagram.com', `Instagram requires login to read ${username}'s posts`);
+    }
+    if (feed?.error === 404) {
+        return new EmptyResultError(command, `No Instagram user named ${username}.`);
+    }
+    if (feed?.error) {
+        return new CommandExecutionError(`Instagram returned HTTP ${feed.error} for ${username}'s posts`, 'Verify you are logged in to Instagram.');
+    }
+    if (feed?.errorKind === 'fetch') {
+        return new CommandExecutionError(`Instagram post feed request failed for ${username}: ${feed.message || 'fetch failed'}`);
+    }
+    if (feed?.errorKind === 'invalid-json') {
+        return new CommandExecutionError(`Instagram post feed returned invalid JSON for ${username}`);
+    }
+    return null;
+}
+
+function normalizeFeedSnapshot(feed, command, username) {
+    const error = readPostsError(feed, command, username);
+    if (error) throw error;
+    if (!feed || typeof feed !== 'object' || Array.isArray(feed)) {
+        throw new CommandExecutionError(`Instagram post feed returned malformed payload for ${username}`);
+    }
+    const ownerId = normalizeNumericId(feed.ownerId);
+    if (!ownerId) {
+        throw new CommandExecutionError(`Instagram post feed returned no valid owner id for ${username}`);
+    }
+    if (!Array.isArray(feed.items)) {
+        throw new CommandExecutionError(`Instagram post feed returned malformed items for ${username}`);
+    }
+    const posts = feed.items.map((item) => {
+        if (!item || typeof item !== 'object') {
+            throw new CommandExecutionError(`Instagram post feed returned malformed post row for ${username}`);
+        }
+        const code = normalizeShortcode(item.code);
+        const pk = normalizeNumericId(item.pk);
+        if (!code || !pk || typeof item.liked !== 'boolean') {
+            throw new CommandExecutionError(`Instagram post feed returned malformed post row for ${username}`);
+        }
+        return {
+            code,
+            pk,
+            caption: typeof item.caption === 'string' ? item.caption : '',
+            liked: item.liked,
+        };
+    });
+    return { ownerId, posts };
+}
+
+async function readPostSnapshot(page, username, index, command) {
+    const feed = unwrapEvaluateResult(await page.evaluate(buildReadPostsJs(username, index)));
+    return normalizeFeedSnapshot(feed, command, username);
+}
+
+function pickPost(snapshot, username, index, command) {
+    const post = snapshot.posts[index - 1];
+    if (!post) {
+        throw new EmptyResultError(command, snapshot.posts.length === 0
+            ? `No visible posts for ${username}; check the username and whether the account is private.`
+            : `Post index ${index} not found; ${username} has ${snapshot.posts.length} recent posts.`);
+    }
+    return post;
+}
+
 export async function setInstagramPostLike(page, kwargs, shouldLike) {
     const username = String(kwargs.username || '').trim();
     const index = kwargs.index;
     const command = shouldLike ? 'instagram like' : 'instagram unlike';
+    if (!username) {
+        throw new ArgumentError('username is required');
+    }
     if (!Number.isInteger(index) || index < 1) {
         throw new ArgumentError('--index must be a positive integer', 'e.g. --index 2 for the second most recent post');
     }
 
-    const feed = unwrapEvaluateResult(await page.evaluate(buildReadPostsJs(username, index)));
-    if (feed?.error) {
-        throw feed.error === 404
-            ? new EmptyResultError(command, `No Instagram user named ${username}.`)
-            : new CommandExecutionError(`Instagram returned HTTP ${feed.error} for ${username}'s posts`, 'Verify you are logged in to Instagram.');
-    }
-    const posts = Array.isArray(feed?.items) ? feed.items : [];
-    const post = posts[index - 1];
-    if (!post) {
-        throw new EmptyResultError(command, posts.length === 0
-            ? `No visible posts for ${username}; check the username and whether the account is private.`
-            : `Post index ${index} not found; ${username} has ${posts.length} recent posts.`);
-    }
-    if (!post.code) {
-        throw new CommandExecutionError('Instagram feed returned a post without a shortcode', 'The response shape may have changed.');
-    }
-
+    const snapshot = await readPostSnapshot(page, username, index, command);
+    const post = pickPost(snapshot, username, index, command);
     const label = post.caption || `(post #${index})`;
     const settled = [{ status: shouldLike ? 'Already liked' : 'Already unliked', user: username, post: label }];
     if (post.liked === shouldLike) return settled;
@@ -109,6 +191,19 @@ export async function setInstagramPostLike(page, kwargs, shouldLike) {
         // A rejected action reverts the icon shortly after the optimistic flip.
         await page.sleep(2);
         if (unwrapEvaluateResult(await page.evaluate(buildReadLikeStateJs(shouldLike))) === true) {
+            const confirmed = pickPost(await readPostSnapshot(page, username, index, command), username, index, command);
+            if (confirmed.code !== post.code || confirmed.pk !== post.pk) {
+                throw new CommandExecutionError(
+                    `Instagram post feed no longer shows the expected post ${post.code} at index ${index}`,
+                    'The profile feed may have re-rendered or changed order; retry after checking the post in the browser.',
+                );
+            }
+            if (confirmed.liked !== shouldLike) {
+                throw new CommandExecutionError(
+                    `Instagram did not persist the ${shouldLike ? 'like' : 'unlike'} on ${post.code}`,
+                    'The action may have been rejected. Retry later, or check the post in the browser.',
+                );
+            }
             return [{ status: shouldLike ? 'Liked' : 'Unliked', user: username, post: label }];
         }
         break;

--- a/clis/instagram/_shared/post-like.js
+++ b/clis/instagram/_shared/post-like.js
@@ -154,6 +154,23 @@ function pickPost(snapshot, username, index, command) {
     return post;
 }
 
+async function confirmPersistedState(page, username, index, command, expectedPost, shouldLike) {
+    const confirmed = pickPost(await readPostSnapshot(page, username, index, command), username, index, command);
+    if (confirmed.code !== expectedPost.code || confirmed.pk !== expectedPost.pk) {
+        throw new CommandExecutionError(
+            `Instagram post feed no longer shows the expected post ${expectedPost.code} at index ${index}`,
+            'The profile feed may have re-rendered or changed order; retry after checking the post in the browser.',
+        );
+    }
+    if (confirmed.liked !== shouldLike) {
+        throw new CommandExecutionError(
+            `Instagram did not persist the ${shouldLike ? 'like' : 'unlike'} on ${expectedPost.code}`,
+            'The action may have been rejected. Retry later, or check the post in the browser.',
+        );
+    }
+    return confirmed;
+}
+
 export async function setInstagramPostLike(page, kwargs, shouldLike) {
     const username = String(kwargs.username || '').trim();
     const index = kwargs.index;
@@ -183,7 +200,10 @@ export async function setInstagramPostLike(page, kwargs, shouldLike) {
             'Open the post in the browser and check whether Instagram is asking you to log in, or set the interface language to English.',
         );
     }
-    if (click.already) return settled;
+    if (click.already) {
+        await confirmPersistedState(page, username, index, command, post, shouldLike);
+        return settled;
+    }
 
     for (let attempt = 0; attempt < 5; attempt += 1) {
         await page.sleep(1);
@@ -191,19 +211,7 @@ export async function setInstagramPostLike(page, kwargs, shouldLike) {
         // A rejected action reverts the icon shortly after the optimistic flip.
         await page.sleep(2);
         if (unwrapEvaluateResult(await page.evaluate(buildReadLikeStateJs(shouldLike))) === true) {
-            const confirmed = pickPost(await readPostSnapshot(page, username, index, command), username, index, command);
-            if (confirmed.code !== post.code || confirmed.pk !== post.pk) {
-                throw new CommandExecutionError(
-                    `Instagram post feed no longer shows the expected post ${post.code} at index ${index}`,
-                    'The profile feed may have re-rendered or changed order; retry after checking the post in the browser.',
-                );
-            }
-            if (confirmed.liked !== shouldLike) {
-                throw new CommandExecutionError(
-                    `Instagram did not persist the ${shouldLike ? 'like' : 'unlike'} on ${post.code}`,
-                    'The action may have been rejected. Retry later, or check the post in the browser.',
-                );
-            }
+            await confirmPersistedState(page, username, index, command, post, shouldLike);
             return [{ status: shouldLike ? 'Liked' : 'Unliked', user: username, post: label }];
         }
         break;

--- a/clis/instagram/_shared/post-like.js
+++ b/clis/instagram/_shared/post-like.js
@@ -1,0 +1,120 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const INSTAGRAM_APP_ID = '936619743392459';
+const LIKE_LABELS = ['Like', '赞'];
+const UNLIKE_LABELS = ['Unlike', '取消赞'];
+
+function unwrapEvaluateResult(result) {
+    return result && typeof result === 'object' && !Array.isArray(result) && 'data' in result && 'session' in result
+        ? result.data
+        : result;
+}
+
+function labelSelector(labels) {
+    return labels.map((label) => `svg[aria-label="${label}"]`).join(', ');
+}
+
+export function buildReadPostsJs(username, count) {
+    return `(async () => {
+  const res = await fetch(
+    'https://www.instagram.com/api/v1/feed/user/' + encodeURIComponent(${JSON.stringify(username)}) + '/username/?count=' + ${count},
+    { credentials: 'include', headers: { 'X-IG-App-ID': '${INSTAGRAM_APP_ID}' } }
+  );
+  if (!res.ok) return { error: res.status };
+  const items = (await res.json())?.items || [];
+  return {
+    items: items.map((item) => ({
+      code: item.code || '',
+      caption: (item.caption?.text || '').substring(0, 60),
+      liked: !!item.has_liked,
+    })),
+  };
+})()`;
+}
+
+// Comment rows repeat the like labels on 16px icons, so only a 24px icon in a
+// sparse section/div[role="group"] is the post control (#2241).
+function buildFindControlJs(body) {
+    return `(() => {
+  const isActionBar = (icon) => {
+    const bar = icon.closest('section, div[role="group"]');
+    return !!bar && bar.querySelectorAll('svg[aria-label]').length <= 8;
+  };
+  const control = Array.from(document.querySelectorAll('${labelSelector([...LIKE_LABELS, ...UNLIKE_LABELS])}'))
+    .find((icon) => Math.round(icon.getBoundingClientRect().width) >= 24 && isActionBar(icon)) || null;
+  const liked = control ? ${JSON.stringify(UNLIKE_LABELS)}.includes(control.getAttribute('aria-label')) : null;
+${body}
+})()`;
+}
+
+export function buildToggleLikeJs(shouldLike) {
+    return buildFindControlJs(`  if (!control) return { found: false };
+  if (liked === ${shouldLike}) return { found: true, already: true };
+  const button = control.closest('div[role="button"], button');
+  if (!button) return { found: false };
+  button.click();
+  return { found: true, already: false };`);
+}
+
+export function buildReadLikeStateJs(shouldLike) {
+    return buildFindControlJs(`  return liked === ${shouldLike};`);
+}
+
+export async function setInstagramPostLike(page, kwargs, shouldLike) {
+    const username = String(kwargs.username || '').trim();
+    const index = kwargs.index;
+    const command = shouldLike ? 'instagram like' : 'instagram unlike';
+    if (!Number.isInteger(index) || index < 1) {
+        throw new ArgumentError('--index must be a positive integer', 'e.g. --index 2 for the second most recent post');
+    }
+
+    const feed = unwrapEvaluateResult(await page.evaluate(buildReadPostsJs(username, index)));
+    if (feed?.error) {
+        throw feed.error === 404
+            ? new EmptyResultError(command, `No Instagram user named ${username}.`)
+            : new CommandExecutionError(`Instagram returned HTTP ${feed.error} for ${username}'s posts`, 'Verify you are logged in to Instagram.');
+    }
+    const posts = Array.isArray(feed?.items) ? feed.items : [];
+    const post = posts[index - 1];
+    if (!post) {
+        throw new EmptyResultError(command, posts.length === 0
+            ? `No visible posts for ${username}; check the username and whether the account is private.`
+            : `Post index ${index} not found; ${username} has ${posts.length} recent posts.`);
+    }
+    if (!post.code) {
+        throw new CommandExecutionError('Instagram feed returned a post without a shortcode', 'The response shape may have changed.');
+    }
+
+    const label = post.caption || `(post #${index})`;
+    const settled = [{ status: shouldLike ? 'Already liked' : 'Already unliked', user: username, post: label }];
+    if (post.liked === shouldLike) return settled;
+
+    await page.goto(`https://www.instagram.com/p/${post.code}/`, { settleMs: 2000 });
+    let click = null;
+    for (let attempt = 0; attempt < 5 && !click?.found; attempt += 1) {
+        if (attempt > 0) await page.sleep(1);
+        click = unwrapEvaluateResult(await page.evaluate(buildToggleLikeJs(shouldLike)));
+    }
+    if (!click?.found) {
+        throw new CommandExecutionError(
+            `Could not find the like control on ${post.code}`,
+            'Open the post in the browser and check whether Instagram is asking you to log in, or set the interface language to English.',
+        );
+    }
+    if (click.already) return settled;
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        await page.sleep(1);
+        if (unwrapEvaluateResult(await page.evaluate(buildReadLikeStateJs(shouldLike))) !== true) continue;
+        // A rejected action reverts the icon shortly after the optimistic flip.
+        await page.sleep(2);
+        if (unwrapEvaluateResult(await page.evaluate(buildReadLikeStateJs(shouldLike))) === true) {
+            return [{ status: shouldLike ? 'Liked' : 'Unliked', user: username, post: label }];
+        }
+        break;
+    }
+    throw new CommandExecutionError(
+        `Instagram did not keep the ${shouldLike ? 'like' : 'unlike'} on ${post.code}`,
+        'The action may have been rejected. Retry later, or check the post in the browser.',
+    );
+}

--- a/clis/instagram/_shared/post-like.test.js
+++ b/clis/instagram/_shared/post-like.test.js
@@ -38,7 +38,7 @@ function createPageMock({ feed, dom, onToggle } = {}) {
         goto: vi.fn().mockResolvedValue(undefined),
         sleep: vi.fn().mockResolvedValue(undefined),
         evaluate: vi.fn((script) => {
-            if (script.includes('/username/?count=')) return Promise.resolve(feed);
+            if (script.includes('/username/?count=')) return Promise.resolve(typeof feed === 'function' ? feed() : feed);
             if (!dom) return Promise.resolve(null);
             const result = dom.window.eval(script);
             if (script.includes('button.click()')) onToggle?.(dom);
@@ -47,7 +47,7 @@ function createPageMock({ feed, dom, onToggle } = {}) {
     };
 }
 
-const onePost = { items: [{ code: 'ABC123', caption: 'a caption', liked: false }] };
+const onePost = { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: false }] };
 const args = { username: 'someone', index: 1 };
 
 describe('instagram post like page scripts', () => {
@@ -88,6 +88,13 @@ describe('instagram post like page scripts', () => {
         expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: false });
     });
 
+    it('finds no control when a full-size like icon lacks action-bar siblings', () => {
+        const dom = new JSDOM('<section><div role="button"><svg aria-label="Like"></svg></div></section>', { runScripts: 'outside-only' });
+        dom.window.document.querySelector('svg').getBoundingClientRect = () => ({ width: 24, height: 24 });
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: false });
+    });
+
     it('finds no control when the full-size icon sits among many labeled comment icons', () => {
         const dom = new JSDOM(`
             <section>
@@ -111,16 +118,21 @@ describe('instagram post like page scripts', () => {
 describe('instagram post like', () => {
     it('reports success only after the flipped icon holds', async () => {
         const dom = createPostDom();
+        let feed = onePost;
         const page = createPageMock({
-            feed: onePost,
+            feed: () => feed,
             dom,
-            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike'),
+            onToggle: (d) => {
+                d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike');
+                feed = { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: true }] };
+            },
         });
 
         await expect(setInstagramPostLike(page, args, true)).resolves.toEqual([
             { status: 'Liked', user: 'someone', post: 'a caption' },
         ]);
         expect(page.goto).toHaveBeenCalledWith('https://www.instagram.com/p/ABC123/', { settleMs: 2000 });
+        expect(page.evaluate.mock.calls.filter(([script]) => script.includes('/username/?count='))).toHaveLength(2);
     });
 
     it('typed-fails when the icon flips and then reverts', async () => {
@@ -149,8 +161,38 @@ describe('instagram post like', () => {
         expect(page.evaluate.mock.calls.filter(([script]) => script.includes('button.click()'))).toHaveLength(5);
     });
 
+    it('typed-fails when the DOM flips but the feed does not persist the state', async () => {
+        const dom = createPostDom();
+        const page = createPageMock({
+            feed: onePost,
+            dom,
+            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike'),
+        });
+
+        await expect(setInstagramPostLike(page, args, true)).rejects.toThrow('Instagram did not persist the like on ABC123');
+    });
+
+    it('typed-fails when the feed changes to a different post after click', async () => {
+        const dom = createPostDom();
+        const page = createPageMock({
+            feed: onePost,
+            dom,
+            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike'),
+        });
+        let reads = 0;
+        const inner = page.evaluate;
+        page.evaluate = vi.fn((script) => {
+            if (script.includes('/username/?count=') && ++reads === 2) {
+                return Promise.resolve({ ownerId: '42', items: [{ code: 'DIFFERENT', pk: '12345', caption: 'other', liked: true }] });
+            }
+            return inner(script);
+        });
+
+        await expect(setInstagramPostLike(page, args, true)).rejects.toThrow('Instagram post feed no longer shows the expected post ABC123 at index 1');
+    });
+
     it('skips the post page when the feed already shows the target state', async () => {
-        const page = createPageMock({ feed: { items: [{ code: 'ABC123', caption: 'a caption', liked: true }] } });
+        const page = createPageMock({ feed: { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: true }] } });
 
         await expect(setInstagramPostLike(page, args, true)).resolves.toEqual([
             { status: 'Already liked', user: 'someone', post: 'a caption' },
@@ -160,10 +202,14 @@ describe('instagram post like', () => {
 
     it('unlikes through the same control and reports the reverse status', async () => {
         const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Unlike' });
+        let feed = { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: true }] };
         const page = createPageMock({
-            feed: { items: [{ code: 'ABC123', caption: 'a caption', liked: true }] },
+            feed: () => feed,
             dom,
-            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Like'),
+            onToggle: (d) => {
+                d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Like');
+                feed = onePost;
+            },
         });
 
         await expect(setInstagramPostLike(page, args, false)).resolves.toEqual([
@@ -172,10 +218,10 @@ describe('instagram post like', () => {
     });
 
     it('names the running command in empty results', async () => {
-        await expect(setInstagramPostLike(createPageMock({ feed: { items: [] } }), { username: 'ghost', index: 1 }, true))
+        await expect(setInstagramPostLike(createPageMock({ feed: { ownerId: '42', items: [] } }), { username: 'ghost', index: 1 }, true))
             .rejects.toMatchObject({ message: 'instagram like returned no data', hint: expect.stringContaining('No visible posts for ghost') });
 
-        await expect(setInstagramPostLike(createPageMock({ feed: { items: [] } }), { username: 'ghost', index: 1 }, false))
+        await expect(setInstagramPostLike(createPageMock({ feed: { ownerId: '42', items: [] } }), { username: 'ghost', index: 1 }, false))
             .rejects.toMatchObject({ message: 'instagram unlike returned no data' });
 
         await expect(setInstagramPostLike(createPageMock({ feed: onePost }), { username: 'someone', index: 4 }, true))
@@ -190,11 +236,36 @@ describe('instagram post like', () => {
         expect(page.goto).not.toHaveBeenCalled();
     });
 
+    it('rejects an empty username before touching the page', async () => {
+        const page = createPageMock({ feed: onePost });
+
+        await expect(setInstagramPostLike(page, { username: '', index: 1 }, true))
+            .rejects.toThrow('username is required');
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
     it('separates a missing account from a transport failure', async () => {
         await expect(setInstagramPostLike(createPageMock({ feed: { error: 404 } }), { username: 'ghost', index: 1 }, true))
             .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('No Instagram user named ghost') });
 
         await expect(setInstagramPostLike(createPageMock({ feed: { error: 429 } }), args, true))
             .rejects.toThrow('Instagram returned HTTP 429');
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { error: 401 } }), args, true))
+            .rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+    });
+
+    it('typed-fails malformed feed payloads and rows', async () => {
+        await expect(setInstagramPostLike(createPageMock({ feed: { items: [] } }), args, true))
+            .rejects.toThrow('Instagram post feed returned no valid owner id for someone');
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { ownerId: '42', items: null } }), args, true))
+            .rejects.toThrow('Instagram post feed returned malformed items for someone');
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { ownerId: '42', items: [{ code: 'ABC123', pk: { bad: true }, liked: false }] } }), args, true))
+            .rejects.toThrow('Instagram post feed returned malformed post row for someone');
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { ownerId: '42', items: [{ code: 'ABC123', pk: '98765' }] } }), args, true))
+            .rejects.toThrow('Instagram post feed returned malformed post row for someone');
     });
 });

--- a/clis/instagram/_shared/post-like.test.js
+++ b/clis/instagram/_shared/post-like.test.js
@@ -200,6 +200,32 @@ describe('instagram post like', () => {
         expect(page.goto).not.toHaveBeenCalled();
     });
 
+    it('requires feed confirmation when the post page already shows the target state', async () => {
+        const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Like' });
+        let reads = 0;
+        const page = createPageMock({
+            feed: () => {
+                reads += 1;
+                return reads === 1
+                    ? onePost
+                    : { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: true }] };
+            },
+            dom,
+        });
+
+        await expect(setInstagramPostLike(page, args, true)).resolves.toEqual([
+            { status: 'Already liked', user: 'someone', post: 'a caption' },
+        ]);
+        expect(page.evaluate.mock.calls.filter(([script]) => script.includes('/username/?count='))).toHaveLength(2);
+    });
+
+    it('typed-fails when an already-state DOM control is not confirmed by the feed', async () => {
+        const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Like' });
+        const page = createPageMock({ feed: onePost, dom });
+
+        await expect(setInstagramPostLike(page, args, true)).rejects.toThrow('Instagram did not persist the like on ABC123');
+    });
+
     it('unlikes through the same control and reports the reverse status', async () => {
         const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Unlike' });
         let feed = { ownerId: '42', items: [{ code: 'ABC123', pk: '98765', caption: 'a caption', liked: true }] };

--- a/clis/instagram/_shared/post-like.test.js
+++ b/clis/instagram/_shared/post-like.test.js
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildReadLikeStateJs, buildToggleLikeJs, setInstagramPostLike } from './post-like.js';
+
+/**
+ * Build a post page carrying an action bar control plus a comment row control
+ * with the same label, so selection has to distinguish them the way the live
+ * page does.
+ */
+function createPostDom({ actionBarLabel = 'Like', commentLabel = 'Like' } = {}) {
+    const dom = new JSDOM(`
+        <section id="comments">
+            ${Array.from({ length: 12 }, () => '<div role="button"><svg aria-label="' + commentLabel + '" data-kind="comment"></svg></div>').join('')}
+        </section>
+        <section id="actions">
+            <div role="button"><svg aria-label="${actionBarLabel}" data-kind="post"></svg></div>
+            <div role="button"><svg aria-label="Comment"></svg></div>
+            <div role="button"><svg aria-label="Share"></svg></div>
+        </section>
+    `, { runScripts: 'outside-only' });
+    for (const icon of dom.window.document.querySelectorAll('svg')) {
+        const size = icon.getAttribute('data-kind') === 'comment' ? 16 : 24;
+        icon.getBoundingClientRect = () => ({ width: size, height: size });
+    }
+    dom.window.document.addEventListener('click', (event) => {
+        const icon = event.target.querySelector?.('svg');
+        if (icon) dom.window.__clicked = icon.getAttribute('data-kind');
+    });
+    return dom;
+}
+
+/**
+ * Build a page whose evaluate answers the feed read from a canned value and
+ * runs the generated page scripts against a JSDOM post page.
+ */
+function createPageMock({ feed, dom, onToggle } = {}) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        sleep: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn((script) => {
+            if (script.includes('/username/?count=')) return Promise.resolve(feed);
+            if (!dom) return Promise.resolve(null);
+            const result = dom.window.eval(script);
+            if (script.includes('button.click()')) onToggle?.(dom);
+            return Promise.resolve(result);
+        }),
+    };
+}
+
+const onePost = { items: [{ code: 'ABC123', caption: 'a caption', liked: false }] };
+const args = { username: 'someone', index: 1 };
+
+describe('instagram post like page scripts', () => {
+    it('clicks the action bar control and leaves comment controls alone', () => {
+        const dom = createPostDom();
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: true, already: false });
+        expect(dom.window.__clicked).toBe('post');
+    });
+
+    it('reports the post as already in the requested state from the action bar label', () => {
+        const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Like' });
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: true, already: true });
+        expect(dom.window.__clicked).toBeUndefined();
+    });
+
+    it('reads the like state from the action bar and not from a comment row', () => {
+        const liked = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Like' });
+        const notLiked = createPostDom({ actionBarLabel: 'Like', commentLabel: 'Unlike' });
+
+        expect(liked.window.eval(buildReadLikeStateJs(true))).toBe(true);
+        expect(notLiked.window.eval(buildReadLikeStateJs(true))).toBe(false);
+        expect(notLiked.window.eval(buildReadLikeStateJs(false))).toBe(true);
+    });
+
+    it('accepts the Chinese labels the interface uses when it is not in English', () => {
+        const dom = createPostDom({ actionBarLabel: '赞', commentLabel: '赞' });
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: true, already: false });
+        expect(dom.window.__clicked).toBe('post');
+    });
+
+    it('finds no control when the labeled icon is 16px even in a sparse container', () => {
+        const dom = new JSDOM('<div role="group"><div role="button"><svg aria-label="Like"></svg></div></div>', { runScripts: 'outside-only' });
+        dom.window.document.querySelector('svg').getBoundingClientRect = () => ({ width: 16, height: 16 });
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: false });
+    });
+
+    it('finds no control when the full-size icon sits among many labeled comment icons', () => {
+        const dom = new JSDOM(`
+            <section>
+                ${Array.from({ length: 12 }, () => '<div role="button"><svg aria-label="Like"></svg></div>').join('')}
+            </section>
+        `, { runScripts: 'outside-only' });
+        for (const icon of dom.window.document.querySelectorAll('svg')) {
+            icon.getBoundingClientRect = () => ({ width: 24, height: 24 });
+        }
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: false });
+    });
+
+    it('finds no control when the action bar has not rendered', () => {
+        const dom = new JSDOM('<section id="comments"></section>', { runScripts: 'outside-only' });
+
+        expect(dom.window.eval(buildToggleLikeJs(true))).toEqual({ found: false });
+    });
+});
+
+describe('instagram post like', () => {
+    it('reports success only after the flipped icon holds', async () => {
+        const dom = createPostDom();
+        const page = createPageMock({
+            feed: onePost,
+            dom,
+            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike'),
+        });
+
+        await expect(setInstagramPostLike(page, args, true)).resolves.toEqual([
+            { status: 'Liked', user: 'someone', post: 'a caption' },
+        ]);
+        expect(page.goto).toHaveBeenCalledWith('https://www.instagram.com/p/ABC123/', { settleMs: 2000 });
+    });
+
+    it('typed-fails when the icon flips and then reverts', async () => {
+        const dom = createPostDom();
+        let reads = 0;
+        const page = createPageMock({
+            feed: onePost,
+            dom,
+            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Unlike'),
+        });
+        const inner = page.evaluate;
+        page.evaluate = vi.fn((script) => {
+            if (script.includes('return liked ===') && ++reads === 2) {
+                dom.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Like');
+            }
+            return inner(script);
+        });
+
+        await expect(setInstagramPostLike(page, args, true)).rejects.toThrow('Instagram did not keep the like on ABC123');
+    });
+
+    it('typed-fails after retrying a post page that never renders the control', async () => {
+        const page = createPageMock({ feed: onePost, dom: new JSDOM('<main></main>', { runScripts: 'outside-only' }) });
+
+        await expect(setInstagramPostLike(page, args, true)).rejects.toThrow('Could not find the like control on ABC123');
+        expect(page.evaluate.mock.calls.filter(([script]) => script.includes('button.click()'))).toHaveLength(5);
+    });
+
+    it('skips the post page when the feed already shows the target state', async () => {
+        const page = createPageMock({ feed: { items: [{ code: 'ABC123', caption: 'a caption', liked: true }] } });
+
+        await expect(setInstagramPostLike(page, args, true)).resolves.toEqual([
+            { status: 'Already liked', user: 'someone', post: 'a caption' },
+        ]);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('unlikes through the same control and reports the reverse status', async () => {
+        const dom = createPostDom({ actionBarLabel: 'Unlike', commentLabel: 'Unlike' });
+        const page = createPageMock({
+            feed: { items: [{ code: 'ABC123', caption: 'a caption', liked: true }] },
+            dom,
+            onToggle: (d) => d.window.document.querySelector('svg[data-kind="post"]').setAttribute('aria-label', 'Like'),
+        });
+
+        await expect(setInstagramPostLike(page, args, false)).resolves.toEqual([
+            { status: 'Unliked', user: 'someone', post: 'a caption' },
+        ]);
+    });
+
+    it('names the running command in empty results', async () => {
+        await expect(setInstagramPostLike(createPageMock({ feed: { items: [] } }), { username: 'ghost', index: 1 }, true))
+            .rejects.toMatchObject({ message: 'instagram like returned no data', hint: expect.stringContaining('No visible posts for ghost') });
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { items: [] } }), { username: 'ghost', index: 1 }, false))
+            .rejects.toMatchObject({ message: 'instagram unlike returned no data' });
+
+        await expect(setInstagramPostLike(createPageMock({ feed: onePost }), { username: 'someone', index: 4 }, true))
+            .rejects.toMatchObject({ hint: expect.stringContaining('Post index 4 not found; someone has 1 recent posts.') });
+    });
+
+    it('rejects a non-positive index before touching the page', async () => {
+        const page = createPageMock({ feed: onePost });
+
+        await expect(setInstagramPostLike(page, { username: 'someone', index: 0 }, true))
+            .rejects.toThrow('--index must be a positive integer');
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('separates a missing account from a transport failure', async () => {
+        await expect(setInstagramPostLike(createPageMock({ feed: { error: 404 } }), { username: 'ghost', index: 1 }, true))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('No Instagram user named ghost') });
+
+        await expect(setInstagramPostLike(createPageMock({ feed: { error: 429 } }), args, true))
+            .rejects.toThrow('Instagram returned HTTP 429');
+    });
+});

--- a/clis/instagram/like.js
+++ b/clis/instagram/like.js
@@ -1,10 +1,13 @@
 import { cli } from '@jackwener/opencli/registry';
+import { setInstagramPostLike } from './_shared/post-like.js';
+
 cli({
     site: 'instagram',
     name: 'like',
     access: 'write',
     description: 'Like an Instagram post',
     domain: 'www.instagram.com',
+    browser: true,
     args: [
         {
             name: 'username',
@@ -15,32 +18,5 @@ cli({
         { name: 'index', type: 'int', default: 1, help: 'Post index (1 = most recent)' },
     ],
     columns: ['status', 'user', 'post'],
-    pipeline: [
-        { navigate: 'https://www.instagram.com' },
-        { evaluate: `(async () => {
-  const username = \${{ args.username | json }};
-  const idx = \${{ args.index }} - 1;
-  const headers = { 'X-IG-App-ID': '936619743392459' };
-  const opts = { credentials: 'include', headers };
-
-  const r1 = await fetch('https://www.instagram.com/api/v1/users/web_profile_info/?username=' + encodeURIComponent(username), opts);
-  if (!r1.ok) throw new Error('User not found: ' + username);
-  const userId = (await r1.json())?.data?.user?.id;
-
-  const r2 = await fetch('https://www.instagram.com/api/v1/feed/user/' + userId + '/?count=' + (idx + 1), opts);
-  const posts = (await r2.json())?.items || [];
-  if (idx >= posts.length) throw new Error('Post index ' + (idx + 1) + ' not found, user has ' + posts.length + ' recent posts');
-  const pk = posts[idx].pk;
-  const caption = (posts[idx].caption?.text || '').substring(0, 60);
-
-  const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
-  const r3 = await fetch('https://www.instagram.com/api/v1/web/likes/' + pk + '/like/', {
-    method: 'POST', credentials: 'include',
-    headers: { ...headers, 'X-CSRFToken': csrf, 'Content-Type': 'application/x-www-form-urlencoded' },
-  });
-  if (!r3.ok) throw new Error('Failed to like: HTTP ' + r3.status);
-  return [{ status: 'Liked', user: username, post: caption || '(post #' + (idx+1) + ')' }];
-})()
-` },
-    ],
+    func: async (page, kwargs) => setInstagramPostLike(page, kwargs, true),
 });

--- a/clis/instagram/unlike.js
+++ b/clis/instagram/unlike.js
@@ -1,10 +1,13 @@
 import { cli } from '@jackwener/opencli/registry';
+import { setInstagramPostLike } from './_shared/post-like.js';
+
 cli({
     site: 'instagram',
     name: 'unlike',
     access: 'write',
     description: 'Unlike an Instagram post',
     domain: 'www.instagram.com',
+    browser: true,
     args: [
         {
             name: 'username',
@@ -15,32 +18,5 @@ cli({
         { name: 'index', type: 'int', default: 1, help: 'Post index (1 = most recent)' },
     ],
     columns: ['status', 'user', 'post'],
-    pipeline: [
-        { navigate: 'https://www.instagram.com' },
-        { evaluate: `(async () => {
-  const username = \${{ args.username | json }};
-  const idx = \${{ args.index }} - 1;
-  const headers = { 'X-IG-App-ID': '936619743392459' };
-  const opts = { credentials: 'include', headers };
-
-  const r1 = await fetch('https://www.instagram.com/api/v1/users/web_profile_info/?username=' + encodeURIComponent(username), opts);
-  if (!r1.ok) throw new Error('User not found: ' + username);
-  const userId = (await r1.json())?.data?.user?.id;
-
-  const r2 = await fetch('https://www.instagram.com/api/v1/feed/user/' + userId + '/?count=' + (idx + 1), opts);
-  const posts = (await r2.json())?.items || [];
-  if (idx >= posts.length) throw new Error('Post index ' + (idx + 1) + ' not found');
-  const pk = posts[idx].pk;
-  const caption = (posts[idx].caption?.text || '').substring(0, 60);
-
-  const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
-  const r3 = await fetch('https://www.instagram.com/api/v1/web/likes/' + pk + '/unlike/', {
-    method: 'POST', credentials: 'include',
-    headers: { ...headers, 'X-CSRFToken': csrf, 'Content-Type': 'application/x-www-form-urlencoded' },
-  });
-  if (!r3.ok) throw new Error('Failed to unlike: HTTP ' + r3.status);
-  return [{ status: 'Unliked', user: username, post: caption || '(post #' + (idx+1) + ')' }];
-})()
-` },
-    ],
+    func: async (page, kwargs) => setInstagramPostLike(page, kwargs, false),
 });


### PR DESCRIPTION
## Description

Instagram retired `/api/v1/web/likes/<pk>/like/`: it answers HTTP 404 for every post and account, so `like` and `unlike` always failed (#2241), and the web client's replacement is a persisted GraphQL mutation whose `doc_id` rotates.

Both commands drive the post's own like control instead. They read the author's recent posts through feed-by-username, open the post page, and click the like icon, taken as the first Like/Unlike-labeled svg rendered at 24px or wider whose nearest `section` or `div[role=group]` ancestor holds at most 8 aria-labeled svgs; the 16px comment-row icons carrying the same labels fail both checks. Instagram flips the icon before the server answers, so success is reported only after the flipped state still holds two seconds later. A post already in the requested state is reported as such without clicking, a control that never renders or never holds raises `CommandExecutionError`, and an unknown account or out-of-range index raises `EmptyResultError`.

This covers the `like` / `unlike` half of #2234, which #2238 leaves out.

Related issue: Closes #2241

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, on any account:

```
$ opencli instagram like instagram
error:
  code: UNKNOWN
  message: 'Error: Failed to like: HTTP 404'
```

After, verified live as a net-zero round trip on `@instagram`:

```
$ opencli instagram like instagram
- status: Liked
$ opencli instagram like instagram
- status: Already liked
$ opencli instagram unlike instagram
- status: Unliked
$ opencli instagram unlike instagram
- status: Already unliked
```

An unknown account and `--index 999` both exit 66 with the count in the hint. Suite 131 / 131, fifteen of them in the new `post-like.test.js` running the generated page scripts against a JSDOM post page; inverting the verification predicate, dropping the 24px width guard, or dropping the action-bar container guard each fails a test. Typecheck, both lint gates and doc coverage pass; `cli-manifest.json` unchanged.
