### PR TITLE
feat(xiaohongshu): add search filter panel options (--sort/--note-type/--publish-time/--scope/--location)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -44972,6 +44972,70 @@
         "default": 20,
         "required": false,
         "help": "Number of results"
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "comprehensive",
+        "required": false,
+        "help": "Sort order",
+        "choices": [
+          "comprehensive",
+          "latest",
+          "most-liked",
+          "most-commented",
+          "most-collected"
+        ]
+      },
+      {
+        "name": "note-type",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "Note type",
+        "choices": [
+          "all",
+          "video",
+          "image"
+        ]
+      },
+      {
+        "name": "publish-time",
+        "type": "string",
+        "default": "anytime",
+        "required": false,
+        "help": "Publish time range",
+        "choices": [
+          "anytime",
+          "day",
+          "week",
+          "half-year"
+        ]
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "Search scope",
+        "choices": [
+          "all",
+          "seen",
+          "unseen",
+          "following"
+        ]
+      },
+      {
+        "name": "location",
+        "type": "string",
+        "default": "all",
+        "required": false,
+        "help": "Location distance",
+        "choices": [
+          "all",
+          "same-city",
+          "nearby"
+        ]
       }
     ],
     "columns": [

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -26,7 +26,7 @@ const WAIT_FOR_CONTENT_JS = `
     const detect = () => {
       if (findNoteCard()) return 'content';
       const bodyText = document.body?.innerText || '';
-      if (/登录后查看搜索结果/.test(bodyText)) return 'login_wall';
+      if (/登录后查看搜索结果/.test(bodyText) || document.querySelector('#login-btn')) return 'login_wall';
       if (/请求太频繁|访问频次异常|安全限制/.test(bodyText)) return 'security_block';
       return null;
     };
@@ -42,6 +42,30 @@ const WAIT_FOR_CONTENT_JS = `
 `;
 const DEFAULT_HARVEST_STEP = 900;
 const CONTENT_WAIT_SECONDS = 5;
+const FILTER_SETTLE_SECONDS = 8;
+
+const SEARCH_FILTERS = [
+    {
+        arg: 'sort', group: '排序依据', defaultValue: 'comprehensive',
+        options: { comprehensive: '综合', latest: '最新', 'most-liked': '最多点赞', 'most-commented': '最多评论', 'most-collected': '最多收藏' },
+    },
+    {
+        arg: 'note-type', group: '笔记类型', defaultValue: 'all',
+        options: { all: '不限', video: '视频', image: '图文' },
+    },
+    {
+        arg: 'publish-time', group: '发布时间', defaultValue: 'anytime',
+        options: { anytime: '不限', day: '一天内', week: '一周内', 'half-year': '半年内' },
+    },
+    {
+        arg: 'scope', group: '搜索范围', defaultValue: 'all',
+        options: { all: '不限', seen: '已看过', unseen: '未看过', following: '已关注' },
+    },
+    {
+        arg: 'location', group: '位置距离', defaultValue: 'all',
+        options: { all: '不限', 'same-city': '同城', nearby: '附近' },
+    },
+];
 
 function isCollapsedRender(diag) {
     return diag.cardCount > 1 &&
@@ -307,6 +331,195 @@ export function parseLimit(raw) {
     }
     return parsed;
 }
+
+function resolveSearchFilters(kwargs) {
+    return SEARCH_FILTERS.map((definition) => {
+        const value = kwargs[definition.arg] ?? definition.defaultValue;
+        const option = typeof value === 'string' ? definition.options[value] : undefined;
+        if (!option) {
+            throw new ArgumentError(
+                `--${definition.arg} must be one of: ${Object.keys(definition.options).join(', ')}, got ${JSON.stringify(value)}`,
+            );
+        }
+        return {
+            group: definition.group,
+            option,
+            capability: value === definition.defaultValue
+                ? ''
+                : definition.arg === 'location'
+                    ? 'location'
+                    : definition.arg === 'scope'
+                        ? 'account'
+                        : '',
+        };
+    });
+}
+
+function buildApplySearchFiltersJs(requestedFilters) {
+    return `
+      (async () => {
+        const requestedFilters = ${JSON.stringify(requestedFilters)};
+        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        const text = (element) => (element?.textContent || '').replace(/\\s+/g, '').trim();
+        const visible = (element) => {
+          if (!element) return false;
+          const rect = element.getBoundingClientRect();
+          const style = getComputedStyle(element);
+          return rect.width > 0 && rect.height > 0 &&
+            style.display !== 'none' && style.visibility !== 'hidden';
+        };
+        const visibleMatches = (root, selector) =>
+          Array.from(root.querySelectorAll(selector)).filter(visible);
+        const authBlocked = () => /登录后查看搜索结果/.test(document.body?.innerText || '') ||
+          visible(document.querySelector('#login-btn'));
+        const locationBlocked = () => /请开启浏览器地理位置权限/.test(document.body?.innerText || '');
+        const panels = () => visibleMatches(document, '.search-layout__top > .filter > .filter-panel');
+        const triggers = () => visibleMatches(document, '.search-layout__top > .filter');
+
+        const openPanel = async () => {
+          let clicked = false;
+          for (let attempt = 0; attempt < 16; attempt++) {
+            if (authBlocked()) return { status: 'auth', detail: 'login_wall' };
+            const currentPanels = panels();
+            if (currentPanels.length === 1) return { status: 'ok', panel: currentPanels[0] };
+            if (currentPanels.length > 1) return { status: 'layout', detail: 'ambiguous_filter_panel' };
+            const currentTriggers = triggers();
+            if (currentTriggers.length > 1) return { status: 'layout', detail: 'ambiguous_filter_trigger' };
+            if (!clicked && currentTriggers.length === 1) {
+              currentTriggers[0].click();
+              clicked = true;
+            }
+            await sleep(100);
+          }
+          return { status: 'layout', detail: 'filter_panel_not_found' };
+        };
+
+        const findOption = (panel, request) => {
+          const groups = visibleMatches(panel, '.filters').filter((group) => {
+            const label = Array.from(group.children).find((child) => child.tagName === 'SPAN');
+            return text(label) === request.group;
+          });
+          if (groups.length !== 1) {
+            return { status: 'layout', detail: groups.length ? 'ambiguous_group' : 'group_not_found' };
+          }
+          const options = visibleMatches(groups[0], '.tag-container > .tags')
+            .filter((option) => text(option) === request.option);
+          if (options.length !== 1) {
+            return { status: 'layout', detail: options.length ? 'ambiguous_option' : 'option_not_found' };
+          }
+          return { status: 'ok', option: options[0] };
+        };
+        const isActive = (option) => option.classList.contains('active');
+        const ready = () => visibleMatches(document, 'section.note-item, section:has(a[href*="/search_result/"]), section:has(a[href*="/explore/"]), .search-empty-wrapper').length > 0;
+        const busy = () => visibleMatches(
+          document,
+          '.search-layout__main [aria-busy="true"], .search-layout__main [class*="skeleton"], .search-layout__main [class*="loading"]',
+        ).length > 0;
+        const snapshot = () => {
+          const rows = visibleMatches(document, 'section.note-item, section:has(a[href*="/search_result/"]), section:has(a[href*="/explore/"])')
+            .map((row) => {
+              const anchor = row.querySelector('a[href*="/search_result/"], a[href*="/explore/"]');
+              return [anchor?.getAttribute('href') || '', text(row)];
+            });
+          const feed = document.querySelector('.feeds-container');
+          return JSON.stringify([
+            rows,
+            visibleMatches(document, '.search-empty-wrapper').length,
+            document.documentElement?.scrollHeight || 0,
+            feed ? feed.clientHeight : null,
+          ]);
+        };
+
+        for (const request of requestedFilters) {
+          const opened = await openPanel();
+          if (opened.status !== 'ok') return opened;
+          let found = findOption(opened.panel, request);
+          if (found.status !== 'ok') {
+            if (request.capability === 'location') return { status: 'location', detail: found.detail };
+            if (request.capability === 'account') return { status: 'capability', detail: found.detail };
+            return found;
+          }
+          if (isActive(found.option)) {
+            continue;
+          }
+
+          const clickedAt = Date.now();
+          found.option.click();
+          let becameActive = false;
+          while (Date.now() - clickedAt < 2500) {
+            if (authBlocked()) return { status: 'auth', detail: 'login_wall' };
+            if (locationBlocked()) return { status: 'location', detail: 'geolocation_denied' };
+            const currentPanels = panels();
+            if (currentPanels.length === 1) {
+              found = findOption(currentPanels[0], request);
+              if (found.status === 'ok' && isActive(found.option)) {
+                becameActive = true;
+                break;
+              }
+            }
+            await sleep(100);
+          }
+          if (!becameActive) {
+            if (request.capability === 'location') return { status: 'location', detail: 'chip_not_active' };
+            if (request.capability === 'account') return { status: 'capability', detail: 'chip_not_active' };
+            return { status: 'inactive', detail: request.group + '/' + request.option };
+          }
+
+          let stableSamples = 0;
+          let previousSnapshot = '';
+          while (Date.now() - clickedAt < ${FILTER_SETTLE_SECONDS * 1000}) {
+            const currentSnapshot = snapshot();
+            if (Date.now() - clickedAt >= 1500 && ready() && !busy()) {
+              stableSamples = currentSnapshot === previousSnapshot ? stableSamples + 1 : 1;
+              previousSnapshot = currentSnapshot;
+              if (stableSamples >= 3) break;
+            }
+            else {
+              stableSamples = 0;
+              previousSnapshot = '';
+            }
+            await sleep(200);
+          }
+          if (stableSamples < 3) {
+            return { status: 'timeout', detail: request.group + '/' + request.option };
+          }
+          const finalPanels = panels();
+          const finalFound = finalPanels.length === 1 ? findOption(finalPanels[0], request) : null;
+          if (!finalFound || finalFound.status !== 'ok' || !isActive(finalFound.option)) {
+            return { status: 'inactive', detail: request.group + '/' + request.option };
+          }
+        }
+        return { status: 'ok' };
+      })()
+    `;
+}
+
+function requireFilterApplication(payload) {
+    const result = unwrapEvaluateResult(payload);
+    if (!result || typeof result !== 'object' || Array.isArray(result) || typeof result.status !== 'string') {
+        throw new CommandExecutionError('Unexpected Xiaohongshu search filter result shape.');
+    }
+    if (result.status === 'ok') {
+        return;
+    }
+    const detail = typeof result.detail === 'string' ? result.detail : 'unknown';
+    if (result.status === 'auth') {
+        throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search filters require a logged-in browser session');
+    }
+    if (result.status === 'timeout') {
+        throw new TimeoutError(`xiaohongshu search filter ${detail}`, FILTER_SETTLE_SECONDS);
+    }
+    if (result.status === 'location') {
+        throw new CommandExecutionError(`Xiaohongshu location filter was not applied (${detail}); enable browser geolocation permission.`);
+    }
+    if (result.status === 'capability') {
+        throw new CommandExecutionError(`Xiaohongshu account-scoped filter was unavailable (${detail}); verify login and account access.`);
+    }
+    if (result.status === 'inactive') {
+        throw new CommandExecutionError(`Xiaohongshu search filter chip did not become active (${detail}).`);
+    }
+    throw new CommandExecutionError(`Xiaohongshu search filter layout did not match the expected visible panel (${detail}).`);
+}
 /**
  * Build a "scroll until enough or plateaued" IIFE used in place of a fixed
  * `autoScroll({ times: N })`. Xiaohongshu's search results page lazy-loads
@@ -570,7 +783,7 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
     `;
 }
 
-async function collectSearchHarvest(page, limit) {
+async function collectSearchHarvest(page, limit, requestedFilters) {
     const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
     if (waitResult === 'login_wall') {
         throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
@@ -584,6 +797,7 @@ async function collectSearchHarvest(page, limit) {
     if (waitResult !== 'content') {
         throw new CommandExecutionError('Unexpected Xiaohongshu search wait payload shape.');
     }
+    requireFilterApplication(await page.evaluate(buildApplySearchFiltersJs(requestedFilters)));
     const harvestOptions = harvestOptionsForLimit(limit);
     const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)), 'www.xiaohongshu.com');
     if (harvest.diag.securityBlock) {
@@ -659,18 +873,24 @@ export const command = cli({
     args: [
         { name: 'query', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
+        { name: 'sort', type: 'string', default: 'comprehensive', choices: ['comprehensive', 'latest', 'most-liked', 'most-commented', 'most-collected'], help: 'Sort order' },
+        { name: 'note-type', type: 'string', default: 'all', choices: ['all', 'video', 'image'], help: 'Note type' },
+        { name: 'publish-time', type: 'string', default: 'anytime', choices: ['anytime', 'day', 'week', 'half-year'], help: 'Publish time range' },
+        { name: 'scope', type: 'string', default: 'all', choices: ['all', 'seen', 'unseen', 'following'], help: 'Search scope' },
+        { name: 'location', type: 'string', default: 'all', choices: ['all', 'same-city', 'nearby'], help: 'Location distance' },
     ],
     columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
     func: async (page, kwargs) => {
         try {
             const limit = parseLimit(kwargs.limit);
+            const requestedFilters = resolveSearchFilters(kwargs);
             const keyword = encodeURIComponent(kwargs.query);
             const url = `https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`;
             await page.goto(url);
-            let harvest = await collectSearchHarvest(page, limit);
+            let harvest = await collectSearchHarvest(page, limit, requestedFilters);
             if (isCollapsedRender(harvest.diag)) {
                 await replaceCollapsedTab(page, url);
-                harvest = await collectSearchHarvest(page, limit);
+                harvest = await collectSearchHarvest(page, limit, requestedFilters);
                 if (isCollapsedRender(harvest.diag)) {
                     throw new CommandExecutionError(
                         'Xiaohongshu search masonry remained collapsed after one fresh-tab recovery.',

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -18,11 +18,14 @@ function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0 });
 }
 function createPageMock(evaluateResults) {
-    const evaluate = vi.fn();
+    const queuedResults = [...evaluateResults];
+    const evaluate = vi.fn(async (script) => {
+        if (String(script).includes('const requestedFilters =')) {
+            return { status: 'ok' };
+        }
+        return queuedResults.shift();
+    });
     let activePage = 'page-old';
-    for (const result of evaluateResults) {
-        evaluate.mockResolvedValueOnce(result);
-    }
     const page = {
         goto: vi.fn().mockResolvedValue(undefined),
         evaluate,
@@ -81,6 +84,164 @@ function noteCard({ id, title = '', likes = '0', signed = false, host = 'www.xia
       </section>
     `;
 }
+
+const FILTER_FIXTURE = [
+    ['排序依据', ['综合', '最新', '最多点赞', '最多评论', '最多收藏']],
+    ['笔记类型', ['不限', '视频', '图文']],
+    ['发布时间', ['不限', '一天内', '一周内', '半年内']],
+    ['搜索范围', ['不限', '已看过', '未看过', '已关注']],
+    ['位置距离', ['不限', '同城', '附近']],
+];
+
+function createFilterBehaviorPage(options = {}) {
+    const dom = new JSDOM(`
+      <body>
+        <div class="search-layout__top"><div class="filter"><span>筛选</span></div></div>
+        <div class="search-layout__main"><div class="feeds-container"></div></div>
+      </body>
+    `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
+    const { document } = dom.window;
+    const state = Object.fromEntries(FILTER_FIXTURE.map(([group, choices]) => [group, choices[0]]));
+    Object.assign(state, options.initial || {});
+    const clicks = [];
+    let panelRenders = 0;
+    let geometry = 1000;
+    const trigger = document.querySelector('.filter');
+    const main = document.querySelector('.search-layout__main');
+    const feeds = document.querySelector('.feeds-container');
+    markVisible(trigger);
+    Object.defineProperty(document.body, 'innerText', {
+        configurable: true,
+        get: () => document.body.textContent || '',
+    });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+        configurable: true,
+        get: () => options.unstableGeometry ? geometry++ : geometry,
+    });
+    Object.defineProperty(feeds, 'clientHeight', { configurable: true, value: 640 });
+
+    const renderResults = (empty = false) => {
+        main.innerHTML = empty
+            ? '<div class="search-empty-wrapper">没有筛选到相关内容</div>'
+            : noteCard({ id: '68e90be80000000004022e66', title: '相同首条', likes: '8' });
+        for (const element of main.querySelectorAll('section.note-item, .search-empty-wrapper')) markVisible(element);
+        if (!empty) {
+            for (const element of main.querySelectorAll('a, .title, .author, .count')) markVisible(element);
+        }
+    };
+    renderResults(false);
+
+    const renderPanel = () => {
+        document.querySelector('.filter-panel')?.remove();
+        const panel = document.createElement('div');
+        panel.className = 'filter-panel';
+        for (const [groupLabel, choices] of FILTER_FIXTURE) {
+            const group = document.createElement('div');
+            group.className = 'filters';
+            const label = document.createElement('span');
+            label.textContent = groupLabel;
+            group.append(label);
+            const container = document.createElement('div');
+            container.className = 'tag-container';
+            for (const choice of choices) {
+                if (options.missing === `${groupLabel}/${choice}`) continue;
+                const copies = options.ambiguous === `${groupLabel}/${choice}` ? 2 : 1;
+                for (let copy = 0; copy < copies; copy++) {
+                    const option = document.createElement('div');
+                    option.className = `tags${state[groupLabel] === choice ? ' active' : ''}`;
+                    const optionLabel = document.createElement('span');
+                    optionLabel.textContent = choice;
+                    option.append(optionLabel);
+                    option.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        clicks.push(`${groupLabel}/${choice}`);
+                        if (options.locationDenied && groupLabel === '位置距离' && choice !== '不限') {
+                            const toast = document.createElement('div');
+                            toast.textContent = '请开启浏览器地理位置权限';
+                            document.body.append(toast);
+                            return;
+                        }
+                        if (options.inactive === `${groupLabel}/${choice}`) return;
+                        state[groupLabel] = choice;
+                        renderPanel();
+                        const loading = document.createElement('div');
+                        loading.className = 'filter-loading';
+                        loading.setAttribute('aria-busy', 'true');
+                        main.append(loading);
+                        setTimeout(() => {
+                            renderResults(options.emptyOn === `${groupLabel}/${choice}`);
+                        }, 300);
+                    });
+                    container.append(option);
+                    markVisible(option);
+                    markVisible(optionLabel);
+                }
+            }
+            group.append(container);
+            panel.append(group);
+            markVisible(group);
+            markVisible(label);
+            markVisible(container);
+        }
+        trigger.append(panel);
+        panelRenders++;
+        markVisible(panel);
+    };
+    trigger.addEventListener('click', () => {
+        const panel = document.querySelector('.filter-panel');
+        if (panel) panel.remove();
+        else renderPanel();
+    });
+
+    const page = createPageMock([]);
+    page.evaluate.mockImplementation(async (script) => {
+        const source = String(script);
+        if (source.includes('findNoteCard')) return 'content';
+        if (source.includes('const requestedFilters =')) {
+            return Function(
+                'document',
+                'window',
+                'getComputedStyle',
+                'setTimeout',
+                `return (${source})`,
+            )(
+                document,
+                dom.window,
+                dom.window.getComputedStyle.bind(dom.window),
+                setTimeout,
+            );
+        }
+        if (source.includes('const targetCount =')) {
+            const empty = Boolean(document.querySelector('.search-empty-wrapper'));
+            return harvestPayload(empty ? [] : [{
+                title: state['排序依据'],
+                author: '作者',
+                likes: '8',
+                url: 'https://www.xiaohongshu.com/search_result/68e90be80000000004022e66',
+                author_url: '',
+            }], { stopReason: empty ? 'exhausted' : 'target' });
+        }
+        throw new Error(`Unexpected evaluate script: ${source.slice(0, 40)}`);
+    });
+    page.filterState = state;
+    page.filterClicks = clicks;
+    page.panelRenderCount = () => panelRenders;
+    page.closeFilterPanel = () => document.querySelector('.filter-panel')?.remove();
+    return page;
+}
+
+async function runFilterCommand(page, args) {
+    const command = getRegistry().get('xiaohongshu/search');
+    const settled = command.func(page, { query: '美食', limit: 1, ...args }).then(
+        (value) => ({ value }),
+        (error) => ({ error }),
+    );
+    await vi.runAllTimersAsync();
+    const outcome = await settled;
+    if (outcome.error) throw outcome.error;
+    return outcome.value;
+}
+
 async function runHarvestFrames(frames, { target = frames.length, stallsBeforeAdvance = 0 } = {}) {
     const dom = new JSDOM('<body></body>', {
         url: 'https://www.xiaohongshu.com/search_result?keyword=test',
@@ -163,6 +324,16 @@ describe('xiaohongshu search', () => {
         await expect(cmd.func(page, { query: '特斯拉', limit: 0 })).rejects.toMatchObject({
             code: 'ARGUMENT',
             message: expect.stringContaining('--limit'),
+        });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+    it('rejects invalid filter values before browser navigation', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([]);
+
+        await expect(cmd.func(page, { query: '特斯拉', limit: 5, sort: 'oldest' })).rejects.toMatchObject({
+            code: 'ARGUMENT',
+            message: expect.stringContaining('--sort'),
         });
         expect(page.goto).not.toHaveBeenCalled();
     });
@@ -353,7 +524,7 @@ describe('xiaohongshu search', () => {
         ]);
         await expect(cmd.func(page, { query: '测试等待', limit: 5 })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
         expect(page.goto).toHaveBeenCalledTimes(1);
-        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
         expect(page.newTab).not.toHaveBeenCalled();
     });
     it('maps an ordinary hydration timeout to TimeoutError without replacing the tab', async () => {
@@ -390,7 +561,8 @@ describe('xiaohongshu search', () => {
         expect(page.closeTab).toHaveBeenCalledWith('page-old');
         expect(page.newTab.mock.invocationCallOrder[0]).toBeLessThan(page.setActivePage.mock.invocationCallOrder[0]);
         expect(page.setActivePage.mock.invocationCallOrder[0]).toBeLessThan(page.closeTab.mock.invocationCallOrder[0]);
-        expect(page.closeTab.mock.invocationCallOrder[0]).toBeLessThan(page.evaluate.mock.invocationCallOrder[2]);
+        expect(page.closeTab.mock.invocationCallOrder[0]).toBeLessThan(page.evaluate.mock.invocationCallOrder[3]);
+        expect(page.evaluate.mock.calls.filter(([script]) => String(script).includes('const requestedFilters ='))).toHaveLength(2);
         expect(page.getActivePage()).toBe('page-new');
     });
     it('fails execution after one fresh target also renders with the proven collapsed signature', async () => {
@@ -472,6 +644,127 @@ describe('xiaohongshu search', () => {
         expect(page.getActivePage()).toBe('page-new');
     });
 });
+
+describe('xiaohongshu search filter behavior', () => {
+    it('converges reused-tab state for filtered -> default and filter set A -> B', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage();
+            await runFilterCommand(page, { sort: 'latest', 'note-type': 'video' });
+            expect(page.filterState).toMatchObject({ '排序依据': '最新', '笔记类型': '视频' });
+
+            page.closeFilterPanel();
+            await runFilterCommand(page, {});
+            expect(page.filterState).toEqual({
+                '排序依据': '综合',
+                '笔记类型': '不限',
+                '发布时间': '不限',
+                '搜索范围': '不限',
+                '位置距离': '不限',
+            });
+
+            await runFilterCommand(page, { sort: 'most-liked', 'note-type': 'image' });
+            await runFilterCommand(page, { sort: 'most-commented', 'note-type': 'video' });
+            expect(page.filterState).toMatchObject({ '排序依据': '最多评论', '笔记类型': '视频' });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('does not toggle an already-active chip and accepts settled rows with the same first href', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ initial: { '排序依据': '最新' } });
+            const result = await runFilterCommand(page, { sort: 'latest' });
+            expect(result[0].title).toBe('最新');
+            expect(page.filterClicks).toEqual([]);
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('reacquires a re-rendered panel while applying a multi-filter combination', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage();
+            await runFilterCommand(page, { sort: 'latest', 'publish-time': 'day', scope: 'following' });
+            expect(page.panelRenderCount()).toBeGreaterThan(3);
+            expect(page.filterState).toMatchObject({
+                '排序依据': '最新',
+                '发布时间': '一天内',
+                '搜索范围': '已关注',
+            });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('fails closed for ambiguous visible options and unavailable account-scoped options', async () => {
+        vi.useFakeTimers();
+        try {
+            const ambiguous = createFilterBehaviorPage({ ambiguous: '排序依据/最新' });
+            await expect(runFilterCommand(ambiguous, { sort: 'latest' })).rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('ambiguous_option'),
+            });
+
+            const unavailable = createFilterBehaviorPage({ missing: '搜索范围/已关注' });
+            await expect(runFilterCommand(unavailable, { scope: 'following' })).rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('account-scoped filter was unavailable'),
+            });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('reports location denial and a non-activating ordinary chip as distinct execution failures', async () => {
+        vi.useFakeTimers();
+        try {
+            const denied = createFilterBehaviorPage({ locationDenied: true });
+            await expect(runFilterCommand(denied, { location: 'nearby' })).rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('geolocation_denied'),
+            });
+
+            const inactive = createFilterBehaviorPage({ inactive: '排序依据/最新' });
+            await expect(runFilterCommand(inactive, { sort: 'latest' })).rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                message: expect.stringContaining('did not become active'),
+            });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('types an active-but-never-stable result surface as a timeout', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ unstableGeometry: true });
+            await expect(runFilterCommand(page, { sort: 'latest' })).rejects.toMatchObject({ code: 'TIMEOUT' });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('preserves a legitimate filtered zero-result state as EmptyResultError', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ emptyOn: '发布时间/一天内' });
+            await expect(runFilterCommand(page, { 'publish-time': 'day' })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
 describe('buildSearchExtractJs', () => {
     it('separates fallback author text from appended relative date', () => {
         const dom = new JSDOM(`

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -32,6 +32,9 @@
 # Search for notes
 opencli xiaohongshu search 美食 --limit 10
 
+# Combine visible search-panel filters
+opencli xiaohongshu search 美食 --sort latest --note-type video --publish-time week
+
 # Ask 点点 and keep the citation audit trail
 opencli xiaohongshu ask "上海露营需要注意什么？" -f json
 
@@ -70,6 +73,8 @@ opencli xiaohongshu delete-note 6a08ba0b000000000702a893
 # Actually delete after the target row and delete action are verified
 opencli xiaohongshu delete-note 6a08ba0b000000000702a893 --execute
 ```
+
+`search` supports the same visible filter-panel choices as the website: `--sort comprehensive|latest|most-liked|most-commented|most-collected`, `--note-type all|video|image`, `--publish-time anytime|day|week|half-year`, `--scope all|seen|unseen|following`, and `--location all|same-city|nearby`. Account-scoped and location filters fail explicitly when the logged-in browser session lacks the required account or geolocation capability.
 
 > Note: `note` and `comments` now require a full signed note URL with `xsec_token`. `download` accepts either a signed note URL or an `xhslink` short link. Bare note IDs are no longer reliable on xiaohongshu.
 > With `comments --with-replies`, `reply_to` is the direct reply target displayed by the page. Replies without an explicit `回复 <name>` marker target the enclosing top-level comment.


### PR DESCRIPTION
## What

Adds five filter options to `opencli xiaohongshu search`, mirroring the web search filter panel (筛选):

| Option | Choices | Panel group |
|---|---|---|
| `--sort` | comprehensive (default) / latest / most-liked / most-commented / most-collected | 排序依据 |
| `--note-type` | all (default) / video / image | 笔记类型 |
| `--publish-time` | anytime (default) / day / week / half-year | 发布时间 |
| `--scope` | all (default) / seen / unseen / following | 搜索范围 |
| `--location` | all (default) / same-city / nearby | 位置距离 |

Example: `opencli xiaohongshu search 美食 --limit 10 --sort latest --publish-time day`

## Why

The command previously exposed no way to filter or sort results; users had to post-filter `published_at` client-side, which wastes results budget (`--limit` max 100) and cannot express sort order at all.

## How

Xiaohongshu's web search does **not** encode filters in the URL — selecting a chip fires a signed `/api/sns/web/v1/search/notes` XHR with a `filters` array, e.g. `{"tags":["time_descending"],"type":"sort_type"}`. Since this adapter is DOM-based (the header comment documents why the XHR approach broke), the implementation reproduces the user's own clicks:

1. After navigation + content wait, `buildApplyFiltersJs()` opens the 筛选 panel (toggle reads 筛选 when idle, 已筛选 when filters are active — both matched).
2. Clicks each requested chip by group label + option text.
3. Waits (bounded) for the result list to re-render after each click before extraction proceeds.

Chip display texts for all five groups were verified against live XHR request bodies. Filters left at their default value are skipped entirely, so existing behavior is unchanged when no new flag is passed. Failures (panel or chip not found, e.g. a XHS layout change) raise a typed `CommandExecutionError` instead of silently returning unfiltered results.

## Testing

- 8 new unit tests in `clis/xiaohongshu/search.test.js` (mapping, IIFE generation, panel driving order, typed failure, no-panel-when-default).
- `npx tsc --noEmit` clean; full suite: 590 files / 6741 tests passed.
- Verified live against xiaohongshu.com with a logged-in session: `--publish-time day` returned only notes from the last 24h, `--sort most-liked` returned descending like counts, `--location same-city` returned local-city results.