### PR TITLE
fix(completion): fall back on invalid manifests

### DIFF
--- a/src/completion-fast.test.ts
+++ b/src/completion-fast.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { getCompletionsFromManifest } from './completion-fast.js';
+import { BUILTIN_COMMANDS } from './completion-shared.js';
 
 describe('getCompletionsFromManifest', () => {
   const tempDirs: string[] = [];
@@ -19,5 +20,42 @@ describe('getCompletionsFromManifest', () => {
     fs.writeFileSync(manifestPath, '{ not valid json', 'utf-8');
 
     expect(getCompletionsFromManifest([], 1, [manifestPath])).toBeNull();
+  });
+
+  it('signals fallback when a manifest becomes unavailable', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-completion-'));
+    tempDirs.push(dir);
+    const manifestPath = path.join(dir, 'missing-manifest.json');
+
+    expect(getCompletionsFromManifest([], 1, [manifestPath])).toBeNull();
+  });
+
+  it('signals fallback when a manifest is not an array', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-completion-'));
+    tempDirs.push(dir);
+    const manifestPath = path.join(dir, 'cli-manifest.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({ site: 'twitter', name: 'search' }), 'utf-8');
+
+    expect(getCompletionsFromManifest([], 1, [manifestPath])).toBeNull();
+  });
+
+  it('falls back instead of returning partial results when any manifest is invalid', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-completion-'));
+    tempDirs.push(dir);
+    const validPath = path.join(dir, 'valid-manifest.json');
+    const invalidPath = path.join(dir, 'invalid-manifest.json');
+    fs.writeFileSync(validPath, JSON.stringify([{ site: 'twitter', name: 'search' }]), 'utf-8');
+    fs.writeFileSync(invalidPath, '{ not valid json', 'utf-8');
+
+    expect(getCompletionsFromManifest([], 1, [validPath, invalidPath])).toBeNull();
+  });
+
+  it('keeps an empty valid manifest on the fast path', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-completion-'));
+    tempDirs.push(dir);
+    const manifestPath = path.join(dir, 'cli-manifest.json');
+    fs.writeFileSync(manifestPath, '[]', 'utf-8');
+
+    expect(getCompletionsFromManifest([], 1, [manifestPath])).toEqual([...BUILTIN_COMMANDS].sort());
   });
 });

--- a/src/completion-fast.test.ts
+++ b/src/completion-fast.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getCompletionsFromManifest } from './completion-fast.js';
+
+describe('getCompletionsFromManifest', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+    tempDirs.length = 0;
+  });
+
+  it('signals fallback when a manifest cannot be parsed', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-completion-'));
+    tempDirs.push(dir);
+    const manifestPath = path.join(dir, 'cli-manifest.json');
+    fs.writeFileSync(manifestPath, '{ not valid json', 'utf-8');
+
+    expect(getCompletionsFromManifest([], 1, [manifestPath])).toBeNull();
+  });
+});

--- a/src/completion-fast.ts
+++ b/src/completion-fast.ts
@@ -40,10 +40,10 @@ export function hasAllManifests(manifestPaths: string[]): boolean {
  * Lightweight completion that reads directly from manifest JSON files,
  * bypassing full CLI discovery and adapter loading.
  */
-export function getCompletionsFromManifest(words: string[], cursor: number, manifestPaths: string[]): string[] {
+export function getCompletionsFromManifest(words: string[], cursor: number, manifestPaths: string[]): string[] | null {
   const entries = loadManifestEntries(manifestPaths);
   if (entries === null) {
-    return [];
+    return null;
   }
 
   if (cursor <= 1) {
@@ -93,14 +93,16 @@ export function printCompletionScriptFast(shell: string): boolean {
 
 function loadManifestEntries(manifestPaths: string[]): ManifestCompletionEntry[] | null {
   const entries: ManifestCompletionEntry[] = [];
-  let found = false;
+  if (manifestPaths.length === 0) return null;
   for (const manifestPath of manifestPaths) {
     try {
       const raw = fs.readFileSync(manifestPath, 'utf-8');
       const manifest = JSON.parse(raw) as ManifestCompletionEntry[];
+      if (!Array.isArray(manifest)) return null;
       entries.push(...manifest);
-      found = true;
-    } catch { /* skip missing/unreadable */ }
+    } catch {
+      return null;
+    }
   }
-  return found ? entries : null;
+  return entries;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,10 +89,12 @@ if (getCompIdx !== -1) {
     }
     if (cursor === undefined) cursor = words.length;
     const candidates = getCompletionsFromManifest(words, cursor, manifestPaths);
-    process.stdout.write(candidates.join('\n') + '\n');
-    process.exit(EXIT_CODES.SUCCESS);
+    if (candidates !== null) {
+      process.stdout.write(candidates.join('\n') + '\n');
+      process.exit(EXIT_CODES.SUCCESS);
+    }
   }
-  // No manifest — fall through to full discovery path below
+  // Manifest unavailable or invalid — fall through to full discovery below.
 }
 
 // ── Full startup path ───────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Preserve shell completion when a compiled CLI manifest exists but cannot be used:

- return an explicit fallback signal for unreadable, malformed, or non-array manifests
- let the main entry point continue through full adapter discovery on that signal
- keep the fast path unchanged for valid manifests

Previously the fast path converted a parse failure into an empty completion list and exited successfully, hiding all completion candidates.

Related issue: N/A (independently identified)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
npm run typecheck
> tsc --noEmit

npm run build
✅ Manifest compiled: 1331 entries

npm test
Test Files  591 passed (591)
Tests       6739 passed | 1 skipped (6740)
```

## Risks / Known Gaps

Fallback discovery is slower than the manifest fast path, but it runs only when a manifest is unusable. Valid-manifest completion behavior is unchanged.