### PR TITLE
fix(xiaohongshu): scan text-card media from publish roots

### DIFF
--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -989,10 +989,10 @@ async function currentComposerMediaCount(page) {
         .map((sel) => Array.from(document.querySelectorAll(sel)))
         .flat()
         .find((el) => visibleBox(el));
-      const root = titleEl?.closest('form, [class*="publish"], [class*="editor"], [class*="note"]') || document.body;
+      const root = document.body;
       const seen = new Set();
       let count = 0;
-      for (const el of Array.from(root.querySelectorAll('img, video, canvas, [style*="background-image"]'))) {
+      for (const el of Array.from(root.querySelectorAll('img, image, svg, video, canvas, [style*="background-image"]'))) {
         if (!visibleMedia(el)) continue;
         const rect = el.getBoundingClientRect();
         const src = el.currentSrc || el.src || el.getAttribute('src') || el.style?.backgroundImage || '';

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -989,17 +989,45 @@ async function currentComposerMediaCount(page) {
         .map((sel) => Array.from(document.querySelectorAll(sel)))
         .flat()
         .find((el) => visibleBox(el));
-      const root = document.body;
+      const imageInputSelector = ${JSON.stringify(IMAGE_INPUT_SELECTOR)};
+      const imageInput = Array.from(document.querySelectorAll(imageInputSelector))
+        .find((el) => visibleBox(el) || el.type === 'file');
+      const rootSelectors = [
+        'main',
+        '[role="main"]',
+        '[class*="publish"]',
+        '[class*="editor"]',
+        'form',
+        '[class*="note"]',
+      ];
+      const roots = [];
+      const addRoot = (root) => {
+        if (root && !roots.includes(root)) roots.push(root);
+      };
+      const addAnchoredRoot = (anchor) => {
+        if (!anchor) return;
+        for (const sel of rootSelectors) {
+          const root = anchor.closest(sel);
+          if (root) { addRoot(root); return; }
+        }
+      };
+      // The generated-card media and title can live in sibling subtrees, so
+      // prefer broad publish/editor ancestors over the old nearest .note match.
+      addAnchoredRoot(imageInput);
+      addAnchoredRoot(titleEl);
+      addRoot(document.querySelector('main'));
       const seen = new Set();
       let count = 0;
-      for (const el of Array.from(root.querySelectorAll('img, image, svg, video, canvas, [style*="background-image"]'))) {
-        if (!visibleMedia(el)) continue;
-        const rect = el.getBoundingClientRect();
-        const src = el.currentSrc || el.src || el.getAttribute('src') || el.style?.backgroundImage || '';
-        const key = src || String(Math.round(rect.left)) + ':' + String(Math.round(rect.top));
-        if (seen.has(key)) continue;
-        seen.add(key);
-        count += 1;
+      for (const root of roots) {
+        for (const el of Array.from(root.querySelectorAll('img, image, svg, video, canvas, [style*="background-image"]'))) {
+          if (!visibleMedia(el)) continue;
+          const rect = el.getBoundingClientRect();
+          const src = el.currentSrc || el.src || el.getAttribute('src') || el.style?.backgroundImage || '';
+          const key = src || String(Math.round(rect.left)) + ':' + String(Math.round(rect.top));
+          if (seen.has(key)) continue;
+          seen.add(key);
+          count += 1;
+        }
       }
       return { ok: true, count };
     })()

--- a/clis/xiaohongshu/publish.js
+++ b/clis/xiaohongshu/publish.js
@@ -993,8 +993,6 @@ async function currentComposerMediaCount(page) {
       const imageInput = Array.from(document.querySelectorAll(imageInputSelector))
         .find((el) => visibleBox(el) || el.type === 'file');
       const rootSelectors = [
-        'main',
-        '[role="main"]',
         '[class*="publish"]',
         '[class*="editor"]',
         'form',
@@ -1012,14 +1010,14 @@ async function currentComposerMediaCount(page) {
         }
       };
       // The generated-card media and title can live in sibling subtrees, so
-      // prefer broad publish/editor ancestors over the old nearest .note match.
+      // anchor from both the image input and title, but keep the scan inside
+      // publish/editor/form roots rather than all of main.
       addAnchoredRoot(imageInput);
       addAnchoredRoot(titleEl);
-      addRoot(document.querySelector('main'));
       const seen = new Set();
       let count = 0;
       for (const root of roots) {
-        for (const el of Array.from(root.querySelectorAll('img, image, svg, video, canvas, [style*="background-image"]'))) {
+        for (const el of Array.from(root.querySelectorAll('img, video, canvas, [style*="background-image"]'))) {
           if (!visibleMedia(el)) continue;
           const rect = el.getBoundingClientRect();
           const src = el.currentSrc || el.src || el.getAttribute('src') || el.style?.backgroundImage || '';

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 import { CommandExecutionError, ArgumentError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
@@ -1130,6 +1131,52 @@ describe('xiaohongshu publish 文字配图 flow', () => {
             if (code.includes('__opencli_xhs_preview_ready')) return { ok: true };
             if (code.includes('__opencli_xhs_card_text')) return { ok: true, text: 'x' };
             if (code.includes('__opencli_xhs_composer_media_count')) return { ok: true, count: 0 };
+            if (code.includes('const sels =') && code.includes('for (const sel of sels)')) return true;
+            return null;
+        }, { insertText });
+
+        await expect(
+            cmd.func(page, { title: 't', content: 'c', 'card-text': '卡片' })
+        ).rejects.toThrow(/generated images/);
+    });
+
+    it('does not count unrelated visible page media as generated card media', async () => {
+        const cmd = getCmd();
+        const capture = { clicks: [] };
+        const insertText = vi.fn().mockResolvedValue(undefined);
+        const page = createConditionalPageMock((code) => {
+            if (code.includes('location.href')) return 'https://creator.xiaohongshu.com/publish/publish?from=menu_left';
+            if (code.includes("const targets = ['上传图文', '图文', '图片']")) return { ok: true, target: '上传图文', text: '上传图文' };
+            if (code.includes('hasTitleInput') && code.includes('hasVideoSurface'))
+                return { state: 'image_surface', hasTitleInput: false, hasImageInput: true, hasVideoSurface: false };
+            if (code.includes('__opencli_xhs_click_label')) {
+                capture.clicks.push(code.match(/wantLabel:\s*"([^"]+)"/)?.[1] ?? 'unknown');
+                return { ok: true };
+            }
+            if (code.includes('__opencli_xhs_focus_card')) return { ok: true };
+            if (code.includes('__opencli_xhs_card_count')) return { ok: true, count: 9, activeEmpty: true };
+            if (code.includes('__opencli_xhs_preview_ready')) return { ok: true };
+            if (code.includes('__opencli_xhs_card_text')) return { ok: true, text: 'x' };
+            if (code.includes('__opencli_xhs_composer_media_count')) {
+                const dom = new JSDOM(`<!doctype html><html><body>
+                  <header>
+                    <img id="site-logo" src="https://static.example/logo.png">
+                  </header>
+                  <main class="publish-page">
+                    <section class="editor-pane">
+                      <input type="file" accept="image/png">
+                      <input placeholder="标题" maxlength="20">
+                    </section>
+                  </main>
+                </body></html>`, {
+                    url: 'https://creator.xiaohongshu.com/publish/publish?from=menu_left',
+                    runScripts: 'outside-only',
+                });
+                const logo = dom.window.document.querySelector('#site-logo');
+                Object.defineProperty(logo, 'offsetParent', { configurable: true, value: dom.window.document.body });
+                logo.getBoundingClientRect = () => ({ left: 1, top: 1, width: 128, height: 128 });
+                return dom.window.eval(code);
+            }
             if (code.includes('const sels =') && code.includes('for (const sel of sels)')) return true;
             return null;
         }, { insertText });

--- a/clis/xiaohongshu/publish.test.js
+++ b/clis/xiaohongshu/publish.test.js
@@ -1159,10 +1159,10 @@ describe('xiaohongshu publish 文字配图 flow', () => {
             if (code.includes('__opencli_xhs_card_text')) return { ok: true, text: 'x' };
             if (code.includes('__opencli_xhs_composer_media_count')) {
                 const dom = new JSDOM(`<!doctype html><html><body>
-                  <header>
-                    <img id="site-logo" src="https://static.example/logo.png">
-                  </header>
-                  <main class="publish-page">
+                  <main class="creator-shell">
+                    <aside>
+                      <img id="site-logo" src="https://static.example/logo.png">
+                    </aside>
                     <section class="editor-pane">
                       <input type="file" accept="image/png">
                       <input placeholder="标题" maxlength="20">


### PR DESCRIPTION
## Description

### Problem
`opencli xiaohongshu publish --card-text` can abort after native text-to-image generation with:

```text
expected at least N visible media item(s), got 0
```

### Root cause
`currentComposerMediaCount()` rooted its media scan at the nearest ancestor of the title field:

```js
const root = titleEl?.closest('form, [class*="publish"], [class*="editor"], [class*="note"]') || document.body;
```

In the current Xiaohongshu creator UI, generated card media can mount in a sibling subtree rather than under that nearest title ancestor, so the scan can miss real generated cards.

### Fix
Use publish/editor/form roots anchored from the image input and title field instead of the too-narrow title ancestor. The final implementation intentionally does **not** count all of `document.body`, `main`, or `[role=main]`: unrelated page media such as logos or side content must not satisfy the generated-card postcondition.

The media selector remains limited to `img`, `video`, `canvas`, and background images; it does not widen to unsupported `svg`/`image` elements.

### Verification
- Added a regression with an unrelated visible image inside `<main>` but outside the editor/publish root; it does not satisfy the generated-card gate.
- `npx vitest run clis/xiaohongshu/publish.test.js` -> 32/32 passing.
- `npm run build` -> PASS, manifest 1331 entries.
- `node dist/src/main.js validate xiaohongshu` -> PASS, 25 commands.
- `git diff --check` -> PASS.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New site adapter
- [ ] Documentation
- [ ] Refactor
- [ ] CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] _Not applicable_ - existing command bug fix, no discoverability change.
