### PR TITLE
fix(twitter): use dynamic features for profile command

### DIFF
--- a/clis/twitter/profile.js
+++ b/clis/twitter/profile.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { describeTwitterApiError, normalizeTwitterScreenName, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+import { describeTwitterApiError, normalizeTwitterScreenName, resolveTwitterQueryId, resolveTwitterOperationMetadata, unwrapBrowserResult } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
 
@@ -93,7 +93,9 @@ cli({
         const ct0 = cookies.find((c) => c.name === 'ct0')?.value || null;
         if (!ct0)
             throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
-        const queryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
+        const __op = await resolveTwitterOperationMetadata(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
+        const queryId = __op.queryId;
+        const __featuresJson = JSON.stringify(__op.features || {});
         const rawResult = unwrapBrowserResult(await page.evaluate(`
       async () => {
         const screenName = ${JSON.stringify(username)};
@@ -111,20 +113,7 @@ cli({
           screen_name: screenName,
           withSafetyModeUserFields: true,
         });
-        const features = JSON.stringify({
-          hidden_profile_subscriptions_enabled: true,
-          rweb_tipjar_consumption_enabled: true,
-          responsive_web_graphql_exclude_directive_enabled: true,
-          verified_phone_label_enabled: false,
-          subscriptions_verification_info_is_identity_verified_enabled: true,
-          subscriptions_verification_info_verified_since_enabled: true,
-          highlights_tweets_tab_ui_enabled: true,
-          responsive_web_twitter_article_notes_tab_enabled: true,
-          subscriptions_feature_can_gift_premium: true,
-          creator_subscriptions_tweet_preview_api_enabled: true,
-          responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-          responsive_web_graphql_timeline_navigation_enabled: true,
-        });
+        const features = ${JSON.stringify(__featuresJson)};
 
         const url = '/i/api/graphql/' + ${JSON.stringify(queryId)} + '/UserByScreenName?variables='
           + encodeURIComponent(variables)


### PR DESCRIPTION
## Summary

Fixes #2273

`opencli twitter profile` returns `0` for `followers/following/tweets/likes` and empty for `bio` because it uses hardcoded `features` flags that Twitter no longer accepts.

## Problem

`clis/twitter/profile.js` hardcodes 13 feature flags for the `UserByScreenName` GraphQL API. When these flags are outdated, Twitter returns a truncated response missing `relationship_counts`, `legacy`, `profile_bio`, `tweet_counts`, and `action_counts` — so all numeric fields default to `0` and `bio` to empty string.

Meanwhile, `shared.js` already provides `resolveTwitterOperationMetadata()` which returns both the correct `queryId` AND the current `features` (fetched from `fa0311/twitter-openapi`). But `profile.js` only calls `resolveTwitterQueryId()` which discards the features.

## Fix

**3 changes in `clis/twitter/profile.js`:**

1. Import `resolveTwitterOperationMetadata` from `shared.js`
2. Replace `resolveTwitterQueryId()` with `resolveTwitterOperationMetadata()` to get both `queryId` and `features`
3. Replace the hardcoded `features` block with the dynamically-resolved features, injected into `page.evaluate` via template literal

```diff
- import { ..., resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+ import { ..., resolveTwitterQueryId, resolveTwitterOperationMetadata, unwrapBrowserResult } from './shared.js';

- const queryId = await resolveTwitterQueryId(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
+ const __op = await resolveTwitterOperationMetadata(page, 'UserByScreenName', USER_BY_SCREEN_NAME_QUERY_ID);
+ const queryId = __op.queryId;
+ const __featuresJson = JSON.stringify(__op.features || {});

- const features = JSON.stringify({
-   hidden_profile_subscriptions_enabled: true,
-   // ... 13 hardcoded flags
- });
+ const features = ${JSON.stringify(__featuresJson)};
```

## Verification

**Before (hardcoded features):**
```json
{"screen_name": "elonmusk", "name": "Elon Musk", "bio": "", "followers": 0, "tweets": 0, "likes": 0}
```

**After (dynamic features):**
```json
{"screen_name": "elonmusk", "name": "Elon Musk", "bio": "https://t.co/ZdBx5WABYx", "followers": 241243979, "following": 1386, "tweets": 106924, "likes": 243349}
```

Tested with `OPENCLI_HEADFUL=1 OPENCLI_KEEP_TAB=true opencli twitter profile @elonmusk --format json`.