### PR TITLE
fix(chatgpt): filter Chinese user-upload previews from generated images

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2565,10 +2565,10 @@ export async function getChatGPTVisibleImageUrls(page) {
                 const heading = (turn?.querySelector('h4')?.innerText || '').toLowerCase();
                 if (/you said|你说/.test(heading)) return true;
                 if (/chatgpt|assistant|助手/.test(heading)) return false;
-                const openButtonLabel = (img.closest('button[aria-label^="Open image:"]')?.getAttribute('aria-label') || '').toLowerCase();
+                const openButtonLabel = (img.closest('button[aria-label^="Open image:"], button[aria-label^="打开图片："]')?.getAttribute('aria-label') || '').toLowerCase();
                 const previewText = [alt, openButtonLabel].join(' ');
                 return /\.(png|jpe?g|webp|gif|heic|heif)(?:\b|$)/i.test(previewText)
-                    || /ref-|reference|参考|upload|uploaded|attachment/.test(previewText);
+                    || /ref-|reference|参考|上传|upload|uploaded|attachment/.test(previewText);
             };
 
             const imgs = Array.from(document.querySelectorAll('img')).filter(img =>

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1476,6 +1476,29 @@ describe('chatgpt generated image detection', () => {
         ]);
     });
 
+    it('ignores user-uploaded previews labeled by the Chinese UI', async () => {
+        const page = createDomPage(`
+            <!doctype html>
+            <button aria-label="打开图片：用户上传的图片">
+              <img alt="" src="https://chatgpt.com/backend-api/files/reference">
+            </button>
+            <section data-testid="conversation-turn-2">
+              <h4>ChatGPT said:</h4>
+              <img alt="generated image" src="https://chatgpt.com/backend-api/generated/foo.webp">
+            </section>
+        `, (window) => {
+            for (const img of window.document.querySelectorAll('img')) {
+                Object.defineProperty(img, 'naturalWidth', { configurable: true, value: 512 });
+                Object.defineProperty(img, 'naturalHeight', { configurable: true, value: 512 });
+                img.getBoundingClientRect = () => ({ width: 512, height: 512 });
+            }
+        });
+
+        await expect(getChatGPTVisibleImageUrls(page)).resolves.toEqual([
+            'https://chatgpt.com/backend-api/generated/foo.webp',
+        ]);
+    });
+
     it('keeps assistant generated images even when they are inside an open-image button', async () => {
         const page = createDomPage(`
             <!doctype html>

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -217,7 +217,7 @@ function unregisterExtensionConnection(ws: WebSocket): void {
 
 // ─── HTTP Server ─────────────────────────────────────────────────────
 
-const MAX_BODY = 32 * 1024 * 1024; // 32 MB — allows base64 image payloads (chatgpt image upload fallback); prevents OOM
+const MAX_BODY = 1024 * 1024; // 1 MB — commands are tiny; this prevents OOM
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -217,7 +217,7 @@ function unregisterExtensionConnection(ws: WebSocket): void {
 
 // ─── HTTP Server ─────────────────────────────────────────────────────
 
-const MAX_BODY = 1024 * 1024; // 1 MB — commands are tiny; this prevents OOM
+const MAX_BODY = 32 * 1024 * 1024; // 32 MB — allows base64 image payloads (chatgpt image upload fallback); prevents OOM
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem

On Chinese ChatGPT UI, `opencli chatgpt image --image <photo>` can report the user's uploaded reference image as the generated result.

`getChatGPTVisibleImageUrls()` filters upload previews using the English button prefix `Open image:` and English upload terms. The Chinese UI uses `打开图片：用户上传的图片`; the re-rendered upload can have an empty `alt`, so it escapes the filter and is downloaded as if ChatGPT generated it.

## Fix

- Recognize the exact Chinese open-image button prefix `打开图片：`.
- Treat `上传` as an upload marker.
- Add a real JSDOM regression case with an empty-alt Chinese upload preview next to an assistant-generated image. The upload must be excluded while the generated image remains.

The earlier global daemon request-limit increase was removed. This PR is now adapter-local: changing a process-wide transport/OOM limit is not justified by one legacy base64 fallback, especially when Browser Bridge file-input injection is the primary path.

## Verification

- `clis/chatgpt/utils.test.js`: 111/111 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
