### PR TITLE
fix(browser): prefer the main Electron window over routed auxiliary windows

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -9,6 +9,7 @@ import * as daemonLifecycle from './browser/daemon-lifecycle.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe('browser helpers', () => {
@@ -114,6 +115,140 @@ describe('browser helpers', () => {
     ]);
 
     expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9226/codex');
+  });
+
+  it('prefers the main Electron window over a routed auxiliary window on the same document', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Favatar-overlay',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/overlay',
+      },
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/main',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/main');
+  });
+
+  it('still connects to a routed window when the app opens no other surface', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Favatar-overlay',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/overlay',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/overlay');
+  });
+
+  it('keeps a routed window that outscores its plain sibling', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Fc%2Fthread',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/thread',
+      },
+      {
+        type: 'page',
+        title: '',
+        url: 'app://-/index.html',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/blank',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/thread');
+  });
+
+  it('ignores uninspectable targets when deciding which window is routed', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html',
+      },
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Fc%2Fthread',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/main',
+      },
+      {
+        type: 'page',
+        title: 'Codex Helper',
+        url: 'about:blank',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/blank',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/main');
+  });
+
+  it('leaves http tabs in document order when one carries a query string', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Example',
+        url: 'https://example.com/app?q=1',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9222/query',
+      },
+      {
+        type: 'page',
+        title: 'Example',
+        url: 'https://example.com/app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9222/plain',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9222/query');
+  });
+
+  it('leaves unknown-scheme documents in document order when one carries a query', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Example',
+        url: 'vscode-file://vscode-app/index.html?windowId=2',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9229/query',
+      },
+      {
+        type: 'page',
+        title: 'Example',
+        url: 'vscode-file://vscode-app/index.html',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9229/plain',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9229/query');
+  });
+
+  it('honors OPENCLI_CDP_TARGET even when it names a routed auxiliary window', () => {
+    vi.stubEnv('OPENCLI_CDP_TARGET', 'avatar-overlay');
+
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Favatar-overlay',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/overlay',
+      },
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/main',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/overlay');
   });
 });
 

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -489,11 +489,31 @@ function matchesCookieDomain(cookieDomain: string, targetDomain: string): boolea
 function selectCDPTarget(targets: CDPTarget[]): CDPTarget | undefined {
   const preferredPattern = compilePreferredPattern(process.env.OPENCLI_CDP_TARGET);
 
-  const ranked = targets
+  const candidates = targets
     .map((target, index) => ({ target, index, score: scoreCDPTarget(target, preferredPattern) }))
-    .filter(({ score }) => Number.isFinite(score))
+    .filter(({ score }) => Number.isFinite(score));
+
+  // Electron apps route auxiliary windows onto the main document through a
+  // query: Codex ships its avatar overlay as
+  // `app://-/index.html?initialRoute=%2Favatar-overlay`, which answers `/json`
+  // first and scores exactly like the main window, so document order used to
+  // send every command to a surface with no app UI (#2242). Only break that
+  // tie; a routed window that outscores its plain sibling is still the better
+  // target, and on http(s) a query is ordinary page state.
+  const plainDocuments = new Set<string>();
+  for (const { target } of candidates) {
+    const url = parseLocalDocumentUrl(target.url);
+    if (url && !url.search) plainDocuments.add(toDocumentKey(url));
+  }
+
+  const ranked = candidates
+    .map((entry) => {
+      const url = parseLocalDocumentUrl(entry.target.url);
+      return { ...entry, routed: !!url && !!url.search && plainDocuments.has(toDocumentKey(url)) };
+    })
     .sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
+      if (a.routed !== b.routed) return a.routed ? 1 : -1;
       return a.index - b.index;
     });
 
@@ -539,6 +559,32 @@ function scoreCDPTarget(target: CDPTarget, preferredPattern?: RegExp): number {
   }
 
   return score;
+}
+
+// Keep this explicit: these are the schemes Electron serves a shared local
+// document over, where a query is a window route (#2242). A "not http(s)"
+// check would also sweep in schemes we know nothing about.
+const LOCAL_DOCUMENT_SCHEMES = new Set(['app:', 'file:']);
+
+/**
+ * Parse a URL that names a local app document eligible for routed-window
+ * demotion (#2242).
+ *
+ * Only allowlisted schemes qualify: on http(s), and on any scheme we cannot
+ * vouch for, a query is ordinary page state, so returning null there keeps
+ * plain document-order selection.
+ */
+function parseLocalDocumentUrl(raw: string | undefined): URL | null {
+  try {
+    const url = new URL(raw ?? '');
+    return LOCAL_DOCUMENT_SCHEMES.has(url.protocol) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function toDocumentKey(url: URL): string {
+  return `${url.protocol}//${url.host}${url.pathname}`;
 }
 
 function compilePreferredPattern(raw: string | undefined): RegExp | undefined {


### PR DESCRIPTION
## Description

Codex exposes two CDP page targets: its avatar overlay at `app://-/index.html?initialRoute=%2Favatar-overlay` and the main window at `app://-/index.html`. Both are `page` type with the app title, so they score identically and the overlay wins on document order. Every `codex` command then runs against a surface with no app UI and fails, for example `send` with `Could not find element: Codex Composer input element` (#2242).

Since the two targets tie, selection now breaks the tie toward the unrouted window: among inspectable candidates, a local app document carrying a query loses to the same document opened without one. Scores are untouched, so a routed window that genuinely outranks its plain sibling still wins, as do `OPENCLI_CDP_TARGET` matches, and local documents are an explicit scheme allowlist (`app:`, `file:`), so `http(s)` and unknown schemes never qualify. When in-app navigation leaves every window routed, there is no unrouted sibling and selection falls back to today's document order.

Related issue: Closes #2242

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Codex 26.727.51351 (Chromium 150.0.7871.182), cold-started with `--remote-debugging-port=9238` so both targets are present, before and after on the same running app:

```
$ opencli codex status          # before
- Status: Connected
  Url: app://-/index.html?initialRoute=%2Favatar-overlay

$ opencli codex send "hello from opencli"        # before
error:
  code: SELECTOR
  message: 'Could not find element: Codex Composer input element'
```

```
$ opencli codex status          # after
- Status: Connected
  Url: app://-/index.html

$ opencli codex send "hello from opencli"        # after
- Status: Success
  InjectedText: hello from opencli
```

`src/browser.test.ts` 29 / 29 with seven new cases covering the genuinely higher-scoring routed window, an uninspectable plain sibling, an unknown custom scheme, and the env override; the main-window case fails with `src/browser/cdp.ts` reverted. Typecheck, both lint gates and doc coverage pass.
