### PR TITLE
chore(deps): bump js-yaml to 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mozilla/readability": "^0.6.0",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
         "undici": "^6.27.0",
@@ -2950,9 +2950,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@mozilla/readability": "^0.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "undici": "^6.27.0",


### PR DESCRIPTION
## Description

The `audit` job fails on every pull request right now, including ones that touch no dependencies. `js-yaml` is a direct production dependency resolved at 4.3.0 in the lockfile, and advisory GHSA-5p4m-2wfm-xmqj, published 2026-08-06, covers 4.0.0 through 4.3.0 at high severity, so `npm audit --omit=dev --audit-level=high` exits non-zero on `main` itself. This bumps the resolved version to the patched 4.3.1.

The declared range moves from `^4.3.0` to `^4.3.1` so the security floor is recorded in `package.json` rather than only in the lockfile. The three `undici` moderates in the same report sit below the gate's `high` threshold and do not trip it. Nothing else changes.

`js-yaml` is the serializer behind the default output format, so the risk is output drift rather than a build break. `src/serialization.test.ts`, `src/engine.test.ts`, `src/help.test.ts` and `tests/e2e/output-formats.test.ts` pass unchanged (33 / 33), `npm run typecheck` is clean, and a real command renders byte-identical YAML on 4.3.0 and 4.3.1.

Related issue: none filed; the failure is reproducible on `main` with `npm audit --omit=dev --audit-level=high`.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Before, on `main`:

```
$ npm audit --omit=dev --audit-level=high
# npm audit report

js-yaml  4.0.0 - 4.3.0
Severity: high
JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported - https://github.com/advisories/GHSA-5p4m-2wfm-xmqj
fix available via `npm audit fix`
node_modules/js-yaml

undici  <=6.27.0
Severity: moderate
undici vulnerable to downstream response desynchronization via retry interceptor - https://github.com/advisories/GHSA-8xcm-r25x-g524
undici vulnerable to CRLF Injection via blob-like body 'type' property - https://github.com/advisories/GHSA-m8rv-5g2x-5cg5
undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields - https://github.com/advisories/GHSA-v3r7-h72x-cjcm
fix available via `npm audit fix`
node_modules/undici

2 vulnerabilities (1 moderate, 1 high)
$ echo $?
1
```

After, on this branch, the high is gone and the gate passes:

```
$ npm audit --omit=dev --audit-level=high
# npm audit report

undici  <=6.27.0
Severity: moderate
undici vulnerable to downstream response desynchronization via retry interceptor - https://github.com/advisories/GHSA-8xcm-r25x-g524
undici vulnerable to CRLF Injection via blob-like body 'type' property - https://github.com/advisories/GHSA-m8rv-5g2x-5cg5
undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields - https://github.com/advisories/GHSA-v3r7-h72x-cjcm
fix available via `npm audit fix`
node_modules/undici

1 moderate severity vulnerability
$ echo $?
0
```

Output is byte-identical on the default YAML formatter, `diff` of the same command run on 4.3.0 and 4.3.1 is empty:

```
$ opencli trip search Tokyo --limit 2
- rank: 1
  name: Tokyo
  type: city
  cityId: 228
  airportCode: null
  province: null
  country: Japan
```
