### PR TITLE
fix(chatgpt): use data-turn to detect upload previews vs generated images

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2560,12 +2560,28 @@ export async function getChatGPTVisibleImageUrls(page) {
                 return /avatar|profile|logo|icon/.test(text);
             };
             const isUserUploadPreview = (img) => {
-                const alt = (img.getAttribute('alt') || '').toLowerCase();
                 const turn = img.closest('section[data-testid^="conversation-turn"]');
-                const heading = (turn?.querySelector('h4')?.innerText || '').toLowerCase();
+                // Authoritative signal first: ChatGPT stamps data-turn directly on the
+                // turn section as soon as the turn mounts, well before an attached
+                // image's alt text/aria-label finish populating. Racing multiple
+                // uploads against that async metadata (the old behaviour here) let
+                // still-generic upload-preview thumbnails pass as "new" images for a
+                // poll or two, which is long enough to satisfy the stability check in
+                // waitForChatGPTImages and return the wrong (uploaded, not generated)
+                // images when 2+ files were attached.
+                const turnRole = turn?.getAttribute('data-turn') || '';
+                if (turnRole === 'user') return true;
+                if (turnRole === 'assistant') return false;
+                // Fallback for markup without data-turn. innerText reads as empty
+                // on a visually-hidden heading in real Chrome (jsdom has no layout and
+                // never exposed this gap) - use textContent instead.
+                const heading = (turn?.querySelector('h4')?.textContent || '').toLowerCase();
                 if (/you said|你说/.test(heading)) return true;
                 if (/chatgpt|assistant|助手/.test(heading)) return false;
-                const openButtonLabel = (img.closest('button[aria-label^="Open image:"], button[aria-label^="打开图片："]')?.getAttribute('aria-label') || '').toLowerCase();
+                const alt = (img.getAttribute('alt') || '').toLowerCase();
+                // ChatGPT's multi-image "Open image" button label now reads
+                // "Open image N of M: name", not the older "Open image: name".
+                const openButtonLabel = (img.closest('button[aria-label*="Open image"], button[aria-label*="打开图片"]')?.getAttribute('aria-label') || '').toLowerCase();
                 const previewText = [alt, openButtonLabel].join(' ');
                 return /\.(png|jpe?g|webp|gif|heic|heif)(?:\b|$)/i.test(previewText)
                     || /ref-|reference|参考|上传|upload|uploaded|attachment/.test(previewText);

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1551,12 +1551,45 @@ describe('chatgpt generated image detection', () => {
     it('ignores user-uploaded previews labeled by the Chinese UI', async () => {
         const page = createDomPage(`
             <!doctype html>
-            <button aria-label="打开图片：用户上传的图片">
+            <button aria-label="打开图片 1 / 2 用户上传的图片">
               <img alt="" src="https://chatgpt.com/backend-api/files/reference">
             </button>
             <section data-testid="conversation-turn-2">
               <h4>ChatGPT said:</h4>
               <img alt="generated image" src="https://chatgpt.com/backend-api/generated/foo.webp">
+            </section>
+        `, (window) => {
+            for (const img of window.document.querySelectorAll('img')) {
+                Object.defineProperty(img, 'naturalWidth', { configurable: true, value: 512 });
+                Object.defineProperty(img, 'naturalHeight', { configurable: true, value: 512 });
+                img.getBoundingClientRect = () => ({ width: 512, height: 512 });
+            }
+        });
+
+        await expect(getChatGPTVisibleImageUrls(page)).resolves.toEqual([
+            'https://chatgpt.com/backend-api/generated/foo.webp',
+        ]);
+    });
+
+    it('ignores multiple upload-preview thumbnails via data-turn before their alt/aria-label metadata populate', async () => {
+        // Reproduces a real regression: uploading 2+ reference images made
+        // waitForChatGPTImages return the just-uploaded thumbnails instead of
+        // the actual generated image. Right after upload, a thumbnail's alt
+        // text and "Open image N of M: <name>" aria-label haven't populated
+        // yet, so the old alt/aria-label-only fallback couldn't tell them
+        // apart from a real result during that window. `data-turn` on the
+        // turn <section> is set immediately and must be checked first.
+        const page = createDomPage(`
+            <!doctype html>
+            <section data-testid="conversation-turn-1" data-turn="user">
+              <h4>You said:</h4>
+              <img alt="" src="https://chatgpt.com/backend-api/uploaded/ref-1.png">
+              <img alt="" src="https://chatgpt.com/backend-api/uploaded/ref-2.png">
+              <img alt="" src="https://chatgpt.com/backend-api/uploaded/ref-3.png">
+            </section>
+            <section data-testid="conversation-turn-2" data-turn="assistant">
+              <h4>ChatGPT said:</h4>
+              <img alt="Generated image: result" src="https://chatgpt.com/backend-api/generated/foo.webp">
             </section>
         `, (window) => {
             for (const img of window.document.querySelectorAll('img')) {
@@ -1590,6 +1623,24 @@ describe('chatgpt generated image detection', () => {
         await expect(getChatGPTVisibleImageUrls(page)).resolves.toEqual([
             'https://chatgpt.com/backend-api/generated/foo.webp',
         ]);
+    });
+
+    it('recognizes the "Open image N of M: name" aria-label ChatGPT uses for multi-attachment uploads', async () => {
+        const page = createDomPage(`
+            <!doctype html>
+            <section data-testid="conversation-turn-1">
+              <button aria-label="Open image 1 of 3: reference.png">
+                <img alt="" src="https://chatgpt.com/backend-api/uploaded/reference.png">
+              </button>
+            </section>
+        `, (window) => {
+            const img = window.document.querySelector('img');
+            Object.defineProperty(img, 'naturalWidth', { configurable: true, value: 512 });
+            Object.defineProperty(img, 'naturalHeight', { configurable: true, value: 512 });
+            img.getBoundingClientRect = () => ({ width: 512, height: 512 });
+        });
+
+        await expect(getChatGPTVisibleImageUrls(page)).resolves.toEqual([]);
     });
 
     it('exports assets for generated CSS background images', async () => {


### PR DESCRIPTION
## Bug

`opencli chatgpt image <prompt> --image a.png,b.png,c.png` (2+ reference images) can silently return the just-uploaded reference thumbnails instead of the actual generated/edited image. With a single `--image` it works correctly.

## Root cause

`isUserUploadPreview()` in `clis/chatgpt/utils.js` is used by `getChatGPTVisibleImageUrls` / `waitForChatGPTImages` to exclude a user's own attachment previews from the "new image appeared" diff. It relied on signals that no longer reliably match ChatGPT's current DOM:

- `turn.querySelector('h4')?.innerText` - the turn heading ("You said:" / "ChatGPT said:") can be visually hidden, so real Chrome's layout-dependent `innerText` may resolve to `''`, even though `.textContent` reads the heading.
- `button[aria-label^="Open image:"]` - ChatGPT's current label for a multi-file attachment can read `"Open image N of M: <name>"`, which no longer starts with `"Open image:"`.

With both fallback signals dead, classification falls through to alt-text sniffing. Right after upload, an attachment thumbnail's `alt` / aria-label metadata may not have populated yet, so uploaded images can be misclassified as new generated images long enough to satisfy the stability check.

## Fix

Check the turn `<section>`'s own `data-turn="user"|"assistant"` attribute first. It is set structurally as soon as the turn mounts, so it is not subject to the attachment metadata race.

The fallback path stays in place for markup without `data-turn`, but now uses `textContent` for the heading and substring `aria-label` selectors for both English and Chinese UI labels:

```js
button[aria-label*="Open image"], button[aria-label*="打开图片"]
```

The Chinese upload-preview wordlist keeps `上传`.

## Verification

- Rebased on current main after #2261, preserving Chinese upload-preview filtering and adding the `data-turn` short-circuit before heading fallback.
- Added regression coverage for multi-image upload thumbnails with empty alt/aria-label metadata, the `"Open image N of M"` label format, and Chinese `"打开图片"` labels.
- `npx vitest run clis/chatgpt/utils.test.js clis/chatgpt/image.test.js` -> 129/129 passing.
- `npm run build` -> PASS, manifest 1331 entries.
- `node dist/src/main.js validate chatgpt` -> PASS, 14 commands.
- `git diff --check` -> PASS.
