### PR TITLE
feat(jira): add custom field support

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -20296,6 +20296,12 @@
         "default": 100,
         "required": false,
         "help": "Max comments to include (1-100)"
+      },
+      {
+        "name": "fields",
+        "type": "string",
+        "required": false,
+        "help": "Fields to request, comma-separated, or auto for all fields"
       }
     ],
     "columns": [

--- a/clis/_atlassian/shared.test.js
+++ b/clis/_atlassian/shared.test.js
@@ -9,7 +9,6 @@ const ENV_KEYS = [
     'ATLASSIAN_API_TOKEN',
     'ATLASSIAN_PAT',
     'ATLASSIAN_JIRA_BASE_URL',
-    'ATLASSIAN_JIRA_FIELDS',
 ];
 
 function clearEnv() {

--- a/clis/_atlassian/shared.test.js
+++ b/clis/_atlassian/shared.test.js
@@ -9,6 +9,7 @@ const ENV_KEYS = [
     'ATLASSIAN_API_TOKEN',
     'ATLASSIAN_PAT',
     'ATLASSIAN_JIRA_BASE_URL',
+    'ATLASSIAN_JIRA_FIELDS',
 ];
 
 function clearEnv() {

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -16,7 +16,6 @@ const ENV_KEYS = [
     'ATLASSIAN_USERNAME',
     'ATLASSIAN_PASSWORD',
     'ATLASSIAN_PAT',
-    'ATLASSIAN_JIRA_FIELDS',
 ];
 
 function clearEnv() {
@@ -100,9 +99,8 @@ describe('jira commands', () => {
         expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
     });
 
-    it('uses configured fields and resolves custom field names', async () => {
+    it('uses --fields and resolves custom field names', async () => {
         setCloudEnv();
-        process.env.ATLASSIAN_JIRA_FIELDS = ' summary , status, customfield_12345, customfield_12345 ';
         vi.stubGlobal('fetch', vi.fn(async (url) => {
             const parsed = new URL(String(url));
             expect(parsed.searchParams.get('fields')).toBe('summary,status,customfield_12345');
@@ -120,7 +118,7 @@ describe('jira commands', () => {
             });
         }));
         const cmd = getRegistry().get('jira/issue');
-        const rows = await cmd.func({ key: 'PROJ-1' });
+        const rows = await cmd.func({ key: 'PROJ-1', fields: ' summary , status, customfield_12345, customfield_12345 ' });
         expect(rows[0]).toMatchObject({
             key: 'PROJ-1',
             summary: 'Checkout fails',
@@ -132,19 +130,17 @@ describe('jira commands', () => {
         expect(rows[0].linkedIssues).toEqual([]);
     });
 
-    it('rejects empty configured Jira fields', async () => {
+    it('rejects empty --fields values', async () => {
         setCloudEnv();
-        process.env.ATLASSIAN_JIRA_FIELDS = ' , ';
         const fetchMock = vi.fn();
         vi.stubGlobal('fetch', fetchMock);
         const cmd = getRegistry().get('jira/issue');
-        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toMatchObject({ code: 'CONFIG' });
+        await expect(cmd.func({ key: 'PROJ-1', fields: ' , ' })).rejects.toMatchObject({ code: 'CONFIG' });
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('fetches all fields in auto mode and cleans nulls with named custom fields', async () => {
         setCloudEnv();
-        process.env.ATLASSIAN_JIRA_FIELDS = 'auto';
         vi.stubGlobal('fetch', vi.fn(async (url) => {
             const parsed = new URL(String(url));
             expect(parsed.searchParams.has('fields')).toBe(false);
@@ -164,7 +160,7 @@ describe('jira commands', () => {
             });
         }));
         const cmd = getRegistry().get('jira/issue');
-        const rows = await cmd.func({ key: 'PROJ-1' });
+        const rows = await cmd.func({ key: 'PROJ-1', fields: 'auto' });
         expect(rows[0].fields).toEqual({
             summary: 'Checkout fails',
             'Customer Segment': 'Enterprise',

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -16,7 +16,30 @@ const ENV_KEYS = [
     'ATLASSIAN_USERNAME',
     'ATLASSIAN_PASSWORD',
     'ATLASSIAN_PAT',
+    'ATLASSIAN_JIRA_ACCEPTANCE_FIELD',
+    'ATLASSIAN_JIRA_SPRINT_FIELD',
+    'ATLASSIAN_JIRA_STORY_POINTS_FIELD',
 ];
+
+const DEFAULT_ISSUE_FIELDS = [
+    'summary',
+    'issuetype',
+    'status',
+    'priority',
+    'labels',
+    'description',
+    'comment',
+    'attachment',
+    'issuelinks',
+    'fixVersions',
+    'versions',
+    'components',
+    'project',
+    'reporter',
+    'assignee',
+    'created',
+    'updated',
+].join(',');
 
 function clearEnv() {
     for (const key of ENV_KEYS) delete process.env[key];
@@ -52,7 +75,10 @@ describe('jira commands', () => {
     it('normalizes a Cloud issue into agent-friendly context', async () => {
         setCloudEnv();
         vi.stubGlobal('fetch', vi.fn(async (url) => {
-            expect(String(url)).toContain('/rest/api/3/issue/PROJ-1?');
+            const parsed = new URL(String(url));
+            expect(parsed.pathname).toBe('/rest/api/3/issue/PROJ-1');
+            expect(parsed.searchParams.get('fields')).toBe(DEFAULT_ISSUE_FIELDS);
+            expect(parsed.searchParams.get('expand')).toBe('renderedFields');
             return jsonResponse({
                 id: '10001',
                 key: 'PROJ-1',
@@ -97,75 +123,174 @@ describe('jira commands', () => {
         expect(rows[0].comments[0].markdown).toBe('Needs RCA');
         expect(rows[0].attachments[0].filename).toBe('log.txt');
         expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
+        expect(rows[0]).not.toHaveProperty('selectedFields');
     });
 
-    it('uses --fields and resolves custom field names', async () => {
+    it('keeps selected field ids when display names collide and preserves request order', async () => {
         setCloudEnv();
         vi.stubGlobal('fetch', vi.fn(async (url) => {
             const parsed = new URL(String(url));
-            expect(parsed.searchParams.get('fields')).toBe('summary,status,customfield_12345');
+            expect(parsed.searchParams.get('fields')).toBe('summary,customfield_12345,customfield_12346');
             expect(parsed.searchParams.get('expand')).toBe('renderedFields,names');
             return jsonResponse({
                 key: 'PROJ-1',
                 fields: {
                     summary: 'Checkout fails',
-                    status: { name: 'In Progress' },
                     customfield_12345: 8,
+                    customfield_12346: { tier: 'enterprise' },
                 },
                 names: {
+                    summary: 'Story Estimate',
                     customfield_12345: 'Story Estimate',
+                    customfield_12346: 'Story Estimate',
                 },
             });
         }));
         const cmd = getRegistry().get('jira/issue');
-        const rows = await cmd.func({ key: 'PROJ-1', fields: ' summary , status, customfield_12345, customfield_12345 ' });
+        const rows = await cmd.func({
+            key: 'PROJ-1',
+            fields: ' summary , customfield_12345, customfield_12346, customfield_12345 ',
+        });
         expect(rows[0]).toMatchObject({
             key: 'PROJ-1',
             summary: 'Checkout fails',
-            status: 'In Progress',
-            customFields: { 'Story Estimate': 8 },
+            selectedFields: [
+                { id: 'summary', name: 'Story Estimate', value: 'Checkout fails' },
+                { id: 'customfield_12345', name: 'Story Estimate', value: 8 },
+                { id: 'customfield_12346', name: 'Story Estimate', value: { tier: 'enterprise' } },
+            ],
         });
         expect(rows[0].comments).toEqual([]);
         expect(rows[0].attachments).toEqual([]);
         expect(rows[0].linkedIssues).toEqual([]);
     });
 
-    it('rejects empty --fields values', async () => {
-        setCloudEnv();
-        const fetchMock = vi.fn();
+    it.each([
+        ' , ',
+        'summary,,status',
+        'auto,summary',
+        'summary/status',
+    ])('rejects invalid --fields value %j before configuration or fetch', async (fields) => {
+        clearEnv();
+        const fetchMock = vi.fn(async () => jsonResponse({}));
         vi.stubGlobal('fetch', fetchMock);
         const cmd = getRegistry().get('jira/issue');
-        await expect(cmd.func({ key: 'PROJ-1', fields: ' , ' })).rejects.toMatchObject({ code: 'CONFIG' });
+        await expect(cmd.func({ key: 'PROJ-1', fields })).rejects.toMatchObject({ code: 'ARGUMENT' });
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('fetches all fields in auto mode and cleans nulls with named custom fields', async () => {
+    it('explicitly requests all fields in auto mode and preserves stable ids, nulls, and objects', async () => {
         setCloudEnv();
         vi.stubGlobal('fetch', vi.fn(async (url) => {
             const parsed = new URL(String(url));
-            expect(parsed.searchParams.has('fields')).toBe(false);
+            expect(parsed.searchParams.get('fields')).toBe('*all');
             expect(parsed.searchParams.get('expand')).toBe('renderedFields,names');
             return jsonResponse({
                 key: 'PROJ-1',
                 fields: {
                     summary: 'Checkout fails',
-                    customfield_12345: 'Enterprise',
+                    customfield_12345: { tier: 'enterprise' },
                     customfield_12346: null,
                     status: { name: 'In Progress' },
+                    comment: { total: 0, comments: [] },
+                    attachment: [],
+                    issuelinks: [],
                 },
                 names: {
                     customfield_12345: 'Customer Segment',
-                    customfield_12346: 'Unused Field',
+                    customfield_12346: null,
                 },
             });
         }));
         const cmd = getRegistry().get('jira/issue');
         const rows = await cmd.func({ key: 'PROJ-1', fields: 'auto' });
-        expect(rows[0].fields).toEqual({
-            summary: 'Checkout fails',
-            'Customer Segment': 'Enterprise',
-            status: { name: 'In Progress' },
+        expect(rows[0].selectedFields.map((field) => field.id)).toEqual([
+            'attachment',
+            'comment',
+            'customfield_12345',
+            'customfield_12346',
+            'issuelinks',
+            'status',
+            'summary',
+        ]);
+        expect(rows[0].selectedFields.find((field) => field.id === 'customfield_12345')).toEqual({
+            id: 'customfield_12345',
+            name: 'Customer Segment',
+            value: { tier: 'enterprise' },
         });
+        expect(rows[0].selectedFields.find((field) => field.id === 'customfield_12346')).toEqual({
+            id: 'customfield_12346',
+            name: 'customfield_12346',
+            value: null,
+        });
+    });
+
+    it('normalizes nested collections when they are explicitly selected', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            key: 'PROJ-1',
+            fields: {
+                comment: {
+                    total: 1,
+                    comments: [{ id: 'c1', author: { displayName: 'Alice' }, created: '2026-05-01', body: 'one' }],
+                },
+                attachment: [{ id: 'a1', filename: 'proof.txt', content: 'https://team.atlassian.net/a1' }],
+                issuelinks: [{ type: { name: 'Blocks' }, outwardIssue: { key: 'PROJ-2' } }],
+            },
+            names: {},
+        })));
+        const cmd = getRegistry().get('jira/issue');
+        const [row] = await cmd.func({ key: 'PROJ-1', fields: 'comment,attachment,issuelinks' });
+        expect(row.comments.map((comment) => comment.id)).toEqual(['c1']);
+        expect(row.attachments.map((attachment) => attachment.id)).toEqual(['a1']);
+        expect(row.linkedIssues.map((issue) => issue.key)).toEqual(['PROJ-2']);
+        expect(row.selectedFields.map((field) => field.id)).toEqual(['comment', 'attachment', 'issuelinks']);
+    });
+
+    it('unions internal transport fields without exposing them as selected fields', async () => {
+        setCloudEnv();
+        const selection = jiraSharedTest.parseIssueFieldSelection('summary');
+        const fetchMock = vi.fn(async (url) => {
+            const parsed = new URL(String(url));
+            expect(parsed.searchParams.get('fields')).toBe('summary,attachment');
+            return jsonResponse({ key: 'PROJ-1', fields: { summary: 'Task', attachment: [] }, names: {} });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const config = {
+            baseUrl: 'https://team.atlassian.net',
+            deployment: 'cloud',
+            product: 'jira',
+            authHeaders: {},
+        };
+        const issue = await jiraSharedTest.fetchIssue(config, 'PROJ-1', ['attachment'], selection);
+        const row = jiraSharedTest.normalizeJiraIssue(issue, config, {
+            selection,
+            requireNestedCollections: false,
+        });
+        expect(row.selectedFields).toEqual([{ id: 'summary', name: 'summary', value: 'Task' }]);
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('fails typed when an explicitly requested field is absent from the response', async () => {
+        setCloudEnv();
+        vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+            key: 'PROJ-1',
+            fields: { summary: 'Task' },
+            names: { customfield_12345: 'Estimate' },
+        })));
+        const cmd = getRegistry().get('jira/issue');
+        await expect(cmd.func({ key: 'PROJ-1', fields: 'summary,customfield_12345' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('validates --comments-limit before Jira configuration or fetch', async () => {
+        clearEnv();
+        const fetchMock = vi.fn(async () => jsonResponse({}));
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('jira/issue');
+        await expect(cmd.func({ key: 'PROJ-1', 'comments-limit': 0 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT' });
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('fails typed when Jira issue payload is missing stable issue identity', async () => {
@@ -272,6 +397,30 @@ describe('jira commands', () => {
         const rows = await cmd.func({ key: 'PROJ-1', 'comments-limit': 10 });
         expect(rows[0].comments.map((comment) => comment.id)).toEqual(['c1', 'c2']);
         expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the Data Center v2 issue endpoint with selected field names', async () => {
+        clearEnv();
+        process.env.ATLASSIAN_JIRA_BASE_URL = 'https://jira.example.com';
+        process.env.ATLASSIAN_DEPLOYMENT = 'datacenter';
+        process.env.ATLASSIAN_PAT = 'secret';
+        vi.stubGlobal('fetch', vi.fn(async (url) => {
+            const parsed = new URL(String(url));
+            expect(parsed.pathname).toBe('/rest/api/2/issue/PROJ-1');
+            expect(parsed.searchParams.get('fields')).toBe('summary,customfield_12345');
+            expect(parsed.searchParams.get('expand')).toBe('renderedFields,names');
+            return jsonResponse({
+                key: 'PROJ-1',
+                fields: { summary: 'Data Center task', customfield_12345: 5 },
+                names: { summary: 'Summary', customfield_12345: 'Estimate' },
+            });
+        }));
+        const cmd = getRegistry().get('jira/issue');
+        const [row] = await cmd.func({ key: 'PROJ-1', fields: 'summary,customfield_12345' });
+        expect(row.selectedFields).toEqual([
+            { id: 'summary', name: 'Summary', value: 'Data Center task' },
+            { id: 'customfield_12345', name: 'Estimate', value: 5 },
+        ]);
     });
 
     it('uses Data Center search endpoint and payload', async () => {

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -16,6 +16,7 @@ const ENV_KEYS = [
     'ATLASSIAN_USERNAME',
     'ATLASSIAN_PASSWORD',
     'ATLASSIAN_PAT',
+    'ATLASSIAN_JIRA_FIELDS',
 ];
 
 function clearEnv() {
@@ -97,6 +98,78 @@ describe('jira commands', () => {
         expect(rows[0].comments[0].markdown).toBe('Needs RCA');
         expect(rows[0].attachments[0].filename).toBe('log.txt');
         expect(rows[0].linkedIssues[0]).toEqual({ key: 'PROJ-2', type: 'Blocks', direction: 'outward' });
+    });
+
+    it('uses configured fields and resolves custom field names', async () => {
+        setCloudEnv();
+        process.env.ATLASSIAN_JIRA_FIELDS = JSON.stringify([' summary ', 'status', 'customfield_12345', 'customfield_12345']);
+        vi.stubGlobal('fetch', vi.fn(async (url) => {
+            const parsed = new URL(String(url));
+            expect(parsed.searchParams.get('fields')).toBe('summary,status,customfield_12345');
+            expect(parsed.searchParams.get('expand')).toBe('renderedFields,names');
+            return jsonResponse({
+                key: 'PROJ-1',
+                fields: {
+                    summary: 'Checkout fails',
+                    status: { name: 'In Progress' },
+                    customfield_12345: 8,
+                },
+                names: {
+                    customfield_12345: 'Story Estimate',
+                },
+            });
+        }));
+        const cmd = getRegistry().get('jira/issue');
+        const rows = await cmd.func({ key: 'PROJ-1' });
+        expect(rows[0]).toMatchObject({
+            key: 'PROJ-1',
+            summary: 'Checkout fails',
+            status: 'In Progress',
+            customFields: { 'Story Estimate': 8 },
+        });
+        expect(rows[0].comments).toEqual([]);
+        expect(rows[0].attachments).toEqual([]);
+        expect(rows[0].linkedIssues).toEqual([]);
+    });
+
+    it('rejects invalid configured Jira fields', async () => {
+        setCloudEnv();
+        process.env.ATLASSIAN_JIRA_FIELDS = '{invalid';
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const cmd = getRegistry().get('jira/issue');
+        await expect(cmd.func({ key: 'PROJ-1' })).rejects.toMatchObject({ code: 'CONFIG' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches all fields in auto mode and cleans nulls with named custom fields', async () => {
+        setCloudEnv();
+        process.env.ATLASSIAN_JIRA_FIELDS = 'auto';
+        vi.stubGlobal('fetch', vi.fn(async (url) => {
+            const parsed = new URL(String(url));
+            expect(parsed.searchParams.has('fields')).toBe(false);
+            expect(parsed.searchParams.get('expand')).toBe('renderedFields,names');
+            return jsonResponse({
+                key: 'PROJ-1',
+                fields: {
+                    summary: 'Checkout fails',
+                    customfield_12345: 'Enterprise',
+                    customfield_12346: null,
+                    status: { name: 'In Progress' },
+                },
+                names: {
+                    customfield_12345: 'Customer Segment',
+                    customfield_12346: 'Unused Field',
+                },
+            });
+        }));
+        const cmd = getRegistry().get('jira/issue');
+        const rows = await cmd.func({ key: 'PROJ-1' });
+        expect(rows[0].fields).toEqual({
+            summary: 'Checkout fails',
+            'Customer Segment': 'Enterprise',
+            status: { name: 'In Progress' },
+        });
     });
 
     it('fails typed when Jira issue payload is missing stable issue identity', async () => {

--- a/clis/jira/commands.test.js
+++ b/clis/jira/commands.test.js
@@ -102,7 +102,7 @@ describe('jira commands', () => {
 
     it('uses configured fields and resolves custom field names', async () => {
         setCloudEnv();
-        process.env.ATLASSIAN_JIRA_FIELDS = JSON.stringify([' summary ', 'status', 'customfield_12345', 'customfield_12345']);
+        process.env.ATLASSIAN_JIRA_FIELDS = ' summary , status, customfield_12345, customfield_12345 ';
         vi.stubGlobal('fetch', vi.fn(async (url) => {
             const parsed = new URL(String(url));
             expect(parsed.searchParams.get('fields')).toBe('summary,status,customfield_12345');
@@ -132,9 +132,9 @@ describe('jira commands', () => {
         expect(rows[0].linkedIssues).toEqual([]);
     });
 
-    it('rejects invalid configured Jira fields', async () => {
+    it('rejects empty configured Jira fields', async () => {
         setCloudEnv();
-        process.env.ATLASSIAN_JIRA_FIELDS = '{invalid';
+        process.env.ATLASSIAN_JIRA_FIELDS = ' , ';
         const fetchMock = vi.fn();
         vi.stubGlobal('fetch', fetchMock);
         const cmd = getRegistry().get('jira/issue');

--- a/clis/jira/issue.js
+++ b/clis/jira/issue.js
@@ -1,5 +1,14 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { fetchComments, fetchIssue, jiraConfig, normalizeJiraIssue, requireIssueKey } from './shared.js';
+import {
+    fetchComments,
+    fetchIssue,
+    issueSelectionIncludes,
+    jiraConfig,
+    normalizeJiraIssue,
+    parseIssueFieldSelection,
+    parseJiraLimit,
+    requireIssueKey,
+} from './shared.js';
 
 cli({
     site: 'jira',
@@ -17,13 +26,18 @@ cli({
     columns: ['key', 'summary', 'issueType', 'status', 'priority', 'assignee', 'updated', 'url'],
     func: async (args) => {
         const key = requireIssueKey(args.key);
+        const selection = parseIssueFieldSelection(args.fields);
+        const commentsLimit = parseJiraLimit(args['comments-limit'], 100, 100);
         const config = jiraConfig();
-        const issue = await fetchIssue(config, key, [], args.fields);
-        const inlineComments = issue?.fields?.comment?.comments;
-        const total = Number(issue?.fields?.comment?.total ?? inlineComments?.length ?? 0);
-        const comments = total > (inlineComments?.length ?? 0)
-            ? await fetchComments(config, key, args['comments-limit'])
-            : inlineComments;
-        return [normalizeJiraIssue(issue, config, { comments, fields: args.fields })];
+        const issue = await fetchIssue(config, key, [], selection);
+        let comments;
+        if (issueSelectionIncludes(selection, 'comment')) {
+            const inlineComments = issue?.fields?.comment?.comments;
+            const total = Number(issue?.fields?.comment?.total ?? inlineComments?.length ?? 0);
+            comments = total > (inlineComments?.length ?? 0)
+                ? await fetchComments(config, key, commentsLimit)
+                : inlineComments;
+        }
+        return [normalizeJiraIssue(issue, config, { comments, selection })];
     },
 });

--- a/clis/jira/issue.js
+++ b/clis/jira/issue.js
@@ -12,17 +12,18 @@ cli({
     args: [
         { name: 'key', positional: true, required: true, help: 'Jira issue key, e.g. PROJ-123' },
         { name: 'comments-limit', type: 'int', default: 100, help: 'Max comments to include (1-100)' },
+        { name: 'fields', type: 'string', help: 'Fields to request, comma-separated, or auto for all fields' },
     ],
     columns: ['key', 'summary', 'issueType', 'status', 'priority', 'assignee', 'updated', 'url'],
     func: async (args) => {
         const key = requireIssueKey(args.key);
         const config = jiraConfig();
-        const issue = await fetchIssue(config, key);
+        const issue = await fetchIssue(config, key, [], args.fields);
         const inlineComments = issue?.fields?.comment?.comments;
         const total = Number(issue?.fields?.comment?.total ?? inlineComments?.length ?? 0);
         const comments = total > (inlineComments?.length ?? 0)
             ? await fetchComments(config, key, args['comments-limit'])
             : inlineComments;
-        return [normalizeJiraIssue(issue, config, { comments })];
+        return [normalizeJiraIssue(issue, config, { comments, fields: args.fields })];
     },
 });

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -11,7 +11,7 @@ import {
     requirePayloadString,
     requireString,
 } from '../_atlassian/shared.js';
-import { ArgumentError, ConfigError } from '@jackwener/opencli/errors';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 const DEFAULT_ISSUE_FIELDS = [
     'summary',
@@ -53,26 +53,45 @@ function configuredFieldNames() {
     };
 }
 
-function configuredIssueFields(raw) {
+export function parseIssueFieldSelection(raw) {
     if (raw === undefined) return null;
-    if (raw.trim().toLowerCase() === 'auto') return 'auto';
+    if (typeof raw !== 'string') {
+        throw new ArgumentError('Jira --fields must be a comma-separated string or auto');
+    }
 
-    const fields = raw.split(',').map((field) => field.trim()).filter(Boolean);
-    if (fields.length === 0) {
-        throw new ConfigError(
-            'Invalid Jira fields',
-            'Set --fields to comma-separated field names, for example summary,status,customfield_12345.',
+    const parts = raw.split(',').map((field) => field.trim());
+    if (parts.length === 0 || parts.some((field) => !field)) {
+        throw new ArgumentError(
+            'Invalid Jira --fields selection',
+            'Use comma-separated field ids without empty entries, for example summary,status,customfield_12345.',
         );
     }
-    return [...new Set(fields)];
+    if (parts.some((field) => field.toLowerCase() === 'auto')) {
+        if (parts.length !== 1) {
+            throw new ArgumentError('Jira --fields auto cannot be combined with other field ids');
+        }
+        return { mode: 'auto' };
+    }
+    if (parts.some((field) => !/^[A-Za-z][A-Za-z0-9_.:-]*$/.test(field))) {
+        throw new ArgumentError(
+            'Invalid Jira field id in --fields',
+            'Use Jira field ids such as summary, status, or customfield_12345.',
+        );
+    }
+    return { mode: 'selected', ids: [...new Set(parts)] };
 }
 
-function issueFields(extraFields = [], fieldsOverride) {
-    const selected = configuredIssueFields(fieldsOverride);
-    if (selected === 'auto') return undefined;
-    if (selected !== null) return selected.join(',');
+function issueFields(extraFields = [], selection = null) {
+    if (selection?.mode === 'auto') return '*all';
+    if (selection?.mode === 'selected') {
+        return [...new Set([...selection.ids, ...extraFields.filter(Boolean)])].join(',');
+    }
     const configured = Object.values(configuredFieldNames()).filter(Boolean);
     return [...new Set([...DEFAULT_ISSUE_FIELDS, ...configured, ...extraFields.filter(Boolean)])].join(',');
+}
+
+export function issueSelectionIncludes(selection, field) {
+    return selection === null || selection?.mode === 'auto' || selection?.ids?.includes(field) === true;
 }
 
 export function parseJiraLimit(value, fallback = 20, max = 100) {
@@ -153,25 +172,21 @@ function customValueToMarkdown(value) {
     return valueName(value);
 }
 
-function autoFields(fields, names) {
-    const result = {};
-    for (const [field, value] of Object.entries(fields)) {
-        if (value === null) continue;
-        const name = field.startsWith('customfield_')
-            && typeof names[field] === 'string'
-            && names[field].trim()
-            ? names[field].trim()
-            : field;
-        result[name] = value;
-    }
-    return result;
-}
-
 function inlineComments(fields, key, options) {
     if (options.comments !== undefined) return requirePayloadArray(options.comments, `jira issue ${key} comments`);
-    if (options.requireNestedCollections === false) return [];
     const commentBlock = requirePayloadObject(fields.comment, `jira issue ${key} comment field`);
     return requirePayloadArray(commentBlock.comments, `jira issue ${key} comment field comments`);
+}
+
+function selectedFieldRows(fields, names, selection, key) {
+    const ids = selection.mode === 'auto' ? Object.keys(fields).sort() : selection.ids;
+    return ids.map((id) => {
+        if (!Object.prototype.hasOwnProperty.call(fields, id)) {
+            throw new CommandExecutionError(`jira issue ${key} did not return requested field ${id}.`);
+        }
+        const name = typeof names[id] === 'string' && names[id].trim() ? names[id].trim() : id;
+        return { id, name, value: fields[id] };
+    });
 }
 
 export function normalizeJiraIssue(issue, config, options = {}) {
@@ -181,14 +196,16 @@ export function normalizeJiraIssue(issue, config, options = {}) {
     const rendered = row.renderedFields && typeof row.renderedFields === 'object' && !Array.isArray(row.renderedFields)
         ? row.renderedFields
         : {};
-    const selectedFields = configuredIssueFields(options.fields);
+    const selection = options.selection ?? null;
     const custom = configuredFieldNames();
-    const requireNestedCollections = selectedFields === null && options.requireNestedCollections !== false;
-    const comments = inlineComments(fields, key, { ...options, requireNestedCollections });
-    const attachments = requireNestedCollections
+    const includeComments = options.requireNestedCollections !== false && issueSelectionIncludes(selection, 'comment');
+    const includeAttachments = options.requireNestedCollections !== false && issueSelectionIncludes(selection, 'attachment');
+    const includeIssueLinks = options.requireNestedCollections !== false && issueSelectionIncludes(selection, 'issuelinks');
+    const comments = includeComments ? inlineComments(fields, key, options) : [];
+    const attachments = includeAttachments
         ? requirePayloadArray(fields.attachment, `jira issue ${key} attachment field`)
         : [];
-    const issueLinks = requireNestedCollections
+    const issueLinks = includeIssueLinks
         ? requirePayloadArray(fields.issuelinks, `jira issue ${key} issuelinks field`)
         : [];
     const normalized = {
@@ -228,19 +245,9 @@ export function normalizeJiraIssue(issue, config, options = {}) {
     if (custom.storyPoints && fields[custom.storyPoints] !== undefined) {
         normalized.storyPoints = Number(fields[custom.storyPoints]);
     }
-    if (selectedFields !== null) {
+    if (selection !== null) {
         const names = row.names && typeof row.names === 'object' && !Array.isArray(row.names) ? row.names : {};
-        if (selectedFields === 'auto') {
-            normalized.fields = autoFields(fields, names);
-        } else {
-            const customFields = {};
-            for (const field of selectedFields) {
-                if (!field.startsWith('customfield_') || fields[field] === undefined) continue;
-                const name = typeof names[field] === 'string' && names[field].trim() ? names[field].trim() : field;
-                customFields[name] = fields[field];
-            }
-            if (Object.keys(customFields).length > 0) normalized.customFields = customFields;
-        }
+        normalized.selectedFields = selectedFieldRows(fields, names, selection, key);
     }
     return normalized;
 }
@@ -259,12 +266,11 @@ export function issueSummaryRow(issue, config) {
     };
 }
 
-export async function fetchIssue(config, key, extraFields = [], fieldsOverride) {
-    const fields = issueFields(extraFields, fieldsOverride);
+export async function fetchIssue(config, key, extraFields = [], selection = null) {
     const params = {
-        expand: 'renderedFields,names',
+        fields: issueFields(extraFields, selection),
+        expand: selection === null ? 'renderedFields' : 'renderedFields,names',
     };
-    if (fields !== undefined) params.fields = fields;
     const issue = await jiraRequest(config, `/issue/${encodeURIComponent(key)}`, {
         params,
         label: `jira issue ${key}`,
@@ -293,6 +299,8 @@ export function jiraConfig() {
 export const __test__ = {
     configuredFieldNames,
     fetchIssue,
+    issueFields,
+    issueSelectionIncludes,
     issueSummaryRow,
     jiraApiPath,
     jiraBodyToMarkdown,
@@ -300,5 +308,6 @@ export const __test__ = {
     normalizeComment,
     normalizeIssueLink,
     normalizeJiraIssue,
+    parseIssueFieldSelection,
     requireIssueKey,
 };

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -58,22 +58,14 @@ function configuredIssueFields() {
     if (raw === undefined) return null;
     if (raw.trim().toLowerCase() === 'auto') return 'auto';
 
-    let parsed;
-    try {
-        parsed = JSON.parse(raw);
-    } catch {
+    const fields = raw.split(',').map((field) => field.trim()).filter(Boolean);
+    if (fields.length === 0) {
         throw new ConfigError(
             'Invalid ATLASSIAN_JIRA_FIELDS',
-            'Set ATLASSIAN_JIRA_FIELDS to a JSON array of field names, for example ["summary","customfield_12345"].',
+            'Set ATLASSIAN_JIRA_FIELDS to comma-separated field names, for example summary,status,customfield_12345.',
         );
     }
-    if (!Array.isArray(parsed) || parsed.some((field) => typeof field !== 'string' || !field.trim())) {
-        throw new ConfigError(
-            'Invalid ATLASSIAN_JIRA_FIELDS',
-            'Set ATLASSIAN_JIRA_FIELDS to a JSON array of non-empty strings.',
-        );
-    }
-    return [...new Set(parsed.map((field) => field.trim()))];
+    return [...new Set(fields)];
 }
 
 function issueFields(extraFields = []) {

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -53,23 +53,22 @@ function configuredFieldNames() {
     };
 }
 
-function configuredIssueFields() {
-    const raw = process.env.ATLASSIAN_JIRA_FIELDS;
+function configuredIssueFields(raw) {
     if (raw === undefined) return null;
     if (raw.trim().toLowerCase() === 'auto') return 'auto';
 
     const fields = raw.split(',').map((field) => field.trim()).filter(Boolean);
     if (fields.length === 0) {
         throw new ConfigError(
-            'Invalid ATLASSIAN_JIRA_FIELDS',
-            'Set ATLASSIAN_JIRA_FIELDS to comma-separated field names, for example summary,status,customfield_12345.',
+            'Invalid Jira fields',
+            'Set --fields to comma-separated field names, for example summary,status,customfield_12345.',
         );
     }
     return [...new Set(fields)];
 }
 
-function issueFields(extraFields = []) {
-    const selected = configuredIssueFields();
+function issueFields(extraFields = [], fieldsOverride) {
+    const selected = configuredIssueFields(fieldsOverride);
     if (selected === 'auto') return undefined;
     if (selected !== null) return selected.join(',');
     const configured = Object.values(configuredFieldNames()).filter(Boolean);
@@ -182,7 +181,7 @@ export function normalizeJiraIssue(issue, config, options = {}) {
     const rendered = row.renderedFields && typeof row.renderedFields === 'object' && !Array.isArray(row.renderedFields)
         ? row.renderedFields
         : {};
-    const selectedFields = configuredIssueFields();
+    const selectedFields = configuredIssueFields(options.fields);
     const custom = configuredFieldNames();
     const requireNestedCollections = selectedFields === null && options.requireNestedCollections !== false;
     const comments = inlineComments(fields, key, { ...options, requireNestedCollections });
@@ -260,8 +259,8 @@ export function issueSummaryRow(issue, config) {
     };
 }
 
-export async function fetchIssue(config, key, extraFields = []) {
-    const fields = issueFields(extraFields);
+export async function fetchIssue(config, key, extraFields = [], fieldsOverride) {
+    const fields = issueFields(extraFields, fieldsOverride);
     const params = {
         expand: 'renderedFields,names',
     };

--- a/clis/jira/shared.js
+++ b/clis/jira/shared.js
@@ -11,7 +11,7 @@ import {
     requirePayloadString,
     requireString,
 } from '../_atlassian/shared.js';
-import { ArgumentError } from '@jackwener/opencli/errors';
+import { ArgumentError, ConfigError } from '@jackwener/opencli/errors';
 
 const DEFAULT_ISSUE_FIELDS = [
     'summary',
@@ -53,7 +53,33 @@ function configuredFieldNames() {
     };
 }
 
+function configuredIssueFields() {
+    const raw = process.env.ATLASSIAN_JIRA_FIELDS;
+    if (raw === undefined) return null;
+    if (raw.trim().toLowerCase() === 'auto') return 'auto';
+
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        throw new ConfigError(
+            'Invalid ATLASSIAN_JIRA_FIELDS',
+            'Set ATLASSIAN_JIRA_FIELDS to a JSON array of field names, for example ["summary","customfield_12345"].',
+        );
+    }
+    if (!Array.isArray(parsed) || parsed.some((field) => typeof field !== 'string' || !field.trim())) {
+        throw new ConfigError(
+            'Invalid ATLASSIAN_JIRA_FIELDS',
+            'Set ATLASSIAN_JIRA_FIELDS to a JSON array of non-empty strings.',
+        );
+    }
+    return [...new Set(parsed.map((field) => field.trim()))];
+}
+
 function issueFields(extraFields = []) {
+    const selected = configuredIssueFields();
+    if (selected === 'auto') return undefined;
+    if (selected !== null) return selected.join(',');
     const configured = Object.values(configuredFieldNames()).filter(Boolean);
     return [...new Set([...DEFAULT_ISSUE_FIELDS, ...configured, ...extraFields.filter(Boolean)])].join(',');
 }
@@ -136,6 +162,20 @@ function customValueToMarkdown(value) {
     return valueName(value);
 }
 
+function autoFields(fields, names) {
+    const result = {};
+    for (const [field, value] of Object.entries(fields)) {
+        if (value === null) continue;
+        const name = field.startsWith('customfield_')
+            && typeof names[field] === 'string'
+            && names[field].trim()
+            ? names[field].trim()
+            : field;
+        result[name] = value;
+    }
+    return result;
+}
+
 function inlineComments(fields, key, options) {
     if (options.comments !== undefined) return requirePayloadArray(options.comments, `jira issue ${key} comments`);
     if (options.requireNestedCollections === false) return [];
@@ -150,9 +190,10 @@ export function normalizeJiraIssue(issue, config, options = {}) {
     const rendered = row.renderedFields && typeof row.renderedFields === 'object' && !Array.isArray(row.renderedFields)
         ? row.renderedFields
         : {};
+    const selectedFields = configuredIssueFields();
     const custom = configuredFieldNames();
-    const comments = inlineComments(fields, key, options);
-    const requireNestedCollections = options.requireNestedCollections !== false;
+    const requireNestedCollections = selectedFields === null && options.requireNestedCollections !== false;
+    const comments = inlineComments(fields, key, { ...options, requireNestedCollections });
     const attachments = requireNestedCollections
         ? requirePayloadArray(fields.attachment, `jira issue ${key} attachment field`)
         : [];
@@ -196,6 +237,20 @@ export function normalizeJiraIssue(issue, config, options = {}) {
     if (custom.storyPoints && fields[custom.storyPoints] !== undefined) {
         normalized.storyPoints = Number(fields[custom.storyPoints]);
     }
+    if (selectedFields !== null) {
+        const names = row.names && typeof row.names === 'object' && !Array.isArray(row.names) ? row.names : {};
+        if (selectedFields === 'auto') {
+            normalized.fields = autoFields(fields, names);
+        } else {
+            const customFields = {};
+            for (const field of selectedFields) {
+                if (!field.startsWith('customfield_') || fields[field] === undefined) continue;
+                const name = typeof names[field] === 'string' && names[field].trim() ? names[field].trim() : field;
+                customFields[name] = fields[field];
+            }
+            if (Object.keys(customFields).length > 0) normalized.customFields = customFields;
+        }
+    }
     return normalized;
 }
 
@@ -214,11 +269,13 @@ export function issueSummaryRow(issue, config) {
 }
 
 export async function fetchIssue(config, key, extraFields = []) {
+    const fields = issueFields(extraFields);
+    const params = {
+        expand: 'renderedFields,names',
+    };
+    if (fields !== undefined) params.fields = fields;
     const issue = await jiraRequest(config, `/issue/${encodeURIComponent(key)}`, {
-        params: {
-            fields: issueFields(extraFields),
-            expand: 'renderedFields',
-        },
+        params,
         label: `jira issue ${key}`,
     });
     return requirePayloadObject(issue, `jira issue ${key}`);

--- a/docs/adapters/browser/jira.md
+++ b/docs/adapters/browser/jira.md
@@ -23,11 +23,11 @@ export ATLASSIAN_EMAIL=you@example.com
 export ATLASSIAN_API_TOKEN=...
 ```
 
-To request a specific set of Jira fields, set a JSON array. When configured,
-the array replaces the default field list:
+To request a specific set of Jira fields, set a comma-separated list. When
+configured, the list replaces the default field list:
 
 ```bash
-export ATLASSIAN_JIRA_FIELDS='["summary","status","customfield_12345"]'
+export ATLASSIAN_JIRA_FIELDS='summary,status,customfield_12345'
 ```
 
 Requested `customfield_*` values are returned under `customFields`, using the

--- a/docs/adapters/browser/jira.md
+++ b/docs/adapters/browser/jira.md
@@ -23,6 +23,24 @@ export ATLASSIAN_EMAIL=you@example.com
 export ATLASSIAN_API_TOKEN=...
 ```
 
+To request a specific set of Jira fields, set a JSON array. When configured,
+the array replaces the default field list:
+
+```bash
+export ATLASSIAN_JIRA_FIELDS='["summary","status","customfield_12345"]'
+```
+
+Requested `customfield_*` values are returned under `customFields`, using the
+human-readable names returned by Jira when available.
+
+Set the value to `auto` to let Jira return all fields. The result adds a
+`fields` object with top-level `null` values removed and `customfield_*` keys
+replaced by their human-readable names from Jira:
+
+```bash
+export ATLASSIAN_JIRA_FIELDS=auto
+```
+
 For Data Center, use a personal access token when available:
 
 ```bash

--- a/docs/adapters/browser/jira.md
+++ b/docs/adapters/browser/jira.md
@@ -23,22 +23,22 @@ export ATLASSIAN_EMAIL=you@example.com
 export ATLASSIAN_API_TOKEN=...
 ```
 
-To request a specific set of Jira fields, set a comma-separated list. When
-configured, the list replaces the default field list:
+To request a specific set of Jira fields, pass a comma-separated list to the
+`issue` command. The list replaces the default field list:
 
 ```bash
-export ATLASSIAN_JIRA_FIELDS='summary,status,customfield_12345'
+opencli jira issue PROJ-123 --fields 'summary,status,customfield_12345'
 ```
 
 Requested `customfield_*` values are returned under `customFields`, using the
 human-readable names returned by Jira when available.
 
-Set the value to `auto` to let Jira return all fields. The result adds a
+Set `--fields` to `auto` to let Jira return all fields. The result adds a
 `fields` object with top-level `null` values removed and `customfield_*` keys
 replaced by their human-readable names from Jira:
 
 ```bash
-export ATLASSIAN_JIRA_FIELDS=auto
+opencli jira issue PROJ-123 --fields auto
 ```
 
 For Data Center, use a personal access token when available:

--- a/docs/adapters/browser/jira.md
+++ b/docs/adapters/browser/jira.md
@@ -30,12 +30,15 @@ To request a specific set of Jira fields, pass a comma-separated list to the
 opencli jira issue PROJ-123 --fields 'summary,status,customfield_12345'
 ```
 
-Requested `customfield_*` values are returned under `customFields`, using the
-human-readable names returned by Jira when available.
+The result adds `selectedFields`, an ordered list of `{ id, name, value }`
+entries. The stable Jira field id is always preserved; display names are
+metadata, so duplicate names and names that collide with standard fields do not
+lose data. Explicit lists keep their first-requested order and ignore duplicate
+ids.
 
-Set `--fields` to `auto` to let Jira return all fields. The result adds a
-`fields` object with top-level `null` values removed and `customfield_*` keys
-replaced by their human-readable names from Jira:
+Set `--fields` to `auto` to explicitly request Jira's `*all` field set. The
+result uses the same `selectedFields` structure, ordered by stable field id;
+`null` and structured JSON values are preserved:
 
 ```bash
 opencli jira issue PROJ-123 --fields auto


### PR DESCRIPTION
## Description

Add explicit Jira issue field selection without changing the existing no-flag request or output.

- `--fields summary,status,customfield_12345` replaces the public default selection while retaining internal transport fields required by consumers.
- `--fields auto` explicitly sends Jira `fields=*all`.
- Selected values use one reversible output shape: `selectedFields: [{ id, name, value }]`.
- Stable Jira field ids are the identity; duplicate/missing display names cannot overwrite or drop values.
- `null` and structured JSON values are preserved.
- Selected `comment`, `attachment`, and `issuelinks` fields still populate the normalized top-level collections.

Without `--fields`, the command keeps the existing default field subset, `expand=renderedFields`, and legacy row shape.

## Data-source contract

- Jira Cloud: `GET /rest/api/3/issue/{issueIdOrKey}`
- Jira Data Center: `GET /rest/api/2/issue/{issueIdOrKey}`
- Authentication remains the adapter's existing Basic/Bearer/PAT configuration.

The request semantics were checked against Atlassian's official Cloud OpenAPI and Data Center REST documentation. No private Jira instance credentials were available for a live replay, so Cloud v3 and Data Center v2 request/response behavior is locked with fixtures.

## Validation

- Jira + shared Atlassian + Confluence adapter tests: 3 files / 40 tests
- Typecheck
- Build and manifest generation (1332 entries)
- Docs build
- Node syntax checks
- Typed-error and silent-column-drop gates
- Production high-severity audit
- Diff and merge-tree checks

## Type of Change

- [x] New feature
- [x] Documentation
- [x] Tests
