### PR TITLE
fix(instagram): download through the media info endpoint and expand ~ in --path

### DIFF
--- a/clis/instagram/download.js
+++ b/clis/instagram/download.js
@@ -7,10 +7,17 @@ import { httpDownload } from '@jackwener/opencli/download';
 const INSTAGRAM_APP_ID = '936619743392459';
 const INSTAGRAM_HOST_SUFFIX = 'instagram.com';
 const INSTAGRAM_SHORTCODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+const MAX_INSTAGRAM_MEDIA_ID = 9223372036854775807n;
 const SUPPORTED_KINDS = new Set(['p', 'reel', 'tv']);
 function displayPath(filePath) {
     const home = os.homedir();
     return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+function unwrapEvaluateResult(result) {
+    if (result && typeof result === 'object' && !Array.isArray(result) && 'session' in result && 'data' in result) {
+        return result.data;
+    }
+    return result;
 }
 export function resolveOutputDir(value) {
     const raw = String(value || '').trim();
@@ -28,7 +35,9 @@ export function shortcodeToMediaId(shortcode) {
         const digit = INSTAGRAM_SHORTCODE_ALPHABET.indexOf(character);
         if (digit < 0) return '';
         mediaId = mediaId * 64n + BigInt(digit);
+        if (mediaId > MAX_INSTAGRAM_MEDIA_ID) return '';
     }
+    if (mediaId <= 0n) return '';
     return mediaId.toString();
 }
 export function parseInstagramMediaTarget(input) {
@@ -74,23 +83,31 @@ export function parseInstagramMediaTarget(input) {
     };
 }
 export function buildInstagramDownloadItems(shortcode, items) {
-    return items
-        .filter((item) => item?.url)
-        .map((item, index) => {
-        const fallbackExt = item.type === 'video' ? '.mp4' : '.jpg';
-        let ext = fallbackExt;
+    if (!Array.isArray(items)) {
+        throw new CommandExecutionError('Instagram media metadata returned a malformed media list');
+    }
+    return items.map((item, index) => {
+        if (!item || typeof item !== 'object' || !['image', 'video'].includes(item.type)) {
+            throw new CommandExecutionError(`Instagram media metadata returned malformed media item #${index + 1}`);
+        }
+        let downloadUrl;
         try {
-            const pathname = new URL(item.url).pathname;
-            const candidateExt = path.extname(pathname).toLowerCase();
-            if (candidateExt && candidateExt.length <= 8)
-                ext = candidateExt;
+            downloadUrl = new URL(String(item.url || ''));
         }
         catch {
-            ext = fallbackExt;
+            throw new CommandExecutionError(`Instagram media metadata returned an invalid download URL for item #${index + 1}`);
         }
+        if (!['http:', 'https:'].includes(downloadUrl.protocol)) {
+            throw new CommandExecutionError(`Instagram media metadata returned an unsupported download URL for item #${index + 1}`);
+        }
+        const fallbackExt = item.type === 'video' ? '.mp4' : '.jpg';
+        let ext = fallbackExt;
+        const candidateExt = path.extname(downloadUrl.pathname).toLowerCase();
+        if (candidateExt && candidateExt.length <= 8)
+            ext = candidateExt;
         return {
             type: item.type,
-            url: item.url,
+            url: downloadUrl.toString(),
             filename: `${shortcode}_${String(index + 1).padStart(2, '0')}${ext}`,
         };
     });
@@ -104,13 +121,22 @@ export function buildInstagramFetchScript(shortcode) {
       const shortcode = ${JSON.stringify(shortcode)};
       const mediaId = ${JSON.stringify(shortcodeToMediaId(shortcode))};
       const url = 'https://www.instagram.com/api/v1/media/' + mediaId + '/info/';
-      const res = await fetch(url, {
-        credentials: 'include',
-        headers: {
-          'Accept': 'application/json,text/plain,*/*',
-          'X-IG-App-ID': ${JSON.stringify(INSTAGRAM_APP_ID)},
-        },
-      });
+      let res = null;
+      try {
+        res = await fetch(url, {
+          credentials: 'include',
+          headers: {
+            'Accept': 'application/json,text/plain,*/*',
+            'X-IG-App-ID': ${JSON.stringify(INSTAGRAM_APP_ID)},
+          },
+        });
+      } catch (err) {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram media info request failed: ' + (err && err.message ? err.message : String(err || 'fetch failed')),
+        };
+      }
       const rawText = await res.text();
 
       let data = null;
@@ -123,9 +149,28 @@ export function buildInstagramFetchScript(shortcode) {
           error: 'Instagram returned non-JSON content while fetching media metadata',
         };
       }
+      if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram returned malformed media metadata',
+        };
+      }
 
       const message = typeof data?.message === 'string' ? data.message : '';
       const lowered = (message || '').toLowerCase();
+      const classifyInBandFailure = () => {
+        if (data?.require_login || lowered.includes('login') || lowered.includes('auth')) {
+          return { ok: false, errorCode: 'AUTH_REQUIRED', error: message || 'Instagram login required' };
+        }
+        if (lowered.includes('wait a few minutes') || lowered.includes('rate')) {
+          return { ok: false, errorCode: 'RATE_LIMITED', error: message || 'Instagram rate limit triggered' };
+        }
+        if (lowered.includes('not found') || lowered.includes('unavailable') || lowered.includes('private')) {
+          return { ok: false, errorCode: 'PRIVATE_OR_UNAVAILABLE', error: message || 'Post may be private or unavailable' };
+        }
+        return { ok: false, errorCode: 'COMMAND_EXEC', error: message || 'Instagram returned a failed media metadata status' };
+      };
 
       if (!res.ok) {
         if (res.status === 401 || res.status === 403 || data?.require_login) {
@@ -146,34 +191,102 @@ export function buildInstagramFetchScript(shortcode) {
       if (lowered.includes('wait a few minutes') || lowered.includes('rate')) {
         return { ok: false, errorCode: 'RATE_LIMITED', error: message || 'Instagram rate limit triggered' };
       }
+      if (typeof data?.status === 'string' && data.status !== 'ok') {
+        return classifyInBandFailure();
+      }
 
-      const media = Array.isArray(data?.items) ? data.items[0] : null;
-      if (!media) {
+      if (!Array.isArray(data?.items)) {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram media metadata returned malformed items',
+        };
+      }
+      if (data.items.length === 0) {
         return {
           ok: false,
           errorCode: 'PRIVATE_OR_UNAVAILABLE',
           error: message || 'Post may be private, unavailable, or inaccessible to the current browser session',
         };
       }
+      const media = data.items[0];
+      if (!media || typeof media !== 'object' || Array.isArray(media)) {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram media metadata returned malformed media item',
+        };
+      }
+      if (media.code !== shortcode) {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram media info returned metadata for a different shortcode',
+        };
+      }
 
-      const nodes = Array.isArray(media?.carousel_media) && media.carousel_media.length > 0
-        ? media.carousel_media
-        : [media];
+      const widest = (candidates, label) => {
+        if (!Array.isArray(candidates) || candidates.length === 0) {
+          return { ok: false, error: 'Instagram media metadata is missing ' + label };
+        }
+        let best = null;
+        for (const candidate of candidates) {
+          if (!candidate || typeof candidate !== 'object' || typeof candidate.url !== 'string' || !candidate.url) continue;
+          const width = Number(candidate.width) || 0;
+          if (!best || width > best.width) best = { width, url: candidate.url };
+        }
+        if (!best) {
+          return { ok: false, error: 'Instagram media metadata has no usable ' + label };
+        }
+        return { ok: true, url: best.url };
+      };
+      const pickNode = (node, index) => {
+        if (!node || typeof node !== 'object' || Array.isArray(node)) {
+          return { ok: false, error: 'Instagram media metadata returned malformed carousel item #' + (index + 1) };
+        }
+        if (node.media_type === 1) {
+          const picked = widest(node?.image_versions2?.candidates, 'image candidates for item #' + (index + 1));
+          return picked.ok ? { ok: true, item: { type: 'image', url: picked.url } } : picked;
+        }
+        if (node.media_type === 2) {
+          const picked = widest(node?.video_versions, 'video renditions for item #' + (index + 1));
+          return picked.ok ? { ok: true, item: { type: 'video', url: picked.url } } : picked;
+        }
+        return { ok: false, error: 'Instagram media metadata returned unsupported media_type for item #' + (index + 1) };
+      };
 
-      // Candidate order is not guaranteed, so pick the widest rather than the
-      // first, and keep the declared media_type: a video whose renditions are
-      // missing must yield no url instead of falling back to its cover image.
-      const widest = (candidates) => (Array.isArray(candidates) ? candidates : [])
-        .reduce((best, candidate) => !best || (Number(candidate?.width) || 0) > (Number(best?.width) || 0) ? candidate : best, null);
-      const pickUrl = (node) => node?.media_type === 2
-        ? { type: 'video', url: String(widest(node?.video_versions)?.url || '') }
-        : { type: 'image', url: String(widest(node?.image_versions2?.candidates)?.url || '') };
+      let nodes = null;
+      if (media.media_type === 8) {
+        if (!Array.isArray(media.carousel_media) || media.carousel_media.length === 0) {
+          return {
+            ok: false,
+            errorCode: 'COMMAND_EXEC',
+            error: 'Instagram carousel metadata returned no media items',
+          };
+        }
+        nodes = media.carousel_media;
+      } else if (media.media_type === 1 || media.media_type === 2) {
+        nodes = [media];
+      } else {
+        return {
+          ok: false,
+          errorCode: 'COMMAND_EXEC',
+          error: 'Instagram media metadata returned unsupported media_type',
+        };
+      }
 
-      const items = nodes.map(pickUrl).filter((item) => item.url);
+      const items = [];
+      for (let index = 0; index < nodes.length; index += 1) {
+        const picked = pickNode(nodes[index], index);
+        if (!picked.ok) {
+          return { ok: false, errorCode: 'COMMAND_EXEC', error: picked.error };
+        }
+        items.push(picked.item);
+      }
 
       return {
         ok: true,
-        shortcode: media.code || shortcode,
+        shortcode: media.code,
         owner: media?.user?.username || '',
         items,
       };
@@ -186,10 +299,14 @@ function ensurePage(page) {
     return page;
 }
 function normalizeFetchResult(result) {
-    if (!result || typeof result !== 'object') {
+    const unwrapped = unwrapEvaluateResult(result);
+    if (!unwrapped || typeof unwrapped !== 'object' || Array.isArray(unwrapped)) {
         throw new CommandExecutionError('Failed to fetch Instagram media metadata');
     }
-    return result;
+    if (typeof unwrapped.ok !== 'boolean') {
+        throw new CommandExecutionError('Instagram media metadata returned malformed result');
+    }
+    return unwrapped;
 }
 function handleFetchFailure(result) {
     const message = result.error || 'Instagram media fetch failed';
@@ -213,6 +330,9 @@ async function downloadInstagramMedia(items, outputDir) {
         });
         if (!result.success) {
             throw new CommandExecutionError(`Failed to download ${item.filename}: ${result.error || 'unknown error'}`);
+        }
+        if (!Number.isFinite(result.size) || result.size <= 0) {
+            throw new CommandExecutionError(`Failed to verify downloaded bytes for ${item.filename}`);
         }
     }
 }

--- a/clis/instagram/download.js
+++ b/clis/instagram/download.js
@@ -4,13 +4,32 @@ import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError, EXIT_CODES } from '@jackwener/opencli/errors';
 import { httpDownload } from '@jackwener/opencli/download';
-const INSTAGRAM_GRAPHQL_DOC_ID = '8845758582119845';
-const INSTAGRAM_GRAPHQL_APP_ID = '936619743392459';
+const INSTAGRAM_APP_ID = '936619743392459';
 const INSTAGRAM_HOST_SUFFIX = 'instagram.com';
+const INSTAGRAM_SHORTCODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 const SUPPORTED_KINDS = new Set(['p', 'reel', 'tv']);
 function displayPath(filePath) {
     const home = os.homedir();
     return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+export function resolveOutputDir(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return path.join(os.homedir(), 'Downloads', 'Instagram');
+    if (raw === '~') return os.homedir();
+    if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
+    return path.resolve(raw);
+}
+/** A shortcode is the media id written in Instagram's base64 alphabet. */
+export function shortcodeToMediaId(shortcode) {
+    const raw = String(shortcode || '');
+    if (!raw) return '';
+    let mediaId = 0n;
+    for (const character of raw) {
+        const digit = INSTAGRAM_SHORTCODE_ALPHABET.indexOf(character);
+        if (digit < 0) return '';
+        mediaId = mediaId * 64n + BigInt(digit);
+    }
+    return mediaId.toString();
 }
 export function parseInstagramMediaTarget(input) {
     const raw = String(input || '').trim();
@@ -45,6 +64,9 @@ export function parseInstagramMediaTarget(input) {
     if (!kind || !shortcode) {
         throw new ArgumentError(`Unsupported Instagram media URL: ${raw}`, 'Only /p/<shortcode>/, /reel/<shortcode>/, and /tv/<shortcode>/ links are supported');
     }
+    if (!shortcodeToMediaId(shortcode)) {
+        throw new ArgumentError(`Invalid Instagram shortcode: ${shortcode}`, 'Copy the link straight from the post, without escaping it');
+    }
     return {
         kind: kind,
         shortcode,
@@ -74,22 +96,19 @@ export function buildInstagramDownloadItems(shortcode, items) {
     });
 }
 export function buildInstagramFetchScript(shortcode) {
+    // The persisted GraphQL query this used to send now answers HTTP 200 with
+    // an execution error and no media, which read as a private post (#2247).
+    // The media info endpoint carries the same fields and needs no rotating id.
     return `
     (async () => {
       const shortcode = ${JSON.stringify(shortcode)};
-      const docId = ${JSON.stringify(INSTAGRAM_GRAPHQL_DOC_ID)};
-      const variables = {
-        shortcode,
-        fetch_tagged_user_count: null,
-        hoisted_comment_id: null,
-        hoisted_reply_id: null,
-      };
-      const url = 'https://www.instagram.com/graphql/query/?doc_id=' + docId + '&variables=' + encodeURIComponent(JSON.stringify(variables));
+      const mediaId = ${JSON.stringify(shortcodeToMediaId(shortcode))};
+      const url = 'https://www.instagram.com/api/v1/media/' + mediaId + '/info/';
       const res = await fetch(url, {
         credentials: 'include',
         headers: {
           'Accept': 'application/json,text/plain,*/*',
-          'X-IG-App-ID': ${JSON.stringify(INSTAGRAM_GRAPHQL_APP_ID)},
+          'X-IG-App-ID': ${JSON.stringify(INSTAGRAM_APP_ID)},
         },
       });
       const rawText = await res.text();
@@ -115,7 +134,7 @@ export function buildInstagramFetchScript(shortcode) {
         if (res.status === 429) {
           return { ok: false, errorCode: 'RATE_LIMITED', error: message || 'HTTP 429' };
         }
-        if (res.status === 404 || res.status === 410) {
+        if (res.status === 404 || res.status === 410 || data?.status === 'fail') {
           return { ok: false, errorCode: 'PRIVATE_OR_UNAVAILABLE', error: message || ('HTTP ' + res.status) };
         }
         return { ok: false, errorCode: 'COMMAND_EXEC', error: message || ('HTTP ' + res.status) };
@@ -128,7 +147,7 @@ export function buildInstagramFetchScript(shortcode) {
         return { ok: false, errorCode: 'RATE_LIMITED', error: message || 'Instagram rate limit triggered' };
       }
 
-      const media = data?.data?.xdt_shortcode_media;
+      const media = Array.isArray(data?.items) ? data.items[0] : null;
       if (!media) {
         return {
           ok: false,
@@ -137,21 +156,25 @@ export function buildInstagramFetchScript(shortcode) {
         };
       }
 
-      const nodes = Array.isArray(media?.edge_sidecar_to_children?.edges) && media.edge_sidecar_to_children.edges.length > 0
-        ? media.edge_sidecar_to_children.edges.map((edge) => edge?.node).filter(Boolean)
+      const nodes = Array.isArray(media?.carousel_media) && media.carousel_media.length > 0
+        ? media.carousel_media
         : [media];
 
-      const items = nodes
-        .map((node) => ({
-          type: node?.is_video ? 'video' : 'image',
-          url: String(node?.is_video ? (node?.video_url || '') : (node?.display_url || '')),
-        }))
-        .filter((item) => item.url);
+      // Candidate order is not guaranteed, so pick the widest rather than the
+      // first, and keep the declared media_type: a video whose renditions are
+      // missing must yield no url instead of falling back to its cover image.
+      const widest = (candidates) => (Array.isArray(candidates) ? candidates : [])
+        .reduce((best, candidate) => !best || (Number(candidate?.width) || 0) > (Number(best?.width) || 0) ? candidate : best, null);
+      const pickUrl = (node) => node?.media_type === 2
+        ? { type: 'video', url: String(widest(node?.video_versions)?.url || '') }
+        : { type: 'image', url: String(widest(node?.image_versions2?.candidates)?.url || '') };
+
+      const items = nodes.map(pickUrl).filter((item) => item.url);
 
       return {
         ok: true,
-        shortcode: media.shortcode || shortcode,
-        owner: media?.owner?.username || '',
+        shortcode: media.code || shortcode,
+        owner: media?.user?.username || '',
         items,
       };
     })()
@@ -208,7 +231,7 @@ cli({
     func: async (page, kwargs) => {
         const browserPage = ensurePage(page);
         const target = parseInstagramMediaTarget(String(kwargs.url ?? ''));
-        const outputRoot = String(kwargs.path ?? path.join(os.homedir(), 'Downloads', 'Instagram'));
+        const outputRoot = resolveOutputDir(kwargs.path);
         await browserPage.goto(target.canonicalUrl);
         const fetchResult = normalizeFetchResult(await browserPage.evaluate(buildInstagramFetchScript(target.shortcode)));
         if (!fetchResult.ok)

--- a/clis/instagram/download.test.js
+++ b/clis/instagram/download.test.js
@@ -1,16 +1,21 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-const { mockHttpDownload, logSpy } = vi.hoisted(() => ({
+const { mockHttpDownload, mockMkdirSync, logSpy } = vi.hoisted(() => ({
     mockHttpDownload: vi.fn(),
+    mockMkdirSync: vi.fn(),
     logSpy: vi.spyOn(console, 'log').mockImplementation(() => undefined),
 }));
 vi.mock('@jackwener/opencli/download', async () => {
     const actual = await vi.importActual('@jackwener/opencli/download');
     return { ...actual, httpDownload: mockHttpDownload };
 });
-const { buildInstagramDownloadItems, parseInstagramMediaTarget, } = await import('./download.js');
+vi.mock('node:fs', () => ({
+    mkdirSync: mockMkdirSync,
+}));
+const { buildInstagramDownloadItems, buildInstagramFetchScript, parseInstagramMediaTarget, resolveOutputDir, shortcodeToMediaId, } = await import('./download.js');
 let cmd;
 beforeAll(() => {
     cmd = getRegistry().get('instagram/download');
@@ -49,6 +54,96 @@ describe('instagram download helpers', () => {
             { type: 'video', url: 'https://cdn.example.com/video.mp4?bar=2', filename: 'DWUR_azCWbN_02.mp4' },
             { type: 'image', url: 'not-a-valid-url', filename: 'DWUR_azCWbN_03.jpg' },
         ]);
+    });
+    it('decodes a shortcode into the media id the info endpoint takes', () => {
+        expect(shortcodeToMediaId('DbnndRYRLRm')).toBe('3956304333007795302');
+        expect(shortcodeToMediaId('')).toBe('');
+        expect(shortcodeToMediaId('not a shortcode')).toBe('');
+    });
+    it('requests the media info endpoint instead of a persisted query', () => {
+        const script = buildInstagramFetchScript('DbnndRYRLRm');
+
+        expect(script).toContain('/api/v1/media/');
+        expect(script).toContain('"3956304333007795302"');
+        expect(script).not.toContain('doc_id');
+    });
+    it('reads media from the info payload, including carousels and videos', async () => {
+        const calls = [];
+        const read = (payload) => new Function('calls', `return (async () => {
+      const fetch = (url, init) => { calls.push([url, init]); return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(${JSON.stringify(JSON.stringify(payload))}) }); };
+      return await ${buildInstagramFetchScript('DbnndRYRLRm')};
+    })()`)(calls);
+
+        await expect(read({
+            items: [
+                {
+                    code: 'DifferentCode',
+                    media_type: 2,
+                    user: { username: 'instagram' },
+                    video_versions: [{ url: 'https://cdn.example.com/small.mp4', width: 480 }, { url: 'https://cdn.example.com/full.mp4', width: 1080 }],
+                    image_versions2: { candidates: [{ url: 'https://cdn.example.com/cover.jpg', width: 1080 }] },
+                },
+                { code: 'SecondItem', media_type: 1, image_versions2: { candidates: [{ url: 'https://cdn.example.com/other.jpg', width: 1080 }] } },
+            ],
+        })).resolves.toEqual({
+            ok: true,
+            shortcode: 'DifferentCode',
+            owner: 'instagram',
+            items: [{ type: 'video', url: 'https://cdn.example.com/full.mp4' }],
+        });
+        expect(calls[0][0]).toBe('https://www.instagram.com/api/v1/media/3956304333007795302/info/');
+        expect(calls[0][1]).toMatchObject({ credentials: 'include', headers: { 'X-IG-App-ID': '936619743392459' } });
+
+        await expect(read({
+            items: [{
+                code: 'DbnndRYRLRm',
+                media_type: 8,
+                user: { username: 'instagram' },
+                carousel_media: [
+                    { media_type: 1, image_versions2: { candidates: [{ url: 'https://cdn.example.com/thumb.jpg', width: 320 }, { url: 'https://cdn.example.com/one.jpg', width: 1080 }] } },
+                    { media_type: 2, video_versions: [{ url: 'https://cdn.example.com/two.mp4', width: 1080 }] },
+                ],
+            }],
+        })).resolves.toMatchObject({
+            items: [
+                { type: 'image', url: 'https://cdn.example.com/one.jpg' },
+                { type: 'video', url: 'https://cdn.example.com/two.mp4' },
+            ],
+        });
+    });
+    it('reports no media rather than a cover image when a video carries no renditions', async () => {
+        const read = (payload) => new Function(`return (async () => {
+      const fetch = () => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(${JSON.stringify(JSON.stringify(payload))}) });
+      return await ${buildInstagramFetchScript('DbnndRYRLRm')};
+    })()`)();
+
+        await expect(read({
+            items: [{
+                code: 'DbnndRYRLRm',
+                media_type: 2,
+                video_versions: [],
+                image_versions2: { candidates: [{ url: 'https://cdn.example.com/cover.jpg', width: 1080 }] },
+            }],
+        })).resolves.toMatchObject({ ok: true, items: [] });
+
+        await expect(read({ items: [] })).resolves.toMatchObject({ ok: false, errorCode: 'PRIVATE_OR_UNAVAILABLE' });
+    });
+    it('treats a status:fail error body as private or unavailable', async () => {
+        const read = (payload) => new Function(`return (async () => {
+      const fetch = () => Promise.resolve({ ok: false, status: 400, text: () => Promise.resolve(${JSON.stringify(JSON.stringify(payload))}) });
+      return await ${buildInstagramFetchScript('DbnndRYRLRm')};
+    })()`)();
+
+        await expect(read({ status: 'fail', message: 'Media not found or unavailable' })).resolves.toEqual({ ok: false, errorCode: 'PRIVATE_OR_UNAVAILABLE', error: 'Media not found or unavailable' });
+    });
+    it('rejects a shortcode that is not in the media id alphabet', () => {
+        expect(() => parseInstagramMediaTarget('https://www.instagram.com/p/DWUR%5FazCWbN/')).toThrow(ArgumentError);
+    });
+    it('expands a leading ~ in the download path', () => {
+        expect(resolveOutputDir('~/Downloads/Instagram')).toBe(path.join(os.homedir(), 'Downloads', 'Instagram'));
+        expect(resolveOutputDir('~')).toBe(os.homedir());
+        expect(resolveOutputDir('instagram-test')).toBe(path.resolve('instagram-test'));
+        expect(resolveOutputDir('')).toBe(path.join(os.homedir(), 'Downloads', 'Instagram'));
     });
 });
 describe('instagram download command', () => {
@@ -101,9 +196,11 @@ describe('instagram download command', () => {
         expect(page.goto.mock.calls[0]?.[0]).toBe('https://www.instagram.com/p/DWUR_azCWbN/');
         expect(mockHttpDownload).toHaveBeenNthCalledWith(1, 'https://cdn.example.com/photo.webp?foo=1', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_01.webp'), expect.objectContaining({ timeout: 60000 }));
         expect(mockHttpDownload).toHaveBeenNthCalledWith(2, 'https://cdn.example.com/video.mp4?bar=2', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_02.mp4'), expect.objectContaining({ timeout: 120000 }));
-        expect(logSpy).toHaveBeenCalledWith('📁 saved: instagram-test/DWUR_azCWbN');
+        const savedDir = path.join(path.resolve('instagram-test'), 'DWUR_azCWbN');
+        const displayed = savedDir.startsWith(os.homedir()) ? `~${savedDir.slice(os.homedir().length)}` : savedDir;
+        expect(logSpy).toHaveBeenCalledWith(`📁 saved: ${displayed}`);
     });
-    it('uses a cross-platform Downloads default when path is omitted', async () => {
+    it('expands the home shorthand the path default carries', async () => {
         mockHttpDownload.mockResolvedValueOnce({ success: true, size: 120_000 });
         const page = createPageMock({
             ok: true,
@@ -112,7 +209,7 @@ describe('instagram download command', () => {
                 { type: 'image', url: 'https://cdn.example.com/photo.webp?foo=1' },
             ],
         });
-        await cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/' });
+        await cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/', path: '~/Downloads/Instagram' });
         expect(mockHttpDownload).toHaveBeenCalledWith('https://cdn.example.com/photo.webp?foo=1', expect.stringContaining(`${os.homedir()}/Downloads/Instagram/DWUR_azCWbN/DWUR_azCWbN_01.webp`), expect.objectContaining({ timeout: 60000 }));
     });
 });

--- a/clis/instagram/download.test.js
+++ b/clis/instagram/download.test.js
@@ -48,17 +48,25 @@ describe('instagram download helpers', () => {
         expect(buildInstagramDownloadItems('DWUR_azCWbN', [
             { type: 'image', url: 'https://cdn.example.com/photo.webp?foo=1' },
             { type: 'video', url: 'https://cdn.example.com/video.mp4?bar=2' },
-            { type: 'image', url: 'not-a-valid-url' },
         ])).toEqual([
             { type: 'image', url: 'https://cdn.example.com/photo.webp?foo=1', filename: 'DWUR_azCWbN_01.webp' },
             { type: 'video', url: 'https://cdn.example.com/video.mp4?bar=2', filename: 'DWUR_azCWbN_02.mp4' },
-            { type: 'image', url: 'not-a-valid-url', filename: 'DWUR_azCWbN_03.jpg' },
         ]);
+    });
+    it('typed-fails malformed download items instead of passing them to the downloader', () => {
+        expect(() => buildInstagramDownloadItems('DWUR_azCWbN', [{ type: 'image', url: 'not-a-valid-url' }]))
+            .toThrow('invalid download URL');
+        expect(() => buildInstagramDownloadItems('DWUR_azCWbN', [{ type: 'image', url: 'file:///tmp/photo.jpg' }]))
+            .toThrow('unsupported download URL');
+        expect(() => buildInstagramDownloadItems('DWUR_azCWbN', [{ type: 'cover', url: 'https://cdn.example.com/photo.jpg' }]))
+            .toThrow('malformed media item');
     });
     it('decodes a shortcode into the media id the info endpoint takes', () => {
         expect(shortcodeToMediaId('DbnndRYRLRm')).toBe('3956304333007795302');
         expect(shortcodeToMediaId('')).toBe('');
         expect(shortcodeToMediaId('not a shortcode')).toBe('');
+        expect(shortcodeToMediaId('A')).toBe('');
+        expect(shortcodeToMediaId('___________')).toBe('');
     });
     it('requests the media info endpoint instead of a persisted query', () => {
         const script = buildInstagramFetchScript('DbnndRYRLRm');
@@ -77,7 +85,7 @@ describe('instagram download helpers', () => {
         await expect(read({
             items: [
                 {
-                    code: 'DifferentCode',
+                    code: 'DbnndRYRLRm',
                     media_type: 2,
                     user: { username: 'instagram' },
                     video_versions: [{ url: 'https://cdn.example.com/small.mp4', width: 480 }, { url: 'https://cdn.example.com/full.mp4', width: 1080 }],
@@ -87,7 +95,7 @@ describe('instagram download helpers', () => {
             ],
         })).resolves.toEqual({
             ok: true,
-            shortcode: 'DifferentCode',
+            shortcode: 'DbnndRYRLRm',
             owner: 'instagram',
             items: [{ type: 'video', url: 'https://cdn.example.com/full.mp4' }],
         });
@@ -111,7 +119,7 @@ describe('instagram download helpers', () => {
             ],
         });
     });
-    it('reports no media rather than a cover image when a video carries no renditions', async () => {
+    it('typed-fails instead of using a cover image when a video carries no renditions', async () => {
         const read = (payload) => new Function(`return (async () => {
       const fetch = () => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(${JSON.stringify(JSON.stringify(payload))}) });
       return await ${buildInstagramFetchScript('DbnndRYRLRm')};
@@ -124,9 +132,32 @@ describe('instagram download helpers', () => {
                 video_versions: [],
                 image_versions2: { candidates: [{ url: 'https://cdn.example.com/cover.jpg', width: 1080 }] },
             }],
-        })).resolves.toMatchObject({ ok: true, items: [] });
+        })).resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('video renditions') });
 
         await expect(read({ items: [] })).resolves.toMatchObject({ ok: false, errorCode: 'PRIVATE_OR_UNAVAILABLE' });
+    });
+    it('typed-fails malformed media info payloads and wrong shortcode identity', async () => {
+        const read = (payload) => new Function(`return (async () => {
+      const fetch = () => Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(${JSON.stringify(JSON.stringify(payload))}) });
+      return await ${buildInstagramFetchScript('DbnndRYRLRm')};
+    })()`)();
+
+        await expect(read({ status: 'ok' })).resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('malformed items') });
+        await expect(read({ status: 'fail', message: 'temporary parser drift' })).resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC' });
+        await expect(read({ items: [{ code: 'DifferentCode', media_type: 1, image_versions2: { candidates: [{ url: 'https://cdn.example.com/photo.jpg', width: 1 }] } }] }))
+            .resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('different shortcode') });
+        await expect(read({ items: [{ code: 'DbnndRYRLRm', media_type: 8, carousel_media: [] }] }))
+            .resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('carousel metadata returned no media items') });
+        await expect(read({ items: [{ code: 'DbnndRYRLRm', media_type: 8, carousel_media: [{ media_type: 1, image_versions2: { candidates: [{ url: 'https://cdn.example.com/one.jpg', width: 1 }] } }, { media_type: 2, video_versions: [] }] }] }))
+            .resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('video renditions') });
+    });
+    it('normalizes fetch failures into typed command errors', async () => {
+        const read = () => new Function(`return (async () => {
+      const fetch = () => Promise.reject(new Error('network down'));
+      return await ${buildInstagramFetchScript('DbnndRYRLRm')};
+    })()`)();
+
+        await expect(read()).resolves.toMatchObject({ ok: false, errorCode: 'COMMAND_EXEC', error: expect.stringContaining('network down') });
     });
     it('treats a status:fail error body as private or unavailable', async () => {
         const read = (payload) => new Function(`return (async () => {
@@ -138,6 +169,7 @@ describe('instagram download helpers', () => {
     });
     it('rejects a shortcode that is not in the media id alphabet', () => {
         expect(() => parseInstagramMediaTarget('https://www.instagram.com/p/DWUR%5FazCWbN/')).toThrow(ArgumentError);
+        expect(() => parseInstagramMediaTarget('https://www.instagram.com/p/___________/')).toThrow(ArgumentError);
     });
     it('expands a leading ~ in the download path', () => {
         expect(resolveOutputDir('~/Downloads/Instagram')).toBe(path.join(os.homedir(), 'Downloads', 'Instagram'));
@@ -149,6 +181,7 @@ describe('instagram download helpers', () => {
 describe('instagram download command', () => {
     beforeEach(() => {
         mockHttpDownload.mockReset();
+        mockMkdirSync.mockClear();
         logSpy.mockClear();
     });
     it('rejects invalid URLs before browser work', async () => {
@@ -175,6 +208,32 @@ describe('instagram download command', () => {
         const page = createPageMock({ ok: true, shortcode: 'DWUR_azCWbN', items: [] });
         await expect(cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/' })).rejects.toThrow(CommandExecutionError);
         expect(mockHttpDownload).not.toHaveBeenCalled();
+    });
+    it('unwraps Browser Bridge envelopes before validating metadata', async () => {
+        mockHttpDownload.mockResolvedValueOnce({ success: true, size: 120_000 });
+        const page = createPageMock({
+            session: 'site:instagram',
+            data: {
+                ok: true,
+                shortcode: 'DWUR_azCWbN',
+                items: [{ type: 'image', url: 'https://cdn.example.com/photo.webp?foo=1' }],
+            },
+        });
+
+        await expect(cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/', path: './instagram-test' })).resolves.toBeNull();
+        expect(mockHttpDownload).toHaveBeenCalledTimes(1);
+    });
+    it('typed-fails malformed Browser Bridge envelopes and zero-byte downloads', async () => {
+        await expect(cmd.func(createPageMock({ session: 'site:instagram' }), { url: 'https://www.instagram.com/p/DWUR_azCWbN/' }))
+            .rejects.toThrow('malformed result');
+
+        mockHttpDownload.mockResolvedValueOnce({ success: true, size: 0 });
+        await expect(cmd.func(createPageMock({
+            ok: true,
+            shortcode: 'DWUR_azCWbN',
+            items: [{ type: 'image', url: 'https://cdn.example.com/photo.webp?foo=1' }],
+        }), { url: 'https://www.instagram.com/p/DWUR_azCWbN/' }))
+            .rejects.toThrow('Failed to verify downloaded bytes');
     });
     it('downloads media and prints saved directory', async () => {
         mockHttpDownload


### PR DESCRIPTION
## Description

`instagram download` failed for every post. It fetched metadata through a hardcoded persisted GraphQL query that Instagram now answers with `{"errors":[{"message":"execution error"}],"data":null}` at HTTP 200, and the missing media read as an access problem, so the command blamed the account (#2247).

The shortcode is the media id in Instagram's base64 alphabet, so the command decodes it and reads `/api/v1/media/<media_id>/info/`, which carries the same fields and needs no rotating id. Carousel nodes are classified by their declared `media_type` so a video missing its renditions reports no media instead of saving the cover image, renditions are chosen by width rather than array position, a shortcode outside the alphabet is an argument error, and a `status: fail` body keeps the private-post hint.

`--path` also defaulted to the string `~/Downloads/Instagram` joined verbatim, so a default run wrote into a literal `~` directory under the working directory; `resolveOutputDir` now expands it.

Related issue: Closes #2247

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, on any post with a logged-in session:

```
$ opencli instagram download "https://www.instagram.com/p/DbnndRYRLRm/"
error:
  code: COMMAND_EXEC
  message: Post may be private, unavailable, or inaccessible to the current browser session
  exitCode: 1
```

After, same session and post, plus a photo post:

```
$ opencli instagram download "https://www.instagram.com/p/DbnndRYRLRm/"
📁 saved: ~/Downloads/Instagram/DbnndRYRLRm      # 15 MB mp4

$ opencli instagram download "https://www.instagram.com/p/Dbnwv3PmgBc/"
📁 saved: ~/Downloads/Instagram/Dbnwv3PmgBc      # 109 KB jpg
```

A four-image carousel saved all four files, and `--path '~/Downloads/IGPathTest'` resolved into the home directory. `clis/instagram` suite 123 / 123; nine of the seventeen download tests fail with `download.js` reverted, and mutating the item pick, the rendition pick, the returned shortcode, the request headers, the video classification, or the `status: fail` branch each fails a test. Typecheck, both lint gates and doc coverage pass; `cli-manifest.json` unchanged.
