### PR TITLE
fix(browser): honor OPENCLI_CDP_ENDPOINT for website CLIs (remote-Chrome mode)

### DIFF
--- a/docs/advanced/remote-chrome.md
+++ b/docs/advanced/remote-chrome.md
@@ -49,6 +49,21 @@ OpenCLI attaches to that exact target instead of opening a dedicated tab
 dedicated tab, e.g. for Electron apps).
 :::
 
+#### Dedicated tab lifecycle
+
+| Situation | What happens to the tab |
+| --- | --- |
+| Command finishes (default, `--site-session ephemeral`) | Closed |
+| `--keep-tab true`, or `--site-session persistent` (which implies keep-tab) | Left open |
+| WebSocket handshake or CDP setup fails | Closed, even with `--keep-tab true` — nothing ever attached to it |
+| Command fails mid-run (navigation error, adapter throw) | Closed, unless keep-tab applies |
+
+A kept tab is **not** reused by the next command: each command opens its own tab.
+Nothing is lost by that — cookies and login state live in the shared Chrome profile,
+not in the tab — so a persistent site session still sees the same logged-in state.
+Keep-tab is there for inspecting what a command did, not for session continuity.
+
+
 ### 4. Verify
 
 ```bash

--- a/docs/advanced/remote-chrome.md
+++ b/docs/advanced/remote-chrome.md
@@ -37,6 +37,18 @@ Use `127.0.0.1` instead of `localhost` in the SSH command to avoid IPv6 resoluti
 export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9222"
 ```
 
+With the endpoint set, website CLIs (e.g. `opencli twitter timeline`) run over CDP
+directly — the Browser Bridge extension is not required in this mode. Each command
+opens a **dedicated tab** on the remote browser and closes it when done, so your
+existing tabs are never hijacked. Electron app CLIs honor the same variable as before.
+
+::: tip
+The endpoint may also be a `ws://` URL pointing at a specific target. In that case
+OpenCLI attaches to that exact target instead of opening a dedicated tab
+(`OPENCLI_CDP_TARGET` filters targets when using an `http://` endpoint without a
+dedicated tab, e.g. for Electron apps).
+:::
+
 ### 4. Verify
 
 ```bash

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -4,12 +4,18 @@ const { MockWebSocket } = vi.hoisted(() => {
   class MockWebSocket {
     static OPEN = 1;
     static lastInstance: MockWebSocket | undefined;
+    /** Set to 'error' to simulate a WebSocket handshake that never connects. */
+    static nextConnect: 'open' | 'error' = 'open';
     readyState = 1;
     private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
 
     constructor(_url: string) {
       MockWebSocket.lastInstance = this;
-      queueMicrotask(() => this.emit('open'));
+      const outcome = MockWebSocket.nextConnect;
+      queueMicrotask(() => {
+        if (outcome === 'error') this.emit('error', new Error('connect ECONNREFUSED'));
+        else this.emit('open');
+      });
     }
 
     on(event: string, handler: (...args: unknown[]) => void): void {
@@ -140,6 +146,7 @@ describe('CDPBridge cookies', () => {
 describe('CDPBridge dedicated targets (remote Chrome)', () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
+    MockWebSocket.nextConnect = 'open';
   });
 
   async function withDevtoolsServer(
@@ -212,6 +219,125 @@ describe('CDPBridge dedicated targets (remote Chrome)', () => {
           'PUT /json/new',
           'GET /json/new',
           'GET /json/close/T2',
+        ]);
+      },
+    );
+  });
+
+  it('asks for the tab with the exact /json/new URL form Chrome expects', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T3', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T3' }) };
+        }
+        if (url === '/json/close/T3') return { status: 200, body: 'Target is closing' };
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+        await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true });
+        await bridge.close();
+
+        // The query string is not cosmetic: Chrome opens the browser's default
+        // new-tab page when `url` is missing, which then navigates on its own and
+        // races the adapter's first goto.
+        expect(seen[0]).toEqual({ method: 'PUT', url: '/json/new?url=about:blank' });
+      },
+    );
+  });
+
+  it('closes the tab it created when the WebSocket handshake fails', async () => {
+    MockWebSocket.nextConnect = 'error';
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T4', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T4' }) };
+        }
+        if (url === '/json/close/T4') return { status: 200, body: 'Target is closing' };
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+
+        // connect() rejects, and nobody calls close() on a bridge that never
+        // connected -- so connect() itself has to take the tab back down.
+        await expect(bridge.connect({ cdpEndpoint: base, dedicatedTarget: true })).rejects.toThrow('connect ECONNREFUSED');
+
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual([
+          'PUT /json/new',
+          'GET /json/close/T4',
+        ]);
+      },
+    );
+  });
+
+  it('closes the tab it created when the CDP session setup fails after connecting', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T5', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T5' }) };
+        }
+        if (url === '/json/close/T5') return { status: 200, body: 'Target is closing' };
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        // Page.enable failing is the realistic version of "the target went away
+        // between /json/new and the first command".
+        vi.spyOn(bridge, 'send').mockRejectedValue(new Error('Target closed'));
+
+        await expect(bridge.connect({ cdpEndpoint: base, dedicatedTarget: true })).rejects.toThrow('Target closed');
+
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual([
+          'PUT /json/new',
+          'GET /json/close/T5',
+        ]);
+      },
+    );
+  });
+
+  it('leaves the tab open on close() when keepTab is requested', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T6', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T6' }) };
+        }
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+        // --keep-tab true, and `--site-session persistent` which implies it.
+        await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true, keepTab: true });
+        await bridge.close();
+
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual(['PUT /json/new']);
+      },
+    );
+  });
+
+  it('still discards the tab when the handshake fails even if keepTab was requested', async () => {
+    MockWebSocket.nextConnect = 'error';
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T7', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T7' }) };
+        }
+        if (url === '/json/close/T7') return { status: 200, body: 'Target is closing' };
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+
+        await expect(bridge.connect({ cdpEndpoint: base, dedicatedTarget: true, keepTab: true })).rejects.toThrow('connect ECONNREFUSED');
+
+        // Nothing ever attached to that tab, so there is nothing worth keeping.
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual([
+          'PUT /json/new',
+          'GET /json/close/T7',
         ]);
       },
     );

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -136,3 +136,109 @@ describe('CDPBridge cookies', () => {
     expect(String(entries[0].requestBodyPreview)).toHaveLength(CDP_REQUEST_BODY_CAPTURE_LIMIT);
   });
 });
+
+describe('CDPBridge dedicated targets (remote Chrome)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function withDevtoolsServer(
+    handler: (req: { method: string; url: string }) => { status: number; body: string },
+    fn: (base: string, seen: Array<{ method: string; url: string }>) => Promise<void>,
+  ): Promise<void> {
+    const { createServer } = await import('node:http');
+    const seen: Array<{ method: string; url: string }> = [];
+    const server = createServer((req, res) => {
+      const entry = { method: req.method ?? '', url: req.url ?? '' };
+      seen.push(entry);
+      const { status, body } = handler(entry);
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(body);
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    try {
+      await fn(`http://127.0.0.1:${port}`, seen);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  it('opens a dedicated tab instead of attaching to an existing one, and closes it on close()', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'PUT' && url.startsWith('/json/new')) {
+          return { status: 200, body: JSON.stringify({ id: 'T1', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T1' }) };
+        }
+        if (method === 'GET' && url === '/json/close/T1') {
+          return { status: 200, body: 'Target is closing' };
+        }
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+        await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true });
+        await bridge.close();
+
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual([
+          'PUT /json/new',
+          'GET /json/close/T1',
+        ]);
+      },
+    );
+  });
+
+  it('falls back to GET /json/new for Chrome versions that reject PUT', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (url.startsWith('/json/new')) {
+          if (method === 'PUT') return { status: 405, body: 'Using unsafe HTTP verb' };
+          return { status: 200, body: JSON.stringify({ id: 'T2', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T2' }) };
+        }
+        if (url === '/json/close/T2') return { status: 200, body: 'Target is closing' };
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+        await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true });
+        await bridge.close();
+
+        expect(seen.map((r) => `${r.method} ${r.url.split('?')[0]}`)).toEqual([
+          'PUT /json/new',
+          'GET /json/new',
+          'GET /json/close/T2',
+        ]);
+      },
+    );
+  });
+
+  it('keeps the legacy attach behaviour when dedicatedTarget is not requested', async () => {
+    await withDevtoolsServer(
+      ({ method, url }) => {
+        if (method === 'GET' && url === '/json') {
+          return {
+            status: 200,
+            body: JSON.stringify([
+              { id: 'P1', type: 'page', url: 'https://example.com', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/P1' },
+            ]),
+          };
+        }
+        return { status: 500, body: '{}' };
+      },
+      async (base, seen) => {
+        const bridge = new CDPBridge();
+        vi.spyOn(bridge, 'send').mockResolvedValue({});
+
+        await bridge.connect({ cdpEndpoint: base });
+        await bridge.close();
+
+        expect(seen.map((r) => `${r.method} ${r.url}`)).toEqual(['GET /json']);
+      },
+    );
+  });
+});

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -21,6 +21,7 @@ import { getAllElectronApps } from '../electron-apps.js';
 import { CDPBasePage } from './base-page.js';
 
 export interface CDPTarget {
+  id?: string;
   type?: string;
   url?: string;
   title?: string;
@@ -53,8 +54,10 @@ export class CDPBridge implements IBrowserFactory {
   private _idCounter = 0;
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
+  private _httpBase: string | null = null;
+  private _createdTargetId: string | null = null;
 
-  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -62,12 +65,25 @@ export class CDPBridge implements IBrowserFactory {
 
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {
-      const targets = await fetchJsonDirect(`${endpoint.replace(/\/$/, '')}/json`) as CDPTarget[];
-      const target = selectCDPTarget(targets);
-      if (!target || !target.webSocketDebuggerUrl) {
-        throw new Error('No inspectable targets found at CDP endpoint');
+      const httpBase = endpoint.replace(/\/$/, '');
+      if (opts?.dedicatedTarget) {
+        // Website sessions on a shared browser must not hijack whichever tab
+        // happens to rank first — open a dedicated tab and clean it up on close().
+        const created = await createDedicatedCDPTarget(httpBase);
+        if (!created.webSocketDebuggerUrl) {
+          throw new Error('CDP endpoint created a target without webSocketDebuggerUrl');
+        }
+        this._httpBase = httpBase;
+        this._createdTargetId = created.id ?? null;
+        wsUrl = created.webSocketDebuggerUrl;
+      } else {
+        const targets = await fetchJsonDirect(`${httpBase}/json`) as CDPTarget[];
+        const target = selectCDPTarget(targets);
+        if (!target || !target.webSocketDebuggerUrl) {
+          throw new Error('No inspectable targets found at CDP endpoint');
+        }
+        wsUrl = target.webSocketDebuggerUrl;
       }
-      wsUrl = target.webSocketDebuggerUrl;
     }
 
     return new Promise((resolve, reject) => {
@@ -138,6 +154,13 @@ export class CDPBridge implements IBrowserFactory {
     }
     this._pending.clear();
     this._eventListeners.clear();
+    if (this._httpBase && this._createdTargetId) {
+      // Best-effort: remove the tab we opened so repeated runs don't litter the
+      // shared browser. Ignore failures — the browser may already be gone.
+      await closeDedicatedCDPTarget(this._httpBase, this._createdTargetId).catch(() => {});
+      this._httpBase = null;
+      this._createdTargetId = null;
+    }
   }
 
   async send(method: string, params: Record<string, unknown> = {}, timeoutMs: number = CDP_SEND_TIMEOUT): Promise<unknown> {
@@ -592,10 +615,10 @@ export const __test__ = {
   scoreCDPTarget,
 };
 
-function fetchJsonDirect(url: string): Promise<unknown> {
+function fetchJsonDirect(url: string, method: 'GET' | 'PUT' = 'GET'): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
-    const request = (parsed.protocol === 'https:' ? httpsRequest : httpRequest)(parsed, (res) => {
+    const request = (parsed.protocol === 'https:' ? httpsRequest : httpRequest)(parsed, { method }, (res) => {
       const statusCode = res.statusCode ?? 0;
       if (statusCode < 200 || statusCode >= 300) {
         res.resume();
@@ -606,10 +629,12 @@ function fetchJsonDirect(url: string): Promise<unknown> {
       const chunks: Buffer[] = [];
       res.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
       res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
         try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-        } catch (error) {
-          reject(error instanceof Error ? error : new Error(String(error)));
+          resolve(JSON.parse(body));
+        } catch {
+          // /json/close (and some older endpoints) reply with plain text.
+          resolve(body);
         }
       });
     });
@@ -618,4 +643,28 @@ function fetchJsonDirect(url: string): Promise<unknown> {
     request.setTimeout(10_000, () => request.destroy(new Error('Timed out fetching CDP targets')));
     request.end();
   });
+}
+
+/**
+ * Open a dedicated tab on a shared browser via the DevTools HTTP API.
+ * Chrome 111+ requires PUT for /json/new; older versions only accept GET —
+ * try PUT first and fall back so both generations work.
+ */
+export async function createDedicatedCDPTarget(httpBase: string): Promise<CDPTarget> {
+  const newUrl = `${httpBase}/json/new?url=about:blank`;
+  let created: unknown;
+  try {
+    created = await fetchJsonDirect(newUrl, 'PUT');
+  } catch {
+    created = await fetchJsonDirect(newUrl, 'GET');
+  }
+  if (!isRecord(created) || typeof created.webSocketDebuggerUrl !== 'string') {
+    throw new Error('CDP /json/new did not return an inspectable target');
+  }
+  return created as CDPTarget;
+}
+
+/** Best-effort close of a tab previously opened by createDedicatedCDPTarget. */
+export async function closeDedicatedCDPTarget(httpBase: string, targetId: string): Promise<void> {
+  await fetchJsonDirect(`${httpBase}/json/close/${targetId}`, 'GET');
 }

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -56,8 +56,9 @@ export class CDPBridge implements IBrowserFactory {
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
   private _httpBase: string | null = null;
   private _createdTargetId: string | null = null;
+  private _keepDedicatedTarget = false;
 
-  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean; keepTab?: boolean }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -75,6 +76,9 @@ export class CDPBridge implements IBrowserFactory {
         }
         this._httpBase = httpBase;
         this._createdTargetId = created.id ?? null;
+        // --keep-tab (and `--site-session persistent`, which implies it) means the
+        // caller wants the tab left behind for inspection or a follow-up command.
+        this._keepDedicatedTarget = opts?.keepTab === true;
         wsUrl = created.webSocketDebuggerUrl;
       } else {
         const targets = await fetchJsonDirect(`${httpBase}/json`) as CDPTarget[];
@@ -86,7 +90,7 @@ export class CDPBridge implements IBrowserFactory {
       }
     }
 
-    return new Promise((resolve, reject) => {
+    const session = new Promise<IPage>((resolve, reject) => {
       const ws = new WebSocket(wsUrl);
       const timeoutMs = (opts?.timeout ?? 10) * 1000;
       const timeout = setTimeout(() => {
@@ -141,6 +145,29 @@ export class CDPBridge implements IBrowserFactory {
         }
       });
     });
+
+    try {
+      return await session;
+    } catch (err) {
+      // The tab exists before the WebSocket handshake starts, so a refused
+      // connection, a connect timeout, or a failed Page.enable would otherwise
+      // strand it on someone's shared browser. Discard it even when keep-tab was
+      // requested: nothing ever attached to it, so there is nothing to keep.
+      await this._discardDedicatedTarget();
+      throw err;
+    }
+  }
+
+  /** Close the tab this bridge opened (if any) and forget it. Never throws. */
+  private async _discardDedicatedTarget(): Promise<void> {
+    const httpBase = this._httpBase;
+    const targetId = this._createdTargetId;
+    this._httpBase = null;
+    this._createdTargetId = null;
+    this._keepDedicatedTarget = false;
+    if (!httpBase || !targetId) return;
+    // Best-effort: the browser may already be gone.
+    await closeDedicatedCDPTarget(httpBase, targetId).catch(() => {});
   }
 
   async close(): Promise<void> {
@@ -154,13 +181,17 @@ export class CDPBridge implements IBrowserFactory {
     }
     this._pending.clear();
     this._eventListeners.clear();
-    if (this._httpBase && this._createdTargetId) {
-      // Best-effort: remove the tab we opened so repeated runs don't litter the
-      // shared browser. Ignore failures — the browser may already be gone.
-      await closeDedicatedCDPTarget(this._httpBase, this._createdTargetId).catch(() => {});
+    if (this._keepDedicatedTarget) {
+      // keep-tab semantics: leave the tab open and just forget it. The next
+      // command opens its own tab -- login state lives in the shared Chrome
+      // profile, not in the tab, so nothing is lost by not reusing this one.
       this._httpBase = null;
       this._createdTargetId = null;
+      this._keepDedicatedTarget = false;
+      return;
     }
+    // Remove the tab we opened so repeated runs don't litter the shared browser.
+    await this._discardDedicatedTarget();
   }
 
   async send(method: string, params: Record<string, unknown> = {}, timeoutMs: number = CDP_SEND_TIMEOUT): Promise<unknown> {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -245,11 +245,12 @@ export async function executeCommand(
   try {
     if (siteSession !== null) {
       const electron = isElectronApp(cmd.site);
+      const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
       let cdpEndpoint: string | undefined;
+      let dedicatedTarget = false;
 
       if (electron) {
         // Electron apps: respect manual endpoint override, then try auto-detect
-        const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
         if (manualEndpoint) {
           const port = Number(new URL(manualEndpoint).port);
           if (!await probeCDP(port)) {
@@ -262,6 +263,14 @@ export async function executeCommand(
         } else {
           cdpEndpoint = await resolveElectronEndpoint(cmd.site);
         }
+      } else if (manualEndpoint) {
+        // Remote-Chrome mode for website CLIs (docs/advanced/remote-chrome.md):
+        // route over CDP instead of the Browser Bridge extension. No localhost
+        // port probe here — the endpoint may live on another machine, and
+        // CDPBridge validates it when it fetches /json. A dedicated tab keeps
+        // us from hijacking whatever the user has open in the shared browser.
+        cdpEndpoint = manualEndpoint;
+        dedicatedTarget = true;
       }
 
       const BrowserFactory = getBrowserFactory(cmd.site);
@@ -420,7 +429,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, dedicatedTarget, ...profileRouting, windowMode, surface: 'adapter', siteSession });
       } catch (err) {
         browserRunError = err;
         throw err;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -429,7 +429,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, dedicatedTarget, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, dedicatedTarget, keepTab, ...profileRouting, windowMode, surface: 'adapter', siteSession });
       } catch (err) {
         browserRunError = err;
         throw err;

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getBrowserFactory } from './runtime.js';
+import { CDPBridge } from './browser/cdp.js';
+import { BrowserBridge } from './browser/bridge.js';
+
+describe('getBrowserFactory', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('routes website CLIs through the Browser Bridge extension by default', () => {
+    expect(getBrowserFactory('twitter')).toBe(BrowserBridge);
+  });
+
+  it('routes website CLIs over CDP when OPENCLI_CDP_ENDPOINT is set (remote-Chrome mode)', () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'http://127.0.0.1:9222');
+    expect(getBrowserFactory('twitter')).toBe(CDPBridge);
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -12,6 +12,10 @@ export { DEFAULT_BROWSER_COMMAND_TIMEOUT, DEFAULT_BROWSER_CONNECT_TIMEOUT };
  */
 export function getBrowserFactory(site?: string): new () => IBrowserFactory {
   if (site && isElectronApp(site)) return CDPBridge;
+  // Remote-Chrome mode (docs/advanced/remote-chrome.md): an explicit endpoint
+  // routes website CLIs over CDP too, so headless/server environments work
+  // without the Browser Bridge extension.
+  if (process.env.OPENCLI_CDP_ENDPOINT) return CDPBridge;
   return BrowserBridge;
 }
 
@@ -54,14 +58,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
+  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -69,6 +73,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       session: opts.session,
       cdpEndpoint: opts.cdpEndpoint,
+      dedicatedTarget: opts.dedicatedTarget,
       contextId: opts.contextId,
       preferredContextId: opts.preferredContextId,
       idleTimeout: opts.idleTimeout,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -58,14 +58,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean; keepTab?: boolean }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean } = {},
+  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean; keepTab?: boolean } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -74,6 +74,7 @@ export async function browserSession<T>(
       session: opts.session,
       cdpEndpoint: opts.cdpEndpoint,
       dedicatedTarget: opts.dedicatedTarget,
+      keepTab: opts.keepTab,
       contextId: opts.contextId,
       preferredContextId: opts.preferredContextId,
       idleTimeout: opts.idleTimeout,

--- a/tests/e2e/remote-cdp-chrome.test.ts
+++ b/tests/e2e/remote-cdp-chrome.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Real-Chrome coverage for remote-Chrome mode (OPENCLI_CDP_ENDPOINT).
+ *
+ * The unit tests in src/browser/cdp.test.ts drive a hand-written DevTools HTTP
+ * server, so they prove our request shapes against our own assumptions. This
+ * file proves the same shapes against a browser that actually enforces them:
+ * /json/new needs PUT on Chrome 111+, and it needs the ?url= query or Chrome
+ * opens the profile's new-tab page instead of a blank one.
+ *
+ * Opt-in (needs a Chrome/Chromium binary on the machine):
+ *   OPENCLI_REMOTE_CDP_E2E=1 npx vitest run --project e2e-remote-cdp
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { CDPBridge, createDedicatedCDPTarget } from '../../src/browser/cdp.js';
+
+type DevtoolsTarget = { id?: string; type?: string; url?: string };
+
+function findChromeExecutable(): string | null {
+  const candidates = [
+    process.env.CHROME_PATH,
+    process.env.GOOGLE_CHROME_BIN,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter((entry): entry is string => !!entry);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  for (const binary of ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']) {
+    const resolved = spawnSync('which', [binary], { encoding: 'utf8' });
+    const found = resolved.stdout.trim();
+    if (resolved.status === 0 && found) return found;
+  }
+  return null;
+}
+
+async function readDevtoolsPort(userDataDir: string, timeoutMs = 20_000): Promise<number> {
+  const portFile = path.join(userDataDir, 'DevToolsActivePort');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(portFile)) {
+      const port = Number(fs.readFileSync(portFile, 'utf8').split('\n')[0]?.trim());
+      if (Number.isFinite(port) && port > 0) return port;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Chrome never wrote DevToolsActivePort');
+}
+
+/**
+ * Only page targets. Chrome brings its own component-extension service workers
+ * up asynchronously, so a raw /json snapshot is not stable enough to diff.
+ */
+async function listTargets(base: string): Promise<DevtoolsTarget[]> {
+  const res = await fetch(`${base}/json`);
+  const targets = await res.json() as DevtoolsTarget[];
+  return targets.filter((t) => t.type === 'page');
+}
+
+/**
+ * Front the real DevTools HTTP endpoint, but rewrite the WebSocket URL of a
+ * freshly created target to a closed port. The tab is real; the session can
+ * never be established.
+ */
+async function startDeadSocketProxy(upstream: string): Promise<{ base: string; seen: string[]; close: () => Promise<void> }> {
+  const { createServer } = await import('node:http');
+  const seen: string[] = [];
+  const server = createServer((req, res) => {
+    void (async () => {
+      const url = req.url ?? '/';
+      seen.push(`${req.method ?? ''} ${url}`);
+      const upstreamRes = await fetch(`${upstream}${url}`, { method: req.method });
+      const text = await upstreamRes.text();
+      let body = text;
+      try {
+        const parsed = JSON.parse(text) as { id?: string; webSocketDebuggerUrl?: string };
+        if (parsed && typeof parsed === 'object' && parsed.webSocketDebuggerUrl) {
+          // Port 1 is never listening.
+          body = JSON.stringify({ ...parsed, webSocketDebuggerUrl: `ws://127.0.0.1:1/devtools/page/${parsed.id}` });
+        }
+      } catch {
+        // Non-JSON bodies (/json/close) pass through untouched.
+      }
+      res.writeHead(upstreamRes.status, { 'Content-Type': 'application/json' });
+      res.end(body);
+    })().catch(() => {
+      res.writeHead(500);
+      res.end('{}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return {
+    base: `http://127.0.0.1:${port}`,
+    seen,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+const enabled = process.env.OPENCLI_REMOTE_CDP_E2E === '1';
+const chromePath = enabled ? findChromeExecutable() : null;
+
+describe.runIf(enabled && chromePath)('remote-Chrome dedicated tabs (real Chrome)', () => {
+  let chrome: ChildProcess | null = null;
+  let userDataDir = '';
+  let base = '';
+
+  beforeAll(async () => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-remote-cdp-'));
+    chrome = spawn(chromePath!, [
+      '--headless=new',
+      '--no-sandbox',
+      '--disable-gpu',
+      '--remote-debugging-port=0',
+      `--user-data-dir=${userDataDir}`,
+      'about:blank',
+    ], { stdio: 'ignore' });
+    const port = await readDevtoolsPort(userDataDir);
+    base = `http://127.0.0.1:${port}`;
+  }, 60_000);
+
+  afterAll(async () => {
+    chrome?.kill('SIGKILL');
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('creates a blank page target through PUT /json/new?url=about:blank', async () => {
+    const created = await createDedicatedCDPTarget(base);
+
+    expect(created.id).toBeTruthy();
+    expect(created.type).toBe('page');
+    // The ?url= query is load-bearing: without it Chrome opens the profile's
+    // new-tab page, which navigates on its own and races the adapter's goto.
+    expect(created.url).toBe('about:blank');
+    expect(String(created.webSocketDebuggerUrl)).toMatch(/^ws:\/\//);
+
+    await fetch(`${base}/json/close/${created.id}`);
+  });
+
+  it('rejects a bare GET /json/new, which is why the PUT-first fallback exists', async () => {
+    const res = await fetch(`${base}/json/new?url=about:blank`, { method: 'GET' });
+
+    // Chrome 111+ answers 405 here; older builds answer 200. Either way the
+    // PUT-first-then-GET order in createDedicatedCDPTarget covers both.
+    expect([200, 405]).toContain(res.status);
+  });
+
+  it('opens its own tab and removes it on close(), leaving the browser as it was', async () => {
+    const before = await listTargets(base);
+    const bridge = new CDPBridge();
+
+    await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true });
+    const during = await listTargets(base);
+    expect(during.length).toBe(before.length + 1);
+
+    await bridge.close();
+    // Chrome removes the target asynchronously after /json/close returns.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const after = await listTargets(base);
+    expect(after.map((t) => t.id).sort()).toEqual(before.map((t) => t.id).sort());
+  });
+
+  it('leaves its tab open when keepTab is requested', async () => {
+    const before = await listTargets(base);
+
+    const bridge = new CDPBridge();
+    await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true, keepTab: true });
+    await bridge.close();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const kept = await listTargets(base);
+    expect(kept.length).toBe(before.length + 1);
+
+    const leftover = kept.find((t) => !before.some((b) => b.id === t.id));
+    expect(leftover?.url).toBe('about:blank');
+    await fetch(`${base}/json/close/${leftover?.id}`);
+  });
+
+  it('removes its tab when the WebSocket handshake fails', async () => {
+    const before = await listTargets(base);
+    // Chrome really creates the tab; only the WebSocket URL handed back to us is
+    // dead, so this exercises the exact window where a target exists but no
+    // session was ever established.
+    const proxy = await startDeadSocketProxy(base);
+    try {
+      const bridge = new CDPBridge();
+      await expect(bridge.connect({
+        cdpEndpoint: proxy.base,
+        dedicatedTarget: true,
+        keepTab: true,
+        timeout: 5,
+      })).rejects.toThrow();
+
+      expect(proxy.seen).toEqual([
+        expect.stringMatching(/^PUT \/json\/new\?url=about:blank$/),
+        expect.stringMatching(/^GET \/json\/close\//),
+      ]);
+    } finally {
+      await proxy.close();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const after = await listTargets(base);
+    expect(after.map((t) => t.id).sort()).toEqual(before.map((t) => t.id).sort());
+  }, 30_000);
+
+  it('removes its tab when navigation fails after connecting', async () => {
+    const before = await listTargets(base);
+    const bridge = new CDPBridge();
+
+    const page = await bridge.connect({ cdpEndpoint: base, dedicatedTarget: true });
+    // A domain that cannot resolve. Page.navigate reports the failure as an
+    // error page rather than throwing on this transport, so the point here is
+    // not the rejection -- it is that a command which navigated nowhere useful
+    // still leaves the browser clean.
+    await page.goto('http://opencli-e2e.invalid/').catch(() => {});
+    await bridge.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const after = await listTargets(base);
+    expect(after.map((t) => t.id).sort()).toEqual(before.map((t) => t.id).sort());
+  }, 30_000);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 const includeExtendedE2e = process.env.OPENCLI_E2E === '1';
 const includeAxChromeE2e = process.env.OPENCLI_AX_E2E === '1';
+// Remote-Chrome (OPENCLI_CDP_ENDPOINT) coverage drives a locally launched
+// Chrome over the DevTools HTTP API. Opt-in: OPENCLI_REMOTE_CDP_E2E=1.
+const includeRemoteCdpE2e = process.env.OPENCLI_REMOTE_CDP_E2E === '1';
 
 export default defineConfig({
   test: {
@@ -48,6 +51,7 @@ export default defineConfig({
             'tests/e2e/plugin-management.test.ts',
             'tests/e2e/article-download-pipeline.test.ts',
             ...(includeAxChromeE2e ? ['tests/e2e/browser-ax-chrome.test.ts'] : []),
+            ...(includeRemoteCdpE2e ? ['tests/e2e/remote-cdp-chrome.test.ts'] : []),
             // Extended browser tests (20+ sites) — opt-in only:
             //   OPENCLI_E2E=1 npx vitest run
             ...(includeExtendedE2e ? ['tests/e2e/browser-public-extended.test.ts', 'tests/e2e/browser-auth.test.ts', 'tests/e2e/douban.test.ts'] : []),


### PR DESCRIPTION
## Problem

[`docs/advanced/remote-chrome.md`](https://github.com/jackwener/OpenCLI/blob/main/docs/advanced/remote-chrome.md) promises that setting `OPENCLI_CDP_ENDPOINT` lets OpenCLI drive a remote Chrome (headless servers, CI — the doc even ships a CI recipe with `xvfb` + `--remote-debugging-port`). In practice the variable is only honored for **Electron app** CLIs: website CLIs always route through the Browser Bridge extension (`getBrowserFactory` → `BrowserBridge`), which cannot be installed in many remote/headless setups. So `opencli twitter timeline` etc. fail with `Browser Bridge extension not connected` even when a perfectly good remote Chrome is reachable.

## Fix

- **runtime**: `getBrowserFactory` returns `CDPBridge` for any site when `OPENCLI_CDP_ENDPOINT` is set (explicit opt-in; default behavior unchanged, Electron unchanged).
- **execution**: pass the manual endpoint for non-Electron sites. No localhost port probe here — the endpoint may live on another machine; `CDPBridge` already validates it when fetching `/json`.
- **cdp**: website sessions open a **dedicated tab** via `/json/new` (PUT, with GET fallback for pre-111 Chrome) instead of attaching to whichever existing tab ranks first — a shared remote browser may have the user's real tabs open, and hijacking one to navigate to the site would be destructive. The tab is closed on `close()` (best-effort). `ws://` endpoints and the existing attach path (Electron / no `dedicatedTarget`) keep their previous behavior, including `OPENCLI_CDP_TARGET` ranking.

## Tests

- Dedicated-tab lifecycle against a real local HTTP server: create → close sequence, `PUT`→`GET` fallback on 405, and legacy attach path unchanged (`GET /json` only).
- Factory routing unit tests (env unset → `BrowserBridge`; set → `CDPBridge`).
- `npx tsc --noEmit` clean; full `npm test` — the only failures are 2 pre-existing ones in `src/download/index.test.ts` (cross-domain redirect cookies), reproducible on a clean `main` checkout in the same environment.

## Verified end-to-end

Against a real Chrome on another machine over the network (no extension installed in that Chrome):

```console
$ export OPENCLI_CDP_ENDPOINT="http://<remote-host>"
$ opencli twitter whoami
logged_in: true
username: <redacted>
$ opencli twitter timeline --type for-you --limit 5 --format json
# 5 tweets, correct content
```

Tab hygiene confirmed: repeated runs leave no extra tabs in the shared browser.

## Docs

`remote-chrome.md` updated to state that website CLIs work in this mode, describe the dedicated-tab semantics, and clarify `ws://` endpoint behavior.
