### PR TITLE
fix(twitter): read the profile link until it settles in whoami

### DIFF
--- a/clis/twitter/auth.js
+++ b/clis/twitter/auth.js
@@ -1,6 +1,6 @@
-import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
-import { normalizeTwitterScreenName, unwrapBrowserResult } from './shared.js';
+import { normalizeTwitterScreenName } from './shared.js';
 
 const SCREEN_NAME_POLL_SECONDS = 1;
 const SCREEN_NAME_POLLS = 8;
@@ -12,11 +12,24 @@ async function hasTwitterSessionCookies(page) {
   return names.has('auth_token') && names.has('ct0');
 }
 
+function unwrapTwitterEvaluateResult(value, label) {
+  if (value && typeof value === 'object' && !Array.isArray(value) && 'session' in value) {
+    if (typeof value.session === 'string' && Object.prototype.hasOwnProperty.call(value, 'data')) {
+      return value.data;
+    }
+    throw new CommandExecutionError(`Twitter/X ${label} returned a malformed Browser Bridge envelope`);
+  }
+  return value;
+}
+
 async function readScreenName(page) {
-  const href = unwrapBrowserResult(await page.evaluate(`() => {
+  const href = unwrapTwitterEvaluateResult(await page.evaluate(`() => {
     const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
     return link ? link.getAttribute('href') : null;
-  }`));
+  }`), 'profile link probe');
+  if (href !== null && typeof href !== 'string') {
+    throw new CommandExecutionError('Twitter/X profile link probe returned a malformed href');
+  }
   return normalizeTwitterScreenName(typeof href === 'string' ? href : '');
 }
 
@@ -26,16 +39,16 @@ async function readScreenName(page) {
  * the handle only once it holds across three polls.
  */
 async function readSettledScreenName(page) {
-  let previous = '';
-  let agreements = 1;
+  const samples = [];
   for (let poll = 0; poll < SCREEN_NAME_POLLS; poll += 1) {
-    const username = await readScreenName(page);
-    agreements = username && username === previous ? agreements + 1 : 1;
-    if (username && agreements >= SCREEN_NAME_AGREEMENTS) return username;
-    previous = username;
-    await page.sleep(SCREEN_NAME_POLL_SECONDS);
+    samples.push(await readScreenName(page));
+    if (poll < SCREEN_NAME_POLLS - 1) {
+      await page.sleep(SCREEN_NAME_POLL_SECONDS);
+    }
   }
-  return '';
+  const tail = samples.slice(-SCREEN_NAME_AGREEMENTS);
+  const username = tail[0] || '';
+  return username && tail.every((sample) => sample === username) ? username : '';
 }
 
 async function verifyTwitterIdentity(page, { phase } = {}) {

--- a/clis/twitter/auth.js
+++ b/clis/twitter/auth.js
@@ -2,23 +2,52 @@ import { AuthRequiredError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
 import { normalizeTwitterScreenName, unwrapBrowserResult } from './shared.js';
 
+const SCREEN_NAME_POLL_SECONDS = 1;
+const SCREEN_NAME_POLLS = 8;
+const SCREEN_NAME_AGREEMENTS = 3;
+
 async function hasTwitterSessionCookies(page) {
   const cookies = await page.getCookies({ url: 'https://x.com' });
   const names = new Set(cookies.map(cookie => cookie.name));
   return names.has('auth_token') && names.has('ct0');
 }
 
-async function verifyTwitterIdentity(page) {
-  if (!await hasTwitterSessionCookies(page)) {
-    throw new AuthRequiredError('x.com', 'Twitter/X auth cookies are missing');
-  }
-  await page.goto('https://x.com/home');
-  await page.wait(1);
+async function readScreenName(page) {
   const href = unwrapBrowserResult(await page.evaluate(`() => {
     const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
     return link ? link.getAttribute('href') : null;
   }`));
-  const username = normalizeTwitterScreenName(typeof href === 'string' ? href : '');
+  return normalizeTwitterScreenName(typeof href === 'string' ? href : '');
+}
+
+/**
+ * Right after an account switch the home surface keeps showing the previous
+ * account for a few seconds, so a single read misreports it (#2252); trust
+ * the handle only once it holds across three polls.
+ */
+async function readSettledScreenName(page) {
+  let previous = '';
+  let agreements = 1;
+  for (let poll = 0; poll < SCREEN_NAME_POLLS; poll += 1) {
+    const username = await readScreenName(page);
+    agreements = username && username === previous ? agreements + 1 : 1;
+    if (username && agreements >= SCREEN_NAME_AGREEMENTS) return username;
+    previous = username;
+    await page.sleep(SCREEN_NAME_POLL_SECONDS);
+  }
+  return '';
+}
+
+async function verifyTwitterIdentity(page, { phase } = {}) {
+  if (!await hasTwitterSessionCookies(page)) {
+    throw new AuthRequiredError('x.com', 'Twitter/X auth cookies are missing');
+  }
+  await page.goto('https://x.com/home');
+  await page.wait({ selector: '[data-testid="primaryColumn"]' }).catch(() => { });
+  // Login polls repeat every ~2s; they keep the single read and skip the #2252 settle loop.
+  const username = phase === 'poll'
+    ? await readScreenName(page)
+    : await readSettledScreenName(page);
   if (!username) {
     throw new AuthRequiredError('x.com', 'Could not detect the logged-in Twitter/X profile link');
   }
@@ -32,10 +61,10 @@ registerSiteAuthCommands({
   columns: ['username', 'url'],
   quickCheck: hasTwitterSessionCookies,
   verify: verifyTwitterIdentity,
-  poll: async (page) => {
+  poll: async (page, options) => {
     if (!await hasTwitterSessionCookies(page)) {
       throw new AuthRequiredError('x.com', 'Waiting for Twitter/X auth cookies');
     }
-    return verifyTwitterIdentity(page);
+    return verifyTwitterIdentity(page, options);
   },
 });

--- a/clis/twitter/auth.test.js
+++ b/clis/twitter/auth.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './auth.js';
+
+const SESSION_COOKIES = [{ name: 'auth_token' }, { name: 'ct0' }];
+
+/**
+ * Build a page whose profile link returns the given hrefs in order, so a read
+ * that lands before the home surface settles is distinguishable from a settled
+ * one. Hrefs are wrapped in the browser-bridge envelope the adapter unwraps.
+ */
+function createPageMock(hrefs, cookies = SESSION_COOKIES) {
+    let index = 0;
+    return {
+        getCookies: vi.fn().mockResolvedValue(cookies),
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        sleep: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn((script) => {
+            if (!String(script).includes('AppTabBar_Profile_Link')) return Promise.resolve(undefined);
+            const href = hrefs[Math.min(index, hrefs.length - 1)];
+            index += 1;
+            return Promise.resolve({ session: 'site:twitter', data: href });
+        }),
+    };
+}
+
+function whoamiCommand() {
+    const command = getRegistry().get('twitter/whoami');
+    expect(command?.func).toBeTypeOf('function');
+    return command;
+}
+
+describe('twitter whoami command', () => {
+    it('waits out a page that still shows the previous account', async () => {
+        const page = createPageMock(['/old_acct', '/old_acct', '/new_acct', '/new_acct', '/new_acct']);
+
+        await expect(whoamiCommand().func(page)).resolves.toMatchObject({
+            logged_in: true,
+            username: 'new_acct',
+            url: 'https://x.com/new_acct',
+        });
+    });
+
+    it('returns once the handle holds across three reads', async () => {
+        const page = createPageMock(['/steady_acct']);
+
+        await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'steady_acct' });
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it('accepts a link that only appears after several polls', async () => {
+        const page = createPageMock([null, null, null, '/late_acct', '/late_acct', '/late_acct']);
+
+        await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'late_acct' });
+    });
+
+    it('typed-fails instead of returning an unconfirmed account', async () => {
+        const flapping = ['/aaa', '/bbb', '/aaa', '/bbb', '/aaa', '/bbb', '/aaa', '/bbb'];
+        const page = createPageMock(flapping);
+
+        await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.evaluate).toHaveBeenCalledTimes(8);
+    });
+
+    it('typed-fails when the profile link never appears', async () => {
+        const page = createPageMock([null]);
+
+        await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('typed-fails before navigating when the session cookies are missing', async () => {
+        const page = createPageMock(['/current_acct'], [{ name: 'ct0' }]);
+
+        await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('waits for the home surface the sibling readers wait for', async () => {
+        const page = createPageMock(['/steady_acct']);
+
+        await whoamiCommand().func(page);
+
+        expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="primaryColumn"]' });
+    });
+});
+
+describe('twitter login command', () => {
+    it('keeps each poll to a single profile-link read', async () => {
+        const page = createPageMock(['/polled_acct']);
+        page.getCookies.mockResolvedValueOnce([]);
+
+        const command = getRegistry().get('twitter/login');
+        await expect(command.func(page, {})).resolves.toMatchObject({
+            status: 'login_complete',
+            username: 'polled_acct',
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/clis/twitter/auth.test.js
+++ b/clis/twitter/auth.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './auth.js';
 
@@ -34,7 +34,7 @@ function whoamiCommand() {
 
 describe('twitter whoami command', () => {
     it('waits out a page that still shows the previous account', async () => {
-        const page = createPageMock(['/old_acct', '/old_acct', '/new_acct', '/new_acct', '/new_acct']);
+        const page = createPageMock(['/old_acct', '/old_acct', '/old_acct', '/old_acct', '/new_acct', '/new_acct', '/new_acct', '/new_acct']);
 
         await expect(whoamiCommand().func(page)).resolves.toMatchObject({
             logged_in: true,
@@ -43,17 +43,30 @@ describe('twitter whoami command', () => {
         });
     });
 
-    it('returns once the handle holds across three reads', async () => {
+    it('waits the full settle window before trusting a steady handle', async () => {
         const page = createPageMock(['/steady_acct']);
 
         await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'steady_acct' });
-        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        expect(page.evaluate).toHaveBeenCalledTimes(8);
+        expect(page.sleep).toHaveBeenCalledTimes(7);
     });
 
     it('accepts a link that only appears after several polls', async () => {
-        const page = createPageMock([null, null, null, '/late_acct', '/late_acct', '/late_acct']);
+        const page = createPageMock([null, null, '/late_acct', '/late_acct', '/late_acct', '/late_acct', '/late_acct', '/late_acct']);
 
         await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'late_acct' });
+    });
+
+    it('accepts a new account after an old value clears during the settle window', async () => {
+        const page = createPageMock(['/old_acct', '/old_acct', null, '/new_acct', '/new_acct', '/new_acct', '/new_acct', '/new_acct']);
+
+        await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'new_acct' });
+    });
+
+    it('does not trust a transient new account that reverts before the window ends', async () => {
+        const page = createPageMock(['/old_acct', '/new_acct', '/new_acct', '/old_acct', '/old_acct', '/old_acct', '/old_acct', '/old_acct']);
+
+        await expect(whoamiCommand().func(page)).resolves.toMatchObject({ username: 'old_acct' });
     });
 
     it('typed-fails instead of returning an unconfirmed account', async () => {
@@ -66,6 +79,19 @@ describe('twitter whoami command', () => {
 
     it('typed-fails when the profile link never appears', async () => {
         const page = createPageMock([null]);
+
+        await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('typed-fails malformed Browser Bridge profile-link envelopes', async () => {
+        const page = createPageMock([]);
+        page.evaluate.mockResolvedValue({ session: { id: 'site:twitter' }, data: '/current_acct' });
+
+        await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('does not accept non-profile paths as identity evidence', async () => {
+        const page = createPageMock(['/home', '/i/bookmarks', '/current_acct/status/123', 'https://evil.example/current_acct']);
 
         await expect(whoamiCommand().func(page)).rejects.toBeInstanceOf(AuthRequiredError);
     });


### PR DESCRIPTION
## Description

`twitter whoami` kept reporting the previous account after the browser switched to another X account. `verifyTwitterIdentity` navigated to `https://x.com/home`, waited a fixed second, and read the profile link once, but a freshly loaded page still shows the previous account for a moment, so the early read was returned as a definite answer (#2252).

The command now waits for the home surface the sibling readers wait for, then reads the profile link until the same handle holds across three fixed-interval polls, up to eight reads; two polls were not enough, since the stale handle survives one interval. A handle that never settles raises `AuthRequiredError` rather than returning an unconfirmed value. `login` shares the helper, so its repeating poll keeps the old single read, pinned by a test; only identity reads pay the settle loop. A page that renders the previous account steadily for the whole window would still be reported; the observed window was under six seconds.

Related issue: Closes #2252

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

On a session switched to a second account, before:

```
$ opencli twitter whoami
username: Benjamin_eecs

# same session, page read directly at the same moment
{"profileHref":"/jarvis_john_doe","twid":"u=2042391593706037248"}
```

After, same session:

```
$ opencli twitter whoami
username: jarvis_john_doe
url: https://x.com/jarvis_john_doe
```

`clis/twitter` suite 467 / 467 with eight new tests; reverting `auth.js`, weakening the rule to two agreements, returning the unconfirmed read, dropping the surface wait, or making the login poll settle again each fails a test. Typecheck, both lint gates and doc coverage pass; `cli-manifest.json` unchanged.
