### PR TITLE
feat(xiaoyuzhou): add playback history

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -45202,6 +45202,55 @@
   },
   {
     "site": "xiaoyuzhou",
+    "name": "history",
+    "description": "List playback history for the logged-in Xiaoyuzhou account",
+    "access": "read",
+    "domain": "api.xiaoyuzhoufm.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum rows to return (default 20, max 5000). Ignored with --all."
+      },
+      {
+        "name": "all",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Fetch every history page until the API cursor is exhausted."
+      },
+      {
+        "name": "max-pages",
+        "type": "int",
+        "default": 500,
+        "required": false,
+        "help": "Pagination safety limit (default 500, max 1000)."
+      }
+    ],
+    "columns": [
+      "rank",
+      "eid",
+      "pid",
+      "title",
+      "podcast",
+      "durationSec",
+      "progressSec",
+      "progressPct",
+      "playedAt",
+      "pubDate",
+      "finished",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "xiaoyuzhou/history.js",
+    "sourceFile": "xiaoyuzhou/history.js"
+  },
+  {
+    "site": "xiaoyuzhou",
     "name": "podcast",
     "description": "View a Xiaoyuzhou podcast profile",
     "access": "read",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -44915,6 +44915,54 @@
   },
   {
     "site": "xiaoyuzhou",
+    "name": "history",
+    "description": "List playback history for the logged-in Xiaoyuzhou account",
+    "access": "read",
+    "domain": "api.xiaoyuzhoufm.com",
+    "strategy": "local",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Maximum rows to return (default 20, max 5000). Ignored with --all."
+      },
+      {
+        "name": "all",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Fetch every history page until the API cursor is exhausted."
+      },
+      {
+        "name": "max-pages",
+        "type": "int",
+        "default": 500,
+        "required": false,
+        "help": "Pagination safety limit (default 500, max 1000)."
+      }
+    ],
+    "columns": [
+      "rank",
+      "eid",
+      "title",
+      "podcast",
+      "durationSec",
+      "progressSec",
+      "progressPct",
+      "playedAt",
+      "pubDate",
+      "finished",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "xiaoyuzhou/history.js",
+    "sourceFile": "xiaoyuzhou/history.js"
+  },
+  {
+    "site": "xiaoyuzhou",
     "name": "podcast",
     "description": "View a Xiaoyuzhou podcast profile",
     "access": "read",

--- a/clis/xiaoyuzhou/auth.js
+++ b/clis/xiaoyuzhou/auth.js
@@ -218,6 +218,9 @@ export async function requestXiaoyuzhouJson(endpoint, options = {}, fetchImpl = 
     }
     const bodyText = await response.text();
     if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+            throw createXiaoyuzhouAuthError(`Xiaoyuzhou API rejected the credentials with HTTP ${response.status}`);
+        }
         throw new CommandExecutionError(`Xiaoyuzhou API request failed with HTTP ${response.status}${bodyText ? `: ${bodyText}` : ''}`);
     }
     let parsed;
@@ -226,6 +229,21 @@ export async function requestXiaoyuzhouJson(endpoint, options = {}, fetchImpl = 
     }
     catch (error) {
         throw new CommandExecutionError(`Xiaoyuzhou API returned invalid JSON: ${getErrorMessage(error)}`);
+    }
+    const serviceCode = parsed?.code;
+    if (serviceCode !== undefined && serviceCode !== null) {
+        const numericCode = Number(serviceCode);
+        if (!Number.isFinite(numericCode)) {
+            throw new CommandExecutionError('Xiaoyuzhou API returned an invalid service code');
+        }
+        if (numericCode === 401 || numericCode === 403) {
+            throw createXiaoyuzhouAuthError(`Xiaoyuzhou API rejected the credentials with service code ${numericCode}`);
+        }
+        if (numericCode !== 0 && numericCode !== 200) {
+            throw new CommandExecutionError(
+                parsed?.message || parsed?.msg || `Xiaoyuzhou API returned service code ${numericCode}`,
+            );
+        }
     }
     if (parsed?.success === false) {
         throw new CommandExecutionError(parsed?.message || parsed?.msg || 'Xiaoyuzhou API returned success=false');

--- a/clis/xiaoyuzhou/auth.test.js
+++ b/clis/xiaoyuzhou/auth.test.js
@@ -100,6 +100,45 @@ describe('xiaoyuzhou auth helpers', () => {
         expect(result.credentials.access_token).toBe('refreshed-access');
     });
 
+    it('reports final HTTP auth rejection after the single refresh retry', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(createJsonResponse(401, { message: 'expired' }))
+            .mockResolvedValueOnce(createJsonResponse(200, {
+                success: true,
+                'x-jike-access-token': 'refreshed-access',
+                'x-jike-refresh-token': 'refreshed-refresh',
+            }))
+            .mockResolvedValueOnce(createJsonResponse(401, { message: 'still unauthorized' }));
+
+        await expect(requestXiaoyuzhouJson('/v1/episode-played/list-history', {
+            method: 'POST',
+            body: {},
+            credentials: normalizeXiaoyuzhouCredentials({
+                access_token: 'old-access',
+                refresh_token: 'old-refresh',
+            }),
+        }, fetchMock)).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it.each([
+        [403, { code: 200, data: [] }, 'AUTH_REQUIRED'],
+        [200, { code: 403, msg: 'credential denied' }, 'AUTH_REQUIRED'],
+        [200, { code: 500, msg: 'service unavailable' }, 'COMMAND_EXEC'],
+        [200, { code: 'unexpected', data: [] }, 'COMMAND_EXEC'],
+    ])('types HTTP/service failures (HTTP %s, body %o)', async (status, payload, code) => {
+        const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(status, payload));
+        await expect(requestXiaoyuzhouJson('/v1/episode-played/list-history', {
+            method: 'POST',
+            body: {},
+            credentials: normalizeXiaoyuzhouCredentials({
+                access_token: 'access',
+                refresh_token: 'refresh',
+            }),
+        }, fetchMock)).rejects.toMatchObject({ code });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('extracts transcript text from segment arrays and direct text payloads', () => {
         expect(extractTranscriptText(JSON.stringify({
             segments: [{ text: 'hello ' }, { text: ' world' }],

--- a/clis/xiaoyuzhou/history.js
+++ b/clis/xiaoyuzhou/history.js
@@ -1,0 +1,250 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { loadXiaoyuzhouCredentials, requestXiaoyuzhouJson } from './auth.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 5000;
+const DEFAULT_MAX_PAGES = 500;
+const HARD_MAX_PAGES = 1000;
+const HISTORY_ENDPOINT = '/v1/episode-played/list-history';
+const PROGRESS_ENDPOINT = '/v1/playback-progress/list';
+const XIAOYUZHOU_ID = /^[0-9a-f]{24}$/i;
+
+function isRecord(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function positiveInteger(value, label, maximum) {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > maximum) {
+        throw new ArgumentError(`--${label} must be an integer between 1 and ${maximum}`);
+    }
+    return parsed;
+}
+
+function requiredId(value, label) {
+    if (typeof value !== 'string' || !XIAOYUZHOU_ID.test(value)) {
+        throw new CommandExecutionError(`Xiaoyuzhou history returned an invalid ${label}`);
+    }
+    return value.toLowerCase();
+}
+
+function requiredString(value, label) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new CommandExecutionError(`Xiaoyuzhou history returned an invalid ${label}`);
+    }
+    return value.trim();
+}
+
+function optionalSeconds(value, label, { positive = false } = {}) {
+    if (value === null) return null;
+    if (!Number.isSafeInteger(value) || value < (positive ? 1 : 0)) {
+        throw new CommandExecutionError(`Xiaoyuzhou history returned an invalid ${label}; expected seconds`);
+    }
+    return value;
+}
+
+function optionalIsoTime(value, label, { required = false } = {}) {
+    if (value === null) {
+        if (required) throw new CommandExecutionError(`Xiaoyuzhou history returned a missing ${label}`);
+        return null;
+    }
+    if (typeof value !== 'string' || !value.includes('T') || !Number.isFinite(Date.parse(value))) {
+        throw new CommandExecutionError(`Xiaoyuzhou history returned an invalid ${label}`);
+    }
+    return new Date(value).toISOString();
+}
+
+function parseHistoryPage(response) {
+    if (!isRecord(response) || !isRecord(response.raw) || response.raw.data !== response.data) {
+        throw new CommandExecutionError('Xiaoyuzhou history returned an unexpected response shape');
+    }
+    const payload = response?.data;
+    let entries;
+    let next;
+    if (Array.isArray(payload)) {
+        entries = payload;
+        next = response.raw?.loadMoreKey;
+    }
+    else if (isRecord(payload) && Array.isArray(payload.data)
+        && !Object.prototype.hasOwnProperty.call(response.raw, 'loadMoreKey')) {
+        entries = payload.data;
+        next = payload.loadMoreKey;
+    }
+    else {
+        throw new CommandExecutionError('Xiaoyuzhou history returned an unexpected response shape');
+    }
+    if (next == null || next === '') return { entries, next: null };
+    if (typeof next !== 'string' || !next.trim()) {
+        throw new CommandExecutionError('Xiaoyuzhou history returned an invalid loadMoreKey');
+    }
+    if (entries.length === 0) {
+        throw new CommandExecutionError('Xiaoyuzhou history returned an empty page with a continuation cursor');
+    }
+    return { entries, next: next.trim() };
+}
+
+function parseHistoryEpisode(entry, rowNumber) {
+    if (!isRecord(entry) || !isRecord(entry.episode)) {
+        throw new CommandExecutionError(`Xiaoyuzhou history row ${rowNumber} is malformed; expected episode metadata`);
+    }
+    const episode = entry.episode;
+    if (!isRecord(episode.podcast) || typeof episode.isFinished !== 'boolean') {
+        throw new CommandExecutionError(`Xiaoyuzhou history row ${rowNumber} is missing podcast or finished state`);
+    }
+    return {
+        eid: requiredId(episode.eid, `eid in row ${rowNumber}`),
+        pid: requiredId(episode.pid, `pid in row ${rowNumber}`),
+        title: requiredString(episode.title, `title in row ${rowNumber}`),
+        podcast: requiredString(episode.podcast.title, `podcast title in row ${rowNumber}`),
+        durationSec: optionalSeconds(episode.duration, `duration in row ${rowNumber}`, { positive: true }),
+        pubDate: optionalIsoTime(episode.pubDate, `pubDate in row ${rowNumber}`, { required: true }),
+        finished: episode.isFinished,
+    };
+}
+
+function parseProgressRows(response, episodes) {
+    if (!Array.isArray(response?.data)) {
+        throw new CommandExecutionError('Xiaoyuzhou playback progress returned an unexpected response shape');
+    }
+    const requested = new Map(episodes.map((episode) => [episode.eid, episode]));
+    const progressById = new Map();
+    for (const [index, row] of response.data.entries()) {
+        if (!isRecord(row)) {
+            throw new CommandExecutionError(`Xiaoyuzhou playback progress row ${index + 1} is malformed`);
+        }
+        const eid = requiredId(row.eid, `progress eid in row ${index + 1}`);
+        const episode = requested.get(eid);
+        if (!episode) {
+            throw new CommandExecutionError(`Xiaoyuzhou playback progress returned unrequested eid ${eid}`);
+        }
+        if (progressById.has(eid)) {
+            throw new CommandExecutionError(`Xiaoyuzhou playback progress returned duplicate eid ${eid}`);
+        }
+        const pid = requiredId(row.pid, `progress pid in row ${index + 1}`);
+        if (pid !== episode.pid) {
+            throw new CommandExecutionError(`Xiaoyuzhou playback progress pid did not match history eid ${eid}`);
+        }
+        const progressSec = optionalSeconds(row.progress, `progress in row ${index + 1}`);
+        if (progressSec !== null && episode.durationSec !== null && progressSec > episode.durationSec) {
+            throw new CommandExecutionError(`Xiaoyuzhou playback progress exceeded duration for eid ${eid}`);
+        }
+        progressById.set(eid, {
+            progressSec,
+            playedAt: optionalIsoTime(row.playedAt, `playedAt in row ${index + 1}`),
+        });
+    }
+    for (const episode of episodes) {
+        if (!progressById.has(episode.eid)) {
+            throw new CommandExecutionError(
+                `Xiaoyuzhou playback progress omitted requested eid ${episode.eid}; the history join is incomplete`,
+            );
+        }
+    }
+    return progressById;
+}
+
+async function fetchHistory(args = {}) {
+    const fetchAll = args.all ?? false;
+    if (typeof fetchAll !== 'boolean') {
+        throw new ArgumentError('--all must be a boolean');
+    }
+    const limit = fetchAll ? null : positiveInteger(args.limit ?? DEFAULT_LIMIT, 'limit', MAX_LIMIT);
+    const maxPages = positiveInteger(args['max-pages'] ?? DEFAULT_MAX_PAGES, 'max-pages', HARD_MAX_PAGES);
+    let credentials = loadXiaoyuzhouCredentials();
+    const seenEpisodeIds = new Set();
+    const seenCursors = new Set();
+    const rows = [];
+    let loadMoreKey = null;
+    let exhausted = false;
+
+    for (let pageNumber = 1; pageNumber <= maxPages; pageNumber += 1) {
+        const historyResponse = await requestXiaoyuzhouJson(HISTORY_ENDPOINT, {
+            method: 'POST',
+            body: loadMoreKey === null ? {} : { loadMoreKey },
+            credentials,
+        });
+        credentials = historyResponse.credentials;
+        const page = parseHistoryPage(historyResponse);
+        const episodes = page.entries.map((entry, index) => parseHistoryEpisode(entry, index + 1));
+        for (const episode of episodes) {
+            if (seenEpisodeIds.has(episode.eid)) {
+                throw new CommandExecutionError(
+                    `Xiaoyuzhou history repeated eid ${episode.eid}; the pagination snapshot may have changed and event-vs-overlap semantics are ambiguous`,
+                );
+            }
+            seenEpisodeIds.add(episode.eid);
+        }
+
+        const remaining = fetchAll ? episodes.length : limit - rows.length;
+        const selected = episodes.slice(0, remaining);
+        if (selected.length > 0) {
+            const progressResponse = await requestXiaoyuzhouJson(PROGRESS_ENDPOINT, {
+                method: 'POST',
+                body: { eids: selected.map((episode) => episode.eid) },
+                credentials,
+            });
+            credentials = progressResponse.credentials;
+            const progressById = parseProgressRows(progressResponse, selected);
+            for (const episode of selected) {
+                const progress = progressById.get(episode.eid);
+                rows.push({
+                    rank: rows.length + 1,
+                    eid: episode.eid,
+                    pid: episode.pid,
+                    title: episode.title,
+                    podcast: episode.podcast,
+                    durationSec: episode.durationSec,
+                    progressSec: progress.progressSec,
+                    progressPct: episode.durationSec !== null && progress.progressSec !== null
+                        ? Number(((progress.progressSec / episode.durationSec) * 100).toFixed(1))
+                        : null,
+                    playedAt: progress.playedAt,
+                    pubDate: episode.pubDate,
+                    finished: episode.finished,
+                    url: `https://www.xiaoyuzhoufm.com/episode/${episode.eid}`,
+                });
+            }
+        }
+        if (!fetchAll && rows.length >= limit) break;
+        if (page.next === null) {
+            exhausted = true;
+            break;
+        }
+        if (page.next === loadMoreKey || seenCursors.has(page.next)) {
+            throw new CommandExecutionError('Xiaoyuzhou history pagination repeated the same cursor');
+        }
+        if (pageNumber === maxPages) {
+            throw new CommandExecutionError(
+                `Xiaoyuzhou history stopped at the --max-pages safety limit (${maxPages}) before reaching the end`,
+            );
+        }
+        seenCursors.add(page.next);
+        loadMoreKey = page.next;
+    }
+
+    if (rows.length === 0) {
+        throw new EmptyResultError('xiaoyuzhou history', 'The logged-in account has no playback history');
+    }
+    if (fetchAll && !exhausted) {
+        throw new CommandExecutionError('Xiaoyuzhou history archive did not reach the end of pagination');
+    }
+    return rows;
+}
+
+cli({
+    site: 'xiaoyuzhou',
+    name: 'history',
+    access: 'read',
+    description: 'List playback history for the logged-in Xiaoyuzhou account',
+    domain: 'api.xiaoyuzhoufm.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Maximum rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}). Ignored with --all.` },
+        { name: 'all', type: 'bool', default: false, help: 'Fetch every history page until the API cursor is exhausted.' },
+        { name: 'max-pages', type: 'int', default: DEFAULT_MAX_PAGES, help: `Pagination safety limit (default ${DEFAULT_MAX_PAGES}, max ${HARD_MAX_PAGES}).` },
+    ],
+    columns: ['rank', 'eid', 'pid', 'title', 'podcast', 'durationSec', 'progressSec', 'progressPct', 'playedAt', 'pubDate', 'finished', 'url'],
+    func: fetchHistory,
+});

--- a/clis/xiaoyuzhou/history.js
+++ b/clis/xiaoyuzhou/history.js
@@ -1,0 +1,184 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    CommandExecutionError,
+    EmptyResultError,
+} from '@jackwener/opencli/errors';
+import { loadXiaoyuzhouCredentials, requestXiaoyuzhouJson } from './auth.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 5000;
+const DEFAULT_MAX_PAGES = 500;
+const HARD_MAX_PAGES = 1000;
+const HISTORY_ENDPOINT = '/v1/episode-played/list-history';
+const PROGRESS_ENDPOINT = '/v1/playback-progress/list';
+const PROGRESS_BATCH_SIZE = 50;
+
+function positiveInteger(value, label, maximum) {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > maximum) {
+        throw new ArgumentError(`${label} must be an integer between 1 and ${maximum}`);
+    }
+    return parsed;
+}
+
+function episodeFrom(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    const episode = entry.episode ?? entry;
+    return episode && typeof episode === 'object' ? episode : null;
+}
+
+function asNumber(value) {
+    if (value == null || value === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asString(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+async function fetchHistory(args) {
+    const fetchAll = Boolean(args.all);
+    const limit = fetchAll
+        ? Number.POSITIVE_INFINITY
+        : positiveInteger(args.limit ?? DEFAULT_LIMIT, 'limit', MAX_LIMIT);
+    const maxPages = positiveInteger(args['max-pages'] ?? DEFAULT_MAX_PAGES, 'max-pages', HARD_MAX_PAGES);
+    const episodesById = new Map();
+    const seenCursors = new Set();
+    let credentials = loadXiaoyuzhouCredentials();
+    let loadMoreKey = null;
+    let exhausted = false;
+
+    for (let pageNumber = 1; pageNumber <= maxPages; pageNumber += 1) {
+        const response = await requestXiaoyuzhouJson(HISTORY_ENDPOINT, {
+            method: 'POST',
+            body: loadMoreKey == null ? {} : { loadMoreKey },
+            credentials,
+        });
+        credentials = response.credentials;
+        const page = response.data;
+        const entries = Array.isArray(page)
+            ? page
+            : (Array.isArray(page?.data) ? page.data : null);
+        if (entries == null) {
+            throw new CommandExecutionError('Xiaoyuzhou history returned an unexpected response shape');
+        }
+        for (const entry of entries) {
+            const episode = episodeFrom(entry);
+            if (episode?.eid && !episodesById.has(String(episode.eid))) {
+                episodesById.set(String(episode.eid), episode);
+            }
+            if (!fetchAll && episodesById.size >= limit) break;
+        }
+        if (!fetchAll && episodesById.size >= limit) break;
+
+        // The live API returns rows in `data` and the cursor beside them at
+        // the response root. Keep the nested fallback for older payloads.
+        const next = response.raw?.loadMoreKey
+            ?? (page && !Array.isArray(page) ? page.loadMoreKey : null);
+        if (entries.length === 0 || next == null || next === '') {
+            exhausted = true;
+            break;
+        }
+        const cursorKey = JSON.stringify(next);
+        if (seenCursors.has(cursorKey)) {
+            throw new CommandExecutionError('Xiaoyuzhou history pagination repeated the same cursor');
+        }
+        seenCursors.add(cursorKey);
+        loadMoreKey = next;
+
+        if (pageNumber === maxPages) {
+            throw new CommandExecutionError(
+                `Xiaoyuzhou history stopped at the --max-pages safety limit (${maxPages}) before reaching the end`,
+                'Increase --max-pages and retry.',
+            );
+        }
+    }
+
+    const episodes = [...episodesById.values()];
+    if (episodes.length === 0) {
+        throw new EmptyResultError('xiaoyuzhou history', 'The logged-in account has no playback history');
+    }
+    if (fetchAll && !exhausted) {
+        throw new CommandExecutionError('Xiaoyuzhou history archive did not reach the end of pagination');
+    }
+
+    const selected = fetchAll ? episodes : episodes.slice(0, limit);
+    const progressById = new Map();
+    for (let offset = 0; offset < selected.length; offset += PROGRESS_BATCH_SIZE) {
+        const eids = selected.slice(offset, offset + PROGRESS_BATCH_SIZE).map((episode) => String(episode.eid));
+        const response = await requestXiaoyuzhouJson(PROGRESS_ENDPOINT, {
+            method: 'POST',
+            body: { eids },
+            credentials,
+        });
+        credentials = response.credentials;
+        const progressRows = Array.isArray(response.data)
+            ? response.data
+            : (Array.isArray(response.data?.data) ? response.data.data : null);
+        if (progressRows == null) {
+            throw new CommandExecutionError('Xiaoyuzhou playback progress returned an unexpected response shape');
+        }
+        for (const progressRow of progressRows) {
+            if (progressRow?.eid) progressById.set(String(progressRow.eid), progressRow);
+        }
+    }
+
+    return selected.map((episode, index) => {
+        const eid = String(episode.eid);
+        const progress = progressById.get(eid);
+        const durationSec = asNumber(episode.duration);
+        const progressSec = asNumber(progress?.progress);
+        return {
+            rank: index + 1,
+            eid,
+            title: asString(episode.title),
+            podcast: asString(episode.podcast?.title),
+            durationSec,
+            progressSec,
+            progressPct: durationSec > 0 && progressSec != null
+                ? Number(((progressSec / durationSec) * 100).toFixed(1))
+                : null,
+            playedAt: asString(progress?.playedAt),
+            pubDate: asString(episode.pubDate),
+            finished: typeof episode.isFinished === 'boolean' ? episode.isFinished : null,
+            url: `https://www.xiaoyuzhoufm.com/episode/${encodeURIComponent(eid)}`,
+        };
+    });
+}
+
+cli({
+    site: 'xiaoyuzhou',
+    name: 'history',
+    access: 'read',
+    description: 'List playback history for the logged-in Xiaoyuzhou account',
+    domain: 'api.xiaoyuzhoufm.com',
+    strategy: Strategy.LOCAL,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: `Maximum rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}). Ignored with --all.` },
+        { name: 'all', type: 'bool', default: false, help: 'Fetch every history page until the API cursor is exhausted.' },
+        { name: 'max-pages', type: 'int', default: DEFAULT_MAX_PAGES, help: `Pagination safety limit (default ${DEFAULT_MAX_PAGES}, max ${HARD_MAX_PAGES}).` },
+    ],
+    columns: [
+        'rank',
+        'eid',
+        'title',
+        'podcast',
+        'durationSec',
+        'progressSec',
+        'progressPct',
+        'playedAt',
+        'pubDate',
+        'finished',
+        'url',
+    ],
+    func: fetchHistory,
+});
+
+export const __test__ = {
+    asNumber,
+    episodeFrom,
+    positiveInteger,
+};

--- a/clis/xiaoyuzhou/history.test.js
+++ b/clis/xiaoyuzhou/history.test.js
@@ -1,0 +1,221 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const { mockRequestJson, mockLoadCredentials } = vi.hoisted(() => ({
+    mockRequestJson: vi.fn(),
+    mockLoadCredentials: vi.fn(),
+}));
+
+vi.mock('./auth.js', async () => ({
+    ...(await vi.importActual('./auth.js')),
+    requestXiaoyuzhouJson: mockRequestJson,
+    loadXiaoyuzhouCredentials: mockLoadCredentials,
+}));
+
+await import('./history.js');
+
+const IDS = {
+    a: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+    b: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+    c: 'cccccccccccccccccccccccc',
+    d: 'dddddddddddddddddddddddd',
+};
+const PIDS = {
+    a: '111111111111111111111111',
+    b: '222222222222222222222222',
+    c: '333333333333333333333333',
+    d: '444444444444444444444444',
+};
+
+let command;
+
+beforeAll(() => {
+    command = getRegistry().get('xiaoyuzhou/history');
+    expect(command?.func).toBeTypeOf('function');
+});
+
+function historyRow(key, overrides = {}) {
+    return {
+        episode: {
+            eid: IDS[key],
+            pid: PIDS[key],
+            title: `Episode ${key.toUpperCase()}`,
+            duration: 100,
+            pubDate: '2026-08-01T00:00:00.000Z',
+            isFinished: false,
+            podcast: { title: 'Example Podcast' },
+            ...overrides,
+        },
+    };
+}
+
+function progressRow(key, overrides = {}) {
+    return {
+        eid: IDS[key],
+        pid: PIDS[key],
+        progress: 25,
+        playedAt: '2026-08-03T01:02:03.000Z',
+        ...overrides,
+    };
+}
+
+function rootPage(rows, loadMoreKey, credentials = {}) {
+    return { data: rows, raw: { data: rows, loadMoreKey }, credentials };
+}
+
+function nestedPage(rows, loadMoreKey, credentials = {}) {
+    const data = { data: rows, loadMoreKey };
+    return { data, raw: { data }, credentials };
+}
+
+describe('xiaoyuzhou history', () => {
+    beforeEach(() => {
+        mockRequestJson.mockReset();
+        mockLoadCredentials.mockReset();
+        mockLoadCredentials.mockReturnValue({ access_token: 'access', refresh_token: 'refresh' });
+    });
+
+    it('accepts both evidenced envelopes and enriches each page before fetching the next', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a')], 'next', { token: 'history-1' }))
+            .mockResolvedValueOnce({ data: [progressRow('a')], credentials: { token: 'progress-1' } })
+            .mockResolvedValueOnce(nestedPage([historyRow('b', { isFinished: true })], null, { token: 'history-2' }))
+            .mockResolvedValueOnce({ data: [progressRow('b', { progress: 50 })], credentials: { token: 'progress-2' } });
+
+        const rows = await command.func({ limit: 2, all: false, 'max-pages': 10 });
+
+        expect(mockRequestJson).toHaveBeenNthCalledWith(1, '/v1/episode-played/list-history', {
+            method: 'POST', body: {}, credentials: { access_token: 'access', refresh_token: 'refresh' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(2, '/v1/playback-progress/list', {
+            method: 'POST', body: { eids: [IDS.a] }, credentials: { token: 'history-1' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(3, '/v1/episode-played/list-history', {
+            method: 'POST', body: { loadMoreKey: 'next' }, credentials: { token: 'progress-1' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(4, '/v1/playback-progress/list', {
+            method: 'POST', body: { eids: [IDS.b] }, credentials: { token: 'history-2' },
+        });
+        expect(rows.map((row) => [row.eid, row.pid])).toEqual([[IDS.a, PIDS.a], [IDS.b, PIDS.b]]);
+        expect(rows[0]).toMatchObject({ rank: 1, progressSec: 25, progressPct: 25, finished: false });
+        expect(rows[1]).toMatchObject({ rank: 2, progressSec: 50, progressPct: 50, finished: true });
+    });
+
+    it('preserves server order across pages and validates rows beyond the requested limit', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('b'), historyRow('a')], 'next', { page: 1 }))
+            .mockResolvedValueOnce({ data: [progressRow('b'), progressRow('a')], credentials: { progress: 1 } })
+            .mockResolvedValueOnce(rootPage([historyRow('c'), { episode: { eid: IDS.d } }], null, { page: 2 }));
+
+        await expect(command.func({ limit: 3, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('row 2'),
+        });
+        expect(mockRequestJson).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects a missing duration instead of treating it as explicit null', async () => {
+        mockRequestJson.mockResolvedValueOnce(rootPage([historyRow('a', { duration: undefined })], null));
+        await expect(command.func({ limit: 1, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC', message: expect.stringContaining('invalid duration'),
+        });
+        expect(mockRequestJson).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts --all and ignores --limit without silently deduplicating', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a')], 'next', { page: 1 }))
+            .mockResolvedValueOnce({ data: [progressRow('a')], credentials: { progress: 1 } })
+            .mockResolvedValueOnce(rootPage([historyRow('b')], null, { page: 2 }))
+            .mockResolvedValueOnce({ data: [progressRow('b')], credentials: { progress: 2 } });
+
+        const rows = await command.func({ limit: 'ignored', all: true, 'max-pages': 10 });
+        expect(rows.map((row) => row.eid)).toEqual([IDS.a, IDS.b]);
+
+        mockRequestJson.mockReset();
+        mockRequestJson.mockResolvedValueOnce(rootPage([historyRow('a'), historyRow('a')], null));
+        await expect(command.func({ all: true, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('event-vs-overlap semantics are ambiguous'),
+        });
+    });
+
+    it.each([
+        [{ all: 'true', limit: 20, 'max-pages': 10 }, '--all'],
+        [{ all: false, limit: 0, 'max-pages': 10 }, '--limit'],
+        [{ all: false, limit: 20, 'max-pages': 1001 }, '--max-pages'],
+    ])('rejects invalid arguments before credentials or network (%s)', async (args, message) => {
+        await expect(command.func(args)).rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining(message) });
+        expect(mockLoadCredentials).not.toHaveBeenCalled();
+        expect(mockRequestJson).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['unexpected envelope', { data: { rows: [] }, raw: {} }, 'unexpected response shape'],
+        ['conflicting root and nested cursors', (() => {
+            const data = { data: [historyRow('a')], loadMoreKey: null };
+            return { data, raw: { data, loadMoreKey: 'conflict' } };
+        })(), 'unexpected response shape'],
+        ['empty page with cursor', rootPage([], 'next'), 'empty page with a continuation cursor'],
+        ['invalid cursor', rootPage([historyRow('a')], { page: 2 }), 'invalid loadMoreKey'],
+    ])('fails closed for %s', async (_label, response, message) => {
+        mockRequestJson.mockResolvedValueOnce(response);
+        await expect(command.func({ limit: 1, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC', message: expect.stringContaining(message),
+        });
+    });
+
+    it('fails on a repeated cursor before returning a partial result', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a')], 'same', { page: 1 }))
+            .mockResolvedValueOnce({ data: [progressRow('a')], credentials: { progress: 1 } })
+            .mockResolvedValueOnce(rootPage([historyRow('b')], 'same', { page: 2 }))
+            .mockResolvedValueOnce({ data: [progressRow('b')], credentials: { progress: 2 } });
+        await expect(command.func({ limit: 3, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC', message: expect.stringContaining('repeated the same cursor'),
+        });
+    });
+
+    it('fails instead of returning a partial archive at --max-pages', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a')], 'more', { page: 1 }))
+            .mockResolvedValueOnce({ data: [progressRow('a')], credentials: { progress: 1 } });
+        await expect(command.func({ all: true, 'max-pages': 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC', message: expect.stringContaining('before reaching the end'),
+        });
+    });
+
+    it.each([
+        ['wrong shape', { data: { rows: [] } }, 'unexpected response shape'],
+        ['extra eid', { data: [progressRow('b')] }, 'unrequested eid'],
+        ['duplicate eid', { data: [progressRow('a'), progressRow('a')] }, 'duplicate eid'],
+        ['pid mismatch', { data: [progressRow('a', { pid: PIDS.b })] }, 'pid did not match'],
+        ['negative progress', { data: [progressRow('a', { progress: -1 })] }, 'invalid progress'],
+        ['missing progress', { data: [progressRow('a', { progress: undefined })] }, 'invalid progress'],
+        ['missing playedAt', { data: [progressRow('a', { playedAt: undefined })] }, 'invalid playedAt'],
+        ['progress beyond duration', { data: [progressRow('a', { progress: 101 })] }, 'exceeded duration'],
+        ['missing requested eid', { data: [] }, 'history join is incomplete'],
+    ])('fails closed for playback progress %s', async (_label, progressResponse, message) => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a')], null, { history: 1 }))
+            .mockResolvedValueOnce({ ...progressResponse, credentials: { progress: 1 } });
+        await expect(command.func({ limit: 1, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC', message: expect.stringContaining(message),
+        });
+    });
+
+    it('preserves explicitly nullable duration, progress, and playedAt fields', async () => {
+        mockRequestJson
+            .mockResolvedValueOnce(rootPage([historyRow('a', { duration: null })], null, { history: 1 }))
+            .mockResolvedValueOnce({ data: [progressRow('a', { progress: null, playedAt: null })], credentials: { progress: 1 } });
+        const [row] = await command.func({ limit: 1, all: false, 'max-pages': 10 });
+        expect(row).toMatchObject({ durationSec: null, progressSec: null, progressPct: null, playedAt: null });
+    });
+
+    it('distinguishes a valid empty history from malformed payloads', async () => {
+        mockRequestJson.mockResolvedValueOnce(rootPage([], null));
+        await expect(command.func({ limit: 20, all: false, 'max-pages': 10 })).rejects.toMatchObject({
+            code: 'EMPTY_RESULT',
+        });
+    });
+});

--- a/clis/xiaoyuzhou/history.test.js
+++ b/clis/xiaoyuzhou/history.test.js
@@ -1,0 +1,194 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+
+const { mockRequestJson, mockLoadCredentials } = vi.hoisted(() => ({
+    mockRequestJson: vi.fn(),
+    mockLoadCredentials: vi.fn(),
+}));
+
+vi.mock('./auth.js', async () => {
+    const actual = await vi.importActual('./auth.js');
+    return {
+        ...actual,
+        requestXiaoyuzhouJson: mockRequestJson,
+        loadXiaoyuzhouCredentials: mockLoadCredentials,
+    };
+});
+
+await import('./history.js');
+
+let cmd;
+
+beforeAll(() => {
+    cmd = getRegistry().get('xiaoyuzhou/history');
+    expect(cmd?.func).toBeTypeOf('function');
+});
+
+function episode(eid, overrides = {}) {
+    return {
+        eid,
+        title: `Episode ${eid.slice(0, 2)}`,
+        duration: 100,
+        pubDate: '2026-08-01T00:00:00.000Z',
+        isFinished: false,
+        podcast: { title: 'Example Podcast' },
+        ...overrides,
+    };
+}
+
+describe('xiaoyuzhou history', () => {
+    beforeEach(() => {
+        mockRequestJson.mockReset();
+        mockLoadCredentials.mockReset();
+        mockLoadCredentials.mockReturnValue({ access_token: 'access', refresh_token: 'refresh' });
+    });
+
+    it('follows the top-level loadMoreKey and enriches rows with playback progress', async () => {
+        const firstId = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+        const secondId = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+        const thirdId = 'cccccccccccccccccccccccc';
+        mockRequestJson
+            .mockResolvedValueOnce({
+                data: [{ episode: episode(firstId) }, { episode: episode(secondId) }],
+                raw: { loadMoreKey: 'cursor-page-2' },
+                credentials: { access_token: 'page-1' },
+            })
+            .mockResolvedValueOnce({
+                data: [{ episode: episode(thirdId, { isFinished: true }) }],
+                raw: { loadMoreKey: null },
+                credentials: { access_token: 'page-2' },
+            })
+            .mockResolvedValueOnce({
+                data: [
+                    { eid: firstId, progress: 25, playedAt: '2026-08-03T01:02:03.000Z' },
+                    { eid: secondId, progress: 50, playedAt: '2026-08-02T01:02:03.000Z' },
+                    { eid: thirdId, progress: 0, playedAt: '2026-08-01T01:02:03.000Z' },
+                ],
+                credentials: { access_token: 'progress' },
+            });
+
+        const result = await cmd.func({ limit: 3, all: false, 'max-pages': 500 });
+
+        expect(mockRequestJson).toHaveBeenNthCalledWith(1, '/v1/episode-played/list-history', {
+            method: 'POST',
+            body: {},
+            credentials: { access_token: 'access', refresh_token: 'refresh' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(2, '/v1/episode-played/list-history', {
+            method: 'POST',
+            body: { loadMoreKey: 'cursor-page-2' },
+            credentials: { access_token: 'page-1' },
+        });
+        expect(mockRequestJson).toHaveBeenNthCalledWith(3, '/v1/playback-progress/list', {
+            method: 'POST',
+            body: { eids: [firstId, secondId, thirdId] },
+            credentials: { access_token: 'page-2' },
+        });
+        expect(result).toHaveLength(3);
+        expect(result[0]).toMatchObject({
+            rank: 1,
+            eid: firstId,
+            progressSec: 25,
+            progressPct: 25,
+            playedAt: '2026-08-03T01:02:03.000Z',
+            finished: false,
+        });
+        expect(result[2]).toMatchObject({
+            eid: thirdId,
+            progressSec: 0,
+            progressPct: 0,
+            finished: true,
+        });
+    });
+
+    it('fetches every page with --all, deduplicates episodes, and batches progress requests', async () => {
+        const firstPage = Array.from({ length: 50 }, (_, index) => episode(index.toString(16).padStart(24, '0')));
+        const secondPage = [firstPage[49], episode('ffffffffffffffffffffffff')];
+        mockRequestJson
+            .mockResolvedValueOnce({ data: firstPage.map((item) => ({ episode: item })), raw: { loadMoreKey: 'next' }, credentials: { page: 1 } })
+            .mockResolvedValueOnce({ data: secondPage.map((item) => ({ episode: item })), raw: {}, credentials: { page: 2 } })
+            .mockResolvedValueOnce({ data: [], credentials: { batch: 1 } })
+            .mockResolvedValueOnce({ data: [], credentials: { batch: 2 } });
+
+        const result = await cmd.func({ limit: 999999, all: true, 'max-pages': 500 });
+
+        expect(result).toHaveLength(51);
+        expect(mockRequestJson).toHaveBeenCalledTimes(4);
+        expect(mockRequestJson.mock.calls[2][1].body.eids).toHaveLength(50);
+        expect(mockRequestJson.mock.calls[3][1].body.eids).toHaveLength(1);
+        expect(result[0].playedAt).toBeNull();
+    });
+
+    it('rejects invalid pagination arguments before calling the API', async () => {
+        await expect(cmd.func({ limit: 0, all: false, 'max-pages': 500 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        await expect(cmd.func({ limit: 20, all: false, 'max-pages': 1001 })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+        });
+        expect(mockRequestJson).not.toHaveBeenCalled();
+    });
+
+    it('fails explicitly when pagination repeats a cursor', async () => {
+        const onlyId = 'dddddddddddddddddddddddd';
+        mockRequestJson
+            .mockResolvedValueOnce({ data: [{ episode: episode(onlyId) }], raw: { loadMoreKey: 'same' }, credentials: { page: 1 } })
+            .mockResolvedValueOnce({ data: [{ episode: episode(onlyId) }], raw: { loadMoreKey: 'same' }, credentials: { page: 2 } });
+
+        await expect(cmd.func({ limit: 2, all: false, 'max-pages': 500 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'Xiaoyuzhou history pagination repeated the same cursor',
+        });
+    });
+
+    it('fails instead of returning a partial --all archive at the page safety limit', async () => {
+        mockRequestJson.mockResolvedValueOnce({
+            data: [{ episode: episode('eeeeeeeeeeeeeeeeeeeeeeee') }],
+            raw: { loadMoreKey: 'more' },
+            credentials: { page: 1 },
+        });
+
+        await expect(cmd.func({ limit: 20, all: true, 'max-pages': 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('before reaching the end'),
+        });
+    });
+
+    it('reports unexpected history and progress payloads as command errors', async () => {
+        mockRequestJson.mockResolvedValueOnce({ data: { rows: [] }, raw: {}, credentials: {} });
+        await expect(cmd.func({ limit: 20, all: false, 'max-pages': 500 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'Xiaoyuzhou history returned an unexpected response shape',
+        });
+
+        mockRequestJson
+            .mockResolvedValueOnce({ data: [{ episode: episode('abababababababababababab') }], raw: {}, credentials: {} })
+            .mockResolvedValueOnce({ data: { rows: [] }, credentials: {} });
+        await expect(cmd.func({ limit: 20, all: false, 'max-pages': 500 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: 'Xiaoyuzhou playback progress returned an unexpected response shape',
+        });
+    });
+
+    it('preserves missing numeric values as null instead of coercing them to zero', async () => {
+        const eid = 'cdcdcdcdcdcdcdcdcdcdcdcd';
+        mockRequestJson
+            .mockResolvedValueOnce({
+                data: [{ episode: episode(eid, { duration: null }) }],
+                raw: {},
+                credentials: {},
+            })
+            .mockResolvedValueOnce({
+                data: [{ eid, progress: null, playedAt: null }],
+                credentials: {},
+            });
+
+        const [result] = await cmd.func({ limit: 20, all: false, 'max-pages': 500 });
+        expect(result).toMatchObject({
+            durationSec: null,
+            progressSec: null,
+            progressPct: null,
+            playedAt: null,
+        });
+    });
+});

--- a/docs/adapters/browser/xiaoyuzhou.md
+++ b/docs/adapters/browser/xiaoyuzhou.md
@@ -9,6 +9,7 @@
 | `opencli xiaoyuzhou podcast` | View a podcast profile (requires local credentials) |
 | `opencli xiaoyuzhou podcast-episodes` | List podcast episodes (requires local credentials) |
 | `opencli xiaoyuzhou episode` | View episode details (requires local credentials) |
+| `opencli xiaoyuzhou history` | List the logged-in account's playback history and progress (requires local credentials) |
 | `opencli xiaoyuzhou download` | Download episode audio (requires local credentials) |
 | `opencli xiaoyuzhou transcript` | Download transcript JSON and extracted text (requires local credentials) |
 
@@ -24,6 +25,12 @@ opencli xiaoyuzhou podcast-episodes 6013f9f58e2f7ee375cf4216 --limit 5
 # Episode details
 opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0
 
+# Recent playback history
+opencli xiaoyuzhou history --limit 20
+
+# Fetch all playback-history pages as JSON
+opencli xiaoyuzhou history --all -f json
+
 # Download episode audio
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou
 
@@ -36,6 +43,12 @@ opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0 -f json
 # Verbose mode
 opencli xiaoyuzhou transcript 69dd0c98e2c8be31551f6a33 -v
 ```
+
+### Playback history semantics
+
+`history` reads Xiaoyuzhou's undocumented app endpoints using the local credential file; the `Local API` label describes that credential carrier, not a public or stable API contract. Rows stay in the service's history order. Episode metadata and playback progress come from separate endpoints, and the command fails instead of returning a partial result if pagination or that join is incomplete.
+
+`durationSec`, `progressSec`, `progressPct`, and `playedAt` can be `null` only when the corresponding API row explicitly has no value. With `--all`, `--limit` is ignored and the command continues until the cursor is exhausted. `--max-pages` is a safety ceiling; reaching it before exhaustion is an error and never returns a partial archive.
 
 ## Prerequisites
 

--- a/docs/adapters/browser/xiaoyuzhou.md
+++ b/docs/adapters/browser/xiaoyuzhou.md
@@ -9,6 +9,7 @@
 | `opencli xiaoyuzhou podcast` | View a podcast profile (requires local credentials) |
 | `opencli xiaoyuzhou podcast-episodes` | List podcast episodes (requires local credentials) |
 | `opencli xiaoyuzhou episode` | View episode details (requires local credentials) |
+| `opencli xiaoyuzhou history` | List the logged-in account's playback history and progress (requires local credentials) |
 | `opencli xiaoyuzhou download` | Download episode audio (requires local credentials) |
 | `opencli xiaoyuzhou transcript` | Download transcript JSON and extracted text (requires local credentials) |
 
@@ -23,6 +24,12 @@ opencli xiaoyuzhou podcast-episodes 6013f9f58e2f7ee375cf4216 --limit 5
 
 # Episode details
 opencli xiaoyuzhou episode 69b3b675772ac2295bfc01d0
+
+# Recent playback history
+opencli xiaoyuzhou history --limit 20
+
+# Fetch all playback-history pages as JSON
+opencli xiaoyuzhou history --all -f json
 
 # Download episode audio
 opencli xiaoyuzhou download 69b3b675772ac2295bfc01d0 --output ./xiaoyuzhou

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -108,7 +108,7 @@ Run `opencli list` for the live registry.
 | **[juejin](./browser/juejin.md)**                 | `recommend` `hot`                                                                                                                              | 🌐 Public    |
 | **[dictionary](./browser/dictionary.md)**         | `search` `synonyms` `examples`                                                                                                                 | 🌐 Public    |
 | **[apple-podcasts](./browser/apple-podcasts.md)** | `search` `episodes` `top`                                                                                                                      | 🌐 Public    |
-| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `download` `transcript` (local credentials required)                                                   | 🔑 Local API |
+| **[xiaoyuzhou](./browser/xiaoyuzhou.md)**         | `podcast` `podcast-episodes` `episode` `history` `download` `transcript` (local credentials required)                                         | 🔑 Local API |
 | **[yahoo-finance](./browser/yahoo-finance.md)**   | `quote`                                                                                                                                        | 🌐 Public    |
 | **[archive](./browser/archive.md)**               | `search` `item` `wayback` `snapshots`                                                                                                          | 🌐 Public    |
 | **[arxiv](./browser/arxiv.md)**                   | `search` `paper`                                                                                                                               | 🌐 Public    |


### PR DESCRIPTION
## 背景

现有小宇宙适配器可以查询播客和单集，但无法读取当前登录账号的播放历史。本 PR 增加一个只读的 `xiaoyuzhou history` 命令，并复用现有本地凭据与自动刷新机制。

## 改动

- 新增 `opencli xiaoyuzhou history --limit 20`，输出单集、播客、播放时间、时长、进度、完成状态和原页链接。
- 支持 `--all` 遍历全部历史页；支持 `--max-pages` 安全上限。
- 正确读取 `POST /v1/episode-played/list-history` 响应顶层的 `loadMoreKey`，并将其作为下一页请求体字段。
- 通过 `POST /v1/playback-progress/list` 按最多 50 个 `eid` 分批补齐进度与 `playedAt`。
- 对重复游标、未穷尽的全量抓取、异常响应结构和非法参数返回 typed errors，避免静默返回不完整结果。
- 缺失的时长、进度或播放时间保留为 `null`，不错误转换为 0 或 Unix epoch。
- 更新 manifest 与小宇宙适配器文档。

## 隐私与范围

本 PR 只包含通用命令、合成测试数据和公开文档；不包含任何账号凭据、个人播放记录、本地归档路径、定时任务或私有知识库逻辑。

## 验证

- `npx vitest run --project adapter clis/xiaoyuzhou/*.test.js`：33 tests passed
- `npm run build`
- `npm run typecheck`
- `npm run check:typed-error-lint -- xiaoyuzhou`
- `npm run check:silent-column-drop -- xiaoyuzhou`
- `node dist/src/main.js validate xiaoyuzhou`
- `bash scripts/check-doc-coverage.sh --strict`：176/176
- `npm run docs:build`
- `npm audit --omit=dev --audit-level=high`
- 使用本地登录态做了只读实测：`--limit 21` 成功跨页，`--all` 成功走到游标穷尽；未保存或提交返回内容。
