### PR TITLE
fix: release bridge uploader as 1.0.23

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.21",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.21",
+      "version": "1.0.23",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/src/extension-manifest-regression.test.ts
+++ b/src/extension-manifest-regression.test.ts
@@ -14,4 +14,20 @@ describe('extension manifest regression', () => {
     expect(manifest.permissions).toContain('cookies');
     expect(manifest.host_permissions).toContain('<all_urls>');
   });
+
+  it('ships the fixed uploader under a new consistent extension version', async () => {
+    const extensionRoot = path.resolve(process.cwd(), 'extension');
+    const [manifestRaw, packageRaw, lockRaw] = await Promise.all([
+      fs.readFile(path.join(extensionRoot, 'manifest.json'), 'utf8'),
+      fs.readFile(path.join(extensionRoot, 'package.json'), 'utf8'),
+      fs.readFile(path.join(extensionRoot, 'package-lock.json'), 'utf8'),
+    ]);
+    const manifest = JSON.parse(manifestRaw) as { version?: string };
+    const packageJson = JSON.parse(packageRaw) as { version?: string };
+    const lock = JSON.parse(lockRaw) as { packages?: { '': { version?: string } } };
+
+    expect(manifest.version).toBe('1.0.23');
+    expect(packageJson.version).toBe(manifest.version);
+    expect(lock.packages?.[''].version).toBe(manifest.version);
+  });
 });


### PR DESCRIPTION
## What changed

Bumps the OpenCLI Browser Bridge release version to `1.0.23` in the extension manifest, package metadata, and lockfile. Adds a regression test that keeps those release versions aligned.

## Why

The current source already uses the file-chooser interception path needed for local file uploads. The Chrome Web Store bridge still ships a compiled `1.0.22` implementation that uses the rejected `nodeId` path, so Chrome does not receive a higher-version update and uploads fail with `Not allowed`.

## Impact

Publishing this as a new extension version lets existing Chrome installations update through their normal Chrome Web Store policy. File inputs then work from any absolute local path, including browser-profile asset uploads.

## Checks

- `npx vitest run --project unit src/extension-manifest-regression.test.ts`
- `npx vitest run --project extension extension/src/cdp.test.ts`
- `npm --prefix extension run build`
