### PR TITLE
fix(dianping): correct 4 wrong cityIds in static city map (kunming/fuzhou/xiamen/hefei)

### DIFF
--- a/clis/dianping/utils.js
+++ b/clis/dianping/utils.js
@@ -36,10 +36,10 @@ export const CITY_ID = {
     changsha: 344, '长沙': 344,
     dalian: 19, '大连': 19,
     shenyang: 18, '沈阳': 18,
-    kunming: 25, '昆明': 25,
-    fuzhou: 110, '福州': 110,
-    xiamen: 14, '厦门': 14,
-    hefei: 26, '合肥': 26,
+    kunming: 267, '昆明': 267,
+    fuzhou: 14, '福州': 14,
+    xiamen: 15, '厦门': 15,
+    hefei: 110, '合肥': 110,
 };
 
 export const SEARCH_COLUMNS = ['rank', 'shop_id', 'name', 'rating', 'reviews', 'price', 'cuisine', 'district', 'url'];


### PR DESCRIPTION
## Problem
The trailing rows of the curated `CITY_ID` map in `clis/dianping/utils.js` contain **4 incorrect cityIds**. When a user runs `opencli dianping search --city <name>` with one of these cities, the adapter builds the search URL with a wrong cityId. `www.dianping.com` does not recognize it, silently ignores it, and returns results for the **cookie's default city** instead — with no error surfaced.

Notably, `fuzhou` and `hefei` previously shared the same id `110`, indicating the last few rows were transposed when the table was hand-written.

## Fix
Corrected the 4 entries, verified against live resolution of `https://www.dianping.com/<slug>` (reading the first `/search/keyword/{id}/` anchor on each city landing page):

| city | before | after (real) |
|------|--------|--------------|
| kunming 昆明 | 25  | **267** |
| fuzhou  福州 | 110 | **14**  |
| xiamen  厦门 | 14  | **15**  |
| hefei   合肥 | 26  | **110** |

## Verification
Live-checked every entry in the static map; the first 16 are correct, only these 4 were wrong:

```
beijing:2 shanghai:1 guangzhou:4 shenzhen:7 hangzhou:3 chengdu:8
chongqing:9 nanjing:5 suzhou:6 xian:17 wuhan:16 tianjin:10 qingdao:21
changsha:344 dalian:19 shenyang:18  -- all OK
kunming:  static=25  real=267  MISMATCH
fuzhou:   static=110 real=14   MISMATCH
xiamen:   static=14  real=15   MISMATCH
hefei:    static=26  real=110  MISMATCH
```

Repro before fix (default city = Tangshan):
```
opencli dianping search "过桥米线" --city 昆明   # returned Tangshan results (wrong)
opencli dianping search "过桥米线" --city 267    # returns Kunming results (correct)
```

- `npx vitest run clis/dianping/dianping.test.js` → 28 passed
- `npx tsx src/main.ts validate dianping` → PASS (4 commands, 0 errors)

Scope: this map is private to the dianping adapter; no other site is affected.