### PR TITLE
fix(extension): omit credentials from daemon ping (fixes #2278)

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -861,8 +861,12 @@ function connect() {
 async function connectAttempt() {
   if (isDaemonSocketActive()) return;
   try {
-    const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1e3) });
+    const res = await fetch(DAEMON_PING_URL, {
+      signal: AbortSignal.timeout(1e3),
+      credentials: "omit"
+    });
     if (!res.ok) {
+      console.warn(`[opencli] daemon ping failed: HTTP ${res.status}`);
       scheduleReconnect();
       return;
     }

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -877,6 +877,30 @@ describe('background tab isolation', () => {
     expect(mod.__test__.getReconnectAttempts()).toBe(0);
   });
 
+  it('pings without credentials and logs a non-OK status instead of swallowing it', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 431 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('./background');
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    // The ping must not attach the localhost cookie jar — that is what pushes
+    // the request past Node's header limit and makes the daemon answer 431.
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ credentials: 'omit' });
+    // A non-OK ping must be logged, not silently swallowed.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('HTTP 431'));
+    // The WebSocket must not be attempted after a failed ping.
+    expect(MockWebSocket.instances).toHaveLength(0);
+
+    warnSpy.mockRestore();
+  });
+
   it('ignores daemon commands delivered to a superseded WebSocket', async () => {
     const { chrome } = createChromeMock();
     vi.stubGlobal('chrome', chrome);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -138,14 +138,24 @@ async function connectAttempt(): Promise<void> {
   if (isDaemonSocketActive()) return;
 
   try {
-    const res = await fetch(DAEMON_PING_URL, { signal: AbortSignal.timeout(1000) });
+    // omit credentials so the browser doesn't attach the localhost cookie jar —
+    // a large jar can push the request past Node's default header limit and make
+    // the daemon answer 431, silently wedging the connect loop forever.
+    const res = await fetch(DAEMON_PING_URL, {
+      signal: AbortSignal.timeout(1000),
+      credentials: 'omit',
+    });
     if (!res.ok) {
+      console.warn(`[opencli] daemon ping failed: HTTP ${res.status}`);
       scheduleReconnect();
       return; // unexpected response — not our daemon, but keep polling.
     }
     // Daemon is reachable — proceed straight to the WebSocket below.
     reconnectAttempts = 0;
   } catch {
+    // Daemon not running is the expected idle state — keep the probe silent to
+    // avoid per-poll service-worker noise (see connect() docstring). The 431
+    // wedge this fixes is surfaced in the !res.ok branch above.
     scheduleReconnect();
     return; // daemon not running — keep polling until the next daemon spawn.
   }


### PR DESCRIPTION
## Problem

Fixes #2278. The extension can silently stop before its WebSocket connection when the daemon `/ping` returns HTTP 431.

A large `localhost` cookie jar can exceed Node's default HTTP header limit. Because the ping used browser-default credentials, Chromium attached those cookies, the daemon answered 431, and the extension silently scheduled another retry without reaching the WebSocket step.

## Fix

- Send only the extension `/ping` request with `credentials: 'omit'`, so browser cookies are not attached.
- Log non-OK ping status codes before scheduling the normal reconnect.
- Keep connection errors silent because a stopped daemon is the expected idle state.
- Rebuild and commit `extension/dist/background.js`, which is the bundle users load.

This deliberately does not raise the daemon header ceiling globally. The reproduced failure is the HTTP ping, omitting credentials resolves that path, and the reporter explicitly confirmed that a direct WebSocket connection succeeds with the same cookie jar. Expanding parsing limits for every daemon HTTP endpoint and WebSocket upgrade therefore lacks supporting evidence.

## Verification

Exact head `4c03e305`:

- extension tests passed (source head: 97/97; rebuilt-dist follow-up: focused 72/72)
- `npm run typecheck` passed
- `cd extension && npm run build` passed
- hosted CI, extension build, security audit, and docs checks all green
- `git diff --check` passed

Final diff: `extension/src/background.ts`, its regression test, and the rebuilt tracked `extension/dist/background.js`.
