### PR TITLE
Make browser state refs read-only

### DIFF
--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -291,7 +291,7 @@ export abstract class BasePage implements IPage {
 
   async annotatedScreenshot(options: ScreenshotOptions = {}): Promise<string> {
     // Refresh DOM refs first so visual labels map to immediate `browser click <ref>` targets.
-    await this.snapshot({ source: 'dom', viewportExpand: 0 });
+    await this.snapshot({ source: 'dom', viewportExpand: 0, annotateRefs: true });
     try {
       await this.evaluate(installVisualRefOverlayJs());
       return await this.screenshot({ ...options, annotate: false });
@@ -1120,6 +1120,7 @@ export abstract class BasePage implements IPage {
       maxDepth: Math.max(1, Math.min(Number(opts.maxDepth) || 50, 200)),
       interactiveOnly: opts.interactive ?? false,
       maxTextLength: opts.maxTextLength ?? 120,
+      annotateRefs: opts.annotateRefs ?? false,
       includeScrollInfo: true,
       bboxDedup: true,
       previousHashes: this._prevSnapshotHashes,

--- a/src/browser/dom-snapshot.test.ts
+++ b/src/browser/dom-snapshot.test.ts
@@ -9,6 +9,7 @@
  * 4. All features are present (Shadow DOM, iframe, table, diff, etc.)
  */
 
+import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest';
 import { generateSnapshotJs, scrollToRefJs, getFormStateJs } from './dom-snapshot.js';
 
@@ -24,6 +25,31 @@ describe('generateSnapshotJs', () => {
     expect(() => new Function(js)).not.toThrow();
   });
 
+  it('does not mutate page DOM when assigning snapshot refs', async () => {
+    const dom = new JSDOM('<!doctype html><button id="apply">Apply</button>', {
+      url: 'https://example.com/',
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const mutations: string[] = [];
+    const observer = new dom.window.MutationObserver((records) => {
+      for (const record of records) {
+        mutations.push(record.attributeName || '');
+      }
+    });
+    observer.observe(dom.window.document.documentElement, {
+      attributes: true,
+      subtree: true,
+    });
+
+    const snapshot = dom.window.eval(generateSnapshotJs());
+    await new Promise<void>((resolve) => dom.window.queueMicrotask(() => resolve()));
+
+    expect(snapshot).toContain('[1]<button');
+    expect(dom.window.document.querySelector('[data-opencli-ref]')).toBeNull();
+    expect(mutations).not.toContain('data-opencli-ref');
+  });
+
   it('embeds default options correctly', () => {
     const js = generateSnapshotJs();
     expect(js).toContain('VIEWPORT_EXPAND = 800');
@@ -35,7 +61,7 @@ describe('generateSnapshotJs', () => {
     expect(js).toContain('INCLUDE_SHADOW_DOM = true');
     expect(js).toContain('INCLUDE_IFRAMES = true');
     expect(js).toContain('PAINT_ORDER_CHECK = true');
-    expect(js).toContain('ANNOTATE_REFS = true');
+    expect(js).toContain('ANNOTATE_REFS = false');
     expect(js).toContain('REPORT_HIDDEN = true');
     expect(js).toContain('FILTER_ADS = true');
     expect(js).toContain('MARKDOWN_TABLES = true');
@@ -73,6 +99,11 @@ describe('generateSnapshotJs', () => {
     expect(js).toContain('REPORT_HIDDEN = false');
     expect(js).toContain('FILTER_ADS = false');
     expect(js).toContain('MARKDOWN_TABLES = false');
+  });
+
+  it('can opt into DOM ref annotation for visual overlays', () => {
+    const js = generateSnapshotJs({ annotateRefs: true });
+    expect(js).toContain('ANNOTATE_REFS = true');
   });
 
   it('clamps maxDepth between 1 and 200', () => {
@@ -136,7 +167,7 @@ describe('generateSnapshotJs', () => {
     expect(js).toContain('isAdElement');
     expect(js).toContain('AD_PATTERNS');
 
-    // data-ref annotation
+    // Optional data-ref annotation and legacy selector fallback
     expect(js).toContain('data-opencli-ref');
 
     // Hidden elements report

--- a/src/browser/dom-snapshot.ts
+++ b/src/browser/dom-snapshot.ts
@@ -15,12 +15,12 @@
  *   8. Attribute whitelist filtering
  *   9. Table-aware serialization (markdown tables)
  *  10. Token-efficient serialization with interactive indices
- *  11. data-ref annotation for click/type targeting
+ *  11. ref bookkeeping for click/type targeting
  *  12. Hidden interactive element hints (scroll-to-reveal)
  *  13. Incremental diff (mark new elements with *)
  *
  * Additional tools:
- *   - scrollToRefJs(ref) — scroll to a data-opencli-ref element
+ *   - scrollToRefJs(ref) — scroll to a data-opencli-ref or in-memory ref element
  *   - getFormStateJs()  — extract all form fields as structured JSON
  *
  * Compound sidecar:
@@ -56,7 +56,7 @@ export interface DomSnapshotOptions {
   maxIframes?: number;
   /** Enable paint-order occlusion detection (default true) */
   paintOrderCheck?: boolean;
-  /** Annotate interactive elements with data-opencli-ref (default true) */
+  /** Annotate interactive elements with data-opencli-ref (default false) */
   annotateRefs?: boolean;
   /** Report hidden interactive elements outside viewport (default true) */
   reportHidden?: boolean;
@@ -71,7 +71,7 @@ export interface DomSnapshotOptions {
 // ─── Utility JS Generators ───────────────────────────────────────────
 
 /**
- * Generate JS to scroll to an element identified by data-opencli-ref.
+ * Generate JS to scroll to an element identified by an in-memory or data-opencli-ref.
  * Completes the snapshot→action loop: snapshot identifies `[3]<button>`,
  * caller can then `scrollToRef('3')` to bring it into view.
  */
@@ -80,7 +80,10 @@ export function scrollToRefJs(ref: string): string {
   return `
     (() => {
       const ref = ${safeRef};
-      const el = document.querySelector('[data-opencli-ref="' + ref + '"]')
+      const elements = window.__opencli_ref_elements || {};
+      const mapped = elements[ref];
+      const el = (mapped && mapped.nodeType === 1 && document.contains(mapped) ? mapped : null)
+        || document.querySelector('[data-opencli-ref="' + ref + '"]')
         || document.querySelector('[data-ref="' + ref + '"]');
       if (!el) throw new Error('Element not found: ref=' + ref);
       el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
@@ -195,7 +198,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   const includeIframes = opts.includeIframes ?? true;
   const maxIframes = opts.maxIframes ?? 5;
   const paintOrderCheck = opts.paintOrderCheck ?? true;
-  const annotateRefs = opts.annotateRefs ?? true;
+  const annotateRefs = opts.annotateRefs ?? false;
   const reportHidden = opts.reportHidden ?? true;
   const filterAds = opts.filterAds ?? true;
   const markdownTables = opts.markdownTables ?? true;
@@ -660,9 +663,28 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   const hiddenInteractives = [];
   const currentHashes = [];
   const refIdentity = {};
+  const refElements = {};
   const compoundInfos = {};
   let iframeCount = 0;
   let crossOriginIndex = 0;
+
+  function fingerprintOf(el) {
+    return {
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute('role') || '',
+      text: (el.textContent || '').trim().slice(0, 30),
+      ariaLabel: el.getAttribute('aria-label') || '',
+      id: el.id || '',
+      testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
+    };
+  }
+
+  function rememberRef(ref, el) {
+    const key = '' + ref;
+    if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', key);
+    refElements[key] = el;
+    refIdentity[key] = fingerprintOf(el);
+  }
 
   function walk(el, depth, parentPropagatingRect) {
     if (depth > MAX_DEPTH) return false;
@@ -679,7 +701,7 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
       let prefix = '';
       if (interactive) {
         interactiveIndex++;
-        if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
+        rememberRef(interactiveIndex, el);
         prefix = '[' + interactiveIndex + ']';
       }
       lines.push('  '.repeat(depth) + prefix + '<svg' + (attrs ? ' ' + attrs : '') + ' />');
@@ -812,17 +834,8 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
     // Interactive index + data-ref + fingerprint
     if (interactive) {
       interactiveIndex++;
-      if (ANNOTATE_REFS) el.setAttribute('data-opencli-ref', '' + interactiveIndex);
+      rememberRef(interactiveIndex, el);
       line += isScrollable ? '|scroll[' + interactiveIndex + ']|' : '[' + interactiveIndex + ']';
-      // Store fingerprint for stale-ref detection
-      refIdentity['' + interactiveIndex] = {
-        tag: tag,
-        role: el.getAttribute('role') || '',
-        text: (el.textContent || '').trim().slice(0, 30),
-        ariaLabel: el.getAttribute('aria-label') || '',
-        id: el.id || '',
-        testId: el.getAttribute('data-testid') || el.getAttribute('data-test') || '',
-      };
       // Compound contract for date/select/file — captured per-ref so the
       // sidecar maps one-to-one with the [N] tokens in the tree.
       const compound = compoundInfoOf(el);
@@ -929,6 +942,8 @@ export function generateSnapshotJs(opts: DomSnapshotOptions = {}): string {
   try { window.__opencli_prev_hashes = JSON.stringify(currentHashes); } catch {}
   // Store ref identity map for stale-ref detection by target resolver
   try { window.__opencli_ref_identity = refIdentity; } catch {}
+  // Store live ref elements without mutating the business DOM.
+  try { window.__opencli_ref_elements = refElements; } catch {}
 
   return lines.join('\\n');
 })()

--- a/src/browser/target-resolver.test.ts
+++ b/src/browser/target-resolver.test.ts
@@ -1,3 +1,4 @@
+import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 import { resolveTargetJs, boundingRectResolvedJs } from './target-resolver.js';
 
@@ -154,8 +155,37 @@ describe('resolveTargetJs', () => {
   it('generates JS that returns structured resolution for numeric ref', () => {
     const js = resolveTargetJs('12');
     expect(js).toContain('data-opencli-ref');
+    expect(js).toContain('__opencli_ref_elements');
     expect(js).toContain('__opencli_ref_identity');
     expect(js).toContain('"12"');
+  });
+
+  it('resolves numeric refs from in-memory elements without mutating DOM attributes', async () => {
+    const dom = new JSDOM('<!doctype html><button id="apply">Apply</button>', {
+      url: 'https://example.com/',
+      runScripts: 'outside-only',
+    });
+    const button = dom.window.document.querySelector('button')!;
+    (dom.window as any).__opencli_ref_elements = { '1': button };
+    (dom.window as any).__opencli_ref_identity = {
+      '1': { tag: 'button', role: '', text: 'Apply', ariaLabel: '', id: 'apply', testId: '' },
+    };
+    const mutations: string[] = [];
+    const observer = new dom.window.MutationObserver((records) => {
+      for (const record of records) mutations.push(record.attributeName || '');
+    });
+    observer.observe(dom.window.document.documentElement, {
+      attributes: true,
+      subtree: true,
+    });
+
+    const result = dom.window.eval(resolveTargetJs('1'));
+    await new Promise<void>((resolve) => dom.window.queueMicrotask(() => resolve()));
+
+    expect(result).toMatchObject({ ok: true, matches_n: 1, match_level: 'exact' });
+    expect((dom.window as any).__resolved).toBe(button);
+    expect(button.getAttribute('data-opencli-ref')).toBeNull();
+    expect(mutations).not.toContain('data-opencli-ref');
   });
 
   it('generates JS that handles CSS selector input', () => {
@@ -249,10 +279,13 @@ describe('resolveTargetJs', () => {
     expect(js).toContain('[aria-label="');
     // Unique match required — never silently picks one of many candidates.
     expect(js).toContain('candidates.length === 1');
-    // Recovered element is re-tagged + identity map refreshed so subsequent
-    // resolves land on 'exact' instead of re-walking the cascade.
-    expect(js).toContain("setAttribute('data-opencli-ref', ref)");
-    expect(js).toContain('identity[ref] = fingerprintOf(recovered)');
+    // Recovered element is remembered without mutating the business DOM so
+    // subsequent resolves land on 'exact' instead of re-walking the cascade.
+    expect(js).toContain('function rememberResolved');
+    expect(js).toContain('elements[ref] = node');
+    expect(js).toContain('identity[ref] = fingerprintOf(node)');
+    expect(js).not.toContain("setAttribute('data-opencli-ref', ref)");
+    expect(js).not.toContain("removeAttribute('data-opencli-ref')");
   });
 
   it('reidentify runs both when data-opencli-ref is missing AND when fingerprint is mismatched', () => {

--- a/src/browser/target-resolver.ts
+++ b/src/browser/target-resolver.ts
@@ -8,8 +8,9 @@
  *    browser parser decide what's valid. No frontend regex whitelist — the
  *    goal is that any selector accepted by `browser find --css` is accepted
  *    by the same selector on `get/click/type/select`.
- * 2. Ref path: cascading match levels (see below), using data-opencli-ref
- *    plus the fingerprint map populated by snapshot + find.
+ * 2. Ref path: cascading match levels (see below), using in-memory refs,
+ *    legacy data-opencli-ref attributes, and the fingerprint map populated
+ *    by snapshot + find.
  * 3. CSS path: querySelectorAll + match-count policy (see ResolveOptions)
  * 4. Structured errors:
  *    - numeric: not_found / stale_ref
@@ -80,6 +81,7 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
       const nth = ${nthJs};
       const firstOnMulti = ${firstOnMulti};
       const identity = window.__opencli_ref_identity || {};
+      const elements = window.__opencli_ref_elements || {};
 
       // ── Classify input ──
       // Numeric = snapshot ref. Everything else is handed to querySelectorAll
@@ -168,18 +170,26 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
           return candidates.length === 1 ? candidates[0] : null;
         }
 
+        function rememberResolved(ref, node) {
+          try {
+            elements[ref] = node;
+            identity[ref] = fingerprintOf(node);
+            window.__opencli_ref_elements = elements;
+            window.__opencli_ref_identity = identity;
+          } catch (_) {}
+        }
+
         const fp = identity[ref];
-        let el = document.querySelector('[data-opencli-ref="' + ref + '"]');
+        const mapped = elements[ref];
+        let el = (mapped && mapped.nodeType === 1 && document.contains(mapped) ? mapped : null);
+        if (!el) el = document.querySelector('[data-opencli-ref="' + ref + '"]');
         if (!el) el = document.querySelector('[data-ref="' + ref + '"]');
 
         // If the ref tag is gone from the DOM, last-chance reidentify.
         if (!el) {
           const recovered = reidentify(fp);
           if (recovered) {
-            try {
-              recovered.setAttribute('data-opencli-ref', ref);
-              identity[ref] = fingerprintOf(recovered);
-            } catch (_) {}
+            rememberResolved(ref, recovered);
             window.__resolved = recovered;
             return { ok: true, matches_n: 1, match_level: 'reidentified' };
           }
@@ -207,14 +217,10 @@ export function resolveTargetJs(ref: string, opts: ResolveOptions = {}): string 
 
         // Tag / strong-id mismatch — try to find the real element elsewhere
         // before giving up. Covers e.g. a modal re-mount that discarded the
-        // data-opencli-ref attribute on the surviving node.
+        // previous snapshot's element identity.
         const recovered = reidentify(fp);
         if (recovered && recovered !== el) {
-          try {
-            el.removeAttribute('data-opencli-ref');
-            recovered.setAttribute('data-opencli-ref', ref);
-            identity[ref] = fingerprintOf(recovered);
-          } catch (_) {}
+          rememberResolved(ref, recovered);
           window.__resolved = recovered;
           return { ok: true, matches_n: 1, match_level: 'reidentified' };
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface SnapshotOptions {
   raw?: boolean;
   viewportExpand?: number;
   maxTextLength?: number;
+  /** Write data-opencli-ref attributes into the page DOM. Defaults to false. */
+  annotateRefs?: boolean;
   /** Observation backend. `dom` is the stable default; `ax` is an opt-in prototype. */
   source?: 'dom' | 'ax';
 }


### PR DESCRIPTION
﻿## Summary

Make normal browser state snapshots read-only for page DOM.

`browser state` still emits stable `[N]` refs, but stores the live element map in `window.__opencli_ref_elements` instead of writing `data-opencli-ref` attributes onto business DOM nodes. The target resolver now prefers that in-memory map and keeps legacy `data-opencli-ref` lookup as a compatibility fallback.

Annotated screenshots still opt into DOM annotation because the visual overlay currently relies on those attributes.

## Root Cause

Some sites monitor unexpected DOM attribute mutations. The previous DOM snapshot path wrote `data-opencli-ref` attributes during ordinary state reads, which could trigger page-side integrity logic and cause repeated refreshes or redirects.

## Validation

- `npx vitest run --project unit src/browser/dom-snapshot.test.ts src/browser/target-resolver.test.ts src/browser/base-page.test.ts`
- `npm run typecheck`
- `npm run build`
- Manual smoke test on `https://www.zhipin.com/web/geek/jobs`: `opencli browser zhipinfix state` returned the page state, and `document.querySelectorAll('[data-opencli-ref]').length` returned `0` after the state read.
