### PR TITLE
fix(twitter): stop reporting another tweet as the posted permalink

### DIFF
--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapBrowserResult } from './shared.js';
 import { isRecoverableFileInputError } from './utils.js';
 
 const MAX_IMAGES = 4;
@@ -40,20 +41,58 @@ function isUnsupportedInsertTextError(err) {
     return lower.includes('unknown action') || lower.includes('not supported') || lower.includes('inserttext returned no inserted flag');
 }
 
+function requirePostActionResult(value, context) {
+    const result = unwrapBrowserResult(value);
+    if (!result || typeof result !== 'object' || Array.isArray(result) || typeof result.ok !== 'boolean') {
+        throw new CommandExecutionError(`${context} returned a malformed result.`);
+    }
+    if (Object.prototype.hasOwnProperty.call(result, 'message') && result.message != null && typeof result.message !== 'string') {
+        throw new CommandExecutionError(`${context} returned a malformed message.`);
+    }
+    if (Object.prototype.hasOwnProperty.call(result, 'error') && result.error != null && typeof result.error !== 'string') {
+        throw new CommandExecutionError(`${context} returned a malformed error.`);
+    }
+    return result;
+}
+
+function validateSubmitStatusPair(result) {
+    if ((result.id && !result.url) || (!result.id && result.url)) {
+        throw new CommandExecutionError('Twitter post completion returned only one of id/url.');
+    }
+    if (!result.id && !result.url) return;
+    if (typeof result.id !== 'string' || !/^\d+$/.test(result.id)) {
+        throw new CommandExecutionError('Twitter post completion returned a malformed status id.');
+    }
+    if (typeof result.url !== 'string') {
+        throw new CommandExecutionError('Twitter post completion returned a malformed status url.');
+    }
+    let url;
+    try {
+        url = new URL(result.url);
+    } catch {
+        throw new CommandExecutionError('Twitter post completion returned a malformed status url.');
+    }
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
+    const match = url.pathname.match(/^\/([^/]+)\/status\/(\d+)\/?$/);
+    if (!['x.com', 'twitter.com', 'mobile.twitter.com'].includes(hostname) || !match || match[2] !== result.id) {
+        throw new CommandExecutionError('Twitter post completion returned a malformed status url.');
+    }
+}
+
 async function focusComposer(page) {
-    return page.evaluate(`(() => {
+    return requirePostActionResult(await page.evaluate(`(() => {
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
         const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
         const box = boxes.find(visible) || boxes[0];
         if (!box) return { ok: false, message: 'Could not find the tweet composer text area. Are you logged in?' };
         box.focus();
         return { ok: true };
-    })()`);
+    })()`), 'Twitter composer focus');
 }
 
 async function verifyComposerText(page, text) {
     const iterations = Math.ceil(COMPOSER_TIMEOUT_MS / COMPOSER_POLL_MS);
-    return page.evaluate(`(async () => {
+    return requirePostActionResult(await page.evaluate(`(async () => {
         const expected = ${JSON.stringify(text)};
         const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
         const normalizedExpected = normalize(expected);
@@ -69,7 +108,7 @@ async function verifyComposerText(page, text) {
             message: 'Could not verify tweet text in the composer after typing.',
             actualText: box ? (box.innerText || box.textContent || '') : ''
         };
-    })()`);
+    })()`), 'Twitter composer text verification');
 }
 
 async function insertComposerText(page, text) {
@@ -97,7 +136,7 @@ async function insertComposerText(page, text) {
         }
     }
 
-    return page.evaluate(`(async () => {
+    return requirePostActionResult(await page.evaluate(`(async () => {
         try {
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
             const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
@@ -116,12 +155,12 @@ async function insertComposerText(page, text) {
             if (normalize(actual).includes(normalize(textToInsert))) return { ok: true };
             return { ok: false, message: 'Could not verify tweet text in the composer after typing.', actualText: actual };
         } catch (e) { return { ok: false, message: String(e) }; }
-    })()`);
+    })()`), 'Twitter composer DOM insertion');
 }
 
 async function waitForImageUpload(page, expectedCount) {
     const iterations = Math.ceil(UPLOAD_TIMEOUT_MS / UPLOAD_POLL_MS);
-    return page.evaluate(`(async () => {
+    return requirePostActionResult(await page.evaluate(`(async () => {
         const expected = ${JSON.stringify(expectedCount)};
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
         for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
@@ -140,7 +179,7 @@ async function waitForImageUpload(page, expectedCount) {
             if (previewCount >= expected && buttonReady) return { ok: true, previewCount };
         }
         return { ok: false, message: 'Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).' };
-    })()`);
+    })()`), 'Twitter image upload verification');
 }
 
 async function attachImagesViaDataTransfer(page, absPaths) {
@@ -159,7 +198,7 @@ async function attachImagesViaDataTransfer(page, absPaths) {
             base64: fs.readFileSync(absPath).toString('base64'),
         };
     });
-    const upload = await page.evaluate(`(() => {
+    const upload = requirePostActionResult(await page.evaluate(`(() => {
         const input = document.querySelector(${JSON.stringify(FILE_INPUT_SELECTOR)});
         if (!input) return { ok: false, error: 'No file input found' };
         const dt = new DataTransfer();
@@ -186,40 +225,46 @@ async function attachImagesViaDataTransfer(page, absPaths) {
         input.dispatchEvent(new Event('change', { bubbles: true }));
         input.dispatchEvent(new Event('input', { bubbles: true }));
         return { ok: true };
-    })()`);
+    })()`), 'Twitter image upload fallback');
     if (!upload?.ok) {
         throw new CommandExecutionError(`Image upload failed (base64 fallback): ${upload?.error ?? 'unknown error'}`);
     }
 }
 
 async function submitTweet(page, text) {
-    const clickResult = await page.evaluate(`(async () => {
+    const clickResult = requirePostActionResult(await page.evaluate(`(async () => {
         try {
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            for (const toast of Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))) {
+                if (visible(toast)) toast.setAttribute('data-opencli-before-submit-toast', 'true');
+            }
             const buttons = Array.from(document.querySelectorAll('[data-testid="tweetButtonInline"], [data-testid="tweetButton"]'));
             const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
             if (!btn) return { ok: false, message: 'Tweet button is disabled or not found.' };
             btn.click();
             return { ok: true };
         } catch (e) { return { ok: false, message: String(e) }; }
-    })()`);
+    })()`), 'Twitter post click');
     if (!clickResult?.ok) return clickResult;
 
     const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
-    return page.evaluate(`(async () => {
+    const result = requirePostActionResult(await page.evaluate(`(async () => {
         const expected = ${JSON.stringify(text)};
         const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
         const expectedText = normalize(expected);
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
         const statusUrl = (root) => {
+            if (!root || typeof root.querySelectorAll !== 'function') return {};
             const links = Array.from(root.querySelectorAll('a[href*="/status/"]'));
             for (const link of links) {
                 const href = link.href || link.getAttribute('href') || '';
                 if (!href) continue;
                 try {
                     const url = new URL(href, window.location.origin);
-                    const match = url.pathname.match(/^\\/(?:[^/]+|i)\\/status\\/(\\d+)/);
-                    if (match) return { url: url.href, id: match[1] };
+                    const hostname = url.hostname.toLowerCase().replace(/^www\\./, '');
+                    if (!['x.com', 'twitter.com', 'mobile.twitter.com'].includes(hostname)) continue;
+                    const match = url.pathname.match(/^\\/([^/]+)\\/status\\/(\\d+)\\/?$/);
+                    if (match) return { url: url.href, id: match[2] };
                 } catch {}
             }
             return {};
@@ -227,29 +272,20 @@ async function submitTweet(page, text) {
         for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
             await new Promise(r => setTimeout(r, ${JSON.stringify(SUBMIT_POLL_MS)}));
             const toasts = Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))
-                .filter((el) => visible(el));
+                .filter((el) => visible(el) && !el.hasAttribute('data-opencli-before-submit-toast'));
             const successToast = toasts.find((el) => /sent|posted|your post was sent|your tweet was sent/i.test(el.textContent || ''));
             if (successToast) return { ok: true, message: 'Tweet posted successfully.', ...statusUrl(successToast) };
             const alert = toasts.find((el) => /failed|error|try again|not sent|could not/i.test(el.textContent || ''));
             if (alert) return { ok: false, message: (alert.textContent || 'Tweet failed to post.').trim() };
 
-            const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
-            const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
-            // Drop the global tweetPhoto query: tweetPhoto exists for every
-            // timeline tweet's image and would pin hasMedia true past the
-            // success path. attachments + blob: URLs are composer-only.
-            const hasMedia = !!document.querySelector('[data-testid="attachments"]')
-                || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
-            if (!composerStillHasText && !hasMedia) {
-                // No permalink here: the compose route is a modal over the home
-                // timeline, so the first /status/ link in the document belongs
-                // to somebody else's tweet (#2250). Only the toast carries a
-                // link that is attributable to this post.
-                return { ok: true, message: 'Tweet posted successfully.' };
-            }
+            // Composer disappearance or text clearing alone is not a reliable
+            // postcondition: X may close/rewrite the modal after failed submits.
+            // Require a fresh success toast so the evidence is tied to this click.
         }
         return { ok: false, message: 'Tweet submission did not complete before timeout.' };
-    })()`);
+    })()`), 'Twitter post completion');
+    validateSubmitStatusPair(result);
+    return result;
 }
 
 cli({

--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -211,7 +211,7 @@ async function submitTweet(page, text) {
         const normalize = s => String(s || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
         const expectedText = normalize(expected);
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
-        const statusUrl = (root = document) => {
+        const statusUrl = (root) => {
             const links = Array.from(root.querySelectorAll('a[href*="/status/"]'));
             for (const link of links) {
                 const href = link.href || link.getAttribute('href') || '';
@@ -241,7 +241,11 @@ async function submitTweet(page, text) {
             const hasMedia = !!document.querySelector('[data-testid="attachments"]')
                 || document.querySelectorAll('img[src^="blob:"], video[src^="blob:"]').length > 0;
             if (!composerStillHasText && !hasMedia) {
-                return { ok: true, message: 'Tweet posted successfully.', ...statusUrl() };
+                // No permalink here: the compose route is a modal over the home
+                // timeline, so the first /status/ link in the document belongs
+                // to somebody else's tweet (#2250). Only the toast carries a
+                // link that is attributable to this post.
+                return { ok: true, message: 'Tweet posted successfully.' };
             }
         }
         return { ok: false, message: 'Tweet submission did not complete before timeout.' };

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './post.js';
 
@@ -215,6 +216,61 @@ describe('twitter post command', () => {
         const submitScript = page.evaluate.mock.calls[3][0];
         expect(submitScript).toContain('successToast');
         expect(submitScript).toContain('your post was sent');
+    });
+
+    // The compose route is a modal over the home timeline, so the submit
+    // script runs against that DOM instead of a stub.
+    const runPostAgainstDom = async (html, text) => {
+        const dom = new JSDOM(`<!doctype html><body>${html}</body>`, {
+            url: 'https://x.com/compose/post',
+            runScripts: 'outside-only',
+        });
+        dom.window.setTimeout = (callback) => {
+            callback();
+            return 0;
+        };
+        dom.window.HTMLElement.prototype.getClientRects = () => [{ width: 10, height: 10 }];
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+        ]);
+        page.evaluate.mockImplementation((script) => dom.window.eval(script)); // submit poll
+        return getCommand().func(page, { text });
+    };
+
+    it('reports no permalink when the post is confirmed by the cleared composer', async () => {
+        const timelineOnly = '<article><a href="/nasa/status/1111111111111111111">someone else</a></article>';
+
+        await expect(runPostAgainstDom(timelineOnly, 'cleared composer')).resolves.toEqual([
+            { status: 'success', message: 'Tweet posted successfully.', text: 'cleared composer' },
+        ]);
+    });
+
+    it('keeps the permalink that the success toast carries', async () => {
+        const toast = `
+            <article><a href="/nasa/status/1111111111111111111">someone else</a></article>
+            <div role="alert">Your post was sent. <a href="/me/status/2222222222222222222">View</a></div>
+        `;
+
+        await expect(runPostAgainstDom(toast, 'toast permalink')).resolves.toEqual([
+            {
+                status: 'success',
+                message: 'Tweet posted successfully.',
+                text: 'toast permalink',
+                id: '2222222222222222222',
+                url: 'https://x.com/me/status/2222222222222222222',
+            },
+        ]);
+    });
+
+    it('requires an explicit root for the permalink lookup', async () => {
+        const command = getCommand();
+        const page = makePage([{ ok: true }, { ok: true }, { ok: true }, { ok: true, message: 'Tweet posted successfully.' }]);
+
+        await command.func(page, { text: 'explicit root' });
+
+        expect(page.evaluate.mock.calls[3][0]).toContain('const statusUrl = (root) =>');
     });
 
     it('does not let global timeline tweetPhoto nodes keep the submit poll pending', async () => {

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -218,10 +218,10 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('your post was sent');
     });
 
-    // The compose route is a modal over the home timeline, so the submit
-    // script runs against that DOM instead of a stub.
-    const runPostAgainstDom = async (html, text) => {
-        const dom = new JSDOM(`<!doctype html><body>${html}</body>`, {
+    // The compose route is a modal over the home timeline. The helper stubs the
+    // pre-submit steps but runs click + submit polling against a real DOM.
+    const runPostAgainstDom = async (html, text, { afterClickHtml = '' } = {}) => {
+        const dom = new JSDOM(`<!doctype html><body><button data-testid="tweetButton">Post</button>${html}</body>`, {
             url: 'https://x.com/compose/post',
             runScripts: 'outside-only',
         });
@@ -230,30 +230,39 @@ describe('twitter post command', () => {
             return 0;
         };
         dom.window.HTMLElement.prototype.getClientRects = () => [{ width: 10, height: 10 }];
-        const page = makePage([
-            { ok: true }, // focus composer
-            { ok: true }, // verify native insertText
-            { ok: true }, // click post
-        ]);
-        page.evaluate.mockImplementation((script) => dom.window.eval(script)); // submit poll
+        const page = makePage([]);
+        let evaluateCount = 0;
+        page.evaluate.mockImplementation((script) => {
+            evaluateCount += 1;
+            if (evaluateCount <= 2) return Promise.resolve({ ok: true });
+            if (evaluateCount === 3) {
+                const result = dom.window.eval(script);
+                if (afterClickHtml) {
+                    dom.window.document.body.insertAdjacentHTML('beforeend', afterClickHtml);
+                }
+                return Promise.resolve(result);
+            }
+            return Promise.resolve(dom.window.eval(script));
+        });
         return getCommand().func(page, { text });
     };
 
-    it('reports no permalink when the post is confirmed by the cleared composer', async () => {
+    it('does not report success from a cleared composer and a timeline permalink', async () => {
         const timelineOnly = '<article><a href="/nasa/status/1111111111111111111">someone else</a></article>';
 
         await expect(runPostAgainstDom(timelineOnly, 'cleared composer')).resolves.toEqual([
-            { status: 'success', message: 'Tweet posted successfully.', text: 'cleared composer' },
+            { status: 'failed', message: 'Tweet submission did not complete before timeout.', text: 'cleared composer' },
         ]);
     });
 
     it('keeps the permalink that the success toast carries', async () => {
+        const timeline = '<article><a href="/nasa/status/1111111111111111111">someone else</a></article>';
         const toast = `
             <article><a href="/nasa/status/1111111111111111111">someone else</a></article>
             <div role="alert">Your post was sent. <a href="/me/status/2222222222222222222">View</a></div>
         `;
 
-        await expect(runPostAgainstDom(toast, 'toast permalink')).resolves.toEqual([
+        await expect(runPostAgainstDom(timeline, 'toast permalink', { afterClickHtml: toast })).resolves.toEqual([
             {
                 status: 'success',
                 message: 'Tweet posted successfully.',
@@ -262,6 +271,112 @@ describe('twitter post command', () => {
                 url: 'https://x.com/me/status/2222222222222222222',
             },
         ]);
+    });
+
+    it('does not export a permalink from an untrusted toast link host', async () => {
+        const toast = `
+            <div role="alert">Your post was sent. <a href="https://example.com/me/status/2222222222222222222">View</a></div>
+        `;
+
+        await expect(runPostAgainstDom('', 'bad host', { afterClickHtml: toast })).resolves.toEqual([
+            { status: 'success', message: 'Tweet posted successfully.', text: 'bad host' },
+        ]);
+    });
+
+    it('ignores a success toast that existed before clicking post', async () => {
+        const oldToast = `
+            <div role="alert">Your post was sent. <a href="/me/status/3333333333333333333">View</a></div>
+        `;
+
+        await expect(runPostAgainstDom(oldToast, 'old toast')).resolves.toEqual([
+            { status: 'failed', message: 'Tweet submission did not complete before timeout.', text: 'old toast' },
+        ]);
+    });
+
+    it('unwraps Browser Bridge envelopes for action results', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { session: 'site:twitter', data: { ok: true } },
+            { session: 'site:twitter', data: { ok: true } },
+            { session: 'site:twitter', data: { ok: true } },
+            {
+                session: 'site:twitter',
+                data: {
+                    ok: true,
+                    message: 'Tweet posted successfully.',
+                    id: '4444444444444444444',
+                    url: 'https://x.com/me/status/4444444444444444444',
+                },
+            },
+        ]);
+
+        await expect(command.func(page, { text: 'wrapped' })).resolves.toEqual([
+            {
+                status: 'success',
+                message: 'Tweet posted successfully.',
+                text: 'wrapped',
+                id: '4444444444444444444',
+                url: 'https://x.com/me/status/4444444444444444444',
+            },
+        ]);
+    });
+
+    it('fails closed when submit completion returns only an id', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true },
+            { ok: true },
+            { ok: true },
+            { ok: true, message: 'Tweet posted successfully.', id: '5555555555555555555' },
+        ]);
+
+        await expect(command.func(page, { text: 'bad pair' })).rejects.toThrow('only one of id/url');
+    });
+
+    it('fails closed when submit completion returns a non-string id', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true },
+            { ok: true },
+            { ok: true },
+            { ok: true, message: 'Tweet posted successfully.', id: 5555555555555555, url: 'https://x.com/me/status/5555555555555555' },
+        ]);
+
+        await expect(command.func(page, { text: 'bad id type' })).rejects.toThrow('malformed status id');
+    });
+
+    it('fails closed when submit completion returns an untrusted status URL', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true },
+            { ok: true },
+            { ok: true },
+            {
+                ok: true,
+                message: 'Tweet posted successfully.',
+                id: '6666666666666666666',
+                url: 'https://example.com/me/status/6666666666666666666',
+            },
+        ]);
+
+        await expect(command.func(page, { text: 'bad url host' })).rejects.toThrow('malformed status url');
+    });
+
+    it('fails closed when submit completion returns a mismatched status id/url', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true },
+            { ok: true },
+            { ok: true },
+            {
+                ok: true,
+                message: 'Tweet posted successfully.',
+                id: '7777777777777777777',
+                url: 'https://x.com/me/status/8888888888888888888',
+            },
+        ]);
+
+        await expect(command.func(page, { text: 'mismatched pair' })).rejects.toThrow('malformed status url');
     });
 
     it('requires an explicit root for the permalink lookup', async () => {
@@ -285,9 +400,9 @@ describe('twitter post command', () => {
         await command.func(page, { text: 'global media should not block' });
 
         const submitScript = page.evaluate.mock.calls[3][0];
-        expect(submitScript).toContain("document.querySelector('[data-testid=\"attachments\"]')");
         expect(submitScript).not.toContain("[data-testid=\"attachments\"], [data-testid=\"tweetPhoto\"]");
         expect(submitScript).not.toContain("document.querySelectorAll('[data-testid=\"tweetPhoto\"]");
+        expect(submitScript).toContain('data-opencli-before-submit-toast');
     });
 
     it('returns failed when image upload times out', async () => {

--- a/clis/twitter/reply.js
+++ b/clis/twitter/reply.js
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { parseTweetUrl } from './shared.js';
+import { parseTweetUrl, unwrapBrowserResult } from './shared.js';
 import {
     COMPOSER_FILE_INPUT_SELECTOR,
     attachComposerImage,
@@ -28,6 +28,35 @@ function isPromiseCollectedError(err) {
     return msg.includes('Promise was collected');
 }
 
+function requireReplyActionResult(value, context) {
+    const result = unwrapBrowserResult(value);
+    if (!result || typeof result !== 'object' || Array.isArray(result) || typeof result.ok !== 'boolean') {
+        throw new CommandExecutionError(`${context} returned a malformed result.`);
+    }
+    if (Object.prototype.hasOwnProperty.call(result, 'message') && result.message != null && typeof result.message !== 'string') {
+        throw new CommandExecutionError(`${context} returned a malformed message.`);
+    }
+    if (Object.prototype.hasOwnProperty.call(result, 'url') && result.url != null && typeof result.url !== 'string') {
+        throw new CommandExecutionError(`${context} returned a malformed status url.`);
+    }
+    return result;
+}
+
+function validateReplyStatusUrl(result) {
+    if (!result.url) return;
+    let url;
+    try {
+        url = new URL(result.url);
+    } catch {
+        throw new CommandExecutionError('Twitter reply completion returned a malformed status url.');
+    }
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
+    const match = url.pathname.match(/^\/([^/]+)\/status\/(\d+)\/?$/);
+    if (!['x.com', 'twitter.com', 'mobile.twitter.com'].includes(hostname) || !match) {
+        throw new CommandExecutionError('Twitter reply completion returned a malformed status url.');
+    }
+}
+
 async function openReplyComposer(page, rawUrl) {
     await page.goto(buildReplyComposerUrl(rawUrl), { waitUntil: 'load', settleMs: 2500 });
     try {
@@ -38,14 +67,14 @@ async function openReplyComposer(page, rawUrl) {
         // timeline behind a loading dialog. Fall back to the canonical tweet
         // page and click the visible Reply action there.
         await page.goto(rawUrl, { waitUntil: 'load', settleMs: 2500 });
-        const clicked = await page.evaluate(`(() => {
+        const clicked = requireReplyActionResult(await page.evaluate(`(() => {
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
             const buttons = Array.from(document.querySelectorAll('[data-testid="reply"]'));
             const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
             if (!btn) return { ok: false, message: 'Could not find the reply button on the target tweet.' };
             btn.click();
             return { ok: true };
-        })()`);
+        })()`), 'Twitter target reply click');
         if (!clicked?.ok) return clicked;
         await page.wait({ selector: COMPOSER_SELECTOR, timeout: 15 });
         return { ok: true };
@@ -53,7 +82,7 @@ async function openReplyComposer(page, rawUrl) {
 }
 
 async function insertReplyText(page, text) {
-    return page.evaluate(`(async () => {
+    return requireReplyActionResult(await page.evaluate(`(async () => {
       try {
           const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
           const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]'));
@@ -86,12 +115,12 @@ async function insertReplyText(page, text) {
       } catch (e) {
           return { ok: false, message: e.toString() };
       }
-  })()`);
+  })()`), 'Twitter reply text insertion');
 }
 
 async function clickReplyButton(page) {
     const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
-    return page.evaluate(`(async () => {
+    return requireReplyActionResult(await page.evaluate(`(async () => {
       try {
           const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
           for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
@@ -100,6 +129,9 @@ async function clickReplyButton(page) {
               );
               const btn = buttons.find((el) => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true');
               if (btn) {
+                  for (const toast of Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))) {
+                      if (visible(toast)) toast.setAttribute('data-opencli-before-reply-toast', 'true');
+                  }
                   btn.click();
                   return { ok: true };
               }
@@ -109,55 +141,83 @@ async function clickReplyButton(page) {
       } catch (e) {
           return { ok: false, message: e.toString() };
       }
-  })()`);
+  })()`), 'Twitter reply click');
 }
 
 async function detectReplySent(page) {
-    return page.evaluate(`(() => {
+    const result = requireReplyActionResult(await page.evaluate(`(() => {
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+        const statusUrl = (root) => {
+            if (!root || typeof root.querySelectorAll !== 'function') return undefined;
+            const links = Array.from(root.querySelectorAll('a[href*="/status/"]'));
+            for (const link of links) {
+                const href = link.href || link.getAttribute('href') || '';
+                if (!href) continue;
+                try {
+                    const url = new URL(href, window.location.origin);
+                    const hostname = url.hostname.toLowerCase().replace(/^www\\./, '');
+                    if (!['x.com', 'twitter.com', 'mobile.twitter.com'].includes(hostname)) continue;
+                    if (/^\\/([^/]+)\\/status\\/(\\d+)\\/?$/.test(url.pathname)) return url.href;
+                } catch {}
+            }
+            return undefined;
+        };
         const toasts = Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))
-            .filter((el) => visible(el));
+            .filter((el) => visible(el) && !el.hasAttribute('data-opencli-before-reply-toast'));
         const successToast = toasts.find((el) => /sent|posted|your post was sent|your tweet was sent/i.test(el.textContent || ''));
         if (!successToast) return { ok: false };
-        const link = successToast.querySelector('a[href*="/status/"]');
         return {
             ok: true,
             message: 'Reply posted successfully.',
-            url: link?.href || link?.getAttribute('href') || undefined
+            url: statusUrl(successToast)
         };
-    })()`);
+    })()`), 'Twitter reply success recovery');
+    validateReplyStatusUrl(result);
+    return result;
 }
 
 async function waitForReplySent(page, text) {
     const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
     try {
-        return await page.evaluate(`(async () => {
-            const expected = ${JSON.stringify(text)};
-            const normalize = s => String(s || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
-            const expectedText = normalize(expected);
+        const result = requireReplyActionResult(await page.evaluate(`(async () => {
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            const statusUrl = (root) => {
+                if (!root || typeof root.querySelectorAll !== 'function') return undefined;
+                const links = Array.from(root.querySelectorAll('a[href*="/status/"]'));
+                for (const link of links) {
+                    const href = link.href || link.getAttribute('href') || '';
+                    if (!href) continue;
+                    try {
+                        const url = new URL(href, window.location.origin);
+                        const hostname = url.hostname.toLowerCase().replace(/^www\\./, '');
+                        if (!['x.com', 'twitter.com', 'mobile.twitter.com'].includes(hostname)) continue;
+                        if (/^\\/([^/]+)\\/status\\/(\\d+)\\/?$/.test(url.pathname)) return url.href;
+                    } catch {}
+                }
+                return undefined;
+            };
             for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
                 await new Promise(r => setTimeout(r, ${JSON.stringify(SUBMIT_POLL_MS)}));
                 const toasts = Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))
-                    .filter((el) => visible(el));
+                    .filter((el) => visible(el) && !el.hasAttribute('data-opencli-before-reply-toast'));
                 const successToast = toasts.find((el) => /sent|posted|your post was sent|your tweet was sent/i.test(el.textContent || ''));
                 if (successToast) {
-                    const link = successToast.querySelector('a[href*="/status/"]');
                     return {
                         ok: true,
                         message: 'Reply posted successfully.',
-                        url: link?.href || link?.getAttribute('href') || undefined
+                        url: statusUrl(successToast)
                     };
                 }
                 const alert = toasts.find((el) => /failed|error|try again|not sent|could not/i.test(el.textContent || ''));
                 if (alert) return { ok: false, message: (alert.textContent || 'Reply failed to post.').trim() };
 
-                const boxes = Array.from(document.querySelectorAll('[data-testid="tweetTextarea_0"]')).filter(visible);
-                const composerStillHasText = boxes.some((box) => normalize(box.innerText || box.textContent || '').includes(expectedText));
-                if (!composerStillHasText) return { ok: true, message: 'Reply posted successfully.' };
+                // Composer disappearance or text clearing alone can happen after
+                // modal rewrites or failed submits. Require a fresh success toast.
             }
             return { ok: false, message: 'Reply submission did not complete before timeout.' };
-        })()`);
+        })()`), 'Twitter reply completion');
+        validateReplyStatusUrl(result);
+        return result;
     } catch (err) {
         // X may route the SPA immediately after click, making CDP collect the
         // polling promise even though the reply was submitted. If the page now

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -158,6 +158,124 @@ describe('twitter reply command', () => {
             url: 'https://x.com/me/status/123',
         }]);
     });
+
+    // Run the click + completion polling scripts against a DOM so current
+    // submit evidence is tested instead of just trusting mocked evaluate rows.
+    const runReplyAgainstDom = async (html, text, { afterClickHtml = '' } = {}) => {
+        const cmd = getRegistry().get('twitter/reply');
+        const dom = new JSDOM(`<!doctype html><body><button data-testid="tweetButton">Reply</button>${html}</body>`, {
+            url: 'https://x.com/compose/post?in_reply_to=2040254679301718161',
+            runScripts: 'outside-only',
+        });
+        dom.window.setTimeout = (callback) => {
+            callback();
+            return 0;
+        };
+        dom.window.HTMLElement.prototype.getClientRects = () => [{ width: 10, height: 10 }];
+        let evaluateCount = 0;
+        const page = createPageMock([], {
+            evaluate: vi.fn((script) => {
+                evaluateCount += 1;
+                if (evaluateCount === 1) return Promise.resolve({ ok: true });
+                if (evaluateCount === 2) {
+                    const result = dom.window.eval(script);
+                    if (afterClickHtml) {
+                        dom.window.document.body.insertAdjacentHTML('beforeend', afterClickHtml);
+                    }
+                    return Promise.resolve(result);
+                }
+                return Promise.resolve(dom.window.eval(script));
+            }),
+        });
+
+        return cmd.func(page, {
+            url: 'https://x.com/_kop6/status/2040254679301718161?s=20',
+            text,
+        });
+    };
+
+    it('does not report reply success from a cleared composer without a fresh toast', async () => {
+        await expect(runReplyAgainstDom('', 'cleared reply')).resolves.toEqual([
+            { status: 'failed', message: 'Reply submission did not complete before timeout.', text: 'cleared reply' },
+        ]);
+    });
+
+    it('ignores a reply success toast that existed before clicking Reply', async () => {
+        const oldToast = `
+            <div role="alert">Your post was sent. <a href="/me/status/3333333333333333333">View</a></div>
+        `;
+
+        await expect(runReplyAgainstDom(oldToast, 'old reply toast')).resolves.toEqual([
+            { status: 'failed', message: 'Reply submission did not complete before timeout.', text: 'old reply toast' },
+        ]);
+    });
+
+    it('returns the permalink from a fresh reply success toast only', async () => {
+        const timeline = '<article><a href="/nasa/status/1111111111111111111">someone else</a></article>';
+        const toast = `
+            <div role="alert">Your post was sent. <a href="/me/status/4444444444444444444">View</a></div>
+        `;
+
+        await expect(runReplyAgainstDom(timeline, 'fresh reply toast', { afterClickHtml: toast })).resolves.toEqual([
+            {
+                status: 'success',
+                message: 'Reply posted successfully.',
+                text: 'fresh reply toast',
+                url: 'https://x.com/me/status/4444444444444444444',
+            },
+        ]);
+    });
+
+    it('does not export a reply permalink from an untrusted toast link host', async () => {
+        const toast = `
+            <div role="alert">Your post was sent. <a href="https://example.com/me/status/5555555555555555555">View</a></div>
+        `;
+
+        await expect(runReplyAgainstDom('', 'reply bad host', { afterClickHtml: toast })).resolves.toEqual([
+            { status: 'success', message: 'Reply posted successfully.', text: 'reply bad host' },
+        ]);
+    });
+
+    it('unwraps Browser Bridge envelopes for reply action results', async () => {
+        const cmd = getRegistry().get('twitter/reply');
+        const page = createPageMock([
+            { session: 'site:twitter', data: { ok: true } },
+            { session: 'site:twitter', data: { ok: true } },
+            {
+                session: 'site:twitter',
+                data: {
+                    ok: true,
+                    message: 'Reply posted successfully.',
+                    url: 'https://x.com/me/status/6666666666666666666',
+                },
+            },
+        ]);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/_kop6/status/2040254679301718161?s=20',
+            text: 'wrapped reply',
+        })).resolves.toEqual([{
+            status: 'success',
+            message: 'Reply posted successfully.',
+            text: 'wrapped reply',
+            url: 'https://x.com/me/status/6666666666666666666',
+        }]);
+    });
+
+    it('fails closed when reply completion returns a malformed status URL', async () => {
+        const cmd = getRegistry().get('twitter/reply');
+        const page = createPageMock([
+            { ok: true },
+            { ok: true },
+            { ok: true, message: 'Reply posted successfully.', url: 'https://example.com/me/status/7777777777777777777' },
+        ]);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/_kop6/status/2040254679301718161?s=20',
+            text: 'bad reply url',
+        })).rejects.toThrow('malformed status url');
+    });
+
     it('rejects using --image and --image-url together', async () => {
         const cmd = getRegistry().get('twitter/reply');
         expect(cmd?.func).toBeTypeOf('function');


### PR DESCRIPTION
## Description

`twitter post` could report the permalink of a tweet it did not write. When the success toast is matched the permalink is read from inside that toast, which is correct, but the fallback path that confirms the post by the cleared composer called `statusUrl()` with no root and took the first `a[href*="/status/"]` in the document. The command posts from `https://x.com/compose/post`, which X renders as a modal over the home timeline, so that link belongs to another account's tweet, and it was surfaced as the row's `id` and `url` (#2250).

The fallback now reports success without a permalink, and `statusUrl` requires an explicit root. An agent reading `url` gets either the toast's own link or nothing.

Related issue: Closes #2250

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

The new tests run the shipped submit script against the compose route's DOM shape; a live post on a test account still reports the toast's own permalink and was deleted through the adapter afterwards:

```
$ opencli twitter post "opencli post path check" --format json
[{ "status": "success", "message": "Tweet posted successfully.",
   "id": "2084913336152719738",
   "url": "https://x.com/jarvis_john_doe/status/2084913336152719738" }]
```

`clis/twitter/post.test.js` 20 / 20; reverting the fix, scoping the fallback lookup to the modal, or restoring the default root each fails a test. Typecheck, both lint gates and doc coverage pass; `cli-manifest.json` unchanged.
