### PR TITLE
fix: 改进 Windows Discord 启动与 CDP 校验

### DIFF
--- a/docs/adapters/desktop/discord.md
+++ b/docs/adapters/desktop/discord.md
@@ -1,65 +1,104 @@
-# Discord
+# Discord 桌面端
 
-Control the **Discord Desktop App** from the terminal via Chrome DevTools Protocol (CDP).
+通过 Chrome DevTools Protocol（CDP）从终端控制已登录的 **Discord Desktop App**。
 
-## Prerequisites
+## 前置条件
 
-Launch with remote debugging port:
+- 已安装 OpenCLI。
+- 已安装 Discord 桌面端并完成登录。
+- CDP 只监听本机 `127.0.0.1:9232`。
+
+正常情况下无需预先设置 `OPENCLI_CDP_ENDPOINT`。直接运行：
+
 ```bash
-/Applications/Discord.app/Contents/MacOS/Discord --remote-debugging-port=9232
+opencli discord-app status -f json
 ```
 
-## Setup
+OpenCLI 会按以下顺序处理：
+
+1. 如果 `9232` 已暴露 Discord 页面目标，直接连接。
+2. macOS/Windows 下自动发现 Discord 安装路径。
+3. 如果 Discord 正在运行但未开启 CDP，先请求确认，再重启应用；确认默认选择“否”，非交互环境不会自动重启。
+4. 使用 `--remote-debugging-port=9232 --remote-allow-origins=*` 启动并等待就绪。
+
+Windows 默认发现 `%LOCALAPPDATA%\Discord\app-*\Discord.exe`。找不到安装目录时，检查 Discord 是否采用了自定义安装路径。
+
+Linux 暂不支持自动发现；请手动启动：
+
+```bash
+discord --remote-debugging-port=9232 --remote-allow-origins=*
+```
+
+只有使用自定义 HTTP(S) 端口或远程端点时才设置：
 
 ```bash
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9232"
 ```
 
-## Commands
+PowerShell：
 
-| Command | Description |
-|---------|-------------|
-| `opencli discord-app status` | Check CDP connection |
-| `opencli discord-app send "message"` | Send a message in the active channel |
-| `opencli discord-app read` | Read recent messages |
-| `opencli discord-app channels` | List channels in the current server, including `guild_id`, `channel_id`, and `url` |
-| `opencli discord-app servers` | List visible joined servers, including `guild_id` and `url` |
-| `opencli discord-app goto` | Open a channel by id/name/url without sending messages |
-| `opencli discord-app threads` | List visible forum/thread posts in a channel |
-| `opencli discord-app thread-read` | Read a forum/thread post by id or URL |
-| `opencli discord-app search "query"` | Search messages (Cmd+F) |
-| `opencli discord-app members` | List online members |
-| `opencli discord-app delete MESSAGE_ID` | Delete a message by its ID |
-
-## Read-only channel targeting
-
-```bash
-# Get stable channel ids/URLs from the currently open server.
-opencli discord-app channels -f json
-
-# Open one channel without clicking the UI.
-opencli discord-app goto --url https://discord.com/channels/<guild_id>/<channel_id>
-opencli discord-app goto --guild <guild_id> --channel <channel_id>
-
-# Read after navigating internally. Omitting the target keeps the old behavior:
-# read the currently active channel.
-opencli discord-app read --url https://discord.com/channels/<guild_id>/<channel_id> --count 20 -f json
-opencli discord-app read --guild <guild_id> --channel <channel_id> --count 20 -f json
+```powershell
+$env:OPENCLI_CDP_ENDPOINT = 'http://127.0.0.1:9232'
 ```
 
-Passing numeric IDs or a channel URL is the most stable mode. Name lookup is
-best-effort for channels visible in the current Discord sidebar.
+CDP 没有应用层认证。不要把调试端点暴露到公网；远程场景应使用受信任的 SSH/VPN 隧道。
 
-Opening a channel through Discord's own route can update Discord's normal
-client-side read/unread state, just like manually opening the channel.
+## 命令
 
-## Forum and thread-style channels
+| 命令 | 说明 |
+|---|---|
+| `opencli discord-app status` | 检查 CDP 连接 |
+| `opencli discord-app send "message"` | 在活动频道发送消息 |
+| `opencli discord-app read` | 读取近期消息 |
+| `opencli discord-app channels` | 列出当前服务器的频道及稳定 ID/URL |
+| `opencli discord-app servers` | 列出侧栏可见的已加入服务器 |
+| `opencli discord-app goto` | 通过 ID、名称或 URL 打开频道，不发送消息 |
+| `opencli discord-app threads` | 列出可见的论坛帖子或线程 |
+| `opencli discord-app thread-read` | 读取指定论坛帖子或线程 |
+| `opencli discord-app search "query"` | 使用 Discord UI 搜索消息 |
+| `opencli discord-app members` | 列出当前频道可见的在线成员 |
+| `opencli discord-app delete MESSAGE_ID` | 删除指定消息 |
+
+## 只读定向采集
+
+优先使用数字 ID 或完整 URL；名称解析仅针对当前侧栏可见频道，属于尽力而为。
 
 ```bash
-# List visible forum/thread post cards from the active or targeted channel.
-opencli discord-app threads --url https://discord.com/channels/<guild_id>/<forum_channel_id> -f json
+# 获取当前服务器的稳定频道 ID/URL。
+opencli discord-app channels -f json
 
-# Read a selected post/thread.
+# 定向读取频道。
+opencli discord-app read --url https://discord.com/channels/<guild_id>/<channel_id> --count 20 -f json
+opencli discord-app read --guild <guild_id> --channel <channel_id> --count 20 -f json
+
+# 仅导航，不读取或发送消息。
+opencli discord-app goto --url https://discord.com/channels/<guild_id>/<channel_id>
+```
+
+通过 Discord 自身路由打开频道，会像人工点击一样改变正常的已读/未读状态。
+
+## 论坛和线程
+
+```bash
+opencli discord-app threads --url https://discord.com/channels/<guild_id>/<forum_channel_id> -f json
 opencli discord-app thread-read --url https://discord.com/channels/<guild_id>/<forum_channel_id>/<thread_id> --count 20 -f json
 opencli discord-app thread-read --guild <guild_id> --channel <forum_channel_id> --thread <thread_id> --count 20 -f json
 ```
+
+## 数据边界
+
+- `read` 只提取当前 DOM 已加载的消息，不提供完整历史分页。
+- 消息正文最多保留约 300 字符。
+- `search` 结果正文最多保留约 200 字符，通常不包含稳定消息 ID。
+- `members` 是当前 UI 可见的在线成员，不是完整成员目录。
+- `threads` 只列出当前 UI 已渲染的帖子卡片。
+
+需要历史同步、SQLite 检索或批量导出时，应使用独立的 `discord-cli` 路径，并明确评估 user-token 自动化的账号风险。
+
+## 故障排查
+
+- `CDP port 9232 is active but does not belong to Discord`：端口被其他 CDP 程序占用；关闭冲突程序后重试。
+- Discord 已运行但命令要求重启：确认后 OpenCLI 才会结束匹配安装目录的 Discord 进程。
+- 找不到 Discord：确认安装位置；自定义 Electron 应用可在 `~/.opencli/apps.yaml` 中登记 `windowsInstallDirs`。
+- Chromium 142+ WebSocket 返回 `403`：确保启动参数包含 `--remote-allow-origins=*`。
+- 选择器漂移：使用 `--trace retain-on-failure`，但 trace 可能包含私密消息，必须按敏感数据处理。

--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -16,6 +16,17 @@ describe('electron-apps registry', () => {
     expect(app!.executableNames).toEqual(['ChatGPT', 'Codex']);
   });
 
+  it('registers Discord Windows discovery and CDP identity metadata', () => {
+    const app = getElectronApp('discord-app');
+
+    expect(app).toMatchObject({
+      port: 9232,
+      processName: 'Discord',
+      windowsInstallDirs: ['%LOCALAPPDATA%\\Discord'],
+      cdpHosts: ['discord.com', 'canary.discord.com', 'ptb.discord.com'],
+    });
+  });
+
   it('keeps builtin Electron app CDP ports unique and off the browser-bridge port', () => {
     const ports = Object.values(builtinApps).map((app) => app.port);
 

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -13,9 +13,9 @@ import yaml from 'js-yaml';
 export interface ElectronAppEntry {
   /** CDP debug port (unique per app) */
   port: number;
-  /** macOS process name for detection via pgrep */
+  /** Process or executable name used for platform-specific detection */
   processName: string;
-  /** Candidate executable names inside Contents/MacOS/, tried in order */
+  /** Candidate executable names, tried in order */
   executableNames?: string[];
   /** macOS bundle ID for path discovery */
   bundleId?: string;
@@ -23,6 +23,10 @@ export interface ElectronAppEntry {
   displayName?: string;
   /** Additional launch args beyond --remote-debugging-port */
   extraArgs?: string[];
+  /** Windows installation roots. Supports %ENV_VAR% placeholders. */
+  windowsInstallDirs?: string[];
+  /** Expected page hosts exposed by the app's CDP target list. */
+  cdpHosts?: string[];
 }
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
@@ -35,7 +39,14 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
     displayName: 'Codex',
   },
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
-  'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
+  'discord-app': {
+    port: 9232,
+    processName: 'Discord',
+    bundleId: 'com.discord.app',
+    displayName: 'Discord',
+    windowsInstallDirs: ['%LOCALAPPDATA%\\Discord'],
+    cdpHosts: ['discord.com', 'canary.discord.com', 'ptb.discord.com'],
+  },
   'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },
   antigravity:   {
     port: 9234,

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -552,24 +552,58 @@ describe('executeCommand', () => {
   });
 
   it('uses launcher for registered Electron apps (chatwise)', async () => {
-    // Mock the launcher to return a fake endpoint (avoids real HTTP/process calls)
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', '');
     const launcher = await import('./launcher.js');
-    const spy = vi.spyOn(launcher, 'resolveElectronEndpoint')
+    const { CDPBridge } = await import('./browser/cdp.js');
+    const launcherSpy = vi.spyOn(launcher, 'resolveElectronEndpoint')
       .mockResolvedValue('http://127.0.0.1:9228');
+    const connectSpy = vi.spyOn(CDPBridge.prototype, 'connect')
+      .mockRejectedValue(new Error('expected test CDP failure'));
 
-    const cmd = cli({
-      site: 'chatwise',
-      name: 'status', access: 'read',
-      description: 'chatwise status',
-      browser: true,
-      strategy: Strategy.PUBLIC,
-      func: async () => [{ ok: true }],
-    });
+    try {
+      const cmd = cli({
+        site: 'chatwise',
+        name: 'status', access: 'read',
+        description: 'chatwise status',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => [{ ok: true }],
+      });
 
-    // CDPBridge.connect() will fail (no actual CDP server), but the launcher
-    // should have been called with 'chatwise'.
-    await expect(executeCommand(cmd, {})).rejects.toThrow();
-    expect(spy).toHaveBeenCalledWith('chatwise');
-    spy.mockRestore();
+      await expect(executeCommand(cmd, {})).rejects.toThrow('expected test CDP failure');
+      expect(launcherSpy).toHaveBeenCalledWith('chatwise');
+      expect(connectSpy).toHaveBeenCalledWith(expect.objectContaining({
+        cdpEndpoint: 'http://127.0.0.1:9228',
+      }));
+    } finally {
+      connectSpy.mockRestore();
+      launcherSpy.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('preserves direct WebSocket overrides for Electron apps without identity metadata', async () => {
+    const endpoint = 'ws://127.0.0.1:9228/devtools/page/test';
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', endpoint);
+    const { CDPBridge } = await import('./browser/cdp.js');
+    const connectSpy = vi.spyOn(CDPBridge.prototype, 'connect')
+      .mockRejectedValue(new Error('expected direct WebSocket failure'));
+
+    try {
+      const cmd = cli({
+        site: 'chatwise',
+        name: 'ws-status-test', access: 'read',
+        description: 'chatwise direct websocket status',
+        browser: true,
+        strategy: Strategy.PUBLIC,
+        func: async () => [{ ok: true }],
+      });
+
+      await expect(executeCommand(cmd, {})).rejects.toThrow('expected direct WebSocket failure');
+      expect(connectSpy).toHaveBeenCalledWith(expect.objectContaining({ cdpEndpoint: endpoint }));
+    } finally {
+      connectSpy.mockRestore();
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -33,8 +33,8 @@ import { profileRouteParams, resolveProfileSelection } from './browser/profile.j
 import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
-import { isElectronApp } from './electron-apps.js';
-import { probeCDP, resolveElectronEndpoint } from './launcher.js';
+import { getElectronApp, isElectronApp } from './electron-apps.js';
+import { probeCDPEndpoint, resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
 
@@ -241,11 +241,20 @@ export async function executeCommand(
         // Electron apps: respect manual endpoint override, then try auto-detect
         const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
         if (manualEndpoint) {
-          const port = Number(new URL(manualEndpoint).port);
-          if (!await probeCDP(port)) {
+          const app = getElectronApp(cmd.site);
+          let protocol: string | undefined;
+          try {
+            protocol = new URL(manualEndpoint).protocol;
+          } catch {
+            // The endpoint probe below returns a controlled error for malformed URLs.
+          }
+          const directWebSocket = protocol === 'ws:' || protocol === 'wss:';
+          const identityRequired = Boolean(app?.cdpHosts?.length);
+          if ((!directWebSocket || identityRequired)
+            && !await probeCDPEndpoint(manualEndpoint, undefined, app?.cdpHosts)) {
             throw new CommandExecutionError(
               `CDP not reachable at ${manualEndpoint}`,
-              'Check that the app is running with --remote-debugging-port and the endpoint is correct.',
+              'Check that the expected app is running with --remote-debugging-port and the endpoint is correct.',
             );
           }
           cdpEndpoint = manualEndpoint;

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -1,18 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
+import { createServer } from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ElectronAppEntry } from './electron-apps.js';
+import { getElectronApp, type ElectronAppEntry } from './electron-apps.js';
 import {
   detectAppProcess,
   detectProcess,
   discoverAppPath,
+  discoverWindowsAppPath,
   electronLaunchArgs,
   findAppProcessPids,
   killAppProcess,
   launchDetachedApp,
   launchElectronApp,
   probeCDP,
+  probeCDPEndpoint,
+  resolveElectronEndpoint,
   resolveExecutableCandidates,
 } from './launcher.js';
 
@@ -44,13 +48,60 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
   spawn: vi.fn(),
 }));
+vi.mock('./tui.js', () => ({
+  confirmPrompt: vi.fn(),
+}));
 
 const cp = vi.mocked(await import('node:child_process'));
+const tui = vi.mocked(await import('./tui.js'));
 
 describe('probeCDP', () => {
   it('returns false when CDP endpoint is unreachable', async () => {
     const result = await probeCDP(59999, 500);
     expect(result).toBe(false);
+  });
+
+  it('validates the expected Electron target host', async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify([{ type: 'page', url: 'https://discord.com/channels/@me' }]));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Test server did not expose a TCP port');
+
+    try {
+      await expect(probeCDP(address.port, 500, ['discord.com'])).resolves.toBe(true);
+      await expect(probeCDP(address.port, 500, ['example.com'])).resolves.toBe(false);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it('probes the exact custom endpoint and preserves its path prefix', async () => {
+    const seenPaths: string[] = [];
+    const server = createServer((req, res) => {
+      seenPaths.push(req.url ?? '');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify([{ type: 'page', url: 'https://discord.com/channels/@me' }]));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Test server did not expose a TCP port');
+
+    try {
+      await expect(
+        probeCDPEndpoint(`http://127.0.0.1:${address.port}/custom-cdp`, 500, ['discord.com']),
+      ).resolves.toBe(true);
+      expect(seenPaths).toEqual(['/custom-cdp/json']);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it('rejects malformed and non-HTTP custom endpoints', async () => {
+    await expect(probeCDPEndpoint('not a URL')).resolves.toBe(false);
+    await expect(probeCDPEndpoint('ws://127.0.0.1:9232')).resolves.toBe(false);
   });
 });
 
@@ -127,6 +178,30 @@ describe('discoverAppPath', () => {
   });
 });
 
+describe('discoverWindowsAppPath', () => {
+  it('chooses the newest Squirrel app directory from an explicit install root', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-windows-launcher-'));
+    const installRoot = path.join(tempDir, 'Discord');
+    const olderDir = path.join(installRoot, 'app-1.0.9');
+    const newerDir = path.join(installRoot, 'app-1.0.10');
+    fs.mkdirSync(olderDir, { recursive: true });
+    fs.mkdirSync(newerDir, { recursive: true });
+    fs.writeFileSync(path.join(olderDir, 'Discord.exe'), '');
+    fs.writeFileSync(path.join(newerDir, 'Discord.exe'), '');
+
+    try {
+      expect(discoverWindowsAppPath({
+        processName: 'Discord',
+        windowsInstallDirs: ['%OPENCLI_TEST_DISCORD_ROOT%'],
+      }, {
+        OPENCLI_TEST_DISCORD_ROOT: installRoot,
+      })).toBe(newerDir);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('launchDetachedApp', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -172,6 +247,135 @@ describe('resolveExecutableCandidates', () => {
       '/Applications/Antigravity.app/Contents/MacOS/Electron',
       '/Applications/Antigravity.app/Contents/MacOS/Antigravity',
     ]);
+  });
+
+  it.skipIf(process.platform !== 'win32')('resolves Windows executable names inside the discovered app directory', () => {
+    const app: ElectronAppEntry = {
+      port: 9232,
+      processName: 'Discord',
+    };
+
+    expect(resolveExecutableCandidates('C:\\Users\\demo\\AppData\\Local\\Discord\\app-1.0.10', app)).toEqual([
+      'C:\\Users\\demo\\AppData\\Local\\Discord\\app-1.0.10\\Discord.exe',
+    ]);
+  });
+});
+
+describe.skipIf(process.platform !== 'win32')('Windows app-scoped process management', () => {
+  const appPath = 'C:\\Users\\demo\\AppData\\Local\\Discord\\app-1.0.10';
+  const discordApp: ElectronAppEntry = {
+    port: 9232,
+    processName: 'Discord',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cp.execFileSync.mockReset();
+    cp.spawn.mockReset();
+    tui.confirmPrompt.mockReset();
+  });
+
+  it('matches only processes whose executable belongs to the discovered app directory', () => {
+    cp.execFileSync.mockImplementation((command) => {
+      if (command !== 'powershell.exe') throw new Error(`unexpected command ${String(command)}`);
+      return JSON.stringify([
+        { ProcessId: 101, ExecutablePath: `${appPath}\\Discord.exe`, CommandLine: `"${appPath}\\Discord.exe"` },
+        { ProcessId: 202, ExecutablePath: 'C:\\Other\\Discord.exe', CommandLine: '"C:\\Other\\Discord.exe"' },
+      ]);
+    });
+
+    expect(findAppProcessPids(appPath, discordApp)).toEqual([101]);
+  });
+
+  it('requires an executable boundary when falling back to the command line', () => {
+    cp.execFileSync.mockImplementation((command) => {
+      if (command !== 'powershell.exe') throw new Error(`unexpected command ${String(command)}`);
+      return JSON.stringify([
+        { ProcessId: 303, ExecutablePath: null, CommandLine: `"${appPath}\\Discord.exe" --type=renderer` },
+        { ProcessId: 404, ExecutablePath: null, CommandLine: `"${appPath}\\Discord.exe.backup" --type=renderer` },
+        { ProcessId: 405, ExecutablePath: null, CommandLine: `"${appPath}\\Discord.exe"unexpected` },
+      ]);
+    });
+
+    expect(findAppProcessPids(appPath, discordApp)).toEqual([303]);
+  });
+
+  it('requests a graceful taskkill before considering force', async () => {
+    let running = true;
+    cp.execFileSync.mockImplementation((command, args) => {
+      if (command === 'powershell.exe') {
+        return running
+          ? JSON.stringify([{ ProcessId: 101, ExecutablePath: `${appPath}\\Discord.exe`, CommandLine: null }])
+          : '[]';
+      }
+      if (command === 'taskkill.exe') {
+        expect(args).toEqual(['/PID', '101', '/T']);
+        running = false;
+        return '';
+      }
+      throw new Error(`unexpected command ${String(command)}`);
+    });
+
+    await killAppProcess(appPath, discordApp);
+
+    expect(cp.execFileSync).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/PID', '101', '/T'],
+      { stdio: 'pipe', timeout: 5_000 },
+    );
+  });
+
+  it('defaults restart confirmation to no and leaves the running app untouched', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-discord-confirm-'));
+    const appDir = path.join(tempDir, 'app-1.0.10');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(path.join(appDir, 'Discord.exe'), '');
+
+    const portServer = createServer();
+    await new Promise<void>((resolve) => portServer.listen(0, '127.0.0.1', resolve));
+    const address = portServer.address();
+    if (!address || typeof address === 'string') throw new Error('Test server did not expose a TCP port');
+    await new Promise<void>((resolve, reject) => portServer.close((error) => error ? reject(error) : resolve()));
+
+    const app = getElectronApp('discord-app');
+    if (!app) throw new Error('Discord app is not registered');
+    const original = {
+      ...app,
+      windowsInstallDirs: app.windowsInstallDirs ? [...app.windowsInstallDirs] : undefined,
+      cdpHosts: app.cdpHosts ? [...app.cdpHosts] : undefined,
+    };
+
+    Object.assign(app, {
+      port: address.port,
+      processName: 'Discord',
+      displayName: 'Discord',
+      windowsInstallDirs: [tempDir],
+      cdpHosts: ['discord.com'],
+    });
+    cp.execFileSync.mockImplementation((command) => {
+      if (command === 'powershell.exe') {
+        return JSON.stringify([{
+          ProcessId: 101,
+          ExecutablePath: `${appDir}\\Discord.exe`,
+          CommandLine: `"${appDir}\\Discord.exe"`,
+        }]);
+      }
+      throw new Error(`unexpected command ${String(command)}`);
+    });
+    tui.confirmPrompt.mockResolvedValue(false);
+
+    try {
+      await expect(resolveElectronEndpoint('discord-app')).rejects.toThrow('needs to be restarted');
+      expect(tui.confirmPrompt).toHaveBeenCalledWith(
+        'Discord is running but CDP is not enabled. Restart with debug port?',
+        false,
+      );
+      expect(cp.spawn).not.toHaveBeenCalled();
+      expect(cp.execFileSync.mock.calls.some(([command]) => command === 'taskkill.exe')).toBe(false);
+    } finally {
+      Object.assign(app, original);
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -12,6 +12,7 @@
 import { execFileSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 import * as path from 'node:path';
 import type { ElectronAppEntry } from './electron-apps.js';
 import { getElectronApp } from './electron-apps.js';
@@ -23,6 +24,18 @@ const POLL_INTERVAL_MS = 500;
 const POLL_TIMEOUT_MS = 15_000;
 const PROBE_TIMEOUT_MS = 2_000;
 const KILL_GRACE_MS = 3_000;
+const MAX_CDP_RESPONSE_BYTES = 1_000_000;
+
+interface WindowsProcessRow {
+  pid: number;
+  executablePath: string | null;
+  commandLine: string | null;
+}
+
+type ElectronAppPathEntry = Pick<
+  ElectronAppEntry,
+  'processName' | 'displayName' | 'bundleId' | 'executableNames' | 'windowsInstallDirs'
+>;
 
 function parsePgrepOutput(output: string): number[] {
   return output
@@ -31,23 +44,181 @@ function parsePgrepOutput(output: string): number[] {
     .filter((value) => Number.isInteger(value) && value > 0);
 }
 
+function cdpTargetsMatchHosts(body: string, expectedHosts: readonly string[]): boolean {
+  if (expectedHosts.length === 0) return true;
+
+  try {
+    const targets = JSON.parse(body) as unknown;
+    if (!Array.isArray(targets)) return false;
+    const normalizedHosts = expectedHosts.map((host) => host.toLowerCase());
+    return targets.some((target) => {
+      if (!target || typeof target !== 'object' || !('url' in target) || typeof target.url !== 'string') return false;
+      try {
+        const hostname = new URL(target.url).hostname.toLowerCase();
+        return normalizedHosts.some((host) => hostname === host || hostname.endsWith(`.${host}`));
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
+}
+
+function windowsProcessQuery(processName: string): string {
+  const escapedName = processName.replace(/'/g, "''");
+  return `
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$targetName = '${escapedName}'
+@(
+  Get-CimInstance Win32_Process |
+    Where-Object { $_.Name -ieq $targetName } |
+    ForEach-Object {
+      [pscustomobject]@{
+        ProcessId = $_.ProcessId
+        ExecutablePath = $_.ExecutablePath
+        CommandLine = $_.CommandLine
+      }
+    }
+) | ConvertTo-Json -Compress
+`;
+}
+
+function parseWindowsProcessOutput(output: string): WindowsProcessRow[] {
+  if (!output.trim()) return [];
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    const rows = Array.isArray(parsed) ? parsed : [parsed];
+    return rows.flatMap((row) => {
+      if (!row || typeof row !== 'object') return [];
+      const raw = row as Record<string, unknown>;
+      const pid = Number(raw.ProcessId);
+      if (!Number.isInteger(pid) || pid <= 0) return [];
+      return [{
+        pid,
+        executablePath: typeof raw.ExecutablePath === 'string' && raw.ExecutablePath ? raw.ExecutablePath : null,
+        commandLine: typeof raw.CommandLine === 'string' && raw.CommandLine ? raw.CommandLine : null,
+      }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function windowsExecutableName(processName: string): string {
+  return processName.toLowerCase().endsWith('.exe') ? processName : `${processName}.exe`;
+}
+
+function windowsCommandStartsWithExecutable(commandLine: string, executable: string): boolean {
+  const command = commandLine.trim().toLowerCase();
+  const candidate = path.win32.normalize(executable).toLowerCase();
+  const quotedCandidate = `"${candidate}"`;
+  if (command.startsWith(quotedCandidate)) {
+    const next = command.charAt(quotedCandidate.length);
+    return next === '' || /\s/.test(next);
+  }
+  if (!command.startsWith(candidate)) return false;
+  const next = command.charAt(candidate.length);
+  return next === '' || /\s/.test(next);
+}
+
+function findWindowsProcesses(processName: string): WindowsProcessRow[] {
+  try {
+    const output = execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      windowsProcessQuery(windowsExecutableName(processName)),
+    ], { encoding: 'utf-8', stdio: 'pipe', timeout: 5_000 });
+    return parseWindowsProcessOutput(output);
+  } catch {
+    return [];
+  }
+}
+
+function taskkill(pid: number, force: boolean): void {
+  try {
+    execFileSync('taskkill.exe', [
+      '/PID',
+      String(pid),
+      '/T',
+      ...(force ? ['/F'] : []),
+    ], { stdio: 'pipe', timeout: 5_000 });
+  } catch {
+    // Process may have already exited or rejected a graceful close.
+  }
+}
+
 /**
- * Probe whether a CDP endpoint is listening on the given port.
- * Returns true if http://127.0.0.1:{port}/json responds successfully.
+ * Probe an HTTP(S) CDP endpoint.
+ * When expectedHosts is provided, at least one page target must belong to that app.
  */
-export function probeCDP(port: number, timeoutMs: number = PROBE_TIMEOUT_MS): Promise<boolean> {
+export function probeCDPEndpoint(
+  endpoint: string,
+  timeoutMs: number = PROBE_TIMEOUT_MS,
+  expectedHosts: readonly string[] = [],
+): Promise<boolean> {
+  let target: URL;
+  try {
+    target = new URL(endpoint);
+    target.pathname = `${target.pathname.replace(/\/$/, '')}/json`;
+    target.search = '';
+    target.hash = '';
+  } catch {
+    return Promise.resolve(false);
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') return Promise.resolve(false);
+
   return new Promise((resolve) => {
-    const req = httpRequest(
-      { hostname: '127.0.0.1', port, path: '/json', method: 'GET', timeout: timeoutMs },
+    let settled = false;
+    const finish = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const request = target.protocol === 'https:' ? httpsRequest : httpRequest;
+    const req = request(
+      target,
+      { method: 'GET', timeout: timeoutMs },
       (res) => {
-        res.resume();
-        resolve(res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300);
+        const success = res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300;
+        if (!success) {
+          res.resume();
+          finish(false);
+          return;
+        }
+        if (expectedHosts.length === 0) {
+          res.resume();
+          finish(true);
+          return;
+        }
+
+        res.setEncoding('utf-8');
+        let body = '';
+        res.on('data', (chunk: string) => {
+          body += chunk;
+          if (body.length > MAX_CDP_RESPONSE_BYTES) {
+            req.destroy();
+            finish(false);
+          }
+        });
+        res.on('error', () => finish(false));
+        res.on('end', () => finish(cdpTargetsMatchHosts(body, expectedHosts)));
       },
     );
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.on('error', () => finish(false));
+    req.on('timeout', () => { req.destroy(); finish(false); });
     req.end();
   });
+}
+
+/** Probe a loopback CDP endpoint by port. */
+export function probeCDP(
+  port: number,
+  timeoutMs: number = PROBE_TIMEOUT_MS,
+  expectedHosts: readonly string[] = [],
+): Promise<boolean> {
+  return probeCDPEndpoint(`http://127.0.0.1:${port}`, timeoutMs, expectedHosts);
 }
 
 /**
@@ -115,17 +286,90 @@ export async function killProcess(processName: string): Promise<void> {
   }
 }
 
-/**
- * Discover the app installation path on macOS.
- * Uses Launch Services/Spotlight metadata to resolve the app to a POSIX path.
- * Returns null if the app is not installed.
- */
+/** Discover the app installation path supported by the current platform. */
 export function discoverAppPath(displayName: string, bundleId?: string): string | null {
-  return discoverAppPathForEntry({ displayName, bundleId });
+  return discoverAppPathForEntry({ displayName, bundleId, processName: displayName });
 }
 
 function normalizeAppPath(appPath: string): string {
-  return appPath.trim().replace(/\/$/, '');
+  return appPath.trim().replace(/[\\/]+$/, '');
+}
+
+function getEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const matched = Object.keys(env).find((key) => key.toLowerCase() === name.toLowerCase());
+  return matched ? env[matched] : undefined;
+}
+
+function expandWindowsEnvironment(value: string, env: NodeJS.ProcessEnv): string | null {
+  const expanded = value.replace(/%([^%]+)%/g, (match, name: string) => getEnvironmentValue(env, name) ?? match);
+  return /%[^%]+%/.test(expanded) ? null : normalizeAppPath(expanded);
+}
+
+function uniquePaths(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = value.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function windowsInstallRoots(app: ElectronAppPathEntry, env: NodeJS.ProcessEnv): string[] {
+  const roots = (app.windowsInstallDirs ?? [])
+    .map((value) => expandWindowsEnvironment(value, env))
+    .filter((value): value is string => Boolean(value));
+  const labels = [...new Set([app.displayName, app.processName].filter((value): value is string => Boolean(value)))];
+  const localAppData = getEnvironmentValue(env, 'LOCALAPPDATA');
+  const programFiles = getEnvironmentValue(env, 'ProgramFiles');
+  const programFilesX86 = getEnvironmentValue(env, 'ProgramFiles(x86)');
+
+  for (const label of labels) {
+    if (localAppData) {
+      roots.push(path.join(localAppData, label));
+      roots.push(path.join(localAppData, 'Programs', label));
+    }
+    if (programFiles) roots.push(path.join(programFiles, label));
+    if (programFilesX86) roots.push(path.join(programFilesX86, label));
+  }
+  return uniquePaths(roots.map(normalizeAppPath));
+}
+
+function windowsExecutableNames(app: ElectronAppPathEntry): string[] {
+  const names = app.executableNames?.length ? app.executableNames : [app.processName];
+  return [...new Set(names.map(windowsExecutableName))];
+}
+
+function findWindowsExecutable(root: string, executableNames: readonly string[]): string | null {
+  for (const name of executableNames) {
+    const direct = path.join(root, name);
+    if (fs.existsSync(direct)) return direct;
+  }
+
+  try {
+    const appDirs = fs.readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && /^app-/i.test(entry.name))
+      .map((entry) => entry.name)
+      .sort((left, right) => right.localeCompare(left, undefined, { numeric: true, sensitivity: 'base' }));
+    for (const appDir of appDirs) {
+      for (const name of executableNames) {
+        const candidate = path.join(root, appDir, name);
+        if (fs.existsSync(candidate)) return candidate;
+      }
+    }
+  } catch {
+    // Missing or unreadable install root.
+  }
+  return null;
+}
+
+export function discoverWindowsAppPath(app: ElectronAppPathEntry, env: NodeJS.ProcessEnv = process.env): string | null {
+  const executableNames = windowsExecutableNames(app);
+  for (const root of windowsInstallRoots(app, env)) {
+    const executable = findWindowsExecutable(root, executableNames);
+    if (executable) return path.dirname(executable);
+  }
+  return null;
 }
 
 function appleScriptString(value: string): string {
@@ -163,10 +407,9 @@ function discoverAppPathByBundleId(bundleId: string): string | null {
   }
 }
 
-function discoverAppPathForEntry(app: Pick<ElectronAppEntry, 'displayName' | 'bundleId'> & { processName?: string }): string | null {
-  if (process.platform !== 'darwin') {
-    return null;
-  }
+function discoverAppPathForEntry(app: ElectronAppPathEntry): string | null {
+  if (process.platform === 'win32') return discoverWindowsAppPath(app);
+  if (process.platform !== 'darwin') return null;
 
   if (app.bundleId) {
     const byBundleId = discoverAppPathByOsascript(app.bundleId, 'id') ?? discoverAppPathByBundleId(app.bundleId);
@@ -178,6 +421,9 @@ function discoverAppPathForEntry(app: Pick<ElectronAppEntry, 'displayName' | 'bu
 }
 
 function resolveExecutable(appPath: string, processName: string): string {
+  if (process.platform === 'win32' && !appPath.toLowerCase().endsWith('.app')) {
+    return path.join(appPath, windowsExecutableName(processName));
+  }
   return `${appPath}/Contents/MacOS/${processName}`;
 }
 
@@ -211,8 +457,6 @@ export function resolveExecutableCandidates(appPath: string, app: ElectronAppEnt
 }
 
 export function findAppProcessPids(appPath: string, app: ElectronAppEntry): number[] {
-  if (process.platform === 'win32') return [];
-
   const executables = resolveExecutableCandidates(appPath, app);
   const candidatesByName = new Map<string, string[]>();
   for (const executable of executables) {
@@ -221,6 +465,25 @@ export function findAppProcessPids(appPath: string, app: ElectronAppEntry): numb
   }
 
   const matched = new Set<number>();
+  if (process.platform === 'win32') {
+    for (const [processName, candidates] of candidatesByName) {
+      const normalizedCandidates = new Set(candidates.map((candidate) => path.win32.normalize(candidate).toLowerCase()));
+      for (const row of findWindowsProcesses(processName)) {
+        if (row.executablePath && normalizedCandidates.has(path.win32.normalize(row.executablePath).toLowerCase())) {
+          matched.add(row.pid);
+          continue;
+        }
+        const commandLine = row.commandLine;
+        if (commandLine) {
+          if (candidates.some((candidate) => windowsCommandStartsWithExecutable(commandLine, candidate))) {
+            matched.add(row.pid);
+          }
+        }
+      }
+    }
+    return [...matched];
+  }
+
   for (const [processName, candidates] of candidatesByName) {
     for (const pid of findProcessPids(processName)) {
       const command = readProcessCommand(pid);
@@ -238,7 +501,18 @@ export function detectAppProcess(appPath: string, app: ElectronAppEntry): boolea
 }
 
 export async function killAppProcess(appPath: string, app: ElectronAppEntry): Promise<void> {
-  if (process.platform === 'win32') return;
+  if (process.platform === 'win32') {
+    for (const pid of findAppProcessPids(appPath, app)) taskkill(pid, false);
+
+    const deadline = Date.now() + KILL_GRACE_MS;
+    while (Date.now() < deadline) {
+      if (findAppProcessPids(appPath, app).length === 0) return;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    for (const pid of findAppProcessPids(appPath, app)) taskkill(pid, true);
+    return;
+  }
 
   for (const pid of findAppProcessPids(appPath, app)) {
     try {
@@ -314,8 +588,11 @@ export async function launchElectronApp(appPath: string, app: ElectronAppEntry, 
   }
 
   if (executables.length > 1) {
+    const location = process.platform === 'win32' && !appPath.toLowerCase().endsWith('.app')
+      ? appPath
+      : path.join(appPath, 'Contents', 'MacOS');
     throw new CommandExecutionError(
-      `Could not launch ${label}: no compatible executable found in ${path.join(appPath, 'Contents', 'MacOS')}`,
+      `Could not launch ${label}: no compatible executable found in ${location}`,
       `Tried: ${executables.map((executable) => path.basename(executable)).join(', ')}. Install ${label}, reinstall it, or register a custom app path in ~/.opencli/apps.yaml`,
     );
   }
@@ -338,10 +615,10 @@ function manualElectronLaunchHint(label: string, port: number): string {
   return `Start ${label} manually with --remote-debugging-port=${port} --remote-allow-origins=*, then either:`;
 }
 
-async function pollForReady(port: number): Promise<void> {
+async function pollForReady(port: number, expectedHosts: readonly string[] = []): Promise<void> {
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (await probeCDP(port, 1_000)) return;
+    if (await probeCDP(port, 1_000, expectedHosts)) return;
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
   throw new CommandExecutionError(
@@ -370,13 +647,20 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
 
   // Step 1: Already running with CDP?
   log.debug(`[launcher] Probing CDP on port ${port}...`);
-  if (await probeCDP(port)) {
+  if (await probeCDP(port, PROBE_TIMEOUT_MS, app.cdpHosts)) {
     log.debug(`[launcher] CDP already available on port ${port}`);
     return endpoint;
   }
 
-  // Step 2: Running without CDP? (process detection requires Unix tools)
-  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  if (app.cdpHosts?.length && await probeCDP(port)) {
+    throw new CommandExecutionError(
+      `CDP port ${port} is active but does not belong to ${label}.`,
+      `Close the conflicting process on 127.0.0.1:${port}, or configure a different port for ${label}.`,
+    );
+  }
+
+  // Step 2: Running without CDP? Auto-launch currently supports macOS and Windows.
+  if (process.platform !== 'darwin' && process.platform !== 'win32') {
     throw new CommandExecutionError(
       `${label} is not reachable on CDP port ${port}.`,
       `Auto-launch is not yet supported on ${process.platform}.\n` +
@@ -400,7 +684,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
     log.debug(`[launcher] ${label} is running but CDP not available`);
     const confirmed = await confirmPrompt(
       `${label} is running but CDP is not enabled. Restart with debug port?`,
-      true,
+      false,
     );
     if (!confirmed) {
       throw new CommandExecutionError(
@@ -426,7 +710,7 @@ export async function resolveElectronEndpoint(site: string): Promise<string> {
 
   // Step 5: Poll for readiness
   process.stderr.write(`  Waiting for ${label} on port ${port}...\n`);
-  await pollForReady(port);
+  await pollForReady(port, app.cdpHosts);
   process.stderr.write(`  Connected to ${label} on port ${port}.\n`);
 
   return endpoint;


### PR DESCRIPTION
## 说明

本 PR 改进 Windows 上 Discord 桌面适配器的应用发现、启动与 CDP 连接流程：

- 自动发现 `%LOCALAPPDATA%` 下 Discord 的最新安装版本。
- Discord 已运行但未启用 CDP 时，交互式请求确认后再重启；非交互环境默认拒绝。
- 仅结束与已确认安装目录匹配的 Discord 进程。
- 校验 CDP `/json` 目标确实属于 Discord，避免连接到占用同一端口的其他 Electron 应用。
- 精确探测自定义 HTTP(S) CDP 端点，同时保留直接 WebSocket 端点兼容性。
- 补充 Windows、身份校验、确认流程和异常路径测试，并更新 Discord 桌面适配器文档。

Related issue: 无

## 变更类型

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## 检查清单

- [x] 已运行本 PR 相关检查
- [x] 已补充测试和文档
- [x] 已提供验证输出

### 文档

- [x] 已更新 `docs/adapters/desktop/discord.md`
- [x] 本次未改变命令发现入口，无需更新 README 或侧边栏

## 验证输出

- `npm run typecheck`：通过
- `npx vitest run --project unit src/launcher.test.ts src/electron-apps.test.ts src/engine.test.ts --reporter=dot`：59 项通过，10 项平台跳过