### PR TITLE
feat(zhihu): preserve comment reply threads

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -47030,7 +47030,7 @@
   {
     "site": "zhihu",
     "name": "answer-comments",
-    "description": "知乎回答评论列表",
+    "description": "知乎回答评论列表（保留回复层级）",
     "access": "read",
     "domain": "www.zhihu.com",
     "strategy": "cookie",
@@ -47056,6 +47056,17 @@
         "default": 3,
         "required": false,
         "help": "Number of replies to include per top-level comment (max 100)"
+      },
+      {
+        "name": "order",
+        "type": "str",
+        "default": "score",
+        "required": false,
+        "help": "Root comment order",
+        "choices": [
+          "score",
+          "latest"
+        ]
       }
     ],
     "columns": [

--- a/clis/zhihu/answer-comments-helpers.js
+++ b/clis/zhihu/answer-comments-helpers.js
@@ -1,0 +1,270 @@
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeCount, normalizeUnixSeconds, stripHtml } from './answer-normalize.js';
+import { unwrapEvaluateResult } from './paginate.js';
+
+const COMMENT_ID_RE = /^\d+$/;
+const PAGE_SIZE = 20;
+const PAGE_OVERLAP_ALLOWANCE = 2;
+function memberName(author) {
+    return String(author?.member?.name || author?.name || '').trim();
+}
+function commentId(value) {
+    if (typeof value === 'string') {
+        const id = value.trim();
+        return COMMENT_ID_RE.test(id) ? id : '';
+    }
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? String(value) : '';
+}
+function normalizePageUrl(value, path, requiredParams) {
+    if (typeof value !== 'string' || !value) return '';
+    try {
+        const url = new URL(value);
+        if (
+            url.protocol !== 'https:' || url.hostname !== 'www.zhihu.com' || url.port ||
+            url.username || url.password || url.hash || url.pathname !== path
+        ) return '';
+        for (const [name, expected] of Object.entries(requiredParams)) {
+            const values = url.searchParams.getAll(name);
+            if (values.length !== 1 || (expected !== null && values[0] !== expected)) return '';
+        }
+        return url.toString();
+    } catch {
+        return '';
+    }
+}
+async function fetchCommentPage(page, url, label, notFoundDetail = '') {
+    const evaluated = await page.evaluate(async (requestUrl) => {
+        const response = await fetch(requestUrl, { credentials: 'include' });
+        let body;
+        try {
+            body = await response.json();
+        } catch (error) {
+            return { __httpStatus: response.status, __malformedJson: error instanceof Error ? error.message : String(error) };
+        }
+        const error = body?.error && typeof body.error === 'object' ? body.error : null;
+        const result = {
+            __httpStatus: response.status,
+            __errorCode: error?.code ?? body?.error_code ?? '',
+            __errorMessage: error?.message || body?.error_msg || '',
+            __needLogin: error?.need_login === true || body?.need_login === true,
+        };
+        return !response.ok || result.__errorCode || result.__errorMessage || result.__needLogin ? result : body;
+    }, url).catch((error) => {
+        throw new CommandExecutionError(
+            `Zhihu ${label} request failed: ${error instanceof Error ? error.message : String(error)}`,
+            'Try again later or rerun with -v for more detail.',
+        );
+    });
+    const payload = unwrapEvaluateResult(evaluated);
+    if (payload?.__malformedJson) {
+        throw new CommandExecutionError(`Zhihu ${label} returned malformed JSON: ${payload.__malformedJson}`);
+    }
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new CommandExecutionError(`Zhihu ${label} returned a malformed payload`);
+    }
+    const status = payload.__httpStatus;
+    const code = String(payload.__errorCode || '');
+    if (status >= 400 || code || payload.__errorMessage || payload.__needLogin) {
+        if (code === '40362') {
+            throw new CommandExecutionError(
+                `Zhihu risk control blocked ${label} (40362): ${payload.__errorMessage || 'abnormal request'}`,
+                'Open the answer in the connected Chrome profile and retry later.',
+            );
+        }
+        if (status === 401 || status === 403 || code === '40353' || payload.__needLogin) {
+            throw new AuthRequiredError('www.zhihu.com', `Failed to fetch Zhihu ${label}`);
+        }
+        if (status === 404 && notFoundDetail) throw new EmptyResultError('zhihu answer-comments', notFoundDetail);
+        if (status >= 400) throw new CommandExecutionError(`Zhihu ${label} request failed (HTTP ${status})`);
+        throw new CommandExecutionError(`Zhihu ${label} returned an error payload: ${payload.__errorMessage || code}`);
+    }
+    if (!Array.isArray(payload.data) || !payload.paging || typeof payload.paging !== 'object') {
+        throw new CommandExecutionError(`Zhihu ${label} returned a malformed payload`);
+    }
+    if (typeof payload.paging.is_end !== 'boolean') {
+        throw new CommandExecutionError(`Zhihu ${label} returned malformed paging state`);
+    }
+    return payload;
+}
+function describeComment(comment, role, expectedRootId = '') {
+    if (!comment || typeof comment !== 'object' || Array.isArray(comment)) {
+        throw new CommandExecutionError(`Zhihu answer comments contained a malformed ${role} row`);
+    }
+    const id = commentId(comment.id);
+    if (!id) throw new CommandExecutionError(`Zhihu answer comments contained a ${role} row without a stable id`);
+    const rootId = role === 'root' ? id : commentId(comment.reply_root_comment_id);
+    const parentId = role === 'root' ? '' : commentId(comment.reply_comment_id);
+    if (role === 'child' && rootId !== expectedRootId) {
+        throw new CommandExecutionError(`Zhihu answer comment ${id} had conflicting root provenance`);
+    }
+    if (role === 'child' && !parentId) {
+        throw new CommandExecutionError(`Zhihu answer comment ${id} did not identify its immediate parent`);
+    }
+    const signature = JSON.stringify({
+        role,
+        rootId,
+        parentId,
+        author: memberName(comment.author),
+        replyTo: role === 'child' ? memberName(comment.reply_to_author) : '',
+        content: stripHtml(comment.content || ''),
+    });
+    return { id, rootId, parentId, signature };
+}
+function addPageComments(byId, comments, role, expectedRootId) {
+    for (const comment of comments) {
+        const descriptor = describeComment(comment, role, expectedRootId);
+        const previous = byId.get(descriptor.id);
+        if (!previous) {
+            byId.set(descriptor.id, { comment, descriptor });
+            continue;
+        }
+        if (previous.descriptor.signature !== descriptor.signature) {
+            throw new CommandExecutionError(`Zhihu answer comments returned conflicting data for comment ${descriptor.id}`);
+        }
+        const oldCount = previous.comment.child_comment_count;
+        const newCount = comment.child_comment_count;
+        if (Number.isInteger(newCount) && (!Number.isInteger(oldCount) || newCount > oldCount)) {
+            previous.comment = { ...previous.comment, child_comment_count: newCount };
+        }
+    }
+}
+async function fetchPages(page, options) {
+    const { firstUrl, limit, label, role, expectedRootId = '', normalizeNext, notFoundDetail = '' } = options;
+    const byId = new Map();
+    const visited = new Set();
+    const maxPages = Math.ceil(limit / PAGE_SIZE) + PAGE_OVERLAP_ALLOWANCE;
+    let pageCount = 0;
+    let url = firstUrl;
+    while (byId.size < limit) {
+        if (visited.has(url)) throw new CommandExecutionError(`Zhihu ${label} pagination returned a repeated next URL`);
+        if (pageCount >= maxPages) throw new CommandExecutionError(`Zhihu ${label} pagination exceeded its fetch budget`);
+        visited.add(url);
+        pageCount += 1;
+        const payload = await fetchCommentPage(page, url, label, notFoundDetail);
+        addPageComments(byId, payload.data, role, expectedRootId);
+        if (payload.paging.is_end || byId.size >= limit) break;
+        url = normalizeNext(payload.paging.next);
+        if (!url) throw new CommandExecutionError(`Zhihu ${label} pagination returned a malformed next URL`);
+    }
+    return [...byId.values()].slice(0, limit).map(({ comment }) => comment);
+}
+export function fetchRootComments(page, answerId, order, limit) {
+    const apiOrder = order === 'latest' ? 'ts' : 'score';
+    const path = `/api/v4/comment_v5/answers/${answerId}/root_comment`;
+    return fetchPages(page, {
+        firstUrl: `https://www.zhihu.com${path}?order_by=${apiOrder}&limit=${PAGE_SIZE}&offset=`,
+        limit,
+        label: 'answer root comments',
+        role: 'root',
+        normalizeNext: (next) => normalizePageUrl(next, path, {
+            order_by: apiOrder,
+            limit: String(PAGE_SIZE),
+            offset: null,
+        }),
+        notFoundDetail: `No Zhihu answer comments resource was found for ${answerId}.`,
+    });
+}
+async function fetchChildComments(page, rootId, limit) {
+    const path = `/api/v4/comment_v5/comment/${rootId}/child_comment`;
+    return fetchPages(page, {
+        firstUrl: `https://www.zhihu.com${path}?limit=${PAGE_SIZE}&offset=0`,
+        limit,
+        label: 'answer child comments',
+        role: 'child',
+        expectedRootId: rootId,
+        normalizeNext: (next) => normalizePageUrl(next, path, { limit: String(PAGE_SIZE), offset: null }),
+    });
+}
+export async function fetchRepliesByRoot(page, roots, repliesLimit) {
+    const repliesByRoot = new Map();
+    if (repliesLimit === 0) return repliesByRoot;
+    for (const root of roots) {
+        const id = describeComment(root, 'root').id;
+        if (!Number.isInteger(root.child_comment_count) || root.child_comment_count < 0) {
+            throw new CommandExecutionError(`Zhihu answer root comment ${id} had malformed child count`);
+        }
+        if (root.child_comment_count === 0) continue;
+        const children = await fetchChildComments(page, id, repliesLimit);
+        if (children.length === 0) {
+            throw new CommandExecutionError(`Zhihu answer root comment ${id} advertised replies but returned none`);
+        }
+        repliesByRoot.set(id, children);
+    }
+    return repliesByRoot;
+}
+function resolveDepths(rootId, childrenById) {
+    const depths = new Map();
+    for (const childId of childrenById.keys()) {
+        if (depths.has(childId)) continue;
+        const chain = [];
+        const active = new Set();
+        let cursor = childId;
+        let depth = 0;
+        while (cursor !== rootId && !depths.has(cursor)) {
+            if (active.has(cursor)) throw new CommandExecutionError(`Zhihu answer comments contained a reply cycle at ${cursor}`);
+            active.add(cursor);
+            chain.push(cursor);
+            const node = childrenById.get(cursor);
+            if (!node) throw new CommandExecutionError(`Zhihu answer comments referenced missing parent ${cursor}`);
+            cursor = node.descriptor.parentId;
+        }
+        if (cursor !== rootId) depth = depths.get(cursor);
+        for (let index = chain.length - 1; index >= 0; index -= 1) depths.set(chain[index], ++depth);
+    }
+    return depths;
+}
+function toRow(comment, descriptor, ranks, context) {
+    return {
+        rank: ranks.rank,
+        comment_rank: ranks.commentRank,
+        reply_rank: ranks.replyRank,
+        depth: ranks.depth,
+        id: descriptor.id,
+        parent_id: descriptor.parentId,
+        author: memberName(comment.author) || 'anonymous',
+        reply_to: descriptor.parentId ? memberName(comment.reply_to_author) : '',
+        likes: normalizeCount(comment.like_count ?? comment.vote_count),
+        created_at: normalizeUnixSeconds(comment.created_time),
+        url: context.questionId
+            ? `https://www.zhihu.com/question/${context.questionId}/answer/${context.answerId}#comment-${descriptor.id}`
+            : typeof comment.url === 'string' ? comment.url : '',
+        content: stripHtml(comment.content || ''),
+    };
+}
+export function buildCommentRows(roots, repliesByRoot, context) {
+    const rows = [];
+    const globalIds = new Set();
+    for (let rootIndex = 0; rootIndex < roots.length; rootIndex += 1) {
+        const root = roots[rootIndex];
+        const rootDescriptor = describeComment(root, 'root');
+        if (globalIds.has(rootDescriptor.id)) {
+            throw new CommandExecutionError(`Zhihu answer comments reused id ${rootDescriptor.id} across graph roles`);
+        }
+        globalIds.add(rootDescriptor.id);
+        rows.push(toRow(root, rootDescriptor, {
+            rank: rows.length + 1, commentRank: rootIndex + 1, replyRank: 0, depth: 0,
+        }, context));
+
+        const childrenById = new Map();
+        for (const child of repliesByRoot.get(rootDescriptor.id) || []) {
+            const descriptor = describeComment(child, 'child', rootDescriptor.id);
+            if (globalIds.has(descriptor.id) || childrenById.has(descriptor.id)) {
+                throw new CommandExecutionError(`Zhihu answer comments reused id ${descriptor.id} across graph roles`);
+            }
+            globalIds.add(descriptor.id);
+            childrenById.set(descriptor.id, { comment: child, descriptor });
+        }
+        const depths = resolveDepths(rootDescriptor.id, childrenById);
+        let replyRank = 0;
+        for (const { comment, descriptor } of childrenById.values()) {
+            replyRank += 1;
+            rows.push(toRow(comment, descriptor, {
+                rank: rows.length + 1,
+                commentRank: rootIndex + 1,
+                replyRank,
+                depth: depths.get(descriptor.id),
+            }, context));
+        }
+    }
+    return rows;
+}

--- a/clis/zhihu/answer-comments.js
+++ b/clis/zhihu/answer-comments.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { normalizeCount, normalizeUnixSeconds, stripHtml } from './answer-normalize.js';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { ANSWER_PATH_RE, parseAnswerTarget } from './answer-target.js';
+import { buildCommentRows, fetchRepliesByRoot, fetchRootComments } from './answer-comments-helpers.js';
 
 function extractQuestionIdFromAnswerUrl(input) {
     const value = String(input ?? '').trim();
@@ -15,109 +15,21 @@ function extractQuestionIdFromAnswerUrl(input) {
     }
 }
 
-function memberName(author) {
-    return author?.member?.name || author?.name || '';
-}
-
-function normalizeCommentId(value) {
-    if (typeof value === 'string') return value.trim();
-    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) return String(value);
-    return '';
-}
-
-function normalizeCommentUrl(url, questionId, answerId, commentId) {
-    if (questionId && answerId && commentId) {
-        return `https://www.zhihu.com/question/${questionId}/answer/${answerId}#comment-${commentId}`;
-    }
-    return typeof url === 'string' ? url : '';
-}
-
-function normalizeCommentsApiUrl(url, answerId) {
-    if (typeof url !== 'string' || !url) return '';
-    try {
-        const parsed = new URL(url);
-        const expectedWwwPath = `/api/v4/answers/${answerId}/comments`;
-        const expectedApiPath = `/answers/${answerId}/comments`;
-        if (parsed.protocol !== 'https:' || parsed.username || parsed.password || parsed.port) return '';
-        if (parsed.hostname === 'www.zhihu.com' && parsed.pathname === expectedWwwPath) return parsed.toString();
-        if (parsed.hostname === 'api.zhihu.com' && parsed.pathname === expectedApiPath) {
-            return `https://www.zhihu.com${expectedWwwPath}${parsed.search}`;
-        }
-    } catch {
-        return '';
-    }
-    return '';
-}
-
-function buildRows(comments, { answerId, questionId, topLevelLimit, repliesLimit }) {
-    const rows = [];
-    let topLevelCount = 0;
-    let currentCommentRank = 0;
-    let currentReplyCount = 0;
-    let reachedTopLevelLimit = false;
-    let malformedComments = 0;
-
-    for (const comment of comments) {
-        if (!comment || typeof comment !== 'object' || Array.isArray(comment)) {
-            malformedComments += 1;
-            continue;
-        }
-        const id = normalizeCommentId(comment.id);
-        if (!id) {
-            malformedComments += 1;
-            continue;
-        }
-        const author = memberName(comment.author);
-        const replyToAuthor = memberName(comment.reply_to_author);
-        const isReply = Boolean(replyToAuthor);
-
-        if (!isReply) {
-            if (topLevelCount >= topLevelLimit) {
-                reachedTopLevelLimit = true;
-                break;
-            }
-            topLevelCount += 1;
-            currentCommentRank = topLevelCount;
-            currentReplyCount = 0;
-        } else if (!currentCommentRank || currentReplyCount >= repliesLimit) {
-            continue;
-        } else {
-            currentReplyCount += 1;
-        }
-
-        rows.push({
-            rank: rows.length + 1,
-            comment_rank: currentCommentRank,
-            reply_rank: isReply ? currentReplyCount : 0,
-            depth: 0,
-            id,
-            parent_id: '',
-            author: author || 'anonymous',
-            reply_to: replyToAuthor,
-            likes: normalizeCount(comment.vote_count),
-            created_at: normalizeUnixSeconds(comment.created_time),
-            url: normalizeCommentUrl(comment.url, questionId, answerId, id),
-            content: stripHtml(comment.content || ''),
-        });
-    }
-    return { rows, topLevelCount, reachedTopLevelLimit, malformedComments };
-}
-
 const MAX_LIMIT = 1000;
 const MAX_REPLIES_LIMIT = 100;
-const ZHIHU_PAGE_SIZE = 20;
 
 cli({
     site: 'zhihu',
     name: 'answer-comments',
     access: 'read',
-    description: '知乎回答评论列表',
+    description: '知乎回答评论列表（保留回复层级）',
     domain: 'www.zhihu.com',
     strategy: Strategy.COOKIE,
     args: [
         { name: 'id', required: true, positional: true, help: 'Answer ID, full Zhihu answer URL, or typed target (answer:<qid>:<aid>)' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of top-level comments (max 1000)' },
         { name: 'replies-limit', type: 'int', default: 3, help: 'Number of replies to include per top-level comment (max 100)' },
+        { name: 'order', default: 'score', choices: ['score', 'latest'], help: 'Root comment order' },
     ],
     columns: ['rank', 'comment_rank', 'reply_rank', 'depth', 'id', 'parent_id', 'author', 'reply_to', 'likes', 'created_at', 'url', 'content'],
     func: async (page, kwargs) => {
@@ -136,6 +48,10 @@ cli({
         if (!Number.isInteger(repliesLimit) || repliesLimit < 0 || repliesLimit > MAX_REPLIES_LIMIT) {
             throw new ArgumentError(`--replies-limit must be an integer between 0 and ${MAX_REPLIES_LIMIT}`);
         }
+        const order = String(kwargs.order ?? 'score');
+        if (order !== 'score' && order !== 'latest') {
+            throw new ArgumentError('--order must be score or latest');
+        }
 
         const { answerId } = target;
         try {
@@ -151,85 +67,11 @@ cli({
             : '';
         const questionId = target.questionId || currentQuestionId;
 
-        let url = `https://www.zhihu.com/api/v4/answers/${answerId}/comments?order=normal&limit=${ZHIHU_PAGE_SIZE}&offset=0&status=open`;
-        const fetched = [];
-        const visited = new Set();
-
-        while (url && !visited.has(url)) {
-            visited.add(url);
-            const data = await page.evaluate(`
-      (async () => {
-        const r = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
-        if (!r.ok) return { __httpError: r.status };
-        try {
-          return await r.json();
-        } catch (error) {
-          return { __malformedJson: error instanceof Error ? error.message : String(error) };
-        }
-      })()
-    `).catch((err) => {
-                throw new CommandExecutionError(
-                    `Zhihu answer comments request failed: ${err instanceof Error ? err.message : String(err)}`,
-                    'Try again later or rerun with -v for more detail.',
-                );
-            });
-            if (!data || data.__httpError) {
-                const status = data?.__httpError;
-                if (status === 401 || status === 403) {
-                    throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch Zhihu answer comments');
-                }
-                if (status === 404) {
-                    throw new EmptyResultError('zhihu answer-comments', `No Zhihu answer comments resource was found for ${answerId}.`);
-                }
-                throw new CommandExecutionError(
-                    status
-                        ? `Zhihu answer comments request failed (HTTP ${status})`
-                        : 'Zhihu answer comments request failed',
-                    'Try again later or rerun with -v for more detail',
-                );
-            }
-            if (data.__malformedJson) {
-                throw new CommandExecutionError(
-                    `Zhihu answer comments returned malformed JSON: ${data.__malformedJson}`,
-                    'Try again later or rerun with -v for more detail',
-                );
-            }
-            if (!Array.isArray(data.data) || !data.paging || typeof data.paging !== 'object') {
-                throw new CommandExecutionError(
-                    'Zhihu answer comments returned a malformed payload',
-                    'Try again later or rerun with -v for more detail',
-                );
-            }
-            fetched.push(...data.data);
-            const built = buildRows(fetched, { answerId, questionId, topLevelLimit, repliesLimit });
-            if (built.malformedComments > 0) {
-                throw new CommandExecutionError('Zhihu answer comments contained rows without comment ids');
-            }
-            if (built.reachedTopLevelLimit || data.paging?.is_end) {
-                if (built.rows.length === 0) {
-                    throw new EmptyResultError('zhihu answer-comments', `No comments found for answer ${answerId}.`);
-                }
-                return built.rows;
-            }
-            const next = normalizeCommentsApiUrl(data.paging?.next, answerId);
-            if (!next) {
-                throw new CommandExecutionError('Zhihu answer comments pagination returned malformed next URL');
-            }
-            if (visited.has(next)) {
-                throw new CommandExecutionError('Zhihu answer comments pagination returned a repeated next URL');
-            }
-            url = next;
-        }
-
-        const built = buildRows(fetched, { answerId, questionId, topLevelLimit, repliesLimit });
-        if (built.malformedComments > 0) {
-            throw new CommandExecutionError('Zhihu answer comments contained rows without comment ids');
-        }
-        if (built.rows.length === 0) {
+        const roots = await fetchRootComments(page, answerId, order, topLevelLimit);
+        if (roots.length === 0) {
             throw new EmptyResultError('zhihu answer-comments', `No comments found for answer ${answerId}.`);
         }
-        return built.rows;
+        const repliesByRoot = await fetchRepliesByRoot(page, roots, repliesLimit);
+        return buildCommentRows(roots, repliesByRoot, { answerId, questionId });
     },
 });
-
-export const __test__ = { normalizeCommentsApiUrl, buildRows };

--- a/clis/zhihu/answer-comments.test.js
+++ b/clis/zhihu/answer-comments.test.js
@@ -1,279 +1,344 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { buildCommentRows } from './answer-comments-helpers.js';
 import './answer-comments.js';
-import { __test__ as helpers } from './answer-comments.js';
+
+const command = () => getRegistry().get('zhihu/answer-comments');
+const args = (overrides = {}) => ({
+    id: '20',
+    limit: 1,
+    'replies-limit': 0,
+    order: 'score',
+    ...overrides,
+});
+
+function pageWith(resolve) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/question/10/answer/20'),
+        evaluate: vi.fn().mockImplementation((_fn, url) => resolve(url)),
+    };
+}
+
+function root(id, content = `root ${id}`, extra = {}) {
+    return {
+        id,
+        author: { member: { name: `author ${id}` } },
+        child_comment_count: 0,
+        content,
+        ...extra,
+    };
+}
+
+function child(id, rootId, parentId, content = `reply ${id}`, extra = {}) {
+    return {
+        id,
+        reply_root_comment_id: rootId,
+        reply_comment_id: parentId,
+        author: { member: { name: `author ${id}` } },
+        content,
+        ...extra,
+    };
+}
 
 describe('zhihu answer-comments', () => {
-    it('registers as a cookie read command', () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
+    it('registers score/latest ordering and reconstructable hierarchy fields', () => {
+        const cmd = command();
         expect(cmd).toBeDefined();
         expect(cmd.access).toBe('read');
         expect(cmd.strategy).toBe('cookie');
+        expect(cmd.args.find((arg) => arg.name === 'order')).toMatchObject({
+            default: 'score',
+            choices: ['score', 'latest'],
+        });
+        expect(cmd.columns).toEqual([
+            'rank', 'comment_rank', 'reply_rank', 'depth', 'id', 'parent_id',
+            'author', 'reply_to', 'likes', 'created_at', 'url', 'content',
+        ]);
     });
 
-    it('returns flattened comments while limiting only top-level comments', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const goto = vi.fn().mockResolvedValue(undefined);
-        const evaluate = vi.fn().mockImplementation(async (js) => {
-            expect(js).toContain('/api/v4/answers/2036567240334653053/comments?order=normal&limit=20');
-            expect(js).toContain("credentials: 'include'");
+    it('uses comment_v5 and preserves root order plus exact reply depth', async () => {
+        const page = pageWith(async (url) => {
+            if (url.includes('/root_comment')) {
+                expect(url).toContain('order_by=score');
+                return {
+                    data: [root('100', '<p>root</p>', {
+                        child_comment_count: 3,
+                        like_count: 4,
+                        created_time: 1700000000,
+                    })],
+                    paging: { is_end: true },
+                };
+            }
+            expect(url).toContain('/comment/100/child_comment');
             return {
                 data: [
-                    {
-                        id: 'c1',
-                        author: { member: { id: 'u1', name: 'alice' } },
-                        vote_count: 3,
-                        created_time: 1700000000,
-                        content: '<p>top &#34;one&#34;</p>',
-                    },
-                    {
-                        id: 'r1',
-                        author: { member: { id: 'u2', name: 'bob' } },
-                        reply_to_author: { member: { id: 'u1', name: 'alice' } },
-                        vote_count: 1,
-                        created_time: 1700000100,
-                        content: '<p>reply one</p>',
-                    },
-                    {
-                        id: 'r2',
-                        author: { member: { id: 'u3', name: 'carol' } },
-                        reply_to_author: { member: { id: 'u1', name: 'alice' } },
-                        vote_count: 2,
-                        created_time: 1700000200,
-                        content: '<p>reply two should be capped</p>',
-                    },
-                    {
-                        id: 'c2',
-                        author: { member: { id: 'u4', name: 'dave' } },
-                        vote_count: 4,
-                        created_time: 1700000300,
-                        content: '<p>top two</p>',
-                    },
-                    {
-                        id: 'c3',
-                        author: { member: { id: 'u5', name: 'erin' } },
-                        vote_count: 5,
-                        content: '<p>top three should stop the page walk</p>',
-                    },
+                    child('101', '100', '100', '<p>direct</p>', { like_count: 2 }),
+                    child('102', '100', '101', '<p>nested</p>', {
+                        reply_to_author: { member: { name: 'author 101' } },
+                    }),
+                    child('103', '100', '102', '<p>deep</p>', {
+                        reply_to_author: { member: { name: 'author 102' } },
+                    }),
                 ],
-                paging: { is_end: false, next: 'https://www.zhihu.com/api/v4/answers/2036567240334653053/comments?offset=20' },
+                paging: { is_end: true },
             };
         });
-        const page = {
-            goto,
-            getCurrentUrl: vi.fn().mockResolvedValue('https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053'),
-            evaluate,
-        };
-        await expect(cmd.func(page, {
-            id: 'https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053',
-            limit: 2,
-            'replies-limit': 1,
-        })).resolves.toEqual([
-            {
-                rank: 1,
-                comment_rank: 1,
-                reply_rank: 0,
-                depth: 0,
-                id: 'c1',
-                parent_id: '',
-                author: 'alice',
-                reply_to: '',
-                likes: 3,
-                created_at: '2023-11-14T22:13:20.000Z',
-                url: 'https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053#comment-c1',
-                content: 'top "one"',
-            },
-            {
-                rank: 2,
-                comment_rank: 1,
-                reply_rank: 1,
-                depth: 0,
-                id: 'r1',
-                parent_id: '',
-                author: 'bob',
-                reply_to: 'alice',
-                likes: 1,
-                created_at: '2023-11-14T22:15:00.000Z',
-                url: 'https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053#comment-r1',
-                content: 'reply one',
-            },
-            {
-                rank: 3,
-                comment_rank: 2,
-                reply_rank: 0,
-                depth: 0,
-                id: 'c2',
-                parent_id: '',
-                author: 'dave',
-                reply_to: '',
-                likes: 4,
-                created_at: '2023-11-14T22:18:20.000Z',
-                url: 'https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053#comment-c2',
-                content: 'top two',
-            },
+
+        const rows = await command().func(page, args({
+            id: 'answer:10:20',
+            'replies-limit': 3,
+        }));
+
+        expect(rows.map((row) => [row.id, row.parent_id, row.depth, row.comment_rank, row.reply_rank])).toEqual([
+            ['100', '', 0, 1, 0],
+            ['101', '100', 1, 1, 1],
+            ['102', '101', 2, 1, 2],
+            ['103', '102', 3, 1, 3],
         ]);
-        expect(goto).toHaveBeenCalledWith('https://www.zhihu.com/answer/2036567240334653053');
-        expect(evaluate).toHaveBeenCalledTimes(1);
+        expect(rows[2]).toMatchObject({ author: 'author 102', reply_to: 'author 101', content: 'nested' });
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
     });
 
-    it('follows paging.next until enough top-level comments are collected', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const evaluate = vi.fn()
+    it('maps latest to order_by=ts and sends no child request when replies-limit is zero', async () => {
+        const page = pageWith(async (url) => {
+            expect(url).toContain('order_by=ts');
+            return {
+                data: [root('100', 'root', { child_comment_count: 5 })],
+                paging: { is_end: true },
+            };
+        });
+        const rows = await command().func(page, args({ order: 'latest' }));
+        expect(rows.map((row) => row.id)).toEqual(['100']);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts unique roots toward limit and idempotently removes equivalent page overlap', async () => {
+        const page = pageWith(vi.fn()
             .mockResolvedValueOnce({
-                data: [
-                    { id: 'c1', author: { member: { id: 'u1', name: 'alice' } }, content: 'first' },
-                    { id: 'r1', author: { member: { id: 'u2', name: 'bob' } }, reply_to_author: { member: { id: 'u1', name: 'alice' } }, content: 'reply' },
-                ],
-                paging: { is_end: false, next: 'https://www.zhihu.com/api/v4/answers/1/comments?offset=20' },
+                data: [root('100'), root('101')],
+                paging: {
+                    is_end: false,
+                    next: 'https://www.zhihu.com/api/v4/comment_v5/answers/20/root_comment?order_by=score&limit=20&offset=next',
+                },
             })
             .mockResolvedValueOnce({
                 data: [
-                    { id: 'c2', author: { member: { id: 'u3', name: 'carol' } }, content: 'second' },
+                    root('101', 'root 101', { like_count: 99 }),
+                    root('102'),
                 ],
                 paging: { is_end: true },
-            });
-        const page = { goto: vi.fn().mockResolvedValue(undefined), evaluate };
-        const rows = await cmd.func(page, { id: '1', limit: 2, 'replies-limit': 0 });
-        expect(rows.map((row) => row.id)).toEqual(['c1', 'c2']);
-        expect(evaluate).toHaveBeenCalledTimes(2);
-        expect(evaluate.mock.calls[1][0]).toContain('offset=20');
+            }));
+
+        const rows = await command().func(page, args({ limit: 3 }));
+        expect(rows.map((row) => row.id)).toEqual(['100', '101', '102']);
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
     });
 
-    it('supports typed answer targets', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({
+    it('rejects same-id root overlap when normalized content or role identity conflicts', async () => {
+        const page = pageWith(vi.fn()
+            .mockResolvedValueOnce({
+                data: [root('100')],
+                paging: {
+                    is_end: false,
+                    next: 'https://www.zhihu.com/api/v4/comment_v5/answers/20/root_comment?order_by=score&limit=20&offset=next',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [root('100', 'different content')],
+                paging: { is_end: true },
+            }));
+
+        await expect(command().func(page, args({ limit: 2 }))).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('counts unique replies toward replies-limit and removes equivalent child overlap', async () => {
+        let childPage = 0;
+        const page = pageWith(async (url) => {
+            if (url.includes('/root_comment')) {
+                return {
+                    data: [root('100', 'root', { child_comment_count: 3 })],
+                    paging: { is_end: true },
+                };
+            }
+            childPage += 1;
+            if (childPage === 1) {
+                return {
+                    data: [child('101', '100', '100'), child('102', '100', '100')],
+                    paging: {
+                        is_end: false,
+                        next: 'https://www.zhihu.com/api/v4/comment_v5/comment/100/child_comment?limit=20&offset=next',
+                    },
+                };
+            }
+            return {
                 data: [
-                    { id: 'c1', author: { member: { id: 'u1', name: 'alice' } }, content: 'typed target comment' },
+                    child('102', '100', '100', 'reply 102', { like_count: 9 }),
+                    child('103', '100', '102'),
                 ],
                 paging: { is_end: true },
-            }),
-        };
-        await expect(cmd.func(page, { id: 'answer:2022852734622114542:2036567240334653053', limit: 1, 'replies-limit': 0 }))
-            .resolves.toMatchObject([{ id: 'c1', url: 'https://www.zhihu.com/question/2022852734622114542/answer/2036567240334653053#comment-c1' }]);
-        expect(page.goto).toHaveBeenCalledWith('https://www.zhihu.com/answer/2036567240334653053');
-    });
-
-    it('maps auth failures to AuthRequiredError', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ __httpError: 403 }),
-        };
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(AuthRequiredError);
-    });
-
-    it('maps 404 not found to EmptyResultError', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ __httpError: 404 }),
-        };
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(EmptyResultError);
-    });
-
-    it('maps malformed responses to CommandExecutionError', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ data: {} }),
-        };
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(CommandExecutionError);
-    });
-
-    it('maps valid empty comments to EmptyResultError', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ data: [], paging: { is_end: true } }),
-        };
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(EmptyResultError);
-    });
-
-    it('rejects malformed pagination next URLs and repeated next URLs', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const malformedNextPage = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({
-                data: [{ id: 'c1', author: { member: { id: 'u1', name: 'alice' } }, content: 'first' }],
-                paging: { is_end: false, next: 'https://evil.example/api/v4/answers/1/comments?offset=20' },
-            }),
-        };
-        await expect(cmd.func(malformedNextPage, { id: '1', limit: 2, 'replies-limit': 0 }))
-            .rejects.toBeInstanceOf(CommandExecutionError);
-
-        const repeatedNextPage = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({
-                data: [{ id: 'c1', author: { member: { id: 'u1', name: 'alice' } }, content: 'first' }],
-                paging: { is_end: false, next: 'https://www.zhihu.com/api/v4/answers/1/comments?order=normal&limit=20&offset=0&status=open' },
-            }),
-        };
-        await expect(cmd.func(repeatedNextPage, { id: '1', limit: 2, 'replies-limit': 0 }))
-            .rejects.toBeInstanceOf(CommandExecutionError);
-    });
-
-    it('rejects comment rows without stable comment id anchors', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({
-                data: [{ author: { member: { id: 'u1', name: 'alice' } }, content: 'missing id' }],
-                paging: { is_end: true },
-            }),
-        };
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(CommandExecutionError);
-    });
-
-    it('rejects null comment items and non-primitive comment ids', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
-        const basePage = (data) => ({
-            goto: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn().mockResolvedValue({ data, paging: { is_end: true } }),
+            };
         });
-        await expect(cmd.func(basePage([null]), { id: '1', limit: 1, 'replies-limit': 0 }))
+
+        const rows = await command().func(page, args({ 'replies-limit': 3 }));
+        expect(rows.map((row) => row.id)).toEqual(['100', '101', '102', '103']);
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects conflicting child overlap and wrong root provenance', async () => {
+        const conflictingOverlap = pageWith(vi.fn()
+            .mockResolvedValueOnce({
+                data: [root('100', 'root', { child_comment_count: 2 })],
+                paging: { is_end: true },
+            })
+            .mockResolvedValueOnce({
+                data: [child('101', '100', '100')],
+                paging: {
+                    is_end: false,
+                    next: 'https://www.zhihu.com/api/v4/comment_v5/comment/100/child_comment?limit=20&offset=next',
+                },
+            })
+            .mockResolvedValueOnce({
+                data: [child('101', '100', '100', 'changed')],
+                paging: { is_end: true },
+            }));
+        await expect(command().func(conflictingOverlap, args({ 'replies-limit': 2 })))
             .rejects.toBeInstanceOf(CommandExecutionError);
-        await expect(cmd.func(basePage([{ id: { value: 'c1' }, content: 'object id' }]), { id: '1', limit: 1, 'replies-limit': 0 }))
+
+        const wrongRoot = pageWith(async (url) => url.includes('/root_comment')
+            ? { data: [root('100', 'root', { child_comment_count: 1 })], paging: { is_end: true } }
+            : { data: [child('101', '999', '100')], paging: { is_end: true } });
+        await expect(command().func(wrongRoot, args({ 'replies-limit': 1 })))
             .rejects.toBeInstanceOf(CommandExecutionError);
-        await expect(cmd.func(basePage([{ id: true, content: 'boolean id' }]), { id: '1', limit: 1, 'replies-limit': 0 }))
+    });
+
+    it('requires exact answer/root/order pagination provenance', async () => {
+        for (const next of [
+            'https://evil.example/api/v4/comment_v5/answers/20/root_comment?order_by=score&limit=20&offset=x',
+            'https://www.zhihu.com/api/v4/comment_v5/answers/21/root_comment?order_by=score&limit=20&offset=x',
+            'https://www.zhihu.com/api/v4/comment_v5/answers/20/root_comment?order_by=ts&limit=20&offset=x',
+        ]) {
+            const page = pageWith(async () => ({
+                data: [root('100')],
+                paging: { is_end: false, next },
+            }));
+            await expect(command().func(page, args({ limit: 2 }))).rejects.toBeInstanceOf(CommandExecutionError);
+        }
+
+        const childWrongRoot = pageWith(async (url) => url.includes('/root_comment')
+            ? { data: [root('100', 'root', { child_comment_count: 2 })], paging: { is_end: true } }
+            : {
+                data: [child('101', '100', '100')],
+                paging: {
+                    is_end: false,
+                    next: 'https://www.zhihu.com/api/v4/comment_v5/comment/999/child_comment?limit=20&offset=x',
+                },
+            });
+        await expect(command().func(childWrongRoot, args({ 'replies-limit': 2 })))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails repeated URLs and unique-URL stalls within a bounded page budget', async () => {
+        const repeated = pageWith(async () => ({
+            data: [root('100')],
+            paging: {
+                is_end: false,
+                next: 'https://www.zhihu.com/api/v4/comment_v5/answers/20/root_comment?order_by=score&limit=20&offset=',
+            },
+        }));
+        await expect(command().func(repeated, args({ limit: 2 }))).rejects.toBeInstanceOf(CommandExecutionError);
+
+        let offset = 0;
+        const stalled = pageWith(async () => {
+            offset += 1;
+            return {
+                data: [root('100')],
+                paging: {
+                    is_end: false,
+                    next: `https://www.zhihu.com/api/v4/comment_v5/answers/20/root_comment?order_by=score&limit=20&offset=${offset}`,
+                },
+            };
+        });
+        await expect(command().func(stalled, args({ limit: 2 }))).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(stalled.evaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it('distinguishes auth, risk control, not found, empty, and malformed responses', async () => {
+        await expect(command().func(pageWith(async () => ({ __httpStatus: 401 })), args()))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(command().func(pageWith(async () => ({
+            __httpStatus: 403,
+            __errorCode: 40362,
+            __errorMessage: 'risk',
+        })), args())).rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command().func(pageWith(async () => ({
+            __httpStatus: 403,
+            __errorCode: 40353,
+            __needLogin: true,
+        })), args())).rejects.toBeInstanceOf(AuthRequiredError);
+        await expect(command().func(pageWith(async () => ({ __httpStatus: 404 })), args()))
+            .rejects.toBeInstanceOf(EmptyResultError);
+        await expect(command().func(pageWith(async () => ({ data: [], paging: { is_end: true } })), args()))
+            .rejects.toBeInstanceOf(EmptyResultError);
+        await expect(command().func(pageWith(async () => ({ data: {}, paging: { is_end: true } })), args()))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        await expect(command().func(pageWith(async () => ({ data: [], paging: {} })), args()))
             .rejects.toBeInstanceOf(CommandExecutionError);
     });
 
     it('rejects invalid inputs before navigation', async () => {
-        const cmd = getRegistry().get('zhihu/answer-comments');
         const page = { goto: vi.fn(), evaluate: vi.fn() };
-        await expect(cmd.func(page, { id: 'not-an-answer', limit: 1, 'replies-limit': 0 })).rejects.toBeInstanceOf(ArgumentError);
-        await expect(cmd.func(page, { id: '1', limit: 0, 'replies-limit': 0 })).rejects.toBeInstanceOf(ArgumentError);
-        await expect(cmd.func(page, { id: '1', limit: 1001, 'replies-limit': 0 })).rejects.toBeInstanceOf(ArgumentError);
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': -1 })).rejects.toBeInstanceOf(ArgumentError);
-        await expect(cmd.func(page, { id: '1', limit: 1, 'replies-limit': 101 })).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command().func(page, args({ id: 'invalid' }))).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command().func(page, args({ limit: 0 }))).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command().func(page, args({ 'replies-limit': 101 }))).rejects.toBeInstanceOf(ArgumentError);
+        await expect(command().func(page, args({ order: 'normal' }))).rejects.toBeInstanceOf(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
-        expect(page.evaluate).not.toHaveBeenCalled();
     });
 });
 
-describe('zhihu answer-comments helpers', () => {
-    it('normalizeCommentsApiUrl only accepts same-answer Zhihu comments API URLs', () => {
-        expect(helpers.normalizeCommentsApiUrl('https://www.zhihu.com/api/v4/answers/123/comments?offset=20', '123'))
-            .toBe('https://www.zhihu.com/api/v4/answers/123/comments?offset=20');
-        expect(helpers.normalizeCommentsApiUrl('https://api.zhihu.com/answers/123/comments?offset=20', '123'))
-            .toBe('https://www.zhihu.com/api/v4/answers/123/comments?offset=20');
-        expect(helpers.normalizeCommentsApiUrl('https://www.zhihu.com/api/v4/answers/999/comments?offset=20', '123')).toBe('');
-        expect(helpers.normalizeCommentsApiUrl('https://evil.example/api/v4/answers/123/comments?offset=20', '123')).toBe('');
+describe('zhihu answer-comments graph', () => {
+    const context = { answerId: '20', questionId: '10' };
+
+    it('preserves exact depth beyond ten levels without recursive traversal', () => {
+        const children = Array.from({ length: 12 }, (_, index) => {
+            const id = String(101 + index);
+            const parentId = index === 0 ? '100' : String(100 + index);
+            return child(id, '100', parentId);
+        });
+        const rows = buildCommentRows(
+            [root('100')],
+            new Map([['100', children]]),
+            context,
+        );
+        expect(rows.slice(1).map((row) => row.depth)).toEqual(
+            Array.from({ length: 12 }, (_, index) => index + 1),
+        );
     });
 
-    it('buildRows keeps replies flat without guessing parent comment ids', () => {
-        const rows = helpers.buildRows([
-            { id: 'c1', author: { member: { id: 'u1', name: 'alice' } }, content: 'top' },
-            { id: 'r1', author: { member: { id: 'u2', name: 'bob' } }, reply_to_author: { member: { id: 'u1', name: 'alice' } }, content: 'reply' },
-            { id: 'r2', author: { member: { id: 'u3', name: 'carol' } }, reply_to_author: { member: { id: 'u2', name: 'bob' } }, content: 'nested' },
-        ], { answerId: 'a1', questionId: 'q1', topLevelLimit: 1, repliesLimit: 5 }).rows;
-        expect(rows.map((row) => [row.id, row.parent_id, row.depth, row.comment_rank, row.reply_rank])).toEqual([
-            ['c1', '', 0, 1, 0],
-            ['r1', '', 0, 1, 1],
-            ['r2', '', 0, 1, 2],
-        ]);
+    it('rejects cycles, unknown parents, and ids reused across graph roles or roots', () => {
+        expect(() => buildCommentRows(
+            [root('100')],
+            new Map([['100', [child('101', '100', '102'), child('102', '100', '101')]]]),
+            context,
+        )).toThrow(CommandExecutionError);
+        expect(() => buildCommentRows(
+            [root('100')],
+            new Map([['100', [child('101', '100', '999')]]]),
+            context,
+        )).toThrow(CommandExecutionError);
+        expect(() => buildCommentRows(
+            [root('100')],
+            new Map([['100', [child('100', '100', '100')]]]),
+            context,
+        )).toThrow(CommandExecutionError);
+        expect(() => buildCommentRows(
+            [root('100'), root('200')],
+            new Map([
+                ['100', [child('300', '100', '100')]],
+                ['200', [child('300', '200', '200')]],
+            ]),
+            context,
+        )).toThrow(CommandExecutionError);
     });
 });

--- a/docs/adapters/browser/zhihu.md
+++ b/docs/adapters/browser/zhihu.md
@@ -11,7 +11,7 @@
 | `opencli zhihu search` | Search Zhihu content |
 | `opencli zhihu question` | Read question answers by question ID |
 | `opencli zhihu answer-detail <id>` | Read one full answer by answer ID, typed target, or answer URL |
-| `opencli zhihu answer-comments <id>` | Read flattened comments for one answer |
+| `opencli zhihu answer-comments <id>` | Read answer comments with reply hierarchy |
 | `opencli zhihu collections` | List your Zhihu favorite collections |
 | `opencli zhihu collection <collection_id>` | List content from a Zhihu favorite collection |
 | `opencli zhihu download` | Export a Zhihu article to Markdown |
@@ -52,6 +52,7 @@ opencli zhihu question 123456 --limit 3
 opencli zhihu answer-detail answer:123456:789012
 opencli zhihu answer-detail "https://www.zhihu.com/question/123456/answer/789012" --max-content 2000
 opencli zhihu answer-comments answer:123456:789012 --limit 20 --replies-limit 3
+opencli zhihu answer-comments answer:123456:789012 --order latest --limit 20 --replies-limit 100
 opencli zhihu collections --limit 20
 opencli zhihu collection 83283292 --limit 20
 opencli zhihu download "https://zhuanlan.zhihu.com/p/998877" --download-images
@@ -78,9 +79,10 @@ opencli zhihu hot -f json
 
 ## Comment Notes
 
-- `answer-comments --limit` counts top-level comments
-- `answer-comments --replies-limit` expands up to that many replies per top-level comment
-- Comment rows are flattened in Zhihu order. Zhihu's comments API does not expose stable parent comment ids here, so `parent_id` stays empty and `depth` does not claim nested-thread evidence; use `reply_to`, `comment_rank`, and `reply_rank` only as display hints within the flat stream.
+- `answer-comments --order score|latest` selects Zhihu's scored or chronological root-comment order
+- `answer-comments --limit` counts unique top-level comment IDs in that root order
+- `answer-comments --replies-limit` expands that many unique replies per root; `0` sends no child-comment requests
+- Comment rows stay flat for table/JSON output, while `parent_id` and `depth` preserve the `comment_v5` reply relationship so callers can rebuild each thread. Pagination is resource-scoped and bounded; malformed or stalled pages fail instead of returning a partial graph.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- move `zhihu answer-comments` from the legacy flat endpoint to the `comment_v5` root/child endpoints;
- add `--order score|latest` while keeping the existing top-level and per-thread limits;
- keep CLI rows flat, but populate `parent_id` from `reply_comment_id` and derive exact, uncapped `depth`, so JSON callers can reconstruct real reply threads;
- reject cyclic, orphaned, duplicate, or unstable comment relationships instead of emitting a silently invalid tree;
- preserve root order, validate every pagination URL against the exact Zhihu resource, and distinguish risk control code `40362` from authentication failures.

The command surface stays the same apart from the optional `--order` argument.

## Retrieval strategy

- Strategy: `PAGE_FETCH`.
- Contract: `internal-unstable`.
- Evidence: direct non-browser retrieval was blocked as abnormal, while logged-in same-origin Browser Bridge requests returned `comment_v5` root/child pagination and stable `reply_comment_id` relationships.
- Why this cost is accepted: the visible UI is lazy and partial, and does not expose a stable complete parent graph or score/latest pagination. Endpoint handling is isolated, every next URL is resource-scoped, and malformed graph data fails explicitly.

## Validation

- `npx vitest run --project adapter clis/zhihu/answer-comments.test.js` — 14 tests passed
- synthetic 12-level reply chain reports depths 1 through 12; cyclic and orphaned relationships are rejected
- `npm test` — 590 files passed; 6737 tests passed, 1 existing skip
- `npm run typecheck`
- `npm run build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `opencli validate zhihu/answer-comments` — 0 errors, 0 warnings
- post-fix live score-order run against the issue answer: 2 roots + 5 replies, 7 unique IDs, 0 orphan parents, 0 depth mismatches
- live latest-order run with `--replies-limit 0`: 2 roots, 0 replies

Refs #2303. Answer Markdown/image export is handled independently in #2304.