### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ See **[TESTING.md](./TESTING.md)** for how to run and write tests.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jackwener/opencli&type=Date)](https://star-history.dera.page/#jackwener/opencli&Date)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -336,7 +336,7 @@ opencli plugin uninstall my-tool                            # 卸载
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jackwener/opencli&type=Date)](https://star-history.com/#jackwener/opencli&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jackwener/opencli&type=Date)](https://star-history.dera.page/#jackwener/opencli&Date)
 
 
 


### PR DESCRIPTION
The star history chart in the README currently fails to render because the data source it relied on is no longer reliable under GitHub's current stargazer API restrictions. This updates the chart link in both README.md and README.zh-CN.md to point to a working endpoint, restoring the chart for all visitors.