### PR TITLE
feat(zhihu): export answers with local images

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ OpenCLI supports downloading images, videos, and articles from supported platfor
 | **pixiv** | Images | Original-quality illustrations, multi-page |
 | **1688** | Images, Videos | Downloads page-visible product media from item pages |
 | **xiaoyuzhou** | Audio, Transcript | Downloads episode audio and transcript JSON/text with local credentials |
-| **zhihu** | Articles (Markdown) | Exports with optional image download |
+| **zhihu** | Column articles, answers (Markdown) | Exports with optional image download |
 | **weixin** | Articles (Markdown) | WeChat Official Account articles |
 
 For video downloads, install `yt-dlp` first: `brew install yt-dlp`

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -47256,9 +47256,9 @@
   {
     "site": "zhihu",
     "name": "download",
-    "description": "导出知乎文章为 Markdown 格式",
+    "description": "导出知乎专栏文章或回答为 Markdown 格式",
     "access": "read",
-    "domain": "zhuanlan.zhihu.com",
+    "domain": "www.zhihu.com",
     "strategy": "cookie",
     "browser": true,
     "args": [
@@ -47266,7 +47266,7 @@
         "name": "url",
         "type": "str",
         "required": true,
-        "help": "Article URL (zhuanlan.zhihu.com/p/xxx)"
+        "help": "Column article URL, answer ID, typed target, or answer URL"
       },
       {
         "name": "output",
@@ -47293,7 +47293,7 @@
     "type": "js",
     "modulePath": "zhihu/download.js",
     "sourceFile": "zhihu/download.js",
-    "navigateBefore": "https://zhuanlan.zhihu.com"
+    "navigateBefore": "https://www.zhihu.com"
   },
   {
     "site": "zhihu",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -47293,7 +47293,7 @@
     "type": "js",
     "modulePath": "zhihu/download.js",
     "sourceFile": "zhihu/download.js",
-    "navigateBefore": "https://www.zhihu.com"
+    "navigateBefore": false
   },
   {
     "site": "zhihu",

--- a/clis/zhihu/download-helpers.js
+++ b/clis/zhihu/download-helpers.js
@@ -6,7 +6,8 @@ import { unwrapEvaluateResult } from './paginate.js';
 const ARTICLE_TYPED_RE = /^article:(\d+)$/;
 const ARTICLE_PATH_RE = /^\/p\/(\d+)\/?$/;
 const ANSWER_API_PATH_RE = /^(?:\/api\/v4)?\/answers\/(\d+)\/?$/;
-const QUESTION_PATH_RE = /^(?:\/api\/v4)?\/questions\/(\d+)\/?$/;
+const QUESTION_API_PATH_RE = /^(?:\/api\/v4)?\/questions\/(\d+)\/?$/;
+const QUESTION_WEB_PATH_RE = /^\/question\/(\d+)\/?$/;
 
 export function parseDownloadTarget(input) {
     const value = String(input ?? '').trim();
@@ -55,7 +56,7 @@ function answerTargetFromUrl(input) {
 function questionIdFromUrl(input) {
     const url = trustedZhihuUrl(input);
     if (!url) return '';
-    return parseAnswerTarget(url.toString())?.questionId || url.pathname.match(QUESTION_PATH_RE)?.[1] || '';
+    return url.pathname.match(QUESTION_API_PATH_RE)?.[1] || url.pathname.match(QUESTION_WEB_PATH_RE)?.[1] || '';
 }
 
 export function normalizeContentImages(contentHtml, documentRef = document) {

--- a/clis/zhihu/download-helpers.js
+++ b/clis/zhihu/download-helpers.js
@@ -1,191 +1,262 @@
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeUnixSeconds } from './answer-normalize.js';
+import { parseAnswerTarget } from './answer-target.js';
+import { unwrapEvaluateResult } from './paginate.js';
 
-const ANSWER_ID_RE = /^\d+$/;
-const ANSWER_TYPED_RE = /^answer:(\d+):(\d+)$/;
-const ANSWER_PATH_RE = /^\/question\/(\d+)\/answer\/(\d+)\/?$/;
-const BARE_ANSWER_PATH_RE = /^\/answer\/(\d+)\/?$/;
 const ARTICLE_TYPED_RE = /^article:(\d+)$/;
 const ARTICLE_PATH_RE = /^\/p\/(\d+)\/?$/;
+const ANSWER_API_PATH_RE = /^(?:\/api\/v4)?\/answers\/(\d+)\/?$/;
+const QUESTION_PATH_RE = /^(?:\/api\/v4)?\/questions\/(\d+)\/?$/;
 
 export function parseDownloadTarget(input) {
     const value = String(input ?? '').trim();
-    if (!value) return null;
-    if (ANSWER_ID_RE.test(value)) return { kind: 'answer', answerId: value, questionId: '' };
-    const typedAnswer = value.match(ANSWER_TYPED_RE);
-    if (typedAnswer) return { kind: 'answer', questionId: typedAnswer[1], answerId: typedAnswer[2] };
     const typedArticle = value.match(ARTICLE_TYPED_RE);
-    if (typedArticle) return { kind: 'article', articleId: typedArticle[1], url: `https://zhuanlan.zhihu.com/p/${typedArticle[1]}` };
+    if (typedArticle) return articleTarget(typedArticle[1]);
     try {
         const url = new URL(value);
-        if (url.protocol !== 'https:' || url.username || url.password || url.port) return null;
-        if (url.hostname === 'zhuanlan.zhihu.com') {
-            const article = url.pathname.match(ARTICLE_PATH_RE);
-            return article
-                ? { kind: 'article', articleId: article[1], url: `https://zhuanlan.zhihu.com/p/${article[1]}` }
-                : null;
-        }
-        if (url.hostname !== 'www.zhihu.com' && url.hostname !== 'zhihu.com') return null;
-        const answer = url.pathname.match(ANSWER_PATH_RE);
-        if (answer) return { kind: 'answer', questionId: answer[1], answerId: answer[2] };
-        const bareAnswer = url.pathname.match(BARE_ANSWER_PATH_RE);
-        return bareAnswer ? { kind: 'answer', questionId: '', answerId: bareAnswer[1] } : null;
-    } catch {
+        const articleId = url.protocol === 'https:' && !url.username && !url.password && !url.port
+            && url.hostname === 'zhuanlan.zhihu.com'
+            ? url.pathname.match(ARTICLE_PATH_RE)?.[1]
+            : '';
+        if (articleId) return articleTarget(articleId);
+    }
+    catch {
+        // The shared answer parser also accepts bare and typed answer ids.
+    }
+    const answer = parseAnswerTarget(value);
+    return answer ? { kind: 'answer', ...answer } : null;
+}
+
+function articleTarget(articleId) {
+    return { kind: 'article', articleId, url: `https://zhuanlan.zhihu.com/p/${articleId}` };
+}
+
+function trustedZhihuUrl(input) {
+    if (typeof input !== 'string' || !input) return '';
+    try {
+        const url = new URL(input);
+        if (url.protocol !== 'https:' || url.username || url.password || url.port
+            || url.hash || !['api.zhihu.com', 'www.zhihu.com', 'zhihu.com'].includes(url.hostname)) return null;
+        return url;
+    }
+    catch {
         return null;
     }
 }
 
-export function extractQuestionId(url) {
-    try {
-        const parsed = new URL(String(url || ''));
-        if (parsed.protocol !== 'https:' || (parsed.hostname !== 'www.zhihu.com' && parsed.hostname !== 'zhihu.com')) return '';
-        return parsed.pathname.match(ANSWER_PATH_RE)?.[1] || '';
-    } catch {
-        return '';
-    }
+function answerTargetFromUrl(input) {
+    const url = trustedZhihuUrl(input);
+    if (!url) return null;
+    const webTarget = parseAnswerTarget(url.toString());
+    const apiAnswerId = url.pathname.match(ANSWER_API_PATH_RE)?.[1];
+    return webTarget || (apiAnswerId ? { answerId: apiAnswerId, questionId: '' } : null);
 }
 
-export function normalizeUnixSeconds(value) {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0
-        ? new Date(value * 1000).toISOString()
-        : '';
+function questionIdFromUrl(input) {
+    const url = trustedZhihuUrl(input);
+    if (!url) return '';
+    return parseAnswerTarget(url.toString())?.questionId || url.pathname.match(QUESTION_PATH_RE)?.[1] || '';
 }
 
 export function normalizeContentImages(contentHtml, documentRef = document) {
     const root = documentRef.createElement('div');
-    root.innerHTML = contentHtml || '';
+    root.innerHTML = typeof contentHtml === 'string' ? contentHtml : '';
     const imageUrls = [];
     const seen = new Set();
+    const normalizeUrl = (raw) => {
+        const value = String(raw || '').trim();
+        if (!value) return '';
+        try {
+            const url = new URL(value, 'https://www.zhihu.com/');
+            return ['http:', 'https:'].includes(url.protocol) && !url.username && !url.password ? url.toString() : '';
+        }
+        catch {
+            return '';
+        }
+    };
+    const normalizeSrcset = (raw) => String(raw || '').split(',').flatMap((entry) => {
+        const [url, ...descriptor] = entry.trim().split(/\s+/);
+        const normalized = normalizeUrl(url);
+        return normalized ? [[normalized, ...descriptor].join(' ')] : [];
+    });
+    const lastSrcsetUrl = (raw) => normalizeSrcset(raw).at(-1)?.split(/\s+/, 1)[0] || '';
+
+    root.querySelectorAll('img, source').forEach((element) => {
+        const srcset = normalizeSrcset(element.getAttribute('data-srcset') || element.getAttribute('srcset'));
+        if (srcset.length) element.setAttribute('srcset', srcset.join(', '));
+        else element.removeAttribute('srcset');
+        element.removeAttribute('data-srcset');
+    });
     root.querySelectorAll('img').forEach((img) => {
-        const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
-        if (!src || src.startsWith('data:')) return;
-        const normalized = src.startsWith('//') ? `https:${src}` : src;
-        img.setAttribute('src', normalized);
-        if (!seen.has(normalized)) {
-            seen.add(normalized);
-            imageUrls.push(normalized);
+        const source = img.closest('picture')?.querySelector('source');
+        const src = normalizeUrl(
+            img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('data-src')
+            || lastSrcsetUrl(img.getAttribute('srcset')) || lastSrcsetUrl(source?.getAttribute('srcset'))
+            || img.getAttribute('src'),
+        );
+        for (const name of ['data-original', 'data-actualsrc', 'data-src']) img.removeAttribute(name);
+        if (!src) img.removeAttribute('src');
+        else {
+            img.setAttribute('src', src);
+            if (!seen.has(src)) {
+                seen.add(src);
+                imageUrls.push(src);
+            }
         }
     });
     return { contentHtml: root.innerHTML, imageUrls };
 }
 
+function requireArticle(raw) {
+    const data = unwrapEvaluateResult(raw);
+    if (!data || typeof data !== 'object' || Array.isArray(data)
+        || typeof data.title !== 'string' || typeof data.contentHtml !== 'string'
+        || !Array.isArray(data.imageUrls) || !data.imageUrls.every((url) => typeof url === 'string')) {
+        throw new CommandExecutionError('Zhihu column download returned malformed article fields');
+    }
+    if (!data.contentHtml.trim()) {
+        throw new EmptyResultError('zhihu download', 'The Zhihu column article had no exportable content.');
+    }
+    return data;
+}
+
 export async function extractColumnArticle(page, target) {
     await page.goto(target.url);
     await page.wait(3);
-    return page.evaluate(`
+    const normalize = `(${normalizeContentImages.toString()})`;
+    const raw = await page.evaluate(`
       (() => {
-        const result = {
-          title: '',
-          author: '',
-          publishTime: '',
-          contentHtml: '',
-          imageUrls: []
+        const content = document.querySelector('.Post-RichTextContainer, .RichText, .ArticleContent');
+        const normalized = ${normalize}(content?.innerHTML || '');
+        return {
+          title: document.querySelector('.Post-Title, h1.ContentItem-title, .ArticleTitle')?.textContent?.trim() || 'untitled',
+          author: document.querySelector('.AuthorInfo-name, .UserLink-link')?.textContent?.trim() || '',
+          publishTime: document.querySelector('.ContentItem-time, .Post-Time')?.textContent?.trim() || '',
+          ...normalized
         };
-        const titleEl = document.querySelector('.Post-Title, h1.ContentItem-title, .ArticleTitle');
-        result.title = titleEl?.textContent?.trim() || 'untitled';
-        const authorEl = document.querySelector('.AuthorInfo-name, .UserLink-link');
-        result.author = authorEl?.textContent?.trim() || '';
-        const timeEl = document.querySelector('.ContentItem-time, .Post-Time');
-        result.publishTime = timeEl?.textContent?.trim() || '';
-        const contentEl = document.querySelector('.Post-RichTextContainer, .RichText, .ArticleContent');
-        if (contentEl) {
-          const clone = contentEl.cloneNode(true);
-          const seen = new Set();
-          clone.querySelectorAll('img').forEach(img => {
-            const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
-            if (!src || src.startsWith('data:')) return;
-            const normalized = src.startsWith('//') ? 'https:' + src : src;
-            img.setAttribute('src', normalized);
-            if (!seen.has(normalized)) {
-              seen.add(normalized);
-              result.imageUrls.push(normalized);
-            }
-          });
-          result.contentHtml = clone.innerHTML;
-        }
-        return result;
       })()
-    `);
+    `).catch((error) => {
+        throw new CommandExecutionError(`Zhihu column extraction failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return requireArticle(raw);
 }
 
 export async function extractAnswer(page, target) {
     try {
         await page.goto(`https://www.zhihu.com/answer/${target.answerId}`);
-    } catch (err) {
+    }
+    catch (error) {
         throw new CommandExecutionError(
-            `Failed to open Zhihu answer ${target.answerId}: ${err instanceof Error ? err.message : String(err)}`,
+            `Failed to open Zhihu answer ${target.answerId}: ${error instanceof Error ? error.message : String(error)}`,
             'Open the answer URL in Chrome and retry after the page is reachable.',
         );
     }
-    const currentUrl = page.getCurrentUrl ? await page.getCurrentUrl().catch(() => '') : '';
-    const apiUrl = `https://www.zhihu.com/api/v4/answers/${target.answerId}?include=content,author,created_time,question`;
-    const normalizeContentImagesSource = `(${normalizeContentImages.toString()})`;
-    const data = await page.evaluate(`
+    const currentUrl = typeof page.getCurrentUrl === 'function' ? await page.getCurrentUrl().catch(() => '') : '';
+    const currentTarget = parseAnswerTarget(currentUrl);
+    if (!currentTarget || currentTarget.answerId !== target.answerId || !currentTarget.questionId
+        || (target.questionId && currentTarget.questionId && target.questionId !== currentTarget.questionId)) {
+        throw new CommandExecutionError(`Zhihu answer navigation changed identity for answer ${target.answerId}`);
+    }
+
+    const apiUrl = `https://www.zhihu.com/api/v4/answers/${target.answerId}?include=content,author,created_time,question,url`;
+    const normalize = `(${normalizeContentImages.toString()})`;
+    const raw = await page.evaluate(`
       (async () => {
-        const response = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
+        let response;
+        try {
+          response = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
+        } catch (error) {
+          return { fetchError: error instanceof Error ? error.message : String(error) };
+        }
         let payload;
         try {
           payload = await response.json();
-        } catch (error) {
-          return { __httpError: response.status, __malformedJson: error instanceof Error ? error.message : String(error) };
+        } catch {
+          return { status: response.status, malformed: true };
         }
-        const errorCode = payload?.error?.code ?? '';
-        const errorMessage = payload?.error?.message || payload?.error_msg || payload?.message || '';
-        if (!response.ok) return { __httpError: response.status, __errorCode: errorCode, __errorMessage: errorMessage };
-        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { __malformedPayload: true };
-        if (errorCode || errorMessage) return { __errorCode: errorCode, __errorMessage: errorMessage };
-        if (!Object.prototype.hasOwnProperty.call(payload, 'content')) return { __missingContent: true };
-
-        const normalizedContent = ${normalizeContentImagesSource}(payload.content || '');
-        return {
-          title: payload.question?.title || 'untitled',
-          author: payload.author?.name || '',
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { status: response.status, malformed: true };
+        const errorCode = payload.error?.code ?? '';
+        const errorMessage = payload.error?.message || payload.error_msg || payload.message || '';
+        const needLogin = payload.error?.need_login === true || payload.need_login === true;
+        if (!response.ok || errorCode || errorMessage || needLogin) {
+          return { status: response.status, errorCode, errorMessage, needLogin };
+        }
+        if (typeof payload.content !== 'string') return { malformed: true };
+        const normalized = ${normalize}(payload.content, document);
+        return { value: {
+          answerUrl: typeof payload.url === 'string' ? payload.url : '',
+          questionUrl: typeof payload.question?.url === 'string' ? payload.question.url : '',
+          title: typeof payload.question?.title === 'string' ? payload.question.title : '',
+          author: typeof payload.author?.name === 'string' ? payload.author.name : '',
           createdTime: payload.created_time,
-          contentHtml: normalizedContent.contentHtml,
-          imageUrls: normalizedContent.imageUrls,
-        };
+          ...normalized
+        } };
       })()
-    `).catch((err) => {
+    `).catch((error) => {
         throw new CommandExecutionError(
-            `Zhihu answer download request failed: ${err instanceof Error ? err.message : String(err)}`,
+            `Zhihu answer download request failed: ${error instanceof Error ? error.message : String(error)}`,
             'Try again later or rerun with -v for more detail.',
         );
     });
 
-    if (!data || data.__httpError) {
-        const status = data?.__httpError;
-        if (status === 403 && String(data?.__errorCode) === '40362') {
-            throw new CommandExecutionError(
-                `Zhihu risk control blocked answer ${target.answerId} (40362): ${data?.__errorMessage || 'abnormal request'}`,
-                'Open the answer in the connected Chrome profile and retry later.',
-            );
-        }
-        if (status === 401 || status === 403) {
-            throw new AuthRequiredError('www.zhihu.com', 'Failed to download Zhihu answer');
-        }
-        if (status === 404) {
-            throw new EmptyResultError('zhihu download', `No Zhihu answer was found for ${target.answerId}.`);
-        }
+    const data = unwrapEvaluateResult(raw);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new CommandExecutionError('Zhihu answer download returned a malformed Browser Bridge payload');
+    }
+    const status = data.status;
+    if (String(data.errorCode) === '40362') {
         throw new CommandExecutionError(
-            status ? `Zhihu answer download request failed (HTTP ${status})` : 'Zhihu answer download request failed',
-            'Try again later or rerun with -v for more detail.',
+            `Zhihu risk control blocked answer ${target.answerId} (40362): ${data.errorMessage || 'abnormal request'}`,
+            'Open the answer in the connected Chrome profile and retry later.',
         );
     }
-    if (data.__malformedJson || data.__malformedPayload || data.__missingContent) {
-        throw new CommandExecutionError('Zhihu answer download returned a malformed payload');
+    if (status === 401 || status === 403 || String(data.errorCode) === '40353' || data.needLogin) {
+        throw new AuthRequiredError('www.zhihu.com', 'Failed to download Zhihu answer');
     }
-    if (data.__errorCode || data.__errorMessage) {
-        throw new CommandExecutionError(`Zhihu answer download returned an error payload: ${data.__errorMessage || data.__errorCode}`);
+    if (status === 404) {
+        throw new EmptyResultError('zhihu download', `No Zhihu answer was found for ${target.answerId}.`);
+    }
+    if (status || data.fetchError) {
+        throw new CommandExecutionError(
+            status ? `Zhihu answer download request failed (HTTP ${status})` : 'Zhihu answer download request failed',
+            String(data.fetchError || data.errorMessage || 'Try again later or rerun with -v for more detail.'),
+        );
+    }
+    if (data.malformed || data.errorCode || data.errorMessage) {
+        throw new CommandExecutionError('Zhihu answer download returned a malformed or error payload');
     }
 
-    const questionId = target.questionId || extractQuestionId(currentUrl);
+    const value = data.value;
+    if (!value || typeof value !== 'object' || Array.isArray(value)
+        || typeof value.contentHtml !== 'string' || !Array.isArray(value.imageUrls)
+        || !value.imageUrls.every((url) => typeof url === 'string')) {
+        throw new CommandExecutionError('Zhihu answer download returned malformed answer fields');
+    }
+    if (!value.contentHtml.trim()) {
+        throw new EmptyResultError('zhihu download', `Zhihu answer ${target.answerId} had no exportable content.`);
+    }
+    const payloadAnswerTarget = answerTargetFromUrl(value.answerUrl);
+    const payloadQuestionId = value.questionUrl ? questionIdFromUrl(value.questionUrl) : '';
+    if (!payloadAnswerTarget || payloadAnswerTarget.answerId !== target.answerId) {
+        throw new CommandExecutionError(`Zhihu answer payload did not match requested answer ${target.answerId}`);
+    }
+    if (!payloadQuestionId) {
+        throw new CommandExecutionError('Zhihu answer download returned an untrusted question URL');
+    }
+    const questionId = target.questionId || currentTarget.questionId || payloadQuestionId;
+    if (!questionId || payloadQuestionId !== questionId
+        || (payloadAnswerTarget.questionId && payloadAnswerTarget.questionId !== questionId)) {
+        throw new CommandExecutionError(`Zhihu answer payload changed question identity for answer ${target.answerId}`);
+    }
+    const title = typeof value.title === 'string' && value.title.trim() ? value.title.trim() : 'Zhihu answer';
     return {
-        title: data.title || 'untitled',
-        author: data.author || '',
-        publishTime: normalizeUnixSeconds(data.createdTime),
+        title: `${target.answerId} - ${title}`,
+        author: typeof value.author === 'string' ? value.author : '',
+        publishTime: normalizeUnixSeconds(value.createdTime),
         sourceUrl: questionId
             ? `https://www.zhihu.com/question/${questionId}/answer/${target.answerId}`
             : `https://www.zhihu.com/answer/${target.answerId}`,
-        contentHtml: data.contentHtml || '',
-        imageUrls: data.imageUrls || [],
+        contentHtml: value.contentHtml,
+        imageUrls: value.imageUrls,
     };
 }

--- a/clis/zhihu/download-helpers.js
+++ b/clis/zhihu/download-helpers.js
@@ -1,0 +1,185 @@
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const ANSWER_ID_RE = /^\d+$/;
+const ANSWER_TYPED_RE = /^answer:(\d+):(\d+)$/;
+const ANSWER_PATH_RE = /^\/question\/(\d+)\/answer\/(\d+)\/?$/;
+const BARE_ANSWER_PATH_RE = /^\/answer\/(\d+)\/?$/;
+const ARTICLE_TYPED_RE = /^article:(\d+)$/;
+const ARTICLE_PATH_RE = /^\/p\/(\d+)\/?$/;
+
+export function parseDownloadTarget(input) {
+    const value = String(input ?? '').trim();
+    if (!value) return null;
+    if (ANSWER_ID_RE.test(value)) return { kind: 'answer', answerId: value, questionId: '' };
+    const typedAnswer = value.match(ANSWER_TYPED_RE);
+    if (typedAnswer) return { kind: 'answer', questionId: typedAnswer[1], answerId: typedAnswer[2] };
+    const typedArticle = value.match(ARTICLE_TYPED_RE);
+    if (typedArticle) return { kind: 'article', articleId: typedArticle[1], url: `https://zhuanlan.zhihu.com/p/${typedArticle[1]}` };
+    try {
+        const url = new URL(value);
+        if (url.protocol !== 'https:' || url.username || url.password || url.port) return null;
+        if (url.hostname === 'zhuanlan.zhihu.com') {
+            const article = url.pathname.match(ARTICLE_PATH_RE);
+            return article
+                ? { kind: 'article', articleId: article[1], url: `https://zhuanlan.zhihu.com/p/${article[1]}` }
+                : null;
+        }
+        if (url.hostname !== 'www.zhihu.com' && url.hostname !== 'zhihu.com') return null;
+        const answer = url.pathname.match(ANSWER_PATH_RE);
+        if (answer) return { kind: 'answer', questionId: answer[1], answerId: answer[2] };
+        const bareAnswer = url.pathname.match(BARE_ANSWER_PATH_RE);
+        return bareAnswer ? { kind: 'answer', questionId: '', answerId: bareAnswer[1] } : null;
+    } catch {
+        return null;
+    }
+}
+
+export function extractQuestionId(url) {
+    try {
+        const parsed = new URL(String(url || ''));
+        if (parsed.protocol !== 'https:' || (parsed.hostname !== 'www.zhihu.com' && parsed.hostname !== 'zhihu.com')) return '';
+        return parsed.pathname.match(ANSWER_PATH_RE)?.[1] || '';
+    } catch {
+        return '';
+    }
+}
+
+export function normalizeUnixSeconds(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? new Date(value * 1000).toISOString()
+        : '';
+}
+
+export async function extractColumnArticle(page, target) {
+    await page.goto(target.url);
+    await page.wait(3);
+    return page.evaluate(`
+      (() => {
+        const result = {
+          title: '',
+          author: '',
+          publishTime: '',
+          contentHtml: '',
+          imageUrls: []
+        };
+        const titleEl = document.querySelector('.Post-Title, h1.ContentItem-title, .ArticleTitle');
+        result.title = titleEl?.textContent?.trim() || 'untitled';
+        const authorEl = document.querySelector('.AuthorInfo-name, .UserLink-link');
+        result.author = authorEl?.textContent?.trim() || '';
+        const timeEl = document.querySelector('.ContentItem-time, .Post-Time');
+        result.publishTime = timeEl?.textContent?.trim() || '';
+        const contentEl = document.querySelector('.Post-RichTextContainer, .RichText, .ArticleContent');
+        if (contentEl) {
+          const clone = contentEl.cloneNode(true);
+          const seen = new Set();
+          clone.querySelectorAll('img').forEach(img => {
+            const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
+            if (!src || src.startsWith('data:')) return;
+            const normalized = src.startsWith('//') ? 'https:' + src : src;
+            img.setAttribute('src', normalized);
+            if (!seen.has(normalized)) {
+              seen.add(normalized);
+              result.imageUrls.push(normalized);
+            }
+          });
+          result.contentHtml = clone.innerHTML;
+        }
+        return result;
+      })()
+    `);
+}
+
+export async function extractAnswer(page, target) {
+    try {
+        await page.goto(`https://www.zhihu.com/answer/${target.answerId}`);
+    } catch (err) {
+        throw new CommandExecutionError(
+            `Failed to open Zhihu answer ${target.answerId}: ${err instanceof Error ? err.message : String(err)}`,
+            'Open the answer URL in Chrome and retry after the page is reachable.',
+        );
+    }
+    const currentUrl = page.getCurrentUrl ? await page.getCurrentUrl().catch(() => '') : '';
+    const apiUrl = `https://www.zhihu.com/api/v4/answers/${target.answerId}?include=content,author,created_time,question`;
+    const data = await page.evaluate(`
+      (async () => {
+        const response = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
+        let payload;
+        try {
+          payload = await response.json();
+        } catch (error) {
+          return { __httpError: response.status, __malformedJson: error instanceof Error ? error.message : String(error) };
+        }
+        const errorCode = payload?.error?.code ?? '';
+        const errorMessage = payload?.error?.message || payload?.error_msg || payload?.message || '';
+        if (!response.ok) return { __httpError: response.status, __errorCode: errorCode, __errorMessage: errorMessage };
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { __malformedPayload: true };
+        if (errorCode || errorMessage) return { __errorCode: errorCode, __errorMessage: errorMessage };
+        if (!Object.prototype.hasOwnProperty.call(payload, 'content')) return { __missingContent: true };
+
+        const root = document.createElement('div');
+        root.innerHTML = payload.content || '';
+        const imageUrls = [];
+        const seen = new Set();
+        root.querySelectorAll('img').forEach(img => {
+          const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
+          if (!src || src.startsWith('data:')) return;
+          const normalized = src.startsWith('//') ? 'https:' + src : src;
+          img.setAttribute('src', normalized);
+          if (!seen.has(normalized)) {
+            seen.add(normalized);
+            imageUrls.push(normalized);
+          }
+        });
+        return {
+          title: payload.question?.title || 'untitled',
+          author: payload.author?.name || '',
+          createdTime: payload.created_time,
+          contentHtml: root.innerHTML,
+          imageUrls,
+        };
+      })()
+    `).catch((err) => {
+        throw new CommandExecutionError(
+            `Zhihu answer download request failed: ${err instanceof Error ? err.message : String(err)}`,
+            'Try again later or rerun with -v for more detail.',
+        );
+    });
+
+    if (!data || data.__httpError) {
+        const status = data?.__httpError;
+        if (status === 403 && String(data?.__errorCode) === '40362') {
+            throw new CommandExecutionError(
+                `Zhihu risk control blocked answer ${target.answerId} (40362): ${data?.__errorMessage || 'abnormal request'}`,
+                'Open the answer in the connected Chrome profile and retry later.',
+            );
+        }
+        if (status === 401 || status === 403) {
+            throw new AuthRequiredError('www.zhihu.com', 'Failed to download Zhihu answer');
+        }
+        if (status === 404) {
+            throw new EmptyResultError('zhihu download', `No Zhihu answer was found for ${target.answerId}.`);
+        }
+        throw new CommandExecutionError(
+            status ? `Zhihu answer download request failed (HTTP ${status})` : 'Zhihu answer download request failed',
+            'Try again later or rerun with -v for more detail.',
+        );
+    }
+    if (data.__malformedJson || data.__malformedPayload || data.__missingContent) {
+        throw new CommandExecutionError('Zhihu answer download returned a malformed payload');
+    }
+    if (data.__errorCode || data.__errorMessage) {
+        throw new CommandExecutionError(`Zhihu answer download returned an error payload: ${data.__errorMessage || data.__errorCode}`);
+    }
+
+    const questionId = target.questionId || extractQuestionId(currentUrl);
+    return {
+        title: data.title || 'untitled',
+        author: data.author || '',
+        publishTime: normalizeUnixSeconds(data.createdTime),
+        sourceUrl: questionId
+            ? `https://www.zhihu.com/question/${questionId}/answer/${target.answerId}`
+            : `https://www.zhihu.com/answer/${target.answerId}`,
+        contentHtml: data.contentHtml || '',
+        imageUrls: data.imageUrls || [],
+    };
+}

--- a/clis/zhihu/download-helpers.js
+++ b/clis/zhihu/download-helpers.js
@@ -50,6 +50,24 @@ export function normalizeUnixSeconds(value) {
         : '';
 }
 
+export function normalizeContentImages(contentHtml, documentRef = document) {
+    const root = documentRef.createElement('div');
+    root.innerHTML = contentHtml || '';
+    const imageUrls = [];
+    const seen = new Set();
+    root.querySelectorAll('img').forEach((img) => {
+        const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
+        if (!src || src.startsWith('data:')) return;
+        const normalized = src.startsWith('//') ? `https:${src}` : src;
+        img.setAttribute('src', normalized);
+        if (!seen.has(normalized)) {
+            seen.add(normalized);
+            imageUrls.push(normalized);
+        }
+    });
+    return { contentHtml: root.innerHTML, imageUrls };
+}
+
 export async function extractColumnArticle(page, target) {
     await page.goto(target.url);
     await page.wait(3);
@@ -100,6 +118,7 @@ export async function extractAnswer(page, target) {
     }
     const currentUrl = page.getCurrentUrl ? await page.getCurrentUrl().catch(() => '') : '';
     const apiUrl = `https://www.zhihu.com/api/v4/answers/${target.answerId}?include=content,author,created_time,question`;
+    const normalizeContentImagesSource = `(${normalizeContentImages.toString()})`;
     const data = await page.evaluate(`
       (async () => {
         const response = await fetch(${JSON.stringify(apiUrl)}, { credentials: 'include' });
@@ -116,26 +135,13 @@ export async function extractAnswer(page, target) {
         if (errorCode || errorMessage) return { __errorCode: errorCode, __errorMessage: errorMessage };
         if (!Object.prototype.hasOwnProperty.call(payload, 'content')) return { __missingContent: true };
 
-        const root = document.createElement('div');
-        root.innerHTML = payload.content || '';
-        const imageUrls = [];
-        const seen = new Set();
-        root.querySelectorAll('img').forEach(img => {
-          const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.getAttribute('src') || '';
-          if (!src || src.startsWith('data:')) return;
-          const normalized = src.startsWith('//') ? 'https:' + src : src;
-          img.setAttribute('src', normalized);
-          if (!seen.has(normalized)) {
-            seen.add(normalized);
-            imageUrls.push(normalized);
-          }
-        });
+        const normalizedContent = ${normalizeContentImagesSource}(payload.content || '');
         return {
           title: payload.question?.title || 'untitled',
           author: payload.author?.name || '',
           createdTime: payload.created_time,
-          contentHtml: root.innerHTML,
-          imageUrls,
+          contentHtml: normalizedContent.contentHtml,
+          imageUrls: normalizedContent.imageUrls,
         };
       })()
     `).catch((err) => {

--- a/clis/zhihu/download.js
+++ b/clis/zhihu/download.js
@@ -1,80 +1,54 @@
 /**
- * Zhihu download — export articles to Markdown format.
- *
- * Usage:
- *   opencli zhihu download --url "https://zhuanlan.zhihu.com/p/xxx" --output ./zhihu
+ * Zhihu download — export column articles or answers to Markdown.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    extractAnswer,
+    extractColumnArticle,
+    extractQuestionId,
+    normalizeUnixSeconds,
+    parseDownloadTarget,
+} from './download-helpers.js';
+
 cli({
     site: 'zhihu',
     name: 'download',
     access: 'read',
-    description: '导出知乎文章为 Markdown 格式',
-    domain: 'zhuanlan.zhihu.com',
+    description: '导出知乎专栏文章或回答为 Markdown 格式',
+    domain: 'www.zhihu.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'url', required: true, help: 'Article URL (zhuanlan.zhihu.com/p/xxx)' },
+        { name: 'url', required: true, help: 'Column article URL, answer ID, typed target, or answer URL' },
         { name: 'output', default: './zhihu-articles', help: 'Output directory' },
         { name: 'download-images', type: 'boolean', default: false, help: 'Download images locally' },
     ],
     columns: ['title', 'author', 'publish_time', 'status', 'size'],
     func: async (page, kwargs) => {
-        const url = kwargs.url;
-        // Navigate to article page
-        await page.goto(url);
-        await page.wait(3);
-        // Extract article content
-        const data = await page.evaluate(`
-      (() => {
-        const result = {
-          title: '',
-          author: '',
-          publishTime: '',
-          contentHtml: '',
-          imageUrls: []
-        };
-
-        // Get title
-        const titleEl = document.querySelector('.Post-Title, h1.ContentItem-title, .ArticleTitle');
-        result.title = titleEl?.textContent?.trim() || 'untitled';
-
-        // Get author
-        const authorEl = document.querySelector('.AuthorInfo-name, .UserLink-link');
-        result.author = authorEl?.textContent?.trim() || '';
-
-        // Get publish time
-        const timeEl = document.querySelector('.ContentItem-time, .Post-Time');
-        result.publishTime = timeEl?.textContent?.trim() || '';
-
-        // Get content HTML
-        const contentEl = document.querySelector('.Post-RichTextContainer, .RichText, .ArticleContent');
-        if (contentEl) {
-          result.contentHtml = contentEl.innerHTML;
-
-          // Extract image URLs
-          contentEl.querySelectorAll('img').forEach(img => {
-            const src = img.getAttribute('data-original') || img.getAttribute('data-actualsrc') || img.src;
-            if (src && !src.includes('data:image')) {
-              result.imageUrls.push(src);
-            }
-          });
+        const target = parseDownloadTarget(kwargs.url);
+        if (!target) {
+            throw new ArgumentError(
+                'Target must be a Zhihu column article URL, answer ID, typed answer target, or answer URL',
+                'Example: opencli zhihu download --url "https://www.zhihu.com/question/123/answer/456"',
+            );
         }
-
-        return result;
-      })()
-    `);
+        const data = target.kind === 'answer'
+            ? await extractAnswer(page, target)
+            : { ...await extractColumnArticle(page, target), sourceUrl: target.url };
         return downloadArticle({
             title: data?.title || '',
             author: data?.author,
             publishTime: data?.publishTime,
-            sourceUrl: url,
+            sourceUrl: data?.sourceUrl,
             contentHtml: data?.contentHtml || '',
             imageUrls: data?.imageUrls,
         }, {
             output: kwargs.output,
             downloadImages: kwargs['download-images'],
-            imageHeaders: { Referer: 'https://zhuanlan.zhihu.com/' },
+            imageHeaders: { Referer: target.kind === 'answer' ? 'https://www.zhihu.com/' : 'https://zhuanlan.zhihu.com/' },
         });
     },
 });
+
+export const __test__ = { parseDownloadTarget, extractQuestionId, normalizeUnixSeconds };

--- a/clis/zhihu/download.js
+++ b/clis/zhihu/download.js
@@ -8,6 +8,7 @@ import {
     extractAnswer,
     extractColumnArticle,
     extractQuestionId,
+    normalizeContentImages,
     normalizeUnixSeconds,
     parseDownloadTarget,
 } from './download-helpers.js';
@@ -51,4 +52,4 @@ cli({
     },
 });
 
-export const __test__ = { parseDownloadTarget, extractQuestionId, normalizeUnixSeconds };
+export const __test__ = { parseDownloadTarget, extractQuestionId, normalizeContentImages, normalizeUnixSeconds };

--- a/clis/zhihu/download.js
+++ b/clis/zhihu/download.js
@@ -7,9 +7,6 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 import {
     extractAnswer,
     extractColumnArticle,
-    extractQuestionId,
-    normalizeContentImages,
-    normalizeUnixSeconds,
     parseDownloadTarget,
 } from './download-helpers.js';
 
@@ -20,6 +17,7 @@ cli({
     description: '导出知乎专栏文章或回答为 Markdown 格式',
     domain: 'www.zhihu.com',
     strategy: Strategy.COOKIE,
+    navigateBefore: false,
     args: [
         { name: 'url', required: true, help: 'Column article URL, answer ID, typed target, or answer URL' },
         { name: 'output', default: './zhihu-articles', help: 'Output directory' },
@@ -48,8 +46,7 @@ cli({
             output: kwargs.output,
             downloadImages: kwargs['download-images'],
             imageHeaders: { Referer: target.kind === 'answer' ? 'https://www.zhihu.com/' : 'https://zhuanlan.zhihu.com/' },
+            ...(target.kind === 'answer' && { requireImageContentType: true }),
         });
     },
 });
-
-export const __test__ = { parseDownloadTarget, extractQuestionId, normalizeContentImages, normalizeUnixSeconds };

--- a/clis/zhihu/download.test.js
+++ b/clis/zhihu/download.test.js
@@ -1,12 +1,148 @@
-import { describe, expect, it } from 'vitest';
-import TurndownService from 'turndown';
-describe('article markdown conversion', () => {
-    it('renders ordered lists with the original list item content', () => {
-        const html = '<ol><li>First item</li><li>Second item</li></ol>';
-        const td = new TurndownService({ headingStyle: 'atx', bulletListMarker: '-' });
-        const md = td.turndown(html);
-        expect(md).toMatch(/1\.\s+First item/);
-        expect(md).toMatch(/2\.\s+Second item/);
-        expect(md).not.toContain('$1');
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { downloadArticle } from '@jackwener/opencli/download/article-download';
+
+vi.mock('@jackwener/opencli/download/article-download', () => ({
+    downloadArticle: vi.fn(async (data) => [{
+        title: data.title,
+        author: data.author || '-',
+        publish_time: data.publishTime || '-',
+        status: 'success',
+        size: '1 KB',
+        saved: '/tmp/export.md',
+    }]),
+}));
+
+import './download.js';
+import { __test__ as helpers } from './download.js';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('zhihu download', () => {
+    it('registers as a cookie read command for articles and answers', () => {
+        const cmd = getRegistry().get('zhihu/download');
+        expect(cmd).toBeDefined();
+        expect(cmd.access).toBe('read');
+        expect(cmd.strategy).toBe('cookie');
+        expect(cmd.description).toContain('回答');
+    });
+
+    it('exports raw answer HTML and normalized image URLs through downloadArticle', async () => {
+        const cmd = getRegistry().get('zhihu/download');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181'),
+            evaluate: vi.fn().mockResolvedValue({
+                title: 'Question title',
+                author: 'alice',
+                createdTime: 1700000000,
+                contentHtml: '<p>body</p><img src="https://pic.example/no-extension">',
+                imageUrls: ['https://pic.example/no-extension'],
+            }),
+        };
+
+        await expect(cmd.func(page, {
+            url: 'https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181',
+            output: '/tmp/zhihu',
+            'download-images': true,
+        })).resolves.toMatchObject([{ status: 'success' }]);
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.zhihu.com/answer/2043281635827766181');
+        expect(page.evaluate.mock.calls[0][0]).toContain('document.createElement');
+        expect(downloadArticle).toHaveBeenCalledWith({
+            title: 'Question title',
+            author: 'alice',
+            publishTime: '2023-11-14T22:13:20.000Z',
+            sourceUrl: 'https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181',
+            contentHtml: '<p>body</p><img src="https://pic.example/no-extension">',
+            imageUrls: ['https://pic.example/no-extension'],
+        }, {
+            output: '/tmp/zhihu',
+            downloadImages: true,
+            imageHeaders: { Referer: 'https://www.zhihu.com/' },
+        });
+    });
+
+    it('keeps the existing column article flow', async () => {
+        const cmd = getRegistry().get('zhihu/download');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({
+                title: 'Column title',
+                author: 'bob',
+                publishTime: 'today',
+                contentHtml: '<p>column</p>',
+                imageUrls: [],
+            }),
+        };
+
+        await cmd.func(page, {
+            url: 'https://zhuanlan.zhihu.com/p/123?utm_source=test',
+            output: '/tmp/zhihu',
+            'download-images': false,
+        });
+
+        expect(page.goto).toHaveBeenCalledWith('https://zhuanlan.zhihu.com/p/123');
+        expect(page.wait).toHaveBeenCalledWith(3);
+        expect(downloadArticle).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'Column title',
+            sourceUrl: 'https://zhuanlan.zhihu.com/p/123',
+        }), expect.objectContaining({
+            imageHeaders: { Referer: 'https://zhuanlan.zhihu.com/' },
+        }));
+    });
+
+    it('distinguishes Zhihu risk control from an auth failure', async () => {
+        const cmd = getRegistry().get('zhihu/download');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/answer/1'),
+            evaluate: vi.fn().mockResolvedValue({
+                __httpError: 403,
+                __errorCode: 40362,
+                __errorMessage: 'abnormal request',
+            }),
+        };
+
+        const promise = cmd.func(page, { url: '1', output: '/tmp/zhihu', 'download-images': false });
+        await expect(promise).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(cmd.func(page, { url: '1', output: '/tmp/zhihu', 'download-images': false }))
+            .rejects.not.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('rejects unsupported targets before browser navigation', async () => {
+        const cmd = getRegistry().get('zhihu/download');
+        const page = { goto: vi.fn(), evaluate: vi.fn() };
+        await expect(cmd.func(page, { url: 'https://example.com/a', output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+});
+
+describe('zhihu download target parsing', () => {
+    it('accepts exact article and answer target forms with string-safe ids', () => {
+        expect(helpers.parseDownloadTarget('2043281635827766181')).toEqual({
+            kind: 'answer', answerId: '2043281635827766181', questionId: '',
+        });
+        expect(helpers.parseDownloadTarget('answer:1918304251865699164:2043281635827766181')).toEqual({
+            kind: 'answer', questionId: '1918304251865699164', answerId: '2043281635827766181',
+        });
+        expect(helpers.parseDownloadTarget('article:123')).toEqual({
+            kind: 'article', articleId: '123', url: 'https://zhuanlan.zhihu.com/p/123',
+        });
+        expect(helpers.parseDownloadTarget('https://www.zhihu.com/question/10/answer/20?share=1')).toEqual({
+            kind: 'answer', questionId: '10', answerId: '20',
+        });
+    });
+
+    it('rejects lookalike hosts and unrelated Zhihu paths', () => {
+        expect(helpers.parseDownloadTarget('https://www.zhihu.com.evil.example/question/10/answer/20')).toBeNull();
+        expect(helpers.parseDownloadTarget('https://www.zhihu.com/question/10')).toBeNull();
+        expect(helpers.parseDownloadTarget('')).toBeNull();
     });
 });

--- a/clis/zhihu/download.test.js
+++ b/clis/zhihu/download.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
@@ -51,7 +52,7 @@ describe('zhihu download', () => {
         })).resolves.toMatchObject([{ status: 'success' }]);
 
         expect(page.goto).toHaveBeenCalledWith('https://www.zhihu.com/answer/2043281635827766181');
-        expect(page.evaluate.mock.calls[0][0]).toContain('document.createElement');
+        expect(page.evaluate.mock.calls[0][0]).toContain('function normalizeContentImages');
         expect(downloadArticle).toHaveBeenCalledWith({
             title: 'Question title',
             author: 'alice',
@@ -144,5 +145,29 @@ describe('zhihu download target parsing', () => {
         expect(helpers.parseDownloadTarget('https://www.zhihu.com.evil.example/question/10/answer/20')).toBeNull();
         expect(helpers.parseDownloadTarget('https://www.zhihu.com/question/10')).toBeNull();
         expect(helpers.parseDownloadTarget('')).toBeNull();
+    });
+
+    it('normalizes lazy and protocol-relative image sources in detached answer HTML', () => {
+        const sourceDom = new JSDOM();
+        const normalized = helpers.normalizeContentImages(`
+            <p>body</p>
+            <img src="https://pic.example/fallback.png" data-original="https://pic.example/original.png">
+            <img src="https://pic.example/original.png">
+            <img data-actualsrc="//pic.example/protocol-relative.svg">
+            <img src="data:image/png;base64,AAAA">
+        `, sourceDom.window.document);
+        const resultDom = new JSDOM(normalized.contentHtml);
+        const images = [...resultDom.window.document.querySelectorAll('img')];
+
+        expect(normalized.imageUrls).toEqual([
+            'https://pic.example/original.png',
+            'https://pic.example/protocol-relative.svg',
+        ]);
+        expect(images.map((img) => img.getAttribute('src'))).toEqual([
+            'https://pic.example/original.png',
+            'https://pic.example/original.png',
+            'https://pic.example/protocol-relative.svg',
+            'data:image/png;base64,AAAA',
+        ]);
     });
 });

--- a/clis/zhihu/download.test.js
+++ b/clis/zhihu/download.test.js
@@ -146,6 +146,12 @@ describe('zhihu download', () => {
             output: '/tmp/zhihu',
         })).rejects.toBeInstanceOf(CommandExecutionError);
 
+        const answerUrlAsQuestion = answerPage({
+            value: answerValue({ questionUrl: `https://www.zhihu.com/question/${QUESTION_ID}/answer/999` }),
+        });
+        await expect(cmd.func(answerUrlAsQuestion, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
         const missingQuestion = answerPage({ value: answerValue({ questionUrl: '' }) });
         await expect(cmd.func(missingQuestion, { url: ANSWER_ID, output: '/tmp/zhihu' }))
             .rejects.toBeInstanceOf(CommandExecutionError);

--- a/clis/zhihu/download.test.js
+++ b/clis/zhihu/download.test.js
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
+import { normalizeContentImages, parseDownloadTarget } from './download-helpers.js';
 
 vi.mock('@jackwener/opencli/download/article-download', () => ({
     downloadArticle: vi.fn(async (data) => [{
@@ -16,68 +17,85 @@ vi.mock('@jackwener/opencli/download/article-download', () => ({
 }));
 
 import './download.js';
-import { __test__ as helpers } from './download.js';
+
+const QUESTION_ID = '1918304251865699164';
+const ANSWER_ID = '2043281635827766181';
+
+function answerValue(overrides = {}) {
+    return {
+        answerUrl: `https://api.zhihu.com/answers/${ANSWER_ID}`,
+        questionUrl: `https://api.zhihu.com/questions/${QUESTION_ID}`,
+        title: 'Question title',
+        author: 'alice',
+        createdTime: 1700000000,
+        contentHtml: '<p>body</p><img src="https://pic.example/no-extension">',
+        imageUrls: ['https://pic.example/no-extension'],
+        ...overrides,
+    };
+}
+
+function answerPage(evaluateResult = { value: answerValue() }, currentUrl = `https://www.zhihu.com/question/${QUESTION_ID}/answer/${ANSWER_ID}`) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        getCurrentUrl: vi.fn().mockResolvedValue(currentUrl),
+        evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    };
+}
 
 beforeEach(() => {
     vi.clearAllMocks();
 });
 
 describe('zhihu download', () => {
-    it('registers as a cookie read command for articles and answers', () => {
+    it('registers a dynamic-navigation cookie read command for articles and answers', () => {
         const cmd = getRegistry().get('zhihu/download');
         expect(cmd).toBeDefined();
         expect(cmd.access).toBe('read');
         expect(cmd.strategy).toBe('cookie');
+        expect(cmd.navigateBefore).toBe(false);
         expect(cmd.description).toContain('回答');
     });
 
-    it('exports raw answer HTML and normalized image URLs through downloadArticle', async () => {
+    it('exports same-head Browser Bridge answer payloads through downloadArticle', async () => {
         const cmd = getRegistry().get('zhihu/download');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181'),
-            evaluate: vi.fn().mockResolvedValue({
-                title: 'Question title',
-                author: 'alice',
-                createdTime: 1700000000,
-                contentHtml: '<p>body</p><img src="https://pic.example/no-extension">',
-                imageUrls: ['https://pic.example/no-extension'],
-            }),
-        };
+        const page = answerPage({ session: 'bridge-session', data: { value: answerValue() } });
 
         await expect(cmd.func(page, {
-            url: 'https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181',
+            url: `https://www.zhihu.com/question/${QUESTION_ID}/answer/${ANSWER_ID}`,
             output: '/tmp/zhihu',
             'download-images': true,
         })).resolves.toMatchObject([{ status: 'success' }]);
 
-        expect(page.goto).toHaveBeenCalledWith('https://www.zhihu.com/answer/2043281635827766181');
-        expect(page.evaluate.mock.calls[0][0]).toContain('function normalizeContentImages');
+        expect(page.goto).toHaveBeenCalledWith(`https://www.zhihu.com/answer/${ANSWER_ID}`);
         expect(downloadArticle).toHaveBeenCalledWith({
-            title: 'Question title',
+            title: `${ANSWER_ID} - Question title`,
             author: 'alice',
             publishTime: '2023-11-14T22:13:20.000Z',
-            sourceUrl: 'https://www.zhihu.com/question/1918304251865699164/answer/2043281635827766181',
+            sourceUrl: `https://www.zhihu.com/question/${QUESTION_ID}/answer/${ANSWER_ID}`,
             contentHtml: '<p>body</p><img src="https://pic.example/no-extension">',
             imageUrls: ['https://pic.example/no-extension'],
         }, {
             output: '/tmp/zhihu',
             downloadImages: true,
             imageHeaders: { Referer: 'https://www.zhihu.com/' },
+            requireImageContentType: true,
         });
     });
 
-    it('keeps the existing column article flow', async () => {
+    it('keeps the existing column article flow and its URL-derived image extensions', async () => {
         const cmd = getRegistry().get('zhihu/download');
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
             evaluate: vi.fn().mockResolvedValue({
-                title: 'Column title',
-                author: 'bob',
-                publishTime: 'today',
-                contentHtml: '<p>column</p>',
-                imageUrls: [],
+                session: 'bridge-session',
+                data: {
+                    title: 'Column title',
+                    author: 'bob',
+                    publishTime: 'today',
+                    contentHtml: '<p>column</p>',
+                    imageUrls: [],
+                },
             }),
         };
 
@@ -95,24 +113,79 @@ describe('zhihu download', () => {
         }), expect.objectContaining({
             imageHeaders: { Referer: 'https://zhuanlan.zhihu.com/' },
         }));
+        expect(downloadArticle.mock.calls[0][1]).not.toHaveProperty('requireImageContentType');
     });
 
-    it('distinguishes Zhihu risk control from an auth failure', async () => {
+    it('fails closed when navigation or API provenance changes answer identity', async () => {
         const cmd = getRegistry().get('zhihu/download');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/answer/1'),
-            evaluate: vi.fn().mockResolvedValue({
-                __httpError: 403,
-                __errorCode: 40362,
-                __errorMessage: 'abnormal request',
-            }),
-        };
+        const wrongNavigation = answerPage(
+            { value: answerValue() },
+            `https://www.zhihu.com/question/${QUESTION_ID}/answer/999`,
+        );
+        await expect(cmd.func(wrongNavigation, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        expect(wrongNavigation.evaluate).not.toHaveBeenCalled();
 
-        const promise = cmd.func(page, { url: '1', output: '/tmp/zhihu', 'download-images': false });
-        await expect(promise).rejects.toBeInstanceOf(CommandExecutionError);
-        await expect(cmd.func(page, { url: '1', output: '/tmp/zhihu', 'download-images': false }))
-            .rejects.not.toBeInstanceOf(AuthRequiredError);
+        const wrongAnswer = answerPage({ value: answerValue({ answerUrl: 'https://api.zhihu.com/answers/999' }) });
+        await expect(cmd.func(wrongAnswer, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        const missingAnswer = answerPage({ value: answerValue({ answerUrl: '' }) });
+        await expect(cmd.func(missingAnswer, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        const hashedAnswer = answerPage({ value: answerValue({ answerUrl: `https://api.zhihu.com/answers/${ANSWER_ID}#other` }) });
+        await expect(cmd.func(hashedAnswer, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        const wrongQuestion = answerPage({
+            value: answerValue({ questionUrl: 'https://www.zhihu.com/api/v4/questions/999' }),
+        });
+        await expect(cmd.func(wrongQuestion, {
+            url: `answer:${QUESTION_ID}:${ANSWER_ID}`,
+            output: '/tmp/zhihu',
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        const missingQuestion = answerPage({ value: answerValue({ questionUrl: '' }) });
+        await expect(cmd.func(missingQuestion, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        const missingNavigationQuestion = answerPage(
+            { value: answerValue() },
+            `https://www.zhihu.com/answer/${ANSWER_ID}`,
+        );
+        await expect(cmd.func(missingNavigationQuestion, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it.each([
+        [{ status: 403, errorCode: 40362, errorMessage: 'abnormal request' }, CommandExecutionError],
+        [{ status: 401 }, AuthRequiredError],
+        [{ errorCode: 40353, needLogin: true }, AuthRequiredError],
+        [{ status: 404 }, EmptyResultError],
+        [{ status: 500 }, CommandExecutionError],
+        [{ fetchError: 'network down' }, CommandExecutionError],
+        [{ malformed: true }, CommandExecutionError],
+        [{ value: answerValue({ contentHtml: '' }) }, EmptyResultError],
+    ])('maps answer fetch failures to typed errors', async (evaluateResult, ErrorClass) => {
+        const cmd = getRegistry().get('zhihu/download');
+        await expect(cmd.func(answerPage(evaluateResult), {
+            url: ANSWER_ID,
+            output: '/tmp/zhihu',
+            'download-images': false,
+        })).rejects.toBeInstanceOf(ErrorClass);
+    });
+
+    it('rejects malformed Browser Bridge envelopes and raw bridge failures', async () => {
+        const cmd = getRegistry().get('zhihu/download');
+        const malformed = answerPage({ session: 'bridge-session', data: null });
+        await expect(cmd.func(malformed, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+
+        const failed = answerPage();
+        failed.evaluate.mockRejectedValue(new Error('bridge disconnected'));
+        await expect(cmd.func(failed, { url: ANSWER_ID, output: '/tmp/zhihu' }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects unsupported targets before browser navigation', async () => {
@@ -125,49 +198,44 @@ describe('zhihu download', () => {
     });
 });
 
-describe('zhihu download target parsing', () => {
-    it('accepts exact article and answer target forms with string-safe ids', () => {
-        expect(helpers.parseDownloadTarget('2043281635827766181')).toEqual({
-            kind: 'answer', answerId: '2043281635827766181', questionId: '',
+describe('zhihu download target and image normalization', () => {
+    it('reuses exact string-safe answer targets and accepts exact article targets', () => {
+        expect(parseDownloadTarget(ANSWER_ID)).toEqual({
+            kind: 'answer', answerId: ANSWER_ID, questionId: '',
         });
-        expect(helpers.parseDownloadTarget('answer:1918304251865699164:2043281635827766181')).toEqual({
-            kind: 'answer', questionId: '1918304251865699164', answerId: '2043281635827766181',
+        expect(parseDownloadTarget(`answer:${QUESTION_ID}:${ANSWER_ID}`)).toEqual({
+            kind: 'answer', questionId: QUESTION_ID, answerId: ANSWER_ID,
         });
-        expect(helpers.parseDownloadTarget('article:123')).toEqual({
+        expect(parseDownloadTarget('article:123')).toEqual({
             kind: 'article', articleId: '123', url: 'https://zhuanlan.zhihu.com/p/123',
         });
-        expect(helpers.parseDownloadTarget('https://www.zhihu.com/question/10/answer/20?share=1')).toEqual({
-            kind: 'answer', questionId: '10', answerId: '20',
-        });
+        expect(parseDownloadTarget('https://www.zhihu.com.evil.example/question/10/answer/20')).toBeNull();
+        expect(parseDownloadTarget('https://www.zhihu.com/question/10')).toBeNull();
     });
 
-    it('rejects lookalike hosts and unrelated Zhihu paths', () => {
-        expect(helpers.parseDownloadTarget('https://www.zhihu.com.evil.example/question/10/answer/20')).toBeNull();
-        expect(helpers.parseDownloadTarget('https://www.zhihu.com/question/10')).toBeNull();
-        expect(helpers.parseDownloadTarget('')).toBeNull();
-    });
-
-    it('normalizes lazy and protocol-relative image sources in detached answer HTML', () => {
+    it('normalizes only downloadable lazy image and picture sources', () => {
         const sourceDom = new JSDOM();
-        const normalized = helpers.normalizeContentImages(`
-            <p>body</p>
-            <img src="https://pic.example/fallback.png" data-original="https://pic.example/original.png">
-            <img src="https://pic.example/original.png">
-            <img data-actualsrc="//pic.example/protocol-relative.svg">
-            <img src="data:image/png;base64,AAAA">
+        const normalized = normalizeContentImages(`
+            <img src="fallback.png" data-original="/original.png">
+            <img data-srcset="//pic.example/small.webp 1x, https://pic.example/large.webp 2x">
+            <picture><source srcset="/small.svg 1x, /large.svg 2x"><img src="data:image/png;base64,AAAA"></picture>
+            <img src="javascript:alert(1)">
         `, sourceDom.window.document);
         const resultDom = new JSDOM(normalized.contentHtml);
         const images = [...resultDom.window.document.querySelectorAll('img')];
 
         expect(normalized.imageUrls).toEqual([
-            'https://pic.example/original.png',
-            'https://pic.example/protocol-relative.svg',
+            'https://www.zhihu.com/original.png',
+            'https://pic.example/large.webp',
+            'https://www.zhihu.com/large.svg',
         ]);
         expect(images.map((img) => img.getAttribute('src'))).toEqual([
-            'https://pic.example/original.png',
-            'https://pic.example/original.png',
-            'https://pic.example/protocol-relative.svg',
-            'data:image/png;base64,AAAA',
+            'https://www.zhihu.com/original.png',
+            'https://pic.example/large.webp',
+            'https://www.zhihu.com/large.svg',
+            null,
         ]);
+        expect(resultDom.window.document.querySelector('source')?.getAttribute('srcset'))
+            .toBe('https://www.zhihu.com/small.svg 1x, https://www.zhihu.com/large.svg 2x');
     });
 });

--- a/docs/adapters/browser/zhihu.md
+++ b/docs/adapters/browser/zhihu.md
@@ -14,7 +14,7 @@
 | `opencli zhihu answer-comments <id>` | Read answer comments with reply hierarchy |
 | `opencli zhihu collections` | List your Zhihu favorite collections |
 | `opencli zhihu collection <collection_id>` | List content from a Zhihu favorite collection |
-| `opencli zhihu download` | Export a Zhihu article to Markdown |
+| `opencli zhihu download` | Export a Zhihu column article or answer to Markdown |
 | `opencli zhihu follow <target> --execute` | Follow a user or question |
 | `opencli zhihu like <target> --execute` | Like an answer or article |
 | `opencli zhihu favorite <target> (--collection <name> \| --collection-id <id>) --execute` | Favorite an answer or article into a specific collection |
@@ -55,7 +55,8 @@ opencli zhihu answer-comments answer:123456:789012 --limit 20 --replies-limit 3
 opencli zhihu answer-comments answer:123456:789012 --order latest --limit 20 --replies-limit 100
 opencli zhihu collections --limit 20
 opencli zhihu collection 83283292 --limit 20
-opencli zhihu download "https://zhuanlan.zhihu.com/p/998877" --download-images
+opencli zhihu download --url "https://zhuanlan.zhihu.com/p/998877" --download-images
+opencli zhihu download --url "https://www.zhihu.com/question/123456/answer/789012" --download-images
 
 # Write flows
 opencli zhihu follow question:123456 --execute

--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -60,10 +60,30 @@ describe('downloadArticle', () => {
     expect(fs.readFileSync(result[0].saved, 'utf8')).toContain('Hello world');
   });
 
-  it('uses the response MIME type for extensionless images', async () => {
+  it('opts into supported image MIME extensions without changing existing callers', async () => {
     const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-article-'));
     tempDirs.push(tempDir);
-    const server = http.createServer((_req, res) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/redirect') {
+        res.writeHead(302, { Location: '/equation' });
+        res.end();
+        return;
+      }
+      if (req.url === '/photo.jpeg') {
+        res.writeHead(200, { 'Content-Type': 'image/png' });
+        res.end('png bytes');
+        return;
+      }
+      if (req.url === '/error') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html>not an image</html>');
+        return;
+      }
+      if (req.url === '/unknown') {
+        res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+        res.end('unknown bytes');
+        return;
+      }
       res.writeHead(200, { 'Content-Type': 'image/svg+xml; charset=utf-8' });
       res.end('<svg xmlns="http://www.w3.org/2000/svg"><circle r="2"/></svg>');
     });
@@ -72,20 +92,46 @@ describe('downloadArticle', () => {
     try {
       const address = server.address();
       if (!address || typeof address === 'string') throw new Error('test server did not expose a TCP port');
-      const imageUrl = `http://127.0.0.1:${address.port}/equation`;
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      const imageUrl = `${baseUrl}/redirect`;
+      const extensionUrl = `${baseUrl}/photo.jpeg`;
+      const errorUrl = `${baseUrl}/error`;
+      const unknownUrl = `${baseUrl}/unknown`;
       const result = await downloadArticle({
         title: 'SVG Article',
-        contentHtml: `<p><img alt="formula" src="${imageUrl}"></p>`,
-        imageUrls: [imageUrl],
+        contentHtml: [
+          `<p><img alt="formula" src="${imageUrl}"></p>`,
+          `<p><img alt="extension" src="${extensionUrl}"></p>`,
+          `<p><img alt="error" src="${errorUrl}"></p>`,
+          `<p><img alt="unknown" src="${unknownUrl}"></p>`,
+        ].join(''),
+        imageUrls: [imageUrl, extensionUrl, errorUrl, unknownUrl],
       }, {
         output: tempDir,
         downloadImages: true,
+        requireImageContentType: true,
       });
 
       const markdown = fs.readFileSync(result[0].saved, 'utf8');
       expect(markdown).toContain('![formula](images/img_001.svg)');
+      expect(markdown).toContain('![extension](images/img_002.jpeg)');
+      expect(markdown).toContain(`![error](${errorUrl})`);
+      expect(markdown).toContain(`![unknown](${unknownUrl})`);
       expect(fs.readFileSync(path.join(path.dirname(result[0].saved), 'images', 'img_001.svg'), 'utf8'))
         .toContain('<svg');
+      expect(fs.existsSync(path.join(path.dirname(result[0].saved), 'images', 'img_003.jpg'))).toBe(false);
+      expect(fs.existsSync(path.join(path.dirname(result[0].saved), 'images', 'img_004.jpg'))).toBe(false);
+
+      const legacyResult = await downloadArticle({
+        title: 'Legacy Article',
+        contentHtml: `<p><img alt="legacy" src="${baseUrl}/declared.png"></p>`,
+        imageUrls: [`${baseUrl}/declared.png`],
+      }, {
+        output: tempDir,
+        downloadImages: true,
+      });
+      const legacyMarkdown = fs.readFileSync(legacyResult[0].saved, 'utf8');
+      expect(legacyMarkdown).toContain('![legacy](images/img_001.png)');
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
     }

--- a/src/download/article-download.test.ts
+++ b/src/download/article-download.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -57,6 +58,37 @@ describe('downloadArticle', () => {
     expect(path.extname(result[0].saved)).toBe('.md');
     expect(fs.existsSync(result[0].saved)).toBe(true);
     expect(fs.readFileSync(result[0].saved, 'utf8')).toContain('Hello world');
+  });
+
+  it('uses the response MIME type for extensionless images', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opencli-article-'));
+    tempDirs.push(tempDir);
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/svg+xml; charset=utf-8' });
+      res.end('<svg xmlns="http://www.w3.org/2000/svg"><circle r="2"/></svg>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('test server did not expose a TCP port');
+      const imageUrl = `http://127.0.0.1:${address.port}/equation`;
+      const result = await downloadArticle({
+        title: 'SVG Article',
+        contentHtml: `<p><img alt="formula" src="${imageUrl}"></p>`,
+        imageUrls: [imageUrl],
+      }, {
+        output: tempDir,
+        downloadImages: true,
+      });
+
+      const markdown = fs.readFileSync(result[0].saved, 'utf8');
+      expect(markdown).toContain('![formula](images/img_001.svg)');
+      expect(fs.readFileSync(path.join(path.dirname(result[0].saved), 'images', 'img_001.svg'), 'utf8'))
+        .toContain('<svg');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+    }
   });
 
   describe('markdown pipeline', () => {

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -14,6 +14,16 @@ import { httpDownload, sanitizeFilename } from './index.js';
 import { formatBytes } from './progress.js';
 
 const IMAGE_CONCURRENCY = 5;
+const IMAGE_EXT_BY_CONTENT_TYPE: Record<string, string> = {
+  'image/avif': 'avif',
+  'image/bmp': 'bmp',
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/svg+xml': 'svg',
+  'image/webp': 'webp',
+  'image/x-icon': 'ico',
+};
 
 // ============================================================
 // Types
@@ -253,6 +263,11 @@ function defaultDetectImageExt(url: string): string {
   return extMatch ? extMatch[1] : 'jpg';
 }
 
+function normalizeImageExt(value: string): string {
+  const ext = value.replace(/^\./, '').toLowerCase();
+  return /^[a-z0-9]{2,5}$/.test(ext) ? ext : 'jpg';
+}
+
 async function downloadImages(
   imgUrls: string[],
   imgDir: string,
@@ -280,19 +295,26 @@ async function downloadImages(
         let imgUrl = rawUrl;
         if (imgUrl.startsWith('//')) imgUrl = `https:${imgUrl}`;
 
-        const ext = detect(imgUrl);
-        const filename = `img_${String(index).padStart(3, '0')}.${ext}`;
-        const filepath = path.join(imgDir, filename);
+        const baseName = `img_${String(index).padStart(3, '0')}`;
+        const guessedExt = normalizeImageExt(detect(imgUrl));
+        const guessedFilename = `${baseName}.${guessedExt}`;
+        const guessedPath = path.join(imgDir, guessedFilename);
 
         try {
-          const result = await httpDownload(imgUrl, filepath, {
+          const result = await httpDownload(imgUrl, guessedPath, {
             headers,
             timeout: 15000,
           });
           if (result.success) {
+            const actualExt = IMAGE_EXT_BY_CONTENT_TYPE[result.contentType || ''] || guessedExt;
+            const filename = `${baseName}.${actualExt}`;
+            if (actualExt !== guessedExt) {
+              await fs.promises.rename(guessedPath, path.join(imgDir, filename));
+            }
             return { remoteUrl: rawUrl, localPath: `images/${filename}` };
           }
         } catch {
+          await fs.promises.rm(guessedPath, { force: true }).catch(() => undefined);
           // Skip failed downloads
         }
         return null;

--- a/src/download/article-download.ts
+++ b/src/download/article-download.ts
@@ -24,6 +24,9 @@ const IMAGE_EXT_BY_CONTENT_TYPE: Record<string, string> = {
   'image/webp': 'webp',
   'image/x-icon': 'ico',
 };
+const RELIABLE_IMAGE_EXTENSIONS = new Set([
+  'avif', 'bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp',
+]);
 
 // ============================================================
 // Types
@@ -57,6 +60,8 @@ export interface ArticleDownloadOptions {
   configureTurndown?: (td: TurndownService) => void;
   /** Custom image extension detector (default: infer from URL extension) */
   detectImageExt?: (url: string) => string;
+  /** Require a supported image Content-Type and use it for the local extension. */
+  requireImageContentType?: boolean;
   /** Custom frontmatter labels (default: Chinese labels) */
   frontmatterLabels?: FrontmatterLabels;
   /**
@@ -268,11 +273,21 @@ function normalizeImageExt(value: string): string {
   return /^[a-z0-9]{2,5}$/.test(ext) ? ext : 'jpg';
 }
 
+function reliableImageExt(url: string): string {
+  try {
+    const ext = path.extname(new URL(url).pathname).slice(1).toLowerCase();
+    return RELIABLE_IMAGE_EXTENSIONS.has(ext) ? ext : '';
+  } catch {
+    return '';
+  }
+}
+
 async function downloadImages(
   imgUrls: string[],
   imgDir: string,
   headers?: Record<string, string>,
   detectExt?: (url: string) => string,
+  requireContentType = false,
 ): Promise<Record<string, string>> {
   const urlMap: Record<string, string> = {};
   if (imgUrls.length === 0) return urlMap;
@@ -296,7 +311,7 @@ async function downloadImages(
         if (imgUrl.startsWith('//')) imgUrl = `https:${imgUrl}`;
 
         const baseName = `img_${String(index).padStart(3, '0')}`;
-        const guessedExt = normalizeImageExt(detect(imgUrl));
+        const guessedExt = requireContentType ? normalizeImageExt(detect(imgUrl)) : detect(imgUrl);
         const guessedFilename = `${baseName}.${guessedExt}`;
         const guessedPath = path.join(imgDir, guessedFilename);
 
@@ -304,12 +319,21 @@ async function downloadImages(
           const result = await httpDownload(imgUrl, guessedPath, {
             headers,
             timeout: 15000,
+            includeContentType: requireContentType,
           });
           if (result.success) {
-            const actualExt = IMAGE_EXT_BY_CONTENT_TYPE[result.contentType || ''] || guessedExt;
+            const responseExt = IMAGE_EXT_BY_CONTENT_TYPE[result.contentType || ''];
+            if (requireContentType && !responseExt) {
+              await fs.promises.rm(guessedPath, { force: true });
+              return null;
+            }
+            const finalUrlExt = requireContentType ? reliableImageExt(result.finalUrl || imgUrl) : '';
+            const actualExt = requireContentType ? (finalUrlExt || responseExt!) : guessedExt;
             const filename = `${baseName}.${actualExt}`;
             if (actualExt !== guessedExt) {
-              await fs.promises.rename(guessedPath, path.join(imgDir, filename));
+              const actualPath = path.join(imgDir, filename);
+              await fs.promises.rm(actualPath, { force: true });
+              await fs.promises.rename(guessedPath, actualPath);
             }
             return { remoteUrl: rawUrl, localPath: `images/${filename}` };
           }
@@ -354,6 +378,7 @@ export async function downloadArticle(
     maxTitleLength = 80,
     configureTurndown,
     detectImageExt,
+    requireImageContentType = false,
     frontmatterLabels,
     cleanSelectors,
     stdout = false,
@@ -401,7 +426,13 @@ export async function downloadArticle(
     const imagesDir = path.join(articleDir, 'images');
     fs.mkdirSync(imagesDir, { recursive: true });
 
-    const urlMap = await downloadImages(data.imageUrls, imagesDir, imageHeaders, detectImageExt);
+    const urlMap = await downloadImages(
+      data.imageUrls,
+      imagesDir,
+      imageHeaders,
+      detectImageExt,
+      requireImageContentType,
+    );
     markdown = replaceImageUrls(markdown, urlMap);
   }
 

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -26,6 +26,13 @@ export interface DownloadOptions {
   maxRedirects?: number;
 }
 
+export interface HttpDownloadResult {
+  success: boolean;
+  size: number;
+  error?: string;
+  contentType?: string;
+}
+
 export interface YtdlpOptions {
   cookies?: string;
   cookiesFile?: string;
@@ -103,7 +110,7 @@ export async function httpDownload(
   destPath: string,
   options: DownloadOptions = {},
   redirectCount = 0,
-): Promise<{ success: boolean; size: number; error?: string }> {
+): Promise<HttpDownloadResult> {
   const { cookies, headers = {}, timeout = 30000, onProgress, maxRedirects = 10 } = options;
 
   const requestHeaders: Record<string, string> = {
@@ -183,7 +190,8 @@ export async function httpDownload(
         fs.createWriteStream(tempPath),
       );
       await fs.promises.rename(tempPath, destPath);
-      return { success: true, size: received };
+      const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+      return { success: true, size: received, ...(contentType && { contentType }) };
     } catch (err) {
       await cleanupTempFile();
       return { success: false, size: 0, error: getErrorMessage(err) };

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -24,6 +24,8 @@ export interface DownloadOptions {
   timeout?: number;
   onProgress?: (received: number, total: number) => void;
   maxRedirects?: number;
+  /** Include the final response MIME type in the result. */
+  includeContentType?: boolean;
 }
 
 export interface HttpDownloadResult {
@@ -31,6 +33,7 @@ export interface HttpDownloadResult {
   size: number;
   error?: string;
   contentType?: string;
+  finalUrl?: string;
 }
 
 export interface YtdlpOptions {
@@ -111,7 +114,9 @@ export async function httpDownload(
   options: DownloadOptions = {},
   redirectCount = 0,
 ): Promise<HttpDownloadResult> {
-  const { cookies, headers = {}, timeout = 30000, onProgress, maxRedirects = 10 } = options;
+  const {
+    cookies, headers = {}, timeout = 30000, onProgress, maxRedirects = 10, includeContentType = false,
+  } = options;
 
   const requestHeaders: Record<string, string> = {
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
@@ -190,8 +195,15 @@ export async function httpDownload(
         fs.createWriteStream(tempPath),
       );
       await fs.promises.rename(tempPath, destPath);
-      const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
-      return { success: true, size: received, ...(contentType && { contentType }) };
+      const contentType = includeContentType
+        ? response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase()
+        : undefined;
+      return {
+        success: true,
+        size: received,
+        ...(includeContentType && { finalUrl: url }),
+        ...(contentType && { contentType }),
+      };
     } catch (err) {
       await cleanupTempFile();
       return { success: false, size: 0, error: getErrorMessage(err) };


### PR DESCRIPTION
## Summary

- extend the existing `zhihu download --url ...` command to accept answer IDs, typed answer targets, and answer URLs while preserving the column-article flow;
- fetch complete raw answer HTML in the logged-in same-origin page context, normalize only lazy `img`/`source`/`srcset` URLs needed for download, and reuse `downloadArticle()`;
- bind navigation plus API answer/question provenance with string-safe IDs and typed failures for Browser Bridge, HTTP, auth, risk-control, malformed, and empty states;
- opt answer image downloads into final-response MIME validation: supported MIME fills an extension only when the final URL has none, while existing callers keep their return shape and URL-extension behavior.

No new top-level command, generalized sanitizer, or archive format is introduced.

## Retrieval strategy

- Strategy: `PAGE_FETCH` for answers; the existing column flow remains DOM-based.
- Contract: `internal-unstable`.
- Evidence: direct non-browser replay was blocked as abnormal, while the logged-in same-origin Browser Bridge fetch returned raw answer content and metadata. Visible/lazy DOM state cannot prove complete answer HTML or image coverage.
- Maintenance boundary: one answer fetch helper reuses `parseAnswerTarget`, `normalizeUnixSeconds`, `unwrapEvaluateResult`, and `downloadArticle`; its output is fail-closed before filesystem writes.

## Validation on refreshed head

- Zhihu adapters: 24 files / 194 tests
- focused download + shared download units: 3 files / 50 tests
- `npm run typecheck`
- `npm run build` — manifest 1332
- `npm run docs:build`
- touched JS and built entry syntax checks
- typed-error lint: new 0, resolved 4
- silent-column-drop: new 0, resolved 2
- listing-id advisory: 14
- production high audit: 0 vulnerabilities
- `git diff --check`; merge-tree clean against refreshed base

The earlier live Browser Bridge proof exported the referenced answer with 13 local image references/files (12 PNG and one extensionless SVG resolved from its final response MIME); final merge gating relies on the refreshed exact-head tests and hosted checks.

Refs #2303. The comment hierarchy/order work remains in separate PR #2306.
