### PR TITLE
fix(browser): dismiss a page's beforeunload prompt instead of wedging the session

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -3,6 +3,21 @@ const DAEMON_HOST = "localhost";
 const DAEMON_WS_URL = `ws://${DAEMON_HOST}:${DAEMON_PORT}/ext`;
 const DAEMON_PING_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}/ping`;
 
+const BEFORE_UNLOAD_GUARD_JS = `
+  (() => {
+    const holder = EventTarget.prototype;
+    const key = '__lsnUnload';  // looks like an internal listener cache
+    if (Object.getOwnPropertyDescriptor(holder, key)) return;
+    try {
+      Object.defineProperty(holder, key, { value: true, enumerable: false, configurable: true });
+    } catch {}
+    window.addEventListener('beforeunload', (event) => {
+      event.stopImmediatePropagation();
+      event.returnValue = '';
+    }, true);
+    window.onbeforeunload = null;
+  })()
+`;
 const attached = /* @__PURE__ */ new Set();
 const tabFrameContexts = /* @__PURE__ */ new Map();
 const frameTargets = /* @__PURE__ */ new Map();
@@ -104,6 +119,13 @@ async function ensureAttached(tabId, aggressiveRetry = false) {
   attached.add(tabId);
   try {
     await sendDebuggerCommand({ tabId }, "Runtime.enable");
+  } catch {
+  }
+  try {
+    await sendDebuggerCommand({ tabId }, "Page.enable");
+    await sendDebuggerCommand({ tabId }, "Page.addScriptToEvaluateOnNewDocument", {
+      source: BEFORE_UNLOAD_GUARD_JS
+    });
   } catch {
   }
   if (preservedNetworkCapture) {
@@ -565,6 +587,16 @@ function registerListeners() {
   chrome.tabs.onUpdated.addListener(async (tabId, info) => {
     if (info.url && !isDebuggableUrl$1(info.url)) {
       await detach(tabId);
+    }
+  });
+  chrome.debugger.onEvent.addListener(async (source, method, params) => {
+    if (method !== "Page.javascriptDialogOpening") return;
+    if (params?.type !== "beforeunload") return;
+    const tabId = source.tabId;
+    if (!tabId) return;
+    try {
+      await sendDebuggerCommand({ tabId }, "Page.handleJavaScriptDialog", { accept: true });
+    } catch {
     }
   });
   chrome.debugger.onEvent.addListener(async (source, method, params) => {

--- a/extension/src/cdp.test.ts
+++ b/extension/src/cdp.test.ts
@@ -466,7 +466,34 @@ describe('cdp network capture survives forced re-attach', () => {
   });
 });
 
-describe('cdp network capture correctness', () => {
+function createNetworkMock() {
+  const onEventListeners = [];
+  const debuggerApi = {
+    attach: vi.fn(async () => {}),
+    detach: vi.fn(async () => {}),
+    sendCommand: vi.fn(async (_target, method, params) => {
+      if (method === 'Runtime.evaluate' && params?.expression === '1') return { result: { value: '1' } };
+      if (method === 'Network.getRequestPostData') return {}; // no override; use inline postData
+      return {};
+    }),
+    onDetach: { addListener: vi.fn() },
+    onEvent: { addListener: vi.fn((fn) => { onEventListeners.push(fn); }) },
+  };
+  const tabs = {
+    get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://x.com/home' })),
+    onRemoved: { addListener: vi.fn() },
+    onUpdated: { addListener: vi.fn() },
+  };
+  const fire = async (method, params) => {
+    for (const fn of onEventListeners) await fn({ tabId: 1 }, method, params);
+  };
+  return {
+    chrome: { tabs, debugger: debuggerApi, scripting: {}, runtime: { id: 'opencli-test' } },
+    fire,
+  };
+}
+
+describe('cdp beforeunload guard', () => {
   beforeEach(() => {
     vi.resetModules();
   });
@@ -475,32 +502,54 @@ describe('cdp network capture correctness', () => {
     vi.unstubAllGlobals();
   });
 
-  function createNetworkMock() {
-    const onEventListeners = [];
-    const debuggerApi = {
-      attach: vi.fn(async () => {}),
-      detach: vi.fn(async () => {}),
-      sendCommand: vi.fn(async (_target, method, params) => {
-        if (method === 'Runtime.evaluate' && params?.expression === '1') return { result: { value: '1' } };
-        if (method === 'Network.getRequestPostData') return {}; // no override; use inline postData
-        return {};
-      }),
-      onDetach: { addListener: vi.fn() },
-      onEvent: { addListener: vi.fn((fn) => { onEventListeners.push(fn); }) },
-    };
-    const tabs = {
-      get: vi.fn(async () => ({ id: 1, windowId: 1, url: 'https://x.com/home' })),
-      onRemoved: { addListener: vi.fn() },
-      onUpdated: { addListener: vi.fn() },
-    };
-    const fire = async (method, params) => {
-      for (const fn of onEventListeners) await fn({ tabId: 1 }, method, params);
-    };
-    return {
-      chrome: { tabs, debugger: debuggerApi, scripting: {}, runtime: { id: 'opencli-test' } },
-      fire,
-    };
-  }
+  it('arms the beforeunload guard for future documents when it attaches', async () => {
+    const mock = createNetworkMock();
+    vi.stubGlobal('chrome', mock.chrome);
+    const mod = await import('./cdp');
+
+    await mod.ensureAttached(1);
+
+    const injected = mock.chrome.debugger.sendCommand.mock.calls
+      .find(([, method]) => method === 'Page.addScriptToEvaluateOnNewDocument');
+    expect(injected?.[2]?.source).toContain('beforeunload');
+    expect(injected?.[2]?.source).toContain('stopImmediatePropagation');
+  });
+
+  it('accepts a beforeunload prompt raised by a document that predates the attach', async () => {
+    const mock = createNetworkMock();
+    vi.stubGlobal('chrome', mock.chrome);
+    const mod = await import('./cdp');
+    mod.registerListeners();
+
+    await mock.fire('Page.javascriptDialogOpening', { type: 'beforeunload', message: 'Leave site?' });
+
+    const handled = mock.chrome.debugger.sendCommand.mock.calls
+      .find(([, method]) => method === 'Page.handleJavaScriptDialog');
+    expect(handled?.[2]).toEqual({ accept: true });
+  });
+
+  it('leaves an alert dialog for the caller to handle', async () => {
+    const mock = createNetworkMock();
+    vi.stubGlobal('chrome', mock.chrome);
+    const mod = await import('./cdp');
+    mod.registerListeners();
+
+    await mock.fire('Page.javascriptDialogOpening', { type: 'alert', message: 'hello' });
+
+    const handled = mock.chrome.debugger.sendCommand.mock.calls
+      .find(([, method]) => method === 'Page.handleJavaScriptDialog');
+    expect(handled).toBeUndefined();
+  });
+});
+
+describe('cdp network capture correctness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
   it('preserves the original POST body when a captured request follows a redirect', async () => {
     const mock = createNetworkMock();

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -6,6 +6,36 @@
  * tabs (resolveTabId in background.ts filters them).
  */
 
+/**
+ * Injected into every document before its own scripts run.
+ *
+ * A page that arms `beforeunload` opens a native "Leave site?" prompt on the
+ * next navigation. The CLI cannot answer it, so navigation never returns and
+ * every later evaluate reads an empty document. Blink dispatches listeners on a
+ * target in registration order, so this has to be registered first, which means
+ * Page.addScriptToEvaluateOnNewDocument rather than a post-load evaluate.
+ *
+ * Kept in step with generateBeforeUnloadGuardJs() in
+ * src/browser/beforeunload-guard.ts, which serves the direct-CDP path; only
+ * the test-facing return values differ. The extension cannot import from the
+ * CLI package.
+ */
+const BEFORE_UNLOAD_GUARD_JS = `
+  (() => {
+    const holder = EventTarget.prototype;
+    const key = '__lsnUnload';  // looks like an internal listener cache
+    if (Object.getOwnPropertyDescriptor(holder, key)) return;
+    try {
+      Object.defineProperty(holder, key, { value: true, enumerable: false, configurable: true });
+    } catch {}
+    window.addEventListener('beforeunload', (event) => {
+      event.stopImmediatePropagation();
+      event.returnValue = '';
+    }, true);
+    window.onbeforeunload = null;
+  })()
+`;
+
 const attached = new Set<number>();
 
 const tabFrameContexts = new Map<number, Map<string, number>>();
@@ -206,6 +236,18 @@ export async function ensureAttached(tabId: number, aggressiveRetry: boolean = f
     await sendDebuggerCommand({ tabId }, 'Runtime.enable');
   } catch {
     // Some pages may not need explicit enable
+  }
+
+  // Arm the beforeunload guard for every document this tab loads from now on,
+  // and dismiss a prompt that a document loaded before the attach can still
+  // raise. Both are best-effort: a tab that rejects Page is still usable.
+  try {
+    await sendDebuggerCommand({ tabId }, 'Page.enable');
+    await sendDebuggerCommand({ tabId }, 'Page.addScriptToEvaluateOnNewDocument', {
+      source: BEFORE_UNLOAD_GUARD_JS,
+    });
+  } catch {
+    // Page domain unavailable on this target
   }
 
   // Restore network capture that the re-attach (detach + onDetach) tore down.
@@ -830,6 +872,20 @@ export function registerListeners(): void {
   chrome.tabs.onUpdated.addListener(async (tabId, info) => {
     if (info.url && !isDebuggableUrl(info.url)) {
       await detach(tabId);
+    }
+  });
+  // A document that loaded before the attach never ran the guard, so its
+  // prompt can still open and block the tab. Accepting it lets the pending
+  // navigation finish; the CLI has no way to answer the dialog itself.
+  chrome.debugger.onEvent.addListener(async (source, method, params) => {
+    if (method !== 'Page.javascriptDialogOpening') return;
+    if ((params as { type?: string } | undefined)?.type !== 'beforeunload') return;
+    const tabId = source.tabId;
+    if (!tabId) return;
+    try {
+      await sendDebuggerCommand({ tabId }, 'Page.handleJavaScriptDialog', { accept: true });
+    } catch {
+      // The dialog may already be gone
     }
   });
   chrome.debugger.onEvent.addListener(async (source, method, params) => {

--- a/src/browser/beforeunload-guard.test.ts
+++ b/src/browser/beforeunload-guard.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import { generateBeforeUnloadGuardJs } from './beforeunload-guard.js';
+
+function createWindow(): JSDOM['window'] {
+  return new JSDOM('<!doctype html><body></body>', { runScripts: 'outside-only' }).window;
+}
+
+describe('beforeunload guard', () => {
+  it('stops a handler the page registers after the guard', () => {
+    const window = createWindow();
+    window.eval(generateBeforeUnloadGuardJs());
+    let handled = false;
+    window.addEventListener('beforeunload', () => { handled = true; });
+
+    window.dispatchEvent(new window.Event('beforeunload', { cancelable: true }));
+
+    expect(handled).toBe(false);
+  });
+
+  it('stops an onbeforeunload assigned after the guard', () => {
+    const window = createWindow();
+    window.eval(generateBeforeUnloadGuardJs());
+    let handled = false;
+    window.onbeforeunload = () => {
+      handled = true;
+      return 'stay';
+    };
+
+    window.dispatchEvent(new window.Event('beforeunload', { cancelable: true }));
+
+    expect(handled).toBe(false);
+  });
+
+  it('installs once per document, without an enumerable window flag', () => {
+    const window = createWindow();
+
+    expect(window.eval(generateBeforeUnloadGuardJs())).toBe('installed');
+    expect(window.eval(generateBeforeUnloadGuardJs())).toBe('skipped');
+    expect(Object.keys(window)).not.toContain('__lsnUnload');
+  });
+
+  it('leaves other events alone', () => {
+    const window = createWindow();
+    window.eval(generateBeforeUnloadGuardJs());
+    let seen = false;
+    window.addEventListener('unload', () => { seen = true; });
+
+    window.dispatchEvent(new window.Event('unload'));
+
+    expect(seen).toBe(true);
+  });
+
+  it('stays in step with the copy the extension injects', () => {
+    const extensionSource = readFileSync(
+      new URL('../../extension/src/cdp.ts', import.meta.url),
+      'utf-8',
+    );
+    const extensionGuard = /const BEFORE_UNLOAD_GUARD_JS = `\n([\s\S]*?)\n`;/.exec(extensionSource)?.[1] ?? '';
+    // The extension cannot import from this package, so it carries the script
+    // inline; only the test-facing return values differ.
+    const normalize = (source: string) => source
+      .replace(/return\s*(?:'installed'|'skipped')?\s*;/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    expect(normalize(extensionGuard)).toBe(normalize(generateBeforeUnloadGuardJs()));
+  });
+
+  it('keeps the calls that a post-load injection cannot substitute for', () => {
+    const source = generateBeforeUnloadGuardJs();
+
+    // jsdom dispatches at-target listeners in capture-then-bubble order while
+    // Blink uses registration order, so the ordering that matters in Chrome is
+    // pinned on the source instead of on a jsdom dispatch.
+    expect(source).toContain('stopImmediatePropagation');
+    expect(source).toContain('window.onbeforeunload = null');
+  });
+});

--- a/src/browser/beforeunload-guard.ts
+++ b/src/browser/beforeunload-guard.ts
@@ -1,0 +1,35 @@
+/**
+ * Keep a page from wedging the session on its own "Leave site?" prompt.
+ *
+ * A site that stages unsaved state arms `beforeunload`, and the next navigation
+ * opens a native dialog. Nothing in the CLI can answer it: the daemon owns the
+ * CDP session, so the dialog events never reach us, and while it is open every
+ * evaluate returns an empty document, which reads as a broken adapter rather
+ * than a blocked tab.
+ *
+ * The script must run before the page's own scripts. Blink dispatches listeners
+ * on a target in registration order, so a guard injected after load is queued
+ * behind the site's handler and cannot stop it; injected first, it wins.
+ *
+ * The flag hides on a built-in prototype for the reason stealth.ts documents: a
+ * bare window property is an automation fingerprint. The extension carries the
+ * same script inline, since it cannot import from this package.
+ */
+export function generateBeforeUnloadGuardJs(): string {
+  return `
+    (() => {
+      const holder = EventTarget.prototype;
+      const key = '__lsnUnload';  // looks like an internal listener cache
+      if (Object.getOwnPropertyDescriptor(holder, key)) return 'skipped';
+      try {
+        Object.defineProperty(holder, key, { value: true, enumerable: false, configurable: true });
+      } catch {}
+      window.addEventListener('beforeunload', (event) => {
+        event.stopImmediatePropagation();
+        event.returnValue = '';
+      }, true);
+      window.onbeforeunload = null;
+      return 'installed';
+    })()
+  `;
+}

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { MockWebSocket } = vi.hoisted(() => {
   class MockWebSocket {
     static OPEN = 1;
+    static instances: MockWebSocket[] = [];
     readyState = 1;
     private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
 
     constructor(_url: string) {
+      MockWebSocket.instances.push(this);
       queueMicrotask(() => this.emit('open'));
     }
 
@@ -22,7 +24,7 @@ const { MockWebSocket } = vi.hoisted(() => {
       this.readyState = 3;
     }
 
-    private emit(event: string, ...args: unknown[]): void {
+    emit(event: string, ...args: unknown[]): void {
       for (const handler of this.handlers.get(event) ?? []) {
         handler(...args);
       }
@@ -95,5 +97,49 @@ describe('CDPBridge cookies', () => {
       ['Page.handleJavaScriptDialog', { accept: true, promptText: 'ok' }],
       ['Page.getLayoutMetrics', {}],
     ]);
+  });
+});
+
+describe('CDPBridge beforeunload dialogs', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts a beforeunload prompt raised by a document that predates the connect', async () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'ws://127.0.0.1:9222/devtools/page/1');
+
+    const bridge = new CDPBridge();
+    const send = vi.spyOn(bridge, 'send').mockResolvedValue({});
+    await bridge.connect();
+    send.mockClear();
+
+    const ws = MockWebSocket.instances.at(-1)!;
+    ws.emit('message', JSON.stringify({
+      method: 'Page.javascriptDialogOpening',
+      params: { type: 'beforeunload', message: 'Leave site?' },
+    }));
+
+    expect(send.mock.calls).toEqual([
+      ['Page.handleJavaScriptDialog', { accept: true }],
+    ]);
+  });
+
+  it('leaves alert, confirm, and prompt dialogs for the caller', async () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'ws://127.0.0.1:9222/devtools/page/1');
+
+    const bridge = new CDPBridge();
+    const send = vi.spyOn(bridge, 'send').mockResolvedValue({});
+    await bridge.connect();
+    send.mockClear();
+
+    const ws = MockWebSocket.instances.at(-1)!;
+    for (const type of ['alert', 'confirm', 'prompt']) {
+      ws.emit('message', JSON.stringify({
+        method: 'Page.javascriptDialogOpening',
+        params: { type, message: 'hello' },
+      }));
+    }
+
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -14,6 +14,7 @@ import { request as httpsRequest } from 'node:https';
 import type { BrowserCookie, BrowserEvaluateFunction, IPage, ScreenshotOptions } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { buildEvaluateExpression } from './utils.js';
+import { generateBeforeUnloadGuardJs } from './beforeunload-guard.js';
 import { generateStealthJs } from './stealth.js';
 import { waitForDomStableJs } from './dom-helpers.js';
 import { isRecord, saveBase64ToFile } from '../utils.js';
@@ -84,11 +85,19 @@ export class CDPBridge implements IBrowserFactory {
         try {
           await this.send('Page.enable');
           await this.send('Page.addScriptToEvaluateOnNewDocument', { source: generateStealthJs() });
+          await this.send('Page.addScriptToEvaluateOnNewDocument', { source: generateBeforeUnloadGuardJs() });
         } catch (err) {
           ws.close();
           reject(err instanceof Error ? err : new Error(String(err)));
           return;
         }
+        // A document already loaded at connect never ran the guard, so its
+        // prompt can still open and block the target. Accepting it lets the
+        // pending navigation finish; alert/confirm/prompt stay with the caller.
+        this.on('Page.javascriptDialogOpening', (params) => {
+          if (!isRecord(params) || params.type !== 'beforeunload') return;
+          this.send('Page.handleJavaScriptDialog', { accept: true }).catch(() => {});
+        });
         resolve(new CDPPage(this));
       });
 


### PR DESCRIPTION
## Description

A page that arms `beforeunload` can wedge a browser session: the next navigation opens the native "Leave site?" prompt, nothing in the CLI can answer it (the daemon owns the CDP session, so `browser dialog dismiss` reports no dialog), navigation never returns, and every later `evaluate` reads an empty document. Any adapter that clicks before navigating can supply the user gesture the prompt needs; `twitter post` wedged a session for me twice.

Both attach paths, the extension and the direct-CDP `CDPBridge`, install two halves: a guard registered through `Page.addScriptToEvaluateOnNewDocument`, early enough to stop the site's own handler, and a `Page.javascriptDialogOpening` handler that accepts only `beforeunload` dialogs, covering documents already loaded at attach. `alert`, `confirm` and `prompt` stay with `browser dialog`.

Related issue: none filed; #1972 is @biospark33's twitter-scoped PR for the same wedge, and this installs the guard for every adapter in the layer that runs before page scripts.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Navigation-level A/B on Chrome 151.0.7922.76 over raw CDP: a page arms `beforeunload` at load, receives a real click for the user gesture, then navigates away. Without the guard the prompt opens and the navigation never completes, which is the wedge; with the guard pre-injected the navigation completes with no dialog:

```
UNGUARDED {"dialogOpened":true,"dialogType":"beforeunload","navigationCompleted":false}
GUARDED   {"dialogOpened":false,"dialogType":null,"navigationCompleted":true}
```

`npx vitest run src/browser` 433 / 433 and the extension suite 99 / 99, with tests for the guard, the injection at attach, the `CDPBridge` dialog accept, keeping the two guard copies in step, and leaving non-`beforeunload` dialogs alone. Typecheck, both lint gates and doc coverage pass. `extension/dist/background.js` is rebuilt, as the repo tracks it.

Not verified end to end through a loaded build of this extension, since the daemon tracks one extension connection at a time and the installed build holds the slot.
