### PR TITLE
fix(args): reject invalid integer values

### DIFF
--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CliCommand } from './registry.js';
-import { executeCommand, prepareCommandArgs } from './execution.js';
+import { coerceAndValidateArgs, executeCommand, prepareCommandArgs } from './execution.js';
 import { ArgumentError, TimeoutError, toEnvelope } from './errors.js';
 import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
@@ -11,6 +11,22 @@ import * as runtime from './runtime.js';
 import * as capRouting from './capabilityRouting.js';
 import * as daemonClient from './browser/daemon-client.js';
 import { BrowserCommandError } from './browser/daemon-client.js';
+
+describe('coerceAndValidateArgs', () => {
+  it('rejects fractional values for integer arguments', () => {
+    const args = [{ name: 'limit', type: 'int' as const, help: 'Result limit' }];
+
+    expect(() => coerceAndValidateArgs(args, { limit: '1.5' })).toThrow(ArgumentError);
+  });
+
+  it('rejects non-finite values for numeric arguments', () => {
+    const integerArgs = [{ name: 'limit', type: 'int' as const, help: 'Result limit' }];
+    const numberArgs = [{ name: 'threshold', type: 'number' as const, help: 'Threshold' }];
+
+    expect(() => coerceAndValidateArgs(integerArgs, { limit: 'Infinity' })).toThrow(ArgumentError);
+    expect(() => coerceAndValidateArgs(numberArgs, { threshold: '-Infinity' })).toThrow(ArgumentError);
+  });
+});
 
 describe('executeCommand — non-browser timeout', () => {
   it('applies the user --timeout arg as the ceiling for non-browser commands', async () => {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -67,8 +67,11 @@ export function coerceAndValidateArgs(cmdArgs: Arg[], kwargs: CommandArgs): Comm
     if (val !== undefined && val !== null) {
       if (argDef.type === 'int' || argDef.type === 'number') {
         const num = Number(val);
-        if (Number.isNaN(num)) {
+        if (!Number.isFinite(num)) {
           throw new ArgumentError(`Argument "${argDef.name}" must be a valid number. Received: "${val}"`);
+        }
+        if (argDef.type === 'int' && !Number.isInteger(num)) {
+          throw new ArgumentError(`Argument "${argDef.name}" must be a valid integer. Received: "${val}"`);
         }
         result[argDef.name] = num;
       } else if (argDef.type === 'boolean' || argDef.type === 'bool') {


### PR DESCRIPTION
## Description

Keep numeric argument coercion aligned with the declared argument type:

- reject fractional values for `int` arguments instead of passing them to adapters
- reject `Infinity` and `-Infinity` for both `int` and `number` arguments
- preserve the existing coercion behavior for finite numeric values

Related issue: N/A (independently identified)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
npm run typecheck
> tsc --noEmit

npm run build
✅ Manifest compiled: 1331 entries

npm test
Test Files  590 passed (590)
Tests       6740 passed | 1 skipped (6741)
```

## Risks / Known Gaps

This intentionally tightens validation for values that cannot satisfy the declared numeric type. Adapters that previously accepted fractional `int` values will now receive an `ArgumentError` before execution.