### PR TITLE
fix(plugin): honor caret ranges below 1.0.0

### DIFF
--- a/src/plugin-manifest.test.ts
+++ b/src/plugin-manifest.test.ts
@@ -195,6 +195,17 @@ describe('satisfiesRange', () => {
     expect(satisfiesRange('1.1.0', '^1.2.0')).toBe(false);
   });
 
+  it('limits caret ranges below 1.0.0 to the next minor version', () => {
+    expect(satisfiesRange('0.2.0', '^0.2.0')).toBe(true);
+    expect(satisfiesRange('0.2.9', '^0.2.0')).toBe(true);
+    expect(satisfiesRange('0.3.0', '^0.2.0')).toBe(false);
+  });
+
+  it('limits caret ranges below 0.1.0 to the next patch version', () => {
+    expect(satisfiesRange('0.0.3', '^0.0.3')).toBe(true);
+    expect(satisfiesRange('0.0.4', '^0.0.3')).toBe(false);
+  });
+
   it('handles ~ (tilde) constraint', () => {
     expect(satisfiesRange('1.2.0', '~1.2.0')).toBe(true);
     expect(satisfiesRange('1.2.9', '~1.2.0')).toBe(true);

--- a/src/plugin-manifest.ts
+++ b/src/plugin-manifest.ts
@@ -136,7 +136,11 @@ function satisfiesSingleConstraint(
   if (trimmed.startsWith('^')) {
     const target = parseVersion(trimmed.slice(1));
     if (!target) return true;
-    const upper: [number, number, number] = [target[0] + 1, 0, 0];
+    const upper: [number, number, number] = target[0] > 0
+      ? [target[0] + 1, 0, 0]
+      : target[1] > 0
+        ? [0, target[1] + 1, 0]
+        : [0, 0, target[2] + 1];
     return compareVersions(version, target) >= 0 && compareVersions(version, upper) < 0;
   }
 


### PR DESCRIPTION
## Description

Apply standard caret compatibility bounds to pre-1.0 plugin versions:

- keep `^1.2.0` bounded below `2.0.0`
- bound `^0.2.0` below `0.3.0`
- bound `^0.0.3` below `0.0.4`

This prevents plugins from being treated as compatible across potentially breaking `0.x` releases.

Related issue: N/A (independently identified)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
npm run typecheck
> tsc --noEmit

npm run build
✅ Manifest compiled: 1331 entries

npm test
Test Files  590 passed (590)
Tests       6740 passed | 1 skipped (6741)
```

## Risks / Known Gaps

This changes compatibility decisions only for caret ranges whose major version is zero. Other supported range forms are unchanged.