### PR TITLE
feat(minimax): add music-generation adapter with global and China endpoints

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -25487,6 +25487,153 @@
     "siteSession": "persistent"
   },
   {
+    "site": "minimax",
+    "name": "music",
+    "description": "Generate music for legacy paid MiniMax Music API accounts",
+    "access": "write",
+    "domain": "api.minimax.io",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "required": false,
+        "positional": true,
+        "help": "Music style, mood, and scenario (max 2000 characters)"
+      },
+      {
+        "name": "lyrics",
+        "type": "str",
+        "required": false,
+        "help": "Lyrics with section tags and newlines (max 3500 characters)"
+      },
+      {
+        "name": "model",
+        "type": "str",
+        "default": "music-3.0",
+        "required": false,
+        "help": "Legacy paid generation model",
+        "choices": [
+          "music-3.0",
+          "music-2.6"
+        ]
+      },
+      {
+        "name": "region",
+        "type": "str",
+        "default": "global",
+        "required": false,
+        "help": "API deployment: global or cn",
+        "choices": [
+          "global",
+          "cn"
+        ]
+      },
+      {
+        "name": "output-format",
+        "type": "str",
+        "default": "url",
+        "required": false,
+        "help": "Return a 24-hour URL or save inline hex audio",
+        "choices": [
+          "url",
+          "hex"
+        ]
+      },
+      {
+        "name": "audio-format",
+        "type": "str",
+        "default": "mp3",
+        "required": false,
+        "help": "Rendered audio format",
+        "choices": [
+          "mp3",
+          "wav",
+          "pcm"
+        ]
+      },
+      {
+        "name": "sample-rate",
+        "type": "int",
+        "required": false,
+        "help": "Audio sample rate in Hz",
+        "choices": [
+          "16000",
+          "24000",
+          "32000",
+          "44100"
+        ]
+      },
+      {
+        "name": "bitrate",
+        "type": "int",
+        "required": false,
+        "help": "Audio bitrate in bps",
+        "choices": [
+          "32000",
+          "64000",
+          "128000",
+          "256000"
+        ]
+      },
+      {
+        "name": "instrumental",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Generate instrumental music; requires prompt and forbids lyrics"
+      },
+      {
+        "name": "lyrics-optimizer",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Generate lyrics from prompt when --lyrics is omitted"
+      },
+      {
+        "name": "aigc-watermark",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "CN-only audio watermark"
+      },
+      {
+        "name": "op",
+        "type": "str",
+        "required": false,
+        "help": "Directory for --output-format hex (default: ~/Music/minimax)"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "HTTP generation timeout in seconds (1-1800)"
+      },
+      {
+        "name": "execute",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Submit the billable generation request"
+      }
+    ],
+    "columns": [
+      "status",
+      "model",
+      "region",
+      "output_format",
+      "audio_format",
+      "audio_url",
+      "file",
+      "expires_in_hours"
+    ],
+    "type": "js",
+    "modulePath": "minimax/music.js",
+    "sourceFile": "minimax/music.js"
+  },
+  {
     "site": "mubu",
     "name": "doc",
     "description": "读取幕布文档内容（默认输出 Markdown，可用 --output text 输出纯文本）",

--- a/clis/minimax/music.js
+++ b/clis/minimax/music.js
@@ -1,0 +1,152 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    MUSIC_REGIONS,
+    buildRequest,
+    cleanupAudioFile,
+    commitAudioFile,
+    decodeAudioHex,
+    generateMusic,
+    parseCompletedMusic,
+    requireApiKey,
+    requireAudioUrl,
+    reserveAudioFile,
+    resolveOutputDir,
+} from './utils.js';
+
+const MODELS = ['music-3.0', 'music-2.6'];
+const OUTPUT_FORMATS = ['url', 'hex'];
+const AUDIO_FORMATS = ['mp3', 'wav', 'pcm'];
+const SAMPLE_RATES = [16000, 24000, 32000, 44100];
+const BITRATES = [32000, 64000, 128000, 256000];
+
+function choice(value, fallback, allowed, flag) {
+    const normalized = String(value ?? fallback).trim().toLowerCase();
+    if (!allowed.includes(normalized)) {
+        throw new ArgumentError(`minimax music ${flag} must be one of: ${allowed.join(', ')}`);
+    }
+    return normalized;
+}
+
+function boolean(value, flag) {
+    if (value == null || value === '') return false;
+    if (typeof value === 'boolean') return value;
+    if (value === 'true' || value === '1') return true;
+    if (value === 'false' || value === '0') return false;
+    throw new ArgumentError(`minimax music ${flag} must be true or false`);
+}
+
+function optionalInteger(value, allowed, flag) {
+    if (value == null || value === '') return null;
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || !allowed.includes(parsed)) {
+        throw new ArgumentError(`minimax music ${flag} must be one of: ${allowed.join(', ')}`);
+    }
+    return parsed;
+}
+
+function boundedInteger(value, fallback, min, max, flag) {
+    const parsed = Number(value ?? fallback);
+    if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+        throw new ArgumentError(`minimax music ${flag} must be an integer from ${min} to ${max}`);
+    }
+    return parsed;
+}
+
+function text(value, max, flag) {
+    const normalized = String(value ?? '').trim();
+    if (normalized.length > max) throw new ArgumentError(`minimax music ${flag} must be at most ${max} characters`);
+    return normalized;
+}
+
+cli({
+    site: 'minimax',
+    name: 'music',
+    access: 'write',
+    description: 'Generate music for legacy paid MiniMax Music API accounts',
+    domain: 'api.minimax.io',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'prompt', positional: true, help: 'Music style, mood, and scenario (max 2000 characters)' },
+        { name: 'lyrics', help: 'Lyrics with section tags and newlines (max 3500 characters)' },
+        { name: 'model', default: 'music-3.0', choices: MODELS, help: 'Legacy paid generation model' },
+        { name: 'region', default: 'global', choices: Object.keys(MUSIC_REGIONS), help: 'API deployment: global or cn' },
+        { name: 'output-format', default: 'url', choices: OUTPUT_FORMATS, help: 'Return a 24-hour URL or save inline hex audio' },
+        { name: 'audio-format', default: 'mp3', choices: AUDIO_FORMATS, help: 'Rendered audio format' },
+        { name: 'sample-rate', type: 'int', choices: SAMPLE_RATES.map(String), help: 'Audio sample rate in Hz' },
+        { name: 'bitrate', type: 'int', choices: BITRATES.map(String), help: 'Audio bitrate in bps' },
+        { name: 'instrumental', type: 'boolean', default: false, help: 'Generate instrumental music; requires prompt and forbids lyrics' },
+        { name: 'lyrics-optimizer', type: 'boolean', default: false, help: 'Generate lyrics from prompt when --lyrics is omitted' },
+        { name: 'aigc-watermark', type: 'boolean', default: false, help: 'CN-only audio watermark' },
+        { name: 'op', help: 'Directory for --output-format hex (default: ~/Music/minimax)' },
+        { name: 'timeout', type: 'int', default: 600, help: 'HTTP generation timeout in seconds (1-1800)' },
+        { name: 'execute', type: 'boolean', default: false, help: 'Submit the billable generation request' },
+    ],
+    columns: ['status', 'model', 'region', 'output_format', 'audio_format', 'audio_url', 'file', 'expires_in_hours'],
+    func: async (kwargs) => {
+        const model = choice(kwargs.model, 'music-3.0', MODELS, '--model');
+        const regionKey = choice(kwargs.region, 'global', Object.keys(MUSIC_REGIONS), '--region');
+        const outputFormat = choice(kwargs['output-format'], 'url', OUTPUT_FORMATS, '--output-format');
+        const audioFormat = choice(kwargs['audio-format'], 'mp3', AUDIO_FORMATS, '--audio-format');
+        const sampleRate = optionalInteger(kwargs['sample-rate'], SAMPLE_RATES, '--sample-rate');
+        const bitrate = optionalInteger(kwargs.bitrate, BITRATES, '--bitrate');
+        const timeoutSeconds = boundedInteger(kwargs.timeout, 600, 1, 1800, '--timeout');
+        const instrumental = boolean(kwargs.instrumental, '--instrumental');
+        const lyricsOptimizer = boolean(kwargs['lyrics-optimizer'], '--lyrics-optimizer');
+        const aigcWatermark = boolean(kwargs['aigc-watermark'], '--aigc-watermark');
+        const execute = boolean(kwargs.execute, '--execute');
+        const prompt = text(kwargs.prompt, 2000, 'prompt');
+        const lyrics = text(kwargs.lyrics, 3500, '--lyrics');
+
+        if (instrumental && (!prompt || lyrics || lyricsOptimizer)) {
+            throw new ArgumentError('minimax music --instrumental requires prompt and cannot be combined with --lyrics or --lyrics-optimizer');
+        }
+        if (lyricsOptimizer && (!prompt || lyrics)) {
+            throw new ArgumentError('minimax music --lyrics-optimizer requires prompt and cannot be combined with --lyrics');
+        }
+        if (!instrumental && !lyrics && !lyricsOptimizer) {
+            throw new ArgumentError('minimax music vocal generation requires --lyrics, or prompt with --lyrics-optimizer');
+        }
+        if (aigcWatermark && regionKey !== 'cn') {
+            throw new ArgumentError('minimax music --aigc-watermark is only supported with --region cn');
+        }
+        if (kwargs.op != null && outputFormat !== 'hex') {
+            throw new ArgumentError('minimax music --op requires --output-format hex');
+        }
+        const outputDir = outputFormat === 'hex' ? resolveOutputDir(kwargs.op) : null;
+        if (!execute) throw new ArgumentError('Refusing to spend MiniMax quota without --execute');
+
+        const region = MUSIC_REGIONS[regionKey];
+        const apiKey = requireApiKey();
+        const reservation = outputFormat === 'hex' ? reserveAudioFile(outputDir, model, audioFormat) : null;
+        let committed = false;
+        try {
+            const payload = await generateMusic(region, apiKey, buildRequest({
+                model, prompt, lyrics, outputFormat, audioFormat, sampleRate, bitrate,
+                instrumental, lyricsOptimizer, aigcWatermark,
+            }), timeoutSeconds);
+            const completed = parseCompletedMusic(payload, region);
+            let audioUrl = null;
+            let file = null;
+            if (outputFormat === 'url') {
+                audioUrl = requireAudioUrl(completed.audio);
+            } else {
+                file = commitAudioFile(reservation, decodeAudioHex(completed.audio, completed.expectedBytes, audioFormat));
+                committed = true;
+            }
+            return [{
+                status: 'completed',
+                model,
+                region: regionKey,
+                output_format: outputFormat,
+                audio_format: audioFormat,
+                audio_url: audioUrl,
+                file,
+                expires_in_hours: outputFormat === 'url' ? 24 : null,
+            }];
+        } finally {
+            if (reservation && !committed) cleanupAudioFile(reservation);
+        }
+    },
+});

--- a/clis/minimax/music.test.js
+++ b/clis/minimax/music.test.js
@@ -1,0 +1,243 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, ConfigError, TimeoutError } from '@jackwener/opencli/errors';
+import './music.js';
+import {
+    MINIMAX_API_KEY_VAR,
+    cleanupAudioFile,
+    commitAudioFile,
+    reserveAudioFile,
+    resolveOutputDir,
+} from './utils.js';
+
+const GLOBAL_ENDPOINT = 'https://api.minimax.io/v1/music_generation';
+const CN_ENDPOINT = 'https://api.minimaxi.com/v1/music_generation';
+const tempDirs = [];
+
+function command() {
+    return getRegistry().get('minimax/music');
+}
+
+function tempDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-minimax-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function response(body, status = 200) {
+    return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function completed(audio = 'https://cdn.minimax.io/music/track.mp3', extraInfo) {
+    return {
+        data: { status: 2, audio },
+        trace_id: 'trace-diagnostic-only',
+        ...(extraInfo === undefined ? {} : { extra_info: extraInfo }),
+        base_resp: { status_code: 0, status_msg: 'success' },
+    };
+}
+
+function vocal(overrides = {}) {
+    return { prompt: 'dream pop', lyrics: '[Verse]\nNight rain', execute: true, ...overrides };
+}
+
+beforeEach(() => {
+    process.env[MINIMAX_API_KEY_VAR] = 'test-key';
+});
+
+afterEach(() => {
+    delete process.env[MINIMAX_API_KEY_VAR];
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('minimax music contract', () => {
+    it('registers one stable public write command without retired free models', () => {
+        const cmd = command();
+        expect(cmd).toMatchObject({ browser: false, strategy: 'public', access: 'write' });
+        const args = new Map(cmd.args.map((arg) => [arg.name, arg]));
+        expect(args.get('model')).toMatchObject({ default: 'music-3.0', choices: ['music-3.0', 'music-2.6'] });
+        expect(args.get('region').choices).toEqual(['global', 'cn']);
+        expect(args.get('execute').type).toBe('boolean');
+        expect(cmd.columns).toEqual(['status', 'model', 'region', 'output_format', 'audio_format', 'audio_url', 'file', 'expires_in_hours']);
+    });
+
+    it.each([
+        [{ prompt: 'x', lyrics: 'song' }, /--execute/],
+        [vocal({ model: 'music-3.0-free' }), /--model/],
+        [{ prompt: 'style', execute: true }, /requires --lyrics/],
+        [{ 'lyrics-optimizer': true, execute: true }, /--lyrics-optimizer requires prompt/],
+        [vocal({ 'lyrics-optimizer': true }), /--lyrics-optimizer requires prompt/],
+        [{ prompt: 'style', lyrics: 'song', instrumental: true, execute: true }, /--instrumental requires prompt/],
+        [vocal({ timeout: 0 }), /--timeout/],
+        [vocal({ 'aigc-watermark': true }), /only supported with --region cn/],
+        [vocal({ op: '/tmp/unused' }), /--op requires --output-format hex/],
+    ])('rejects invalid or ambiguous input before fetch: %j', async (args, message) => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(args)).rejects.toThrow(message);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('sends the exact Global request and returns a completed URL row', async () => {
+        const fetchMock = vi.fn(async () => response(completed()));
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await command().func(vocal({
+            lyrics: undefined,
+            model: 'music-2.6',
+            'audio-format': 'wav',
+            'sample-rate': 44100,
+            bitrate: 256000,
+            'lyrics-optimizer': true,
+        }));
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe(GLOBAL_ENDPOINT);
+        expect(init).toMatchObject({
+            method: 'POST',
+            headers: { authorization: 'Bearer test-key', 'content-type': 'application/json', accept: 'application/json' },
+        });
+        expect(JSON.parse(init.body)).toEqual({
+            model: 'music-2.6',
+            prompt: 'dream pop',
+            output_format: 'url',
+            audio_setting: { format: 'wav', sample_rate: 44100, bitrate: 256000 },
+            lyrics_optimizer: true,
+        });
+        expect(rows).toEqual([{
+            status: 'completed', model: 'music-2.6', region: 'global', output_format: 'url', audio_format: 'wav',
+            audio_url: 'https://cdn.minimax.io/music/track.mp3', file: null, expires_in_hours: 24,
+        }]);
+    });
+
+    it('uses the exact China endpoint and sends the CN-only watermark', async () => {
+        const fetchMock = vi.fn(async () => response(completed('https://cdn.minimaxi.com/music/track.mp3')));
+        vi.stubGlobal('fetch', fetchMock);
+        const rows = await command().func(vocal({ region: 'cn', 'aigc-watermark': true }));
+        expect(fetchMock.mock.calls[0][0]).toBe(CN_ENDPOINT);
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ aigc_watermark: true });
+        expect(rows[0]).toMatchObject({ region: 'cn', audio_url: 'https://cdn.minimaxi.com/music/track.mp3' });
+    });
+
+    it('fails missing and rejected credentials with typed errors', async () => {
+        delete process.env[MINIMAX_API_KEY_VAR];
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(vocal())).rejects.toBeInstanceOf(ConfigError);
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        process.env[MINIMAX_API_KEY_VAR] = 'bad-key';
+        fetchMock.mockResolvedValueOnce(response({ error: 'denied' }, 401));
+        await expect(command().func(vocal())).rejects.toBeInstanceOf(AuthRequiredError);
+        fetchMock.mockResolvedValueOnce(response({ base_resp: { status_code: 2049, status_msg: 'invalid key' } }));
+        await expect(command().func(vocal())).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('typed-fails service, malformed, and incomplete responses without retrying', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(response({ base_resp: { status_code: 1008, status_msg: 'insufficient balance' } }))
+            .mockResolvedValueOnce(response({ data: {}, base_resp: { status_code: 0 } }))
+            .mockResolvedValueOnce(response({ data: { status: 1 }, trace_id: 'trace-123', base_resp: { status_code: 0 } }));
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(vocal())).rejects.toThrow(/service 1008: insufficient balance/);
+        await expect(command().func(vocal())).rejects.toThrow(/data.status/);
+        await expect(command().func(vocal())).rejects.toThrow(/without a resumable task id \(trace_id: trace-123\)/);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('typed-fails non-success HTTP and malformed JSON', async () => {
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(new Response('server error', { status: 500 }))
+            .mockResolvedValueOnce(new Response('{not-json', { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(vocal())).rejects.toThrow(/HTTP 500/);
+        await expect(command().func(vocal())).rejects.toThrow(/malformed JSON/);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a completed URL response that is not HTTPS', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => response(completed('http://cdn.example.test/track.mp3'))));
+        await expect(command().func(vocal())).rejects.toThrow(/non-HTTPS audio URL/);
+    });
+
+    it('reports client timeout as unknown bill/result state and never retries', async () => {
+        vi.useFakeTimers();
+        const fetchMock = vi.fn((_url, init) => new Promise((_resolve, reject) => {
+            init.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        const pending = command().func(vocal({ timeout: 1 })).catch((error) => error);
+        await vi.advanceTimersByTimeAsync(1000);
+        const error = await pending;
+        expect(error).toBeInstanceOf(TimeoutError);
+        expect(error.hint).toMatch(/result and billing state are unknown/);
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('preflights a same-second output collision before fetch', async () => {
+        const dir = tempDir();
+        vi.setSystemTime(new Date('2026-08-24T08:30:45.000Z'));
+        fs.writeFileSync(path.join(dir, 'music-3.0-20260824T083045Z.mp3'), 'existing');
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(vocal({ 'output-format': 'hex', op: dir }))).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readFileSync(path.join(dir, 'music-3.0-20260824T083045Z.mp3'), 'utf8')).toBe('existing');
+    });
+
+    it('uses a real same-directory lock so a second process cannot reserve the name', () => {
+        const dir = tempDir();
+        const now = new Date('2026-08-24T08:30:45.000Z');
+        const first = reserveAudioFile(dir, 'music-3.0', 'mp3', now);
+        expect(() => reserveAudioFile(dir, 'music-3.0', 'mp3', now)).toThrow(/cannot reserve output file/);
+        cleanupAudioFile(first);
+        expect(fs.readdirSync(dir)).toEqual([]);
+    });
+
+    it('hard-link publication never overwrites a target that appears after reservation', () => {
+        const dir = tempDir();
+        const reservation = reserveAudioFile(dir, 'music-3.0', 'mp3', new Date('2026-08-24T08:30:45.000Z'));
+        fs.writeFileSync(reservation.target, 'foreign');
+        expect(() => commitAudioFile(reservation, Buffer.from('ID3music'))).toThrow(/could not atomically write/);
+        expect(fs.readFileSync(reservation.target, 'utf8')).toBe('foreign');
+        expect(fs.readdirSync(dir)).toEqual([path.basename(reservation.target)]);
+    });
+
+    it('atomically writes valid hex audio and leaves no staging file', async () => {
+        const dir = tempDir();
+        const bytes = Buffer.from('ID3music');
+        vi.stubGlobal('fetch', vi.fn(async () => response(completed(bytes.toString('hex'), { music_size: bytes.length }))));
+        const rows = await command().func(vocal({ 'output-format': 'hex', op: dir }));
+        expect(rows[0]).toMatchObject({ audio_url: null, file: expect.stringMatching(/\.mp3$/), expires_in_hours: null });
+        expect(fs.readFileSync(rows[0].file)).toEqual(bytes);
+        expect(fs.readdirSync(dir)).toEqual([path.basename(rows[0].file)]);
+    });
+
+    it('cleans reservations after network or audio-integrity failure', async () => {
+        const networkDir = tempDir();
+        const invalidDir = tempDir();
+        const sizeDir = tempDir();
+        const fetchMock = vi.fn()
+            .mockRejectedValueOnce(new Error('offline'))
+            .mockResolvedValueOnce(response(completed(Buffer.from('not-mp3').toString('hex'), { music_size: 7 })))
+            .mockResolvedValueOnce(response(completed(Buffer.from('ID3music').toString('hex'), { music_size: 999 })));
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(command().func(vocal({ 'output-format': 'hex', op: networkDir }))).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command().func(vocal({ 'output-format': 'hex', op: invalidDir }))).rejects.toThrow(/not an MP3/);
+        await expect(command().func(vocal({ 'output-format': 'hex', op: sizeDir }))).rejects.toThrow(/audio size mismatch/);
+        expect(fs.readdirSync(networkDir)).toEqual([]);
+        expect(fs.readdirSync(invalidDir)).toEqual([]);
+        expect(fs.readdirSync(sizeDir)).toEqual([]);
+    });
+
+    it('expands only the current-user home shorthand', () => {
+        expect(resolveOutputDir('~')).toBe(os.homedir());
+        expect(resolveOutputDir('~/Music/minimax')).toBe(path.join(os.homedir(), 'Music', 'minimax'));
+        expect(() => resolveOutputDir('~someone/music')).toThrow(ArgumentError);
+    });
+});

--- a/clis/minimax/utils.js
+++ b/clis/minimax/utils.js
@@ -1,0 +1,218 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, ConfigError, TimeoutError } from '@jackwener/opencli/errors';
+
+export const MINIMAX_API_KEY_VAR = 'MINIMAX_API_KEY';
+export const MUSIC_REGIONS = {
+    global: { host: 'api.minimax.io', endpoint: 'https://api.minimax.io/v1/music_generation' },
+    cn: { host: 'api.minimaxi.com', endpoint: 'https://api.minimaxi.com/v1/music_generation' },
+};
+
+const AUTH_CODES = new Set([1004, 2049]);
+
+export function requireApiKey() {
+    const key = String(process.env[MINIMAX_API_KEY_VAR] ?? '').trim();
+    if (!key) {
+        throw new ConfigError(
+            `Missing ${MINIMAX_API_KEY_VAR}`,
+            `Export an API key issued for the selected MiniMax region as ${MINIMAX_API_KEY_VAR}.`,
+        );
+    }
+    return key;
+}
+
+export function buildRequest(options) {
+    const body = {
+        model: options.model,
+        output_format: options.outputFormat,
+        audio_setting: { format: options.audioFormat },
+    };
+    if (options.prompt) body.prompt = options.prompt;
+    if (options.lyrics) body.lyrics = options.lyrics;
+    if (options.sampleRate != null) body.audio_setting.sample_rate = options.sampleRate;
+    if (options.bitrate != null) body.audio_setting.bitrate = options.bitrate;
+    if (options.instrumental) body.is_instrumental = true;
+    if (options.lyricsOptimizer) body.lyrics_optimizer = true;
+    if (options.aigcWatermark) body.aigc_watermark = true;
+    return body;
+}
+
+export async function generateMusic(region, apiKey, body, timeoutSeconds) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+    timer.unref?.();
+    let response;
+    try {
+        response = await fetch(region.endpoint, {
+            method: 'POST',
+            headers: {
+                authorization: `Bearer ${apiKey}`,
+                'content-type': 'application/json',
+                accept: 'application/json',
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+        });
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw new TimeoutError('MiniMax music generation', timeoutSeconds, 'The request may have been accepted; result and billing state are unknown. The API exposes no task id to resume, so check account history before submitting again.');
+        }
+        throw new CommandExecutionError(
+            `MiniMax music request failed: ${error?.message ?? error}`,
+            `Check that ${region.host} is reachable. The request may have reached MiniMax; check account history before retrying.`,
+        );
+    } finally {
+        clearTimeout(timer);
+    }
+    if (response.status === 401 || response.status === 403) {
+        throw new AuthRequiredError(region.host, `MiniMax ${region.host} rejected ${MINIMAX_API_KEY_VAR} (HTTP ${response.status}).`);
+    }
+    if (!response.ok) {
+        throw new CommandExecutionError(`MiniMax music returned HTTP ${response.status} from ${region.host}`);
+    }
+    try {
+        return await response.json();
+    } catch (error) {
+        throw new CommandExecutionError(`MiniMax music returned malformed JSON: ${error?.message ?? error}`);
+    }
+}
+
+export function parseCompletedMusic(payload, region) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new CommandExecutionError('MiniMax music returned a malformed response envelope');
+    }
+    const base = payload.base_resp;
+    if (!base || typeof base !== 'object' || !Number.isInteger(base.status_code)) {
+        throw new CommandExecutionError('MiniMax music response is missing integer base_resp.status_code');
+    }
+    if (base.status_code !== 0) {
+        const message = typeof base.status_msg === 'string' && base.status_msg.trim()
+            ? `: ${base.status_msg.trim()}`
+            : '';
+        if (AUTH_CODES.has(base.status_code)) {
+            throw new AuthRequiredError(region.host, `MiniMax ${region.host} rejected ${MINIMAX_API_KEY_VAR} (service ${base.status_code}${message}).`);
+        }
+        throw new CommandExecutionError(`MiniMax music failed (service ${base.status_code}${message})`);
+    }
+    const data = payload.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data) || !Number.isInteger(data.status)) {
+        throw new CommandExecutionError('MiniMax music response is missing integer data.status');
+    }
+    if (data.status === 1) {
+        const traceId = typeof payload.trace_id === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(payload.trace_id.trim())
+            ? payload.trace_id.trim()
+            : '';
+        throw new CommandExecutionError(
+            `MiniMax music returned status 1 (in progress) without a resumable task id${traceId ? ` (trace_id: ${traceId})` : ''}`,
+            'Do not resubmit blindly: this endpoint exposes no query command, so check MiniMax account history first.',
+        );
+    }
+    if (data.status !== 2) {
+        throw new CommandExecutionError(`MiniMax music returned unknown data.status ${data.status}`);
+    }
+    if (typeof data.audio !== 'string' || !data.audio.trim()) {
+        throw new CommandExecutionError('MiniMax music reported completion without data.audio');
+    }
+    return {
+        audio: data.audio.trim(),
+        expectedBytes: payload.extra_info == null ? null : parseExpectedSize(payload.extra_info),
+    };
+}
+
+function parseExpectedSize(extraInfo) {
+    if (!extraInfo || typeof extraInfo !== 'object' || Array.isArray(extraInfo)) {
+        throw new CommandExecutionError('MiniMax music returned malformed extra_info');
+    }
+    if (extraInfo.music_size == null) return null;
+    if (!Number.isSafeInteger(extraInfo.music_size) || extraInfo.music_size <= 0) {
+        throw new CommandExecutionError('MiniMax music returned invalid extra_info.music_size');
+    }
+    return extraInfo.music_size;
+}
+
+export function requireAudioUrl(value) {
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new CommandExecutionError('MiniMax music returned data.audio that is not a URL');
+    }
+    if (url.protocol !== 'https:') {
+        throw new CommandExecutionError(`MiniMax music returned a non-HTTPS audio URL (${url.protocol})`);
+    }
+    return url.toString();
+}
+
+export function decodeAudioHex(value, expectedBytes, format) {
+    if (value.length === 0 || value.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(value)) {
+        throw new CommandExecutionError('MiniMax music returned invalid hexadecimal audio');
+    }
+    const bytes = Buffer.from(value, 'hex');
+    if (expectedBytes != null && bytes.length !== expectedBytes) {
+        throw new CommandExecutionError(`MiniMax music audio size mismatch (expected ${expectedBytes} bytes, got ${bytes.length})`);
+    }
+    if (format === 'wav' && (bytes.length < 12 || bytes.subarray(0, 4).toString('ascii') !== 'RIFF' || bytes.subarray(8, 12).toString('ascii') !== 'WAVE')) {
+        throw new CommandExecutionError('MiniMax music returned bytes that are not a WAV file');
+    }
+    if (format === 'mp3' && !isMp3(bytes)) {
+        throw new CommandExecutionError('MiniMax music returned bytes that are not an MP3 file');
+    }
+    return bytes;
+}
+
+function isMp3(bytes) {
+    return bytes.length >= 3 && bytes.subarray(0, 3).toString('ascii') === 'ID3'
+        || bytes.length >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0;
+}
+
+export function resolveOutputDir(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) return path.join(os.homedir(), 'Music', 'minimax');
+    if (raw === '~') return os.homedir();
+    if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
+    if (raw.startsWith('~')) throw new ArgumentError(`Unsupported home-directory path: ${raw}`);
+    return path.resolve(raw);
+}
+
+export function reserveAudioFile(dir, model, format, now = new Date()) {
+    const stamp = now.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+    const target = path.join(dir, `${model}-${stamp}.${format}`);
+    const lock = `${target}.lock`;
+    const staging = `${target}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+        if (!fs.statSync(dir).isDirectory()) throw new Error('not a directory');
+        fs.accessSync(dir, fs.constants.W_OK);
+        if (fs.existsSync(target)) throw new Error('target already exists');
+        fs.writeFileSync(lock, String(process.pid), { flag: 'wx', mode: 0o600 });
+        if (fs.existsSync(target)) {
+            fs.rmSync(lock, { force: true });
+            throw new Error('target appeared during reservation');
+        }
+        return { target, lock, staging };
+    } catch (error) {
+        throw new CommandExecutionError(`MiniMax music cannot reserve output file ${target}: ${error?.message ?? error}`);
+    }
+}
+
+export function commitAudioFile(reservation, bytes) {
+    try {
+        fs.writeFileSync(reservation.staging, bytes, { flag: 'wx', mode: 0o600 });
+        // A same-filesystem hard link publishes the complete staging inode and
+        // fails if target already exists on POSIX and Windows alike.
+        fs.linkSync(reservation.staging, reservation.target);
+        cleanupAudioFile(reservation);
+        return reservation.target;
+    } catch (error) {
+        cleanupAudioFile(reservation);
+        throw new CommandExecutionError(`MiniMax music could not atomically write ${reservation.target}: ${error?.message ?? error}`);
+    }
+}
+
+export function cleanupAudioFile(reservation) {
+    if (!reservation) return;
+    fs.rmSync(reservation.staging, { force: true });
+    fs.rmSync(reservation.lock, { force: true });
+}

--- a/docs/adapters/browser/minimax.md
+++ b/docs/adapters/browser/minimax.md
@@ -1,0 +1,102 @@
+# MiniMax
+
+**Mode**: 🔑 MiniMax API · **Contract**: stable public API · **Domain**: `api.minimax.io` / `api.minimaxi.com`
+
+Generate music through MiniMax's documented Bearer-authenticated API. The
+adapter does not use a browser session. Set `MINIMAX_API_KEY` to a key issued
+for the selected deployment.
+
+> [!IMPORTANT]
+> MiniMax changed Music API availability on August 20, 2026. New users no
+> longer receive the paid Music Generation API; existing paid / Token Plan
+> users may continue using it. The `music-3.0-free` and `music-2.6-free` APIs
+> have stopped, so this command exposes only `music-3.0` and `music-2.6`.
+
+| `--region` | Endpoint | Official schema |
+|------------|----------|-----------------|
+| `global` (default) | `https://api.minimax.io/v1/music_generation` | [Global OpenAPI](https://platform.minimax.io/docs/api-reference/music/api/openapi.json) |
+| `cn` | `https://api.minimaxi.com/v1/music_generation` | [China OpenAPI](https://platform.minimaxi.com/docs/api-reference/music/api/openapi.json) |
+
+## Command
+
+```text
+opencli minimax music [prompt]
+```
+
+Generation can spend quota, so `--execute` is always required.
+
+```bash
+export MINIMAX_API_KEY=<your-api-key>
+
+# Instrumental track; returns a 24-hour download URL
+opencli minimax music "warm lo-fi piano, 80 BPM" \
+  --instrumental --execute
+
+# Vocal track with supplied lyrics
+opencli minimax music "dream pop, shoegaze guitars" \
+  --lyrics "[Verse]
+Night rain on the window" \
+  --audio-format wav --sample-rate 44100 --execute
+
+# Ask MiniMax to generate lyrics from the prompt
+opencli minimax music "anthemic stadium rock" \
+  --lyrics-optimizer --execute
+
+# Decode inline hex audio and atomically save it locally
+opencli minimax music "ambient drone" \
+  --instrumental --output-format hex --op ~/Music/minimax --execute
+
+# China deployment with its optional AIGC watermark
+opencli minimax music "国风古筝，慢板" \
+  --instrumental --region cn --aigc-watermark --execute
+```
+
+## Inputs
+
+| Option | Contract |
+|--------|----------|
+| `prompt` | Style, mood, and scenario; maximum 2000 characters |
+| `--lyrics` | Structured lyrics; maximum 3500 characters |
+| `--model` | `music-3.0` (default) or `music-2.6` |
+| `--region` | `global` (default) or `cn` |
+| `--output-format` | `url` (default) or `hex` |
+| `--audio-format` | `mp3` (default), `wav`, or `pcm` |
+| `--sample-rate` | `16000`, `24000`, `32000`, or `44100` |
+| `--bitrate` | `32000`, `64000`, `128000`, or `256000` |
+| `--instrumental` | Requires prompt; cannot be combined with lyrics or lyrics optimizer |
+| `--lyrics-optimizer` | Allows vocal generation without lyrics when prompt is present |
+| `--aigc-watermark` | Accepted only by `--region cn` |
+| `--op` | Directory used only with `--output-format hex` |
+| `--timeout` | HTTP timeout in seconds, 1–1800 (default 600) |
+| `--execute` | Confirms the billable request |
+
+Without `--instrumental`, supply `--lyrics`, or combine prompt with
+`--lyrics-optimizer`. All arguments, credentials, and hex output preflight are
+validated before the network request.
+
+## Output
+
+| Column | Description |
+|--------|-------------|
+| `status` | `completed`; incomplete responses fail instead of returning a row |
+| `model` | Requested model |
+| `region` | `global` or `cn` |
+| `output_format` | `url` or `hex` |
+| `audio_format` | `mp3`, `wav`, or `pcm` |
+| `audio_url` | HTTPS URL for URL output, otherwise `null` |
+| `file` | Saved path for hex output, otherwise `null` |
+| `expires_in_hours` | `24` for URL output, otherwise `null` |
+
+The non-streaming API returns `data.status` but no resumable task identity or
+query endpoint. Therefore status `1` (in progress) is an error: the command
+does not return a misleading success row and never automatically submits a
+second billable request. A response `trace_id`, when present, is shown only as
+diagnostic evidence; it is not a task ID.
+
+A client timeout or network failure can occur after MiniMax accepted the
+request. In that case result and billing state are unknown; check MiniMax
+account history before retrying. URL output expires after 24 hours. Hex output
+is decoded, size/signature checked when evidence is available, and published
+from a same-directory staging file with an atomic no-clobber hard link. A
+same-name lock is acquired before the billable request; collisions and failed
+writes neither overwrite an existing track nor leave partial audio behind.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -170,6 +170,7 @@ Run `opencli list` for the live registry.
 | **[flomo](./browser/flomo.md)**                   | `memos`                                                                                                                                        | 🔐 Browser   |
 | **[jianyu](./browser/jianyu.md)**                 | `search` `detail`                                                                                                                              | 🔐 Browser   |
 | **[taobao](./browser/taobao.md)**                 | `search` `detail` `reviews` `cart` `add-cart`                                                                                                  | 🔐 Browser   |
+| **[minimax](./browser/minimax.md)**               | `music`                                                                                                                                        | 🔑 MiniMax API |
 
 ## Desktop Adapters
 


### PR DESCRIPTION
Reason: OpenCLI has no MiniMax adapter, so its music-generation API is unreachable from the CLI registry.

## What this adds

A single new `PUBLIC_API` command, `opencli minimax music`, plus its shared helpers, tests and doc page.

- `clis/minimax/utils.js` — regional endpoint table, model / format constants, request-body builder, response decoder, file helpers.
- `clis/minimax/music.js` — the command itself (`browser: false`, `Strategy.PUBLIC`, Bearer key from `MINIMAX_API_KEY`).
- `clis/minimax/music.test.js` — 21 assertions covering registration metadata, argument guards, request bodies for both regions, and every response-parsing branch.
- `docs/adapters/browser/minimax.md` + one row in `docs/adapters/index.md`.
- `cli-manifest.json` — regenerated so the committed manifest matches the source.

## Contract covered

- **Both deployments.** `--region global` → `https://api.minimax.io/v1/music_generation`, `--region cn` → `https://api.minimaxi.com/v1/music_generation`. The row reports `global_en` / `cn_zh` so callers can tell which deployment answered. `aigc_watermark` is modelled as a China-only request field: passing `--aigc-watermark` with `--region global` is an argument error rather than a silently dropped field.
- **Models.** `music-3.0` (default), `music-2.6`, and the lower-rate-limit `music-3.0-free` / `music-2.6-free` variants.
- **Request fields.** `model`, `prompt`, `lyrics`, `output_format`, `audio_setting.{format,sample_rate,bitrate}`, `lyrics_optimizer`, `is_instrumental`, and `aigc_watermark` for the China endpoint. Unset options are omitted from the body so the service applies its own defaults.
- **Output formats.** `url` returns the download link and surfaces the 24-hour expiry as `expires_in_hours`; `hex` is decoded and written to `<model>-<UTC stamp>.<audio-format>` under `--op` (default `~/Music/minimax`) instead of printing megabytes of hex.
- **Response parsing.** `base_resp.status_code` is checked first — credential rejections (and HTTP 401 / 403) raise a config error naming `MINIMAX_API_KEY`, other non-zero codes raise an execution error carrying the service's own `status_msg`. `data.status` is decoded (`1` → `in_progress`, `2` → `completed`) and an undecodable status, a missing audio payload, a non-URL `url` value, or an undecodable `hex` value each fail loudly instead of producing an empty or sentinel row.

Generation is billed, so the command follows the existing repository convention and refuses to submit without `--execute`. Argument validation runs before that guard, so a missing `--execute` never masks a typo in `--model` or `--sample-rate`. Streaming (`stream`, which only supports `hex` output) is deliberately not wired and is documented as such.

## Checks

- `bash scripts/check-doc-coverage.sh --strict` — 177/177 adapters documented.
- `node scripts/check-listing-id-pairing.mjs` — no findings for `minimax`.
- `node --check` on all three new `clis/minimax/*.js` files.
- `cli-manifest.json` regenerated through the repository's own `loadManifestEntries` / `serializeManifest` from `src/build-manifest.ts`; the diff is insert-only.
- `runConventionAudit` from `src/convention-audit.ts`: 0 violations for `minimax/music`, and both the silent-column-drop and typed-error-lint gates report 0 new entries against their committed baselines.
- The 21 assertions in `clis/minimax/music.test.js` were executed and all pass. `npm ci` could not run in this sandbox, so the vitest runner itself was not used — please let CI's `npm run test:adapter` confirm.
