### PR TITLE
fix(twitter): fail typed when a write command does not go through

### DIFF
--- a/clis/twitter/block.js
+++ b/clis/twitter/block.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 cli({
     site: 'twitter',
@@ -19,6 +19,7 @@ cli({
         await page.goto(`https://x.com/${username}`);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             let attempts = 0;
 
@@ -64,22 +65,27 @@ cli({
 
             // Confirm the block in the dialog
             const confirmBtn = document.querySelector('[data-testid="confirmationSheetConfirm"]');
-            if (confirmBtn) {
-                confirmBtn.click();
-                await new Promise(r => setTimeout(r, 1500));
+            if (!confirmBtn) {
+                return { ok: false, message: 'Block confirmation dialog did not appear.' };
             }
+            writeStarted = true;
+            confirmBtn.click();
+            await new Promise(r => setTimeout(r, 1500));
 
             // Verify
             const verify = document.querySelector('[data-testid$="-unblock"]');
             if (verify) {
                 return { ok: true, message: 'Successfully blocked @${username}.' };
             } else {
-                return { ok: false, message: 'Block action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Block action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter block confirmation', 1.5, `${result.message} Check the profile before retrying; the block may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
         }

--- a/clis/twitter/block.js
+++ b/clis/twitter/block.js
@@ -80,10 +80,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/block.test.js
+++ b/clis/twitter/block.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './block.js';
+import { createPageMock } from '../test-utils.js';
+
+describe('twitter block command', () => {
+    it('navigates to the profile URL and reports success when the block script confirms', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        expect(cmd?.func).toBeTypeOf('function');
+        const page = createPageMock([
+            { ok: true, message: 'Successfully blocked @alice.' },
+        ]);
+        const result = await cmd.func(page, {
+            username: 'alice',
+        });
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/alice');
+        expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="primaryColumn"]' });
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
+        const script = page.evaluate.mock.calls[0][0];
+        // Idempotency probe: when already blocking ([data-testid$="-unblock"] present),
+        // the script returns ok:true with an "already blocking" message.
+        expect(script).toContain('[data-testid$="-unblock"]');
+        expect(script).toContain('[data-testid="userActions"]');
+        expect(script).toContain("includes('Block')");
+        expect(script).toContain('blockItem.click()');
+        expect(script).toContain('[data-testid="confirmationSheetConfirm"]');
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully blocked @alice.' },
+        ]);
+    });
+
+    it('typed-fails without re-waiting when the block script reports a UI mismatch', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const page = createPageMock([
+            {
+                ok: false,
+                message: 'Could not find user actions menu. Are you logged in?',
+            },
+        ]);
+        await expect(cmd.func(page, {
+            username: 'alice',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find user actions menu. Are you logged in?',
+        });
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CommandExecutionError when no page is provided', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        await expect(cmd.func(undefined, {
+            username: 'alice',
+        })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/twitter/block.test.js
+++ b/clis/twitter/block.test.js
@@ -3,6 +3,7 @@ import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './block.js';
 import { createPageMock } from '../test-utils.js';
+import { createTwitterDomPage } from './test-dom-utils.js';
 
 describe('twitter block command', () => {
     it('navigates to the profile URL and reports success when the block script confirms', async () => {
@@ -47,6 +48,37 @@ describe('twitter block command', () => {
             message: 'Could not find user actions menu. Are you logged in?',
         });
         expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps a missing confirmation dialog a definite pre-write failure', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const page = createTwitterDomPage(`
+            <button data-testid="userActions">More</button>
+            <button role="menuitem">Block @alice</button>
+        `, 'https://x.com/alice');
+
+        await expect(cmd.func(page, { username: 'alice' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Block confirmation dialog did not appear.',
+        });
+    });
+
+    it('treats a missing post-confirm profile state change as unconfirmed', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const page = createTwitterDomPage(`
+            <button data-testid="userActions">More</button>
+            <button role="menuitem">Block @alice</button>
+            <button data-testid="confirmationSheetConfirm">Confirm</button>
+        `, 'https://x.com/alice');
+
+        await expect(cmd.func(page, { username: 'alice' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already have succeeded'),
+        });
     });
 
     it('throws CommandExecutionError when no page is provided', async () => {

--- a/clis/twitter/bookmark.js
+++ b/clis/twitter/bookmark.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             // Article-scoped: on conversation pages multiple bookmark/remove
@@ -49,6 +50,7 @@ cli({
                 return { ok: false, message: 'Could not find Bookmark button on the requested tweet. Are you logged in?' };
             }
 
+            writeStarted = true;
             bookmarkBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -58,12 +60,15 @@ cli({
             if (verify) {
                 return { ok: true, message: 'Tweet successfully bookmarked.' };
             } else {
-                return { ok: false, message: 'Bookmark action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Bookmark action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter bookmark confirmation', 1, `${result.message} Check the tweet before retrying; the bookmark may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/bookmark.js
+++ b/clis/twitter/bookmark.js
@@ -64,10 +64,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/bookmark.test.js
+++ b/clis/twitter/bookmark.test.js
@@ -35,7 +35,7 @@ describe('twitter bookmark command', () => {
         ]);
     });
 
-    it('returns a failed row without re-waiting when the bookmark script reports a UI mismatch', async () => {
+    it('typed-fails without re-waiting when the bookmark script reports a UI mismatch', async () => {
         const cmd = getRegistry().get('twitter/bookmark');
         const page = createPageMock([
             {
@@ -43,15 +43,14 @@ describe('twitter bookmark command', () => {
                 message: 'Could not find Bookmark button on the requested tweet. Are you logged in?',
             },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Bookmark button on the requested tweet. Are you logged in?',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find Bookmark button on the requested tweet. Are you logged in?',
-            },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 

--- a/clis/twitter/delete.js
+++ b/clis/twitter/delete.js
@@ -84,12 +84,12 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' }); // Wait for tweet to load completely
         const result = unwrapBrowserResult(await page.evaluate(buildDeleteScript(target.id)));
-        if (result.ok) {
-            // Wait for the deletion request to be processed
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/delete.test.js
+++ b/clis/twitter/delete.test.js
@@ -49,7 +49,7 @@ describe('twitter delete command', () => {
             },
         ]);
     });
-    it('passes through matched-tweet lookup failures', async () => {
+    it('typed-fails on matched-tweet lookup failures', async () => {
         const cmd = getRegistry().get('twitter/delete');
         expect(cmd?.func).toBeTypeOf('function');
         const page = {
@@ -60,15 +60,14 @@ describe('twitter delete command', () => {
                 message: 'Could not find the tweet card matching the requested URL.',
             }),
         };
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find the tweet card matching the requested URL.',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find the tweet card matching the requested URL.',
-            },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
     it('unwraps Browser Bridge evaluate envelopes before checking delete success', async () => {

--- a/clis/twitter/follow.js
+++ b/clis/twitter/follow.js
@@ -57,10 +57,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/follow.js
+++ b/clis/twitter/follow.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 cli({
     site: 'twitter',
@@ -19,6 +19,7 @@ cli({
         await page.goto(`https://x.com/${username}`);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             let attempts = 0;
             let followBtn = null;
@@ -43,6 +44,7 @@ cli({
                 return { ok: false, message: 'Could not find Follow button. Are you logged in?' };
             }
 
+            writeStarted = true;
             followBtn.click();
             await new Promise(r => setTimeout(r, 1500));
 
@@ -51,12 +53,15 @@ cli({
             if (verify) {
                 return { ok: true, message: 'Successfully followed @${username}.' };
             } else {
-                return { ok: false, message: 'Follow action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Follow action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter follow confirmation', 1.5, `${result.message} Check the profile before retrying; the follow may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
         }

--- a/clis/twitter/follow.test.js
+++ b/clis/twitter/follow.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './follow.js';
+import { createPageMock } from '../test-utils.js';
+
+describe('twitter follow command', () => {
+    it('navigates to the profile URL and reports success when the follow script confirms', async () => {
+        const cmd = getRegistry().get('twitter/follow');
+        expect(cmd?.func).toBeTypeOf('function');
+        const page = createPageMock([
+            { ok: true, message: 'Successfully followed @alice.' },
+        ]);
+        const result = await cmd.func(page, {
+            username: 'alice',
+        });
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/alice');
+        expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="primaryColumn"]' });
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
+        const script = page.evaluate.mock.calls[0][0];
+        // Idempotency probe: when already following ([data-testid$="-unfollow"] present),
+        // the script returns ok:true with an "already following" message.
+        expect(script).toContain('[data-testid$="-unfollow"]');
+        expect(script).toContain('[data-testid$="-follow"]');
+        expect(script).toContain('followBtn.click()');
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully followed @alice.' },
+        ]);
+    });
+
+    it('typed-fails without re-waiting when the follow script reports a UI mismatch', async () => {
+        const cmd = getRegistry().get('twitter/follow');
+        const page = createPageMock([
+            {
+                ok: false,
+                message: 'Could not find Follow button. Are you logged in?',
+            },
+        ]);
+        await expect(cmd.func(page, {
+            username: 'alice',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Follow button. Are you logged in?',
+        });
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CommandExecutionError when no page is provided', async () => {
+        const cmd = getRegistry().get('twitter/follow');
+        await expect(cmd.func(undefined, {
+            username: 'alice',
+        })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/twitter/hide-reply.js
+++ b/clis/twitter/hide-reply.js
@@ -77,10 +77,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/hide-reply.test.js
+++ b/clis/twitter/hide-reply.test.js
@@ -37,7 +37,7 @@ describe('twitter hide-reply command', () => {
         ]);
     });
 
-    it('returns a failed row without re-waiting when the hide-reply script reports a UI mismatch', async () => {
+    it('typed-fails without re-waiting when the hide-reply script reports a UI mismatch', async () => {
         const cmd = getRegistry().get('twitter/hide-reply');
         const page = createPageMock([
             {
@@ -45,15 +45,14 @@ describe('twitter hide-reply command', () => {
                 message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.',
             },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.',
-            },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 

--- a/clis/twitter/like.js
+++ b/clis/twitter/like.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' }); // Wait for tweet to load completely
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             // Poll for the tweet to render. We scope state probes to the
@@ -53,6 +54,7 @@ cli({
             }
 
             // Click Like
+            writeStarted = true;
             likeBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -62,12 +64,15 @@ cli({
             if (verifyBtn) {
                 return { ok: true, message: 'Tweet successfully liked.' };
             } else {
-                return { ok: false, message: 'Like action was initiated but UI did not update as expected.' };
+                return { ok: false, unconfirmed: true, message: 'Like action was initiated but UI did not update as expected.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter like confirmation', 1, `${result.message} Check the tweet before retrying; the like may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/like.js
+++ b/clis/twitter/like.js
@@ -68,12 +68,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok) {
-            // Wait for the like network request to be processed
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/like.test.js
+++ b/clis/twitter/like.test.js
@@ -33,7 +33,15 @@ describe('twitter like command', () => {
         ]);
     });
 
-    it('returns a failed row without re-waiting when the like script reports a UI mismatch', async () => {
+    it('keeps an already-liked tweet a success rather than a failure', async () => {
+        const cmd = getRegistry().get('twitter/like');
+        const page = createPageMock([{ ok: true, message: 'Tweet is already liked.' }]);
+
+        await expect(cmd.func(page, { url: 'https://x.com/alice/status/2040254679301718161' }))
+            .resolves.toEqual([{ status: 'success', message: 'Tweet is already liked.' }]);
+    });
+
+    it('typed-fails without re-waiting when the like script reports a UI mismatch', async () => {
         const cmd = getRegistry().get('twitter/like');
         const page = createPageMock([
             {
@@ -41,15 +49,14 @@ describe('twitter like command', () => {
                 message: 'Could not find the Like button on this tweet after waiting 10 seconds. Are you logged in?',
             },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find the Like button on this tweet after waiting 10 seconds. Are you logged in?',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find the Like button on this tweet after waiting 10 seconds. Are you logged in?',
-            },
-        ]);
         // Only the primaryColumn wait should run when ok is false.
         expect(page.wait).toHaveBeenCalledTimes(1);
     });

--- a/clis/twitter/like.test.js
+++ b/clis/twitter/like.test.js
@@ -3,6 +3,7 @@ import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors'
 import { getRegistry } from '@jackwener/opencli/registry';
 import './like.js';
 import { createPageMock } from '../test-utils.js';
+import { createTwitterDomPage } from './test-dom-utils.js';
 
 describe('twitter like command', () => {
     it('navigates to the tweet URL and reports success when the like script confirms', async () => {
@@ -58,6 +59,26 @@ describe('twitter like command', () => {
             message: 'Could not find the Like button on this tweet after waiting 10 seconds. Are you logged in?',
         });
         // Only the primaryColumn wait should run when ok is false.
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats a post-click state mismatch as unconfirmed rather than safe to retry', async () => {
+        const cmd = getRegistry().get('twitter/like');
+        const page = createTwitterDomPage(`
+            <article>
+              <a href="https://x.com/alice/status/2040254679301718161">tweet</a>
+              <button data-testid="like">Like</button>
+            </article>
+        `);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already have succeeded'),
+        });
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 

--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { unwrapBrowserResult } from './shared.js';
 import { isRecoverableFileInputError } from './utils.js';
 
@@ -282,7 +282,7 @@ async function submitTweet(page, text) {
             // postcondition: X may close/rewrite the modal after failed submits.
             // Require a fresh success toast so the evidence is tied to this click.
         }
-        return { ok: false, message: 'Tweet submission did not complete before timeout.' };
+        return { ok: false, unconfirmed: true, message: 'Tweet submission did not complete before timeout.' };
     })()`), 'Twitter post completion');
     validateSubmitStatusPair(result);
     return result;
@@ -332,7 +332,7 @@ cli({
             }
             const uploadState = await waitForImageUpload(page, absPaths.length);
             if (!uploadState?.ok) {
-                return [{ status: 'failed', message: uploadState?.message ?? `Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).`, text }];
+                throw new TimeoutError('twitter image upload', UPLOAD_TIMEOUT_MS / 1000, 'Nothing was posted. Retry, or attach a smaller image.');
             }
         }
 
@@ -340,17 +340,26 @@ cli({
         // the final Draft.js composer state immediately before clicking Post.
         const typeResult = await insertComposerText(page, text);
         if (!typeResult?.ok) {
-            return [{ status: 'failed', message: typeResult?.message ?? 'Could not type tweet text.', text }];
+            throw new CommandExecutionError(typeResult?.message ?? 'Could not type tweet text.', 'Open the composer in the browser and check whether X is asking you to log in.');
         }
 
         await page.wait(1);
         const result = await submitTweet(page, text);
+        if (result?.unconfirmed) {
+            // The poll expiring does not mean the tweet stayed in the composer,
+            // so this must not read as a definite failure: the agent workflow
+            // retries CommandExecutionError and would post twice (#2255).
+            throw new TimeoutError('twitter post', SUBMIT_TIMEOUT_MS / 1000, `${result.message} Check \`opencli twitter tweets --limit 1\` before retrying; the post may already be live.`);
+        }
+        if (!result?.ok) {
+            throw new CommandExecutionError(result?.message ?? 'Tweet failed to post.', 'Nothing was posted. Open the composer in the browser and retry.');
+        }
         return [{
-            status: result?.ok ? 'success' : 'failed',
-            message: result?.message ?? 'Tweet failed to post.',
+            status: 'success',
+            message: result.message,
             text,
-            ...(result?.id ? { id: result.id } : {}),
-            ...(result?.url ? { url: result.url } : {}),
+            ...(result.id ? { id: result.id } : {}),
+            ...(result.url ? { url: result.url } : {}),
         }];
     }
 });

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './post.js';
 
@@ -95,15 +96,13 @@ describe('twitter post command', () => {
         }]);
     });
 
-    it('returns failed when text area not found', async () => {
+    it('typed-fails when text area not found', async () => {
         const command = getCommand();
         const page = makePage([
             { ok: false, message: 'Could not find the tweet composer text area. Are you logged in?' },
         ]);
 
-        const result = await command.func(page, { text: 'hello' });
-
-        expect(result).toEqual([{ status: 'failed', message: 'Could not find the tweet composer text area. Are you logged in?', text: 'hello' }]);
+        await expect(command.func(page, { text: 'hello' })).rejects.toBeInstanceOf(CommandExecutionError);
         expect(page.insertText).not.toHaveBeenCalled();
     });
 
@@ -250,9 +249,12 @@ describe('twitter post command', () => {
     it('does not report success from a cleared composer and a timeline permalink', async () => {
         const timelineOnly = '<article><a href="/nasa/status/1111111111111111111">someone else</a></article>';
 
-        await expect(runPostAgainstDom(timelineOnly, 'cleared composer')).resolves.toEqual([
-            { status: 'failed', message: 'Tweet submission did not complete before timeout.', text: 'cleared composer' },
-        ]);
+        await expect(runPostAgainstDom(timelineOnly, 'cleared composer')).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('Tweet submission did not complete before timeout.'),
+        });
     });
 
     it('keeps the permalink that the success toast carries', async () => {
@@ -288,9 +290,12 @@ describe('twitter post command', () => {
             <div role="alert">Your post was sent. <a href="/me/status/3333333333333333333">View</a></div>
         `;
 
-        await expect(runPostAgainstDom(oldToast, 'old toast')).resolves.toEqual([
-            { status: 'failed', message: 'Tweet submission did not complete before timeout.', text: 'old toast' },
-        ]);
+        await expect(runPostAgainstDom(oldToast, 'old toast')).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('Tweet submission did not complete before timeout.'),
+        });
     });
 
     it('unwraps Browser Bridge envelopes for action results', async () => {
@@ -405,16 +410,53 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('data-opencli-before-submit-toast');
     });
 
-    it('returns failed when image upload times out', async () => {
+    it('typed-fails when image upload times out', async () => {
         const command = getCommand();
         const page = makePage([
             { ok: false, message: 'Image upload timed out (30s).' },
         ]);
 
-        const result = await command.func(page, { text: 'timeout', images: 'a.png' });
-
-        expect(result).toEqual([{ status: 'failed', message: 'Image upload timed out (30s).', text: 'timeout' }]);
+        await expect(command.func(page, { text: 'timeout', images: 'a.png' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+        });
         expect(page.insertText).not.toHaveBeenCalled();
+    });
+
+    it('typed-fails with a non-zero exit code when the post never goes out', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: false, message: 'Tweet button is disabled or not found.' },
+        ]);
+
+        await expect(command.func(page, { text: 'never sent' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Tweet button is disabled or not found.',
+            hint: expect.stringContaining('Nothing was posted'),
+        });
+    });
+
+    it('reports an unconfirmed submit as temporary, without claiming nothing was posted', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: false, unconfirmed: true, message: 'Tweet submission did not complete before timeout.' },
+        ]);
+
+        await expect(command.func(page, { text: 'unconfirmed' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already be live'),
+        });
     });
 
     it('falls back to DOM insertion when native insertText is unavailable', async () => {

--- a/clis/twitter/quote.js
+++ b/clis/twitter/quote.js
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 import {
@@ -8,6 +8,9 @@ import {
     downloadRemoteImage,
     resolveImagePath,
 } from './utils.js';
+
+const SUBMIT_POLL_MS = 500;
+const SUBMIT_TIMEOUT_MS = 15_000;
 
 function buildQuoteComposerUrl(url) {
     // Twitter/X quote-tweet compose URL: the `url` param attaches the source
@@ -18,6 +21,7 @@ function buildQuoteComposerUrl(url) {
 }
 
 async function submitQuote(page, text, tweetId) {
+    const iterations = Math.ceil(SUBMIT_TIMEOUT_MS / SUBMIT_POLL_MS);
     return page.evaluate(`(async () => {
         try {
             ${buildTwitterArticleScopeSource(tweetId)}
@@ -79,8 +83,8 @@ async function submitQuote(page, text, tweetId) {
 
             const normalize = s => String(s || '').replace(/\\u00a0/g, ' ').replace(/\\s+/g, ' ').trim();
             const expectedText = normalize(textToInsert);
-            for (let i = 0; i < 30; i++) {
-                await new Promise(r => setTimeout(r, 500));
+            for (let i = 0; i < ${JSON.stringify(iterations)}; i++) {
+                await new Promise(r => setTimeout(r, ${JSON.stringify(SUBMIT_POLL_MS)}));
                 const toasts = Array.from(document.querySelectorAll('[role="alert"], [data-testid="toast"]'))
                     .filter((el) => visible(el));
                 const successToast = toasts.find((el) => /sent|posted|your post was sent|your tweet was sent/i.test(el.textContent || ''));
@@ -94,7 +98,7 @@ async function submitQuote(page, text, tweetId) {
                 );
                 if (!composerStillHasText) return { ok: true, message: 'Quote tweet posted successfully.' };
             }
-            return { ok: false, message: 'Quote tweet submission did not complete before timeout.' };
+            return { ok: false, unconfirmed: true, message: 'Quote tweet submission did not complete before timeout.' };
         } catch (e) {
             return { ok: false, message: e.toString() };
         }
@@ -152,8 +156,14 @@ cli({
                 // Wait for network submission to complete
                 await page.wait(3);
             }
+            if (result.unconfirmed) {
+                throw new TimeoutError('twitter quote', SUBMIT_TIMEOUT_MS / 1000, `${result.message} Check your profile before retrying; the quote may already be live.`);
+            }
+            if (!result.ok) {
+                throw new CommandExecutionError(result.message, 'Nothing was posted. Open the tweet in the browser and retry.');
+            }
             return [{
-                    status: result.ok ? 'success' : 'failed',
+                    status: 'success',
                     message: result.message,
                     text: kwargs.text,
                     ...(kwargs.image ? { image: kwargs.image } : {}),

--- a/clis/twitter/quote.test.js
+++ b/clis/twitter/quote.test.js
@@ -152,25 +152,40 @@ describe('twitter quote command', () => {
         })).rejects.toThrow(CommandExecutionError);
     });
 
-    it('returns a failed row when the quote target fails to render', async () => {
+    it('typed-fails when the quote target fails to render', async () => {
         const cmd = getRegistry().get('twitter/quote');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
             { ok: false, message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.' },
         ]);
-        const result = await cmd.func(page, {
+
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
             text: 'orphaned quote',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            hint: expect.stringContaining('Nothing was posted'),
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Quote target did not render in the composer. The source tweet may be deleted or restricted.',
-                text: 'orphaned quote',
-            },
-        ]);
-        // Only the textarea wait should run when ok is false (no extra 3s post-submit wait).
         expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports an unconfirmed quote as temporary, without claiming nothing was posted', async () => {
+        const cmd = getRegistry().get('twitter/quote');
+        const page = createPageMock([
+            { ok: false, unconfirmed: true, message: 'Quote tweet submission did not complete before timeout.' },
+        ]);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/alice/status/2040254679301718161',
+            text: 'unconfirmed',
+        })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already be live'),
+        });
     });
 
     it('throws CommandExecutionError when no page is provided', async () => {

--- a/clis/twitter/reply.js
+++ b/clis/twitter/reply.js
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, unwrapBrowserResult } from './shared.js';
 import {
@@ -214,7 +214,7 @@ async function waitForReplySent(page, text) {
                 // Composer disappearance or text clearing alone can happen after
                 // modal rewrites or failed submits. Require a fresh success toast.
             }
-            return { ok: false, message: 'Reply submission did not complete before timeout.' };
+            return { ok: false, unconfirmed: true, message: 'Reply submission did not complete before timeout.' };
         })()`), 'Twitter reply completion');
         validateReplyStatusUrl(result);
         return result;
@@ -280,15 +280,21 @@ cli({
             // back to the target tweet's visible Reply action.
             const composer = await openReplyComposer(page, kwargs.url);
             if (!composer?.ok) {
-                return [{ status: 'failed', message: composer?.message ?? 'Could not open the reply composer.', text: kwargs.text }];
+                throw new CommandExecutionError(composer?.message ?? 'Could not open the reply composer.', 'Open the tweet in the browser and check whether the reply box is available.');
             }
             if (localImagePath) {
                 await page.wait({ selector: COMPOSER_FILE_INPUT_SELECTOR, timeout: 20 });
                 await attachComposerImage(page, localImagePath);
             }
             const result = await submitReply(page, kwargs.text);
+            if (result.unconfirmed) {
+                throw new TimeoutError('twitter reply', SUBMIT_TIMEOUT_MS / 1000, `${result.message} Check the tweet before retrying; the reply may already be live.`);
+            }
+            if (!result.ok) {
+                throw new CommandExecutionError(result.message, 'Nothing was posted. Open the tweet in the browser and retry.');
+            }
             return [{
-                    status: result.ok ? 'success' : 'failed',
+                    status: 'success',
                     message: result.message,
                     text: kwargs.text,
                     ...(result.url ? { url: result.url } : {}),

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -32,6 +32,45 @@ describe('twitter reply command', () => {
             },
         ]);
     });
+    it('typed-fails when the reply never leaves the composer', async () => {
+        const cmd = getRegistry().get('twitter/reply');
+        const page = createPageMock([
+            { ok: true },
+            { ok: true },
+            { ok: false, message: 'Reply button is disabled or not found.' },
+        ]);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/_kop6/status/2040254679301718161',
+            text: 'never sent',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Reply button is disabled or not found.',
+            hint: expect.stringContaining('Nothing was posted'),
+        });
+    });
+
+    it('reports an unconfirmed reply as temporary, without claiming nothing was posted', async () => {
+        const cmd = getRegistry().get('twitter/reply');
+        const page = createPageMock([
+            { ok: true },
+            { ok: true },
+            { ok: false, unconfirmed: true, message: 'Reply submission did not complete before timeout.' },
+        ]);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/_kop6/status/2040254679301718161',
+            text: 'unconfirmed',
+        })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already be live'),
+        });
+    });
+
     it('uploads a local image through the dedicated reply composer when --image is provided', async () => {
         const cmd = getRegistry().get('twitter/reply');
         expect(cmd?.func).toBeTypeOf('function');
@@ -195,9 +234,12 @@ describe('twitter reply command', () => {
     };
 
     it('does not report reply success from a cleared composer without a fresh toast', async () => {
-        await expect(runReplyAgainstDom('', 'cleared reply')).resolves.toEqual([
-            { status: 'failed', message: 'Reply submission did not complete before timeout.', text: 'cleared reply' },
-        ]);
+        await expect(runReplyAgainstDom('', 'cleared reply')).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('Reply submission did not complete before timeout.'),
+        });
     });
 
     it('ignores a reply success toast that existed before clicking Reply', async () => {
@@ -205,9 +247,12 @@ describe('twitter reply command', () => {
             <div role="alert">Your post was sent. <a href="/me/status/3333333333333333333">View</a></div>
         `;
 
-        await expect(runReplyAgainstDom(oldToast, 'old reply toast')).resolves.toEqual([
-            { status: 'failed', message: 'Reply submission did not complete before timeout.', text: 'old reply toast' },
-        ]);
+        await expect(runReplyAgainstDom(oldToast, 'old reply toast')).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('Reply submission did not complete before timeout.'),
+        });
     });
 
     it('returns the permalink from a fresh reply success toast only', async () => {

--- a/clis/twitter/retweet.js
+++ b/clis/twitter/retweet.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             // Poll for the tweet to render. State probes scoped to the article
@@ -67,6 +68,7 @@ cli({
             if (!confirmBtn) {
                 return { ok: false, message: 'Retweet menu opened but the confirm option did not appear.' };
             }
+            writeStarted = true;
             confirmBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -76,12 +78,15 @@ cli({
             if (verifyBtn) {
                 return { ok: true, message: 'Tweet successfully retweeted.' };
             } else {
-                return { ok: false, message: 'Retweet action was initiated but UI did not update as expected.' };
+                return { ok: false, unconfirmed: true, message: 'Retweet action was initiated but UI did not update as expected.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter retweet confirmation', 1, `${result.message} Check the tweet before retrying; the retweet may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/retweet.js
+++ b/clis/twitter/retweet.js
@@ -82,12 +82,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok) {
-            // Wait for the retweet network request to be processed
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/retweet.test.js
+++ b/clis/twitter/retweet.test.js
@@ -39,18 +39,20 @@ describe('twitter retweet command', () => {
         ]);
     });
 
-    it('returns a failed row when the confirm menu item never appears', async () => {
+    it('typed-fails when the confirm menu item never appears', async () => {
         const cmd = getRegistry().get('twitter/retweet');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
             { ok: false, message: 'Retweet menu opened but the confirm option did not appear.' },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Retweet menu opened but the confirm option did not appear.',
         });
-        expect(result).toEqual([
-            { status: 'failed', message: 'Retweet menu opened but the confirm option did not appear.' },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 

--- a/clis/twitter/retweet.test.js
+++ b/clis/twitter/retweet.test.js
@@ -3,6 +3,7 @@ import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors'
 import { getRegistry } from '@jackwener/opencli/registry';
 import './retweet.js';
 import { createPageMock } from '../test-utils.js';
+import { createTwitterDomPage } from './test-dom-utils.js';
 
 describe('twitter retweet command', () => {
     it('clicks the retweet button then the confirm menu item and reports success', async () => {
@@ -52,6 +53,27 @@ describe('twitter retweet command', () => {
             code: 'COMMAND_EXEC',
             exitCode: 1,
             message: 'Retweet menu opened but the confirm option did not appear.',
+        });
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats a missing post-confirm state change as unconfirmed', async () => {
+        const cmd = getRegistry().get('twitter/retweet');
+        const page = createTwitterDomPage(`
+            <article>
+              <a href="https://x.com/alice/status/2040254679301718161">tweet</a>
+              <button data-testid="retweet">Retweet</button>
+            </article>
+            <button data-testid="retweetConfirm">Confirm retweet</button>
+        `);
+
+        await expect(cmd.func(page, {
+            url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already have succeeded'),
         });
         expect(page.wait).toHaveBeenCalledTimes(1);
     });

--- a/clis/twitter/test-dom-utils.js
+++ b/clis/twitter/test-dom-utils.js
@@ -1,0 +1,17 @@
+import { JSDOM } from 'jsdom';
+import { vi } from 'vitest';
+import { createPageMock } from '../test-utils.js';
+
+export function createTwitterDomPage(html, url = 'https://x.com/alice/status/2040254679301718161') {
+    const dom = new JSDOM(html, {
+        url,
+        runScripts: 'outside-only',
+    });
+    dom.window.setTimeout = (callback) => {
+        callback();
+        return 0;
+    };
+    return createPageMock([], {
+        evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
+    });
+}

--- a/clis/twitter/unblock.js
+++ b/clis/twitter/unblock.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 cli({
     site: 'twitter',
@@ -19,6 +19,7 @@ cli({
         await page.goto(`https://x.com/${username}`);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             let attempts = 0;
             let unblockBtn = null;
@@ -47,22 +48,27 @@ cli({
 
             // Confirm the unblock in the dialog
             const confirmBtn = document.querySelector('[data-testid="confirmationSheetConfirm"]');
-            if (confirmBtn) {
-                confirmBtn.click();
-                await new Promise(r => setTimeout(r, 1000));
+            if (!confirmBtn) {
+                return { ok: false, message: 'Unblock confirmation dialog did not appear.' };
             }
+            writeStarted = true;
+            confirmBtn.click();
+            await new Promise(r => setTimeout(r, 1000));
 
             // Verify
             const verify = document.querySelector('[data-testid$="-follow"]');
             if (verify) {
                 return { ok: true, message: 'Successfully unblocked @${username}.' };
             } else {
-                return { ok: false, message: 'Unblock action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Unblock action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter unblock confirmation', 1, `${result.message} Check the profile before retrying; the unblock may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
         }

--- a/clis/twitter/unblock.js
+++ b/clis/twitter/unblock.js
@@ -63,10 +63,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/unblock.test.js
+++ b/clis/twitter/unblock.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './unblock.js';
+import { createPageMock } from '../test-utils.js';
+
+describe('twitter unblock command', () => {
+    it('navigates to the profile URL and reports success when the unblock script confirms', async () => {
+        const cmd = getRegistry().get('twitter/unblock');
+        expect(cmd?.func).toBeTypeOf('function');
+        const page = createPageMock([
+            { ok: true, message: 'Successfully unblocked @alice.' },
+        ]);
+        const result = await cmd.func(page, {
+            username: 'alice',
+        });
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/alice');
+        expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="primaryColumn"]' });
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
+        const script = page.evaluate.mock.calls[0][0];
+        // Idempotency probe: when the Follow button is visible ([data-testid$="-follow"]
+        // present, so not blocked), the script returns ok:true with an "already unblocked" message.
+        expect(script).toContain('[data-testid$="-follow"]');
+        expect(script).toContain('[data-testid$="-unblock"]');
+        expect(script).toContain('unblockBtn.click()');
+        expect(script).toContain('[data-testid="confirmationSheetConfirm"]');
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully unblocked @alice.' },
+        ]);
+    });
+
+    it('typed-fails without re-waiting when the unblock script reports a UI mismatch', async () => {
+        const cmd = getRegistry().get('twitter/unblock');
+        const page = createPageMock([
+            {
+                ok: false,
+                message: 'Could not find Unblock button. Are you logged in?',
+            },
+        ]);
+        await expect(cmd.func(page, {
+            username: 'alice',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Unblock button. Are you logged in?',
+        });
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CommandExecutionError when no page is provided', async () => {
+        const cmd = getRegistry().get('twitter/unblock');
+        await expect(cmd.func(undefined, {
+            username: 'alice',
+        })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/twitter/unbookmark.js
+++ b/clis/twitter/unbookmark.js
@@ -61,10 +61,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/unbookmark.js
+++ b/clis/twitter/unbookmark.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             let attempts = 0;
@@ -46,6 +47,7 @@ cli({
                 return { ok: false, message: 'Could not find Remove Bookmark button on the requested tweet. Are you logged in?' };
             }
 
+            writeStarted = true;
             removeBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -55,12 +57,15 @@ cli({
             if (verify) {
                 return { ok: true, message: 'Tweet successfully removed from bookmarks.' };
             } else {
-                return { ok: false, message: 'Unbookmark action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Unbookmark action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter unbookmark confirmation', 1, `${result.message} Check the tweet before retrying; the removal may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/unbookmark.test.js
+++ b/clis/twitter/unbookmark.test.js
@@ -34,7 +34,7 @@ describe('twitter unbookmark command', () => {
         ]);
     });
 
-    it('returns a failed row without re-waiting when the unbookmark script reports a UI mismatch', async () => {
+    it('typed-fails without re-waiting when the unbookmark script reports a UI mismatch', async () => {
         const cmd = getRegistry().get('twitter/unbookmark');
         const page = createPageMock([
             {
@@ -42,15 +42,14 @@ describe('twitter unbookmark command', () => {
                 message: 'Could not find Remove Bookmark button on the requested tweet. Are you logged in?',
             },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Remove Bookmark button on the requested tweet. Are you logged in?',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find Remove Bookmark button on the requested tweet. Are you logged in?',
-            },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 

--- a/clis/twitter/unfollow.js
+++ b/clis/twitter/unfollow.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 cli({
     site: 'twitter',
     name: 'unfollow',
@@ -19,6 +19,7 @@ cli({
         await page.goto(`https://x.com/${username}`);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             let attempts = 0;
             let unfollowBtn = null;
@@ -47,22 +48,27 @@ cli({
 
             // Confirm the unfollow in the dialog
             const confirmBtn = document.querySelector('[data-testid="confirmationSheetConfirm"]');
-            if (confirmBtn) {
-                confirmBtn.click();
-                await new Promise(r => setTimeout(r, 1000));
+            if (!confirmBtn) {
+                return { ok: false, message: 'Unfollow confirmation dialog did not appear.' };
             }
+            writeStarted = true;
+            confirmBtn.click();
+            await new Promise(r => setTimeout(r, 1000));
 
             // Verify
             const verify = document.querySelector('[data-testid$="-follow"]');
             if (verify) {
                 return { ok: true, message: 'Successfully unfollowed @${username}.' };
             } else {
-                return { ok: false, message: 'Unfollow action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Unfollow action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter unfollow confirmation', 1, `${result.message} Check the profile before retrying; the unfollow may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
         }

--- a/clis/twitter/unfollow.js
+++ b/clis/twitter/unfollow.js
@@ -63,10 +63,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok)
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the profile in the browser and retry.');
+        }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/unfollow.test.js
+++ b/clis/twitter/unfollow.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './unfollow.js';
+import { createPageMock } from '../test-utils.js';
+
+describe('twitter unfollow command', () => {
+    it('navigates to the profile URL and reports success when the unfollow script confirms', async () => {
+        const cmd = getRegistry().get('twitter/unfollow');
+        expect(cmd?.func).toBeTypeOf('function');
+        const page = createPageMock([
+            { ok: true, message: 'Successfully unfollowed @alice.' },
+        ]);
+        const result = await cmd.func(page, {
+            username: 'alice',
+        });
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/alice');
+        expect(page.wait).toHaveBeenNthCalledWith(1, { selector: '[data-testid="primaryColumn"]' });
+        expect(page.wait).toHaveBeenNthCalledWith(2, 2);
+        const script = page.evaluate.mock.calls[0][0];
+        // Idempotency probe: when the Follow button is visible ([data-testid$="-follow"]
+        // present, so not following), the script returns ok:true with an "already unfollowed" message.
+        expect(script).toContain('[data-testid$="-follow"]');
+        expect(script).toContain('[data-testid$="-unfollow"]');
+        expect(script).toContain('unfollowBtn.click()');
+        expect(script).toContain('[data-testid="confirmationSheetConfirm"]');
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully unfollowed @alice.' },
+        ]);
+    });
+
+    it('typed-fails without re-waiting when the unfollow script reports a UI mismatch', async () => {
+        const cmd = getRegistry().get('twitter/unfollow');
+        const page = createPageMock([
+            {
+                ok: false,
+                message: 'Could not find Unfollow button. Are you logged in?',
+            },
+        ]);
+        await expect(cmd.func(page, {
+            username: 'alice',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Unfollow button. Are you logged in?',
+        });
+        expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CommandExecutionError when no page is provided', async () => {
+        const cmd = getRegistry().get('twitter/unfollow');
+        await expect(cmd.func(undefined, {
+            username: 'alice',
+        })).rejects.toThrow(CommandExecutionError);
+    });
+});

--- a/clis/twitter/unlike.js
+++ b/clis/twitter/unlike.js
@@ -68,12 +68,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok) {
-            // Wait for the unlike network request to be processed
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/unlike.js
+++ b/clis/twitter/unlike.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             // Poll for the tweet to render. State probes scoped to the article
@@ -53,6 +54,7 @@ cli({
             }
 
             // Click Unlike
+            writeStarted = true;
             unlikeBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -62,12 +64,15 @@ cli({
             if (verifyBtn) {
                 return { ok: true, message: 'Tweet successfully unliked.' };
             } else {
-                return { ok: false, message: 'Unlike action was initiated but UI did not update as expected.' };
+                return { ok: false, unconfirmed: true, message: 'Unlike action was initiated but UI did not update as expected.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter unlike confirmation', 1, `${result.message} Check the tweet before retrying; the unlike may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/unlike.test.js
+++ b/clis/twitter/unlike.test.js
@@ -34,7 +34,7 @@ describe('twitter unlike command', () => {
         ]);
     });
 
-    it('returns a failed row without re-waiting when the unlike script reports a UI mismatch', async () => {
+    it('typed-fails without re-waiting when the unlike script reports a UI mismatch', async () => {
         const cmd = getRegistry().get('twitter/unlike');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
@@ -43,15 +43,14 @@ describe('twitter unlike command', () => {
                 message: 'Could not find the Unlike button on this tweet after waiting 10 seconds. Are you logged in?',
             },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find the Unlike button on this tweet after waiting 10 seconds. Are you logged in?',
         });
-        expect(result).toEqual([
-            {
-                status: 'failed',
-                message: 'Could not find the Unlike button on this tweet after waiting 10 seconds. Are you logged in?',
-            },
-        ]);
         // Only the primaryColumn wait should run when ok is false.
         expect(page.wait).toHaveBeenCalledTimes(1);
     });

--- a/clis/twitter/unretweet.js
+++ b/clis/twitter/unretweet.js
@@ -82,12 +82,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
-        if (result.ok) {
-            // Wait for the unretweet network request to be processed
-            await page.wait(2);
+        if (!result.ok) {
+            throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }
+        await page.wait(2);
         return [{
-                status: result.ok ? 'success' : 'failed',
+                status: 'success',
                 message: result.message
             }];
     }

--- a/clis/twitter/unretweet.js
+++ b/clis/twitter/unretweet.js
@@ -1,4 +1,4 @@
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { parseTweetUrl, buildTwitterArticleScopeSource } from './shared.js';
 
@@ -21,6 +21,7 @@ cli({
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
         const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             // Poll for the tweet to render. State probes scoped to the article
@@ -67,6 +68,7 @@ cli({
             if (!confirmBtn) {
                 return { ok: false, message: 'Unretweet menu opened but the confirm option did not appear.' };
             }
+            writeStarted = true;
             confirmBtn.click();
             await new Promise(r => setTimeout(r, 1000));
 
@@ -76,12 +78,15 @@ cli({
             if (verifyBtn) {
                 return { ok: true, message: 'Tweet successfully unretweeted.' };
             } else {
-                return { ok: false, message: 'Unretweet action was initiated but UI did not update as expected.' };
+                return { ok: false, unconfirmed: true, message: 'Unretweet action was initiated but UI did not update as expected.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
+        if (result.unconfirmed) {
+            throw new TimeoutError('twitter unretweet confirmation', 1, `${result.message} Check the tweet before retrying; the removal may already have succeeded.`);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/unretweet.test.js
+++ b/clis/twitter/unretweet.test.js
@@ -39,18 +39,20 @@ describe('twitter unretweet command', () => {
         ]);
     });
 
-    it('returns a failed row when the confirm menu item never appears', async () => {
+    it('typed-fails when the confirm menu item never appears', async () => {
         const cmd = getRegistry().get('twitter/unretweet');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
             { ok: false, message: 'Unretweet menu opened but the confirm option did not appear.' },
         ]);
-        const result = await cmd.func(page, {
+        await expect(cmd.func(page, {
             url: 'https://x.com/alice/status/2040254679301718161',
+        })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Unretweet menu opened but the confirm option did not appear.',
         });
-        expect(result).toEqual([
-            { status: 'failed', message: 'Unretweet menu opened but the confirm option did not appear.' },
-        ]);
         expect(page.wait).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Problem

Closes #2255. Fifteen single-target Twitter write commands returned a `status: failed` row when a write did not happen, so the process still exited 0 and agents could not distinguish success from failure.

A second safety boundary matters once these become errors: after a write click, failure to observe the expected UI state does **not** prove the server rejected the write. Treating that as a definite `CommandExecutionError` invites an automatic retry and duplicate likes, follows, blocks, retweets, or posts.

## Fix

The adapter now preserves the write phase:

- Before the final write click — missing controls, menus, confirmation items, unusable composers, or X failure toasts — throw `CommandExecutionError` because nothing changed.
- After the final write click — confirmation polling expires, the UI does not switch state, or an exception occurs — return `unconfirmed` from the page script and throw `TimeoutError` (exit 75) with a “check before retrying” hint.
- Already-correct/idempotent states remain success.
- Batch commands keep per-item partial-result rows.

This applies to post/reply/quote; like/unlike/bookmark/unbookmark; follow/unfollow/block/unblock; retweet/unretweet. Delete and hide-reply keep definite errors for their pre-write failure branches.

## Regression coverage

In addition to command-level typed-error tests, three real JSDOM script executions pin the phase boundary across different UI families:

- direct toggle: Like click with no observed Unlike state → `TimeoutError`
- two-step menu: Retweet confirm click with no observed Unretweet state → `TimeoutError`
- profile confirmation: missing Block confirmation dialog → `CommandExecutionError`; confirm click with no observed blocked state → `TimeoutError`

The DOM helper executes the exact injected browser script with waits collapsed, rather than mocking its returned phase metadata.

## Verification

Exact head `74088913`:

- Twitter suite: 43 files / 509 tests passed
- `npm run typecheck` passed
- `npm run build` passed; manifest 1331 entries
- typed-error lint: no new violations
- silent-column-drop gate: no new violations
- `git diff --check` passed
