### PR TITLE
fix: 兼容 Windows prepare 脚本

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "preuninstall": "node -e \"fetch('http://127.0.0.1:19825/shutdown',{method:'POST',headers:{'X-OpenCLI':'1'},signal:AbortSignal.timeout(3000)}).catch(()=>{})\" || true",
     "postinstall": "node scripts/postinstall.js || true; node scripts/fetch-adapters.js || true",
     "typecheck": "tsc --noEmit",
-    "prepare": "[ -d src ] && npm run build || true",
+    "prepare": "node scripts/prepare.cjs",
     "prepublishOnly": "npm run build",
     "test": "vitest run --project unit --project extension --project adapter",
     "test:bun": "bun vitest run --project unit --project extension --project adapter",

--- a/scripts/prepare.cjs
+++ b/scripts/prepare.cjs
@@ -1,0 +1,22 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+if (!fs.existsSync(path.join(process.cwd(), 'src'))) {
+  process.exit(0);
+}
+
+const npmExecPath = process.env.npm_execpath;
+const command = npmExecPath ? process.execPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+const args = npmExecPath ? [npmExecPath, 'run', 'build'] : ['run', 'build'];
+const result = spawnSync(command, args, {
+  stdio: 'inherit',
+  shell: !npmExecPath && process.platform === 'win32',
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/prepare.cjs
+++ b/scripts/prepare.cjs
@@ -7,11 +7,16 @@ if (!fs.existsSync(path.join(process.cwd(), 'src'))) {
 }
 
 const npmExecPath = process.env.npm_execpath;
-const command = npmExecPath ? process.execPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
-const args = npmExecPath ? [npmExecPath, 'run', 'build'] : ['run', 'build'];
+// npm, pnpm, and Yarn expose a JavaScript CLI entry here, which Node can run
+// directly. Bun exposes its native executable instead; passing that binary to
+// Node would make `bun install` fail during prepare, so use npm for non-JS
+// runners (the build scripts themselves already invoke npm).
+const hasJsExecPath = npmExecPath && /\.(?:c|m)?js$/i.test(npmExecPath);
+const command = hasJsExecPath ? process.execPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+const args = hasJsExecPath ? [npmExecPath, 'run', 'build'] : ['run', 'build'];
 const result = spawnSync(command, args, {
   stdio: 'inherit',
-  shell: !npmExecPath && process.platform === 'win32',
+  shell: !hasJsExecPath && process.platform === 'win32',
 });
 
 if (result.error) {


### PR DESCRIPTION
## 说明

现有 `prepare` 使用 POSIX shell 条件表达式，在 Windows npm 环境中无法执行。本 PR 将其替换为跨平台 Node.js 入口：

- 源码目录存在时，通过当前 npm 执行入口运行 `npm run build`。
- 发布包或其他不包含 `src` 的目录中直接成功退出，保持原有跳过语义。
- 正确透传构建失败和进程启动错误。

Related issue: 无

## 变更类型

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🔧 CI / build / tooling

## 检查清单

- [x] 已运行本 PR 相关检查
- [ ] 无需更新测试或文档
- [x] 已提供验证输出

## 验证输出

- Windows 源码仓库执行 `node scripts/prepare.cjs`：构建成功，生成 1331 条 manifest 记录
- 在不包含 `src` 的目录执行同一脚本：退出码 0