### PR TITLE
fix(codex): handle current desktop CDP layout

### DIFF
--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -22,11 +22,21 @@ export const askCommand = cli({
             throw new ArgumentError('--timeout must be a positive integer (seconds)');
         }
         const selected = await openCodexConversation(page, kwargs);
-        // Snapshot the current content length before sending
-        const beforeLen = await page.evaluate(`
+        // Snapshot the latest assistant identity. Codex virtualizes older turns, so
+        // message/turn counts can stay constant even after a new response appears.
+        const beforeState = await page.evaluate(`
       (function() {
-        const turns = document.querySelectorAll('[data-content-search-turn-key]');
-        return turns.length;
+        const messages = Array.from(document.querySelectorAll('[data-markdown-text-style="assistant-message"]'));
+        const lastMessage = messages[messages.length - 1] || null;
+        const unit = lastMessage?.closest('[data-content-search-unit-key]');
+        const annotation = lastMessage?.closest('[data-response-annotation-target]');
+        return {
+          assistantKey: unit?.getAttribute('data-content-search-unit-key')
+            || annotation?.getAttribute('data-response-annotation-target')
+            || '',
+          assistantCount: messages.length,
+          turnCount: document.querySelectorAll('[data-content-search-turn-key]').length,
+        };
       })()
     `);
         // Inject and send
@@ -51,13 +61,34 @@ export const askCommand = cli({
         for (let i = 0; i < maxPolls; i++) {
             await page.wait(pollInterval);
             const result = await page.evaluate(`
-        (function(prevLen) {
-          const turns = document.querySelectorAll('[data-content-search-turn-key]');
-          if (turns.length <= prevLen) return null;
-          const lastTurn = turns[turns.length - 1];
-          const text = lastTurn.innerText || lastTurn.textContent;
-          return text ? text.trim() : null;
-        })(${beforeLen})
+        (function(prevState) {
+          const assistantMessages = Array.from(document.querySelectorAll('[data-markdown-text-style="assistant-message"]'));
+          const lastMessage = assistantMessages[assistantMessages.length - 1] || null;
+          if (lastMessage) {
+            const unit = lastMessage.closest('[data-content-search-unit-key]');
+            const annotation = lastMessage.closest('[data-response-annotation-target]');
+            const assistantKey = unit?.getAttribute('data-content-search-unit-key')
+              || annotation?.getAttribute('data-response-annotation-target')
+              || '';
+            if ((assistantKey && assistantKey !== prevState.assistantKey)
+              || (!assistantKey && assistantMessages.length > prevState.assistantCount)) {
+              const text = lastMessage.innerText || lastMessage.textContent;
+              return text ? text.trim() : null;
+            }
+          }
+
+          // Older Codex builds did not expose assistant-message markers.
+          if (prevState.assistantCount === 0 && assistantMessages.length === 0) {
+            const turns = document.querySelectorAll('[data-content-search-turn-key]');
+            if (turns.length > prevState.turnCount) {
+              const lastTurn = turns[turns.length - 1];
+              const text = lastTurn.innerText || lastTurn.textContent;
+              return text ? text.trim() : null;
+            }
+          }
+
+          return null;
+        })(${JSON.stringify(beforeState)})
       `);
             if (result) {
                 response = result;

--- a/clis/codex/ask.test.js
+++ b/clis/codex/ask.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { askCommand } from './ask.js';
+
+describe('codex ask', () => {
+  it('detects a new assistant identity even when virtualized counts are unchanged', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce({ assistantKey: 'old-key', assistantCount: 1, turnCount: 1 })
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('OPENCLI_OK');
+    const page = {
+      evaluate,
+      wait: vi.fn().mockResolvedValue(undefined),
+      pressKey: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await askCommand.func(page, { text: 'reply OPENCLI_OK', timeout: 3 });
+
+    expect(result).toEqual([
+      { Role: 'User', Project: '', Conversation: '', Text: 'reply OPENCLI_OK' },
+      { Role: 'Assistant', Project: '', Conversation: '', Text: 'OPENCLI_OK' },
+    ]);
+    expect(evaluate.mock.calls[0][0]).toContain('data-content-search-unit-key');
+    expect(evaluate.mock.calls[2][0]).toContain('assistantKey');
+  });
+});

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -115,6 +115,25 @@ describe('browser helpers', () => {
 
     expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9226/codex');
   });
+
+  it('prefers the Codex main renderer over the avatar overlay', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html?initialRoute=%2Favatar-overlay',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/overlay',
+      },
+      {
+        type: 'page',
+        title: 'Codex',
+        url: 'app://-/index.html',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9238/main',
+      },
+    ]);
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9238/main');
+  });
 });
 
 describe('BrowserBridge state', () => {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -526,6 +526,8 @@ function scoreCDPTarget(target: CDPTarget, preferredPattern?: RegExp): number {
   if (url.startsWith('http://127.0.0.1') || url.startsWith('https://127.0.0.1')) score += 50;
   if (url.startsWith('about:blank')) score -= 120;
   if (url === '' || url === 'about:blank') score -= 40;
+  // Auxiliary Codex avatar overlay shares the main app's CDP port/title but has no composer.
+  if (url.includes('initialroute=%2favatar-overlay')) score -= 200;
 
   if (title && title !== 'devtools') score += 25;
 


### PR DESCRIPTION
## Summary
- deprioritize Codex's auxiliary avatar-overlay CDP target so the main renderer is selected
- make `codex ask` track the latest assistant message identity instead of relying on virtualized turn/message counts
- add regressions for both behaviors

## Reproduction
On Windows with OpenCLI 1.8.6 and current Codex Desktop, CDP 9238 exposes both:
- `app://-/index.html?initialRoute=%2Favatar-overlay`
- `app://-/index.html`

Because both targets otherwise receive the same effective score, `/json` order can select the overlay. `codex status` then reports Connected, while `codex ask` cannot find the composer.

After selecting the main renderer, prompts can be sent. Current Codex also virtualizes the thread DOM, so the number of `[data-content-search-turn-key]` elements may stay unchanged while a new assistant response replaces the visible turn. Assistant messages expose stable per-message identity through `data-content-search-unit-key` / `data-response-annotation-target`, which this change uses for polling, with the old turn-count behavior kept as a fallback for older builds.

## Validation
- real Windows Codex Desktop E2E through CDP: `askCommand.func(..., timeout: 60)` returned `DIRECT60_OK`
- JS syntax checks passed for the modified Codex command and regression test
- regression tests added for CDP target selection and response detection

Local Vitest startup was blocked by a Windows Rolldown/native-binding lock in the temporary dependency install, so repository CI is the source of truth for the full test matrix.