### PR TITLE
test(launcher): skip pgrep-backed app detection tests on Windows

### DIFF
--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -175,7 +175,7 @@ describe('resolveExecutableCandidates', () => {
   });
 });
 
-describe('app-scoped process detection', () => {
+describe.skipIf(process.platform === 'win32')('app-scoped process detection', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     cp.execFileSync.mockReset();


### PR DESCRIPTION
## Description

The `unit-test (windows-latest)` shard is red on `main` since 18f1ceba: the `app-scoped process detection` tests added in #2232 mock `pgrep` / `ps`, but `findAppProcessPids` intentionally short-circuits to `[]` on win32 (`src/launcher.ts:214`) and `killAppProcess` returns early (`src/launcher.ts:241`). On the Windows runner the POSIX process mocks are never reached, so the app-scoped suite fails even though the production Windows behavior is intentional. The PR run was green because PR CI runs unit shards on ubuntu only, while pushes to `main` run the full OS matrix (see `.github/workflows/ci.yml:68`).

This marks the whole POSIX-only `app-scoped process detection` suite with `describe.skipIf(process.platform === 'win32')`, matching the file's existing guarded pgrep test pattern. Test-only change; no production code touched.

Related issue: none filed; the failing run is https://github.com/jackwener/OpenCLI/actions/runs/31256460252 and the failures reproduce on win32 for `src/launcher.test.ts` before this guard.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Local checks on macOS:

```
$ npx vitest run src/launcher.test.ts --reporter=verbose
 Test Files  1 passed (1)
      Tests  20 passed | 1 skipped (21)

$ npm run typecheck
# passed
```

Exact-head full matrix verification:

- Commit: `7c1459510cc69752268984c346c2b68e43fd3b65`
- Manual `workflow_dispatch` run: https://github.com/jackwener/OpenCLI/actions/runs/31264223074
- Result: success
- Relevant Windows jobs: `unit-test (windows-latest, 22, 1)` success, `unit-test (windows-latest, 22, 2)` success, `build (windows-latest)` success
