### PR TITLE
fix(douyin): restore stats via creator item list after metrics_trend retired

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12731,7 +12731,7 @@
   {
     "site": "douyin",
     "name": "stats",
-    "description": "作品数据分析",
+    "description": "获取单个作品的创作者中心深层指标",
     "access": "read",
     "domain": "creator.douyin.com",
     "strategy": "cookie",

--- a/clis/douyin/stats.js
+++ b/clis/douyin/stats.js
@@ -1,10 +1,39 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { browserFetch } from './_shared/browser-fetch.js';
+
+// The creator item list carries the full per-work metric set (play/completion/
+// bounce/cover/fan metrics) that the retired item_analysis/metrics_trend endpoint
+// used to expose. It is cursor-paginated the same way work_list is.
+const ITEM_LIST_URL = 'https://creator.douyin.com/web/api/creator/item/list';
+const PAGE_SIZE = 50;
+const MAX_HOPS = 50;
+
+export function normalizeAwemeId(raw) {
+    const value = String(raw ?? '').trim();
+    if (!/^\d{16,20}$/.test(value)) {
+        throw new ArgumentError('douyin stats aweme_id must be a 16-20 digit numeric ID');
+    }
+    return value;
+}
+
+export function sameAwemeId(value, target) {
+    if (value == null)
+        return false;
+    const source = String(value);
+    if (source === target)
+        return true;
+    // This endpoint serializes the work id as a JSON number, so the browser's
+    // JSON.parse has already rounded it to IEEE-754 precision before the adapter
+    // sees it. Compare numerically as well so the lookup still resolves.
+    return /^\d+$/.test(source) && Number(source) === Number(target);
+}
+
 cli({
     site: 'douyin',
     name: 'stats',
     access: 'read',
-    description: '作品数据分析',
+    description: '获取单个作品的创作者中心深层指标',
     domain: 'creator.douyin.com',
     strategy: Strategy.COOKIE,
     args: [
@@ -12,17 +41,38 @@ cli({
     ],
     columns: ['metric', 'value'],
     func: async (page, kwargs) => {
-        const now = Math.floor(Date.now() / 1000);
-        const sevenDaysAgo = now - 7 * 86400;
-        const url = 'https://creator.douyin.com/janus/douyin/creator/data/item_analysis/metrics_trend';
-        const body = {
-            aweme_id: kwargs.aweme_id,
-            start_time: sevenDaysAgo,
-            end_time: now,
-            metrics: ['play_count', 'like_count', 'comment_count', 'share_count'],
-        };
-        const res = await browserFetch(page, 'POST', url, { body });
-        const data = res.data ?? {};
-        return Object.entries(data).map(([metric, value]) => ({ metric, value }));
+        const awemeId = normalizeAwemeId(kwargs.aweme_id);
+        let cursor;
+
+        for (let hop = 0; hop < MAX_HOPS; hop++) {
+            const params = new URLSearchParams({
+                count: String(PAGE_SIZE),
+                order_by: '1',
+                fields: 'metrics,review,visibility',
+                need_cooperation: 'true',
+                need_long_article: 'true',
+            });
+            if (cursor !== undefined)
+                params.set('max_cursor', String(cursor));
+
+            const response = await browserFetch(page, 'GET', `${ITEM_LIST_URL}?${params.toString()}`);
+            const item = (response.items ?? []).find((candidate) => sameAwemeId(candidate?.id, awemeId));
+            if (item) {
+                const metrics = item.metrics;
+                if (!metrics || typeof metrics !== 'object' || Array.isArray(metrics)) {
+                    throw new EmptyResultError(`douyin stats ${awemeId}`, 'The work exists, but creator metrics are unavailable');
+                }
+                return Object.entries(metrics).map(([metric, value]) => ({ metric, value }));
+            }
+
+            const nextCursor = response.max_cursor;
+            if (!response.has_more || nextCursor === undefined || nextCursor === null
+                || (cursor !== undefined && String(nextCursor) === String(cursor))) {
+                break;
+            }
+            cursor = nextCursor;
+        }
+
+        throw new EmptyResultError(`douyin stats ${awemeId}`, 'The work was not found in the logged-in creator account');
     },
 });

--- a/clis/douyin/stats.js
+++ b/clis/douyin/stats.js
@@ -2,9 +2,9 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
 import { browserFetch } from './_shared/browser-fetch.js';
 
-// The creator item list carries the full per-work metric set (play/completion/
-// bounce/cover/fan metrics) that the retired item_analysis/metrics_trend endpoint
-// used to expose. It is cursor-paginated the same way work_list is.
+// The creator item list is where the per-work metric set lives: play, completion,
+// 2s bounce, cover impressions/CTR, fan-vs-visitor split and follow conversion,
+// 26 fields in total. It is cursor-paginated the same way work_list is.
 const ITEM_LIST_URL = 'https://creator.douyin.com/web/api/creator/item/list';
 const PAGE_SIZE = 50;
 const MAX_HOPS = 50;

--- a/clis/douyin/stats.test.js
+++ b/clis/douyin/stats.test.js
@@ -1,22 +1,118 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const { browserFetchMock } = vi.hoisted(() => ({
+    browserFetchMock: vi.fn(),
+}));
+vi.mock('./_shared/browser-fetch.js', () => ({
+    browserFetch: browserFetchMock,
+}));
 import { getRegistry } from '@jackwener/opencli/registry';
-import './stats.js';
+import { normalizeAwemeId, sameAwemeId } from './stats.js';
+
+function getCommand() {
+    const command = [...getRegistry().values()].find((cmd) => cmd.site === 'douyin' && cmd.name === 'stats');
+    if (!command?.func)
+        throw new Error('douyin stats command not registered');
+    return command;
+}
+
+// JSON.parse is what actually rounds the id: the endpoint sends it as a number,
+// so the adapter never sees the exact digits. Reproduce that instead of writing
+// an out-of-range numeric literal.
+const parseId = (digits) => JSON.parse(`{"id":${digits}}`).id;
+
+const METRICS = {
+    view_count: '1173',
+    bounce_rate_2s: '0.288638',
+    completion_rate_5s: '0.515173',
+    avg_view_second: '22.987297',
+    cover_show: '5',
+};
+
 describe('douyin stats registration', () => {
     it('registers the stats command', () => {
-        const registry = getRegistry();
-        const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'stats');
-        expect(cmd).toBeDefined();
-        expect(cmd?.args.some(a => a.name === 'aweme_id')).toBe(true);
+        const command = getCommand();
+        expect(command).toBeDefined();
+        expect(command.args.some((a) => a.name === 'aweme_id')).toBe(true);
     });
+
     it('has expected columns', () => {
-        const registry = getRegistry();
-        const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'stats');
-        expect(cmd?.columns).toContain('metric');
-        expect(cmd?.columns).toContain('value');
+        const command = getCommand();
+        expect(command.columns).toContain('metric');
+        expect(command.columns).toContain('value');
     });
+
     it('uses COOKIE strategy', () => {
-        const registry = getRegistry();
-        const cmd = [...registry.values()].find(c => c.site === 'douyin' && c.name === 'stats');
-        expect(cmd?.strategy).toBe('cookie');
+        expect(getCommand().strategy).toBe('cookie');
+    });
+});
+
+describe('douyin stats aweme_id handling', () => {
+    it('rejects non-numeric and out-of-range ids before fetching', () => {
+        expect(normalizeAwemeId('7665918107357121842')).toBe('7665918107357121842');
+        expect(() => normalizeAwemeId('abc')).toThrow('16-20 digit');
+        expect(() => normalizeAwemeId('123')).toThrow('16-20 digit');
+        expect(() => normalizeAwemeId(undefined)).toThrow('16-20 digit');
+    });
+
+    it('matches ids the API already rounded to float64 precision', () => {
+        // The endpoint returns `id` as a JSON number, so 7665918107357121842
+        // arrives as 7665918107357122000 after JSON.parse.
+        expect(sameAwemeId(parseId('7665918107357121842'), '7665918107357121842')).toBe(true);
+        expect(sameAwemeId('7665918107357121842', '7665918107357121842')).toBe(true);
+        expect(sameAwemeId(parseId('7643316353033571594'), '7665918107357121842')).toBe(false);
+        expect(sameAwemeId(null, '7665918107357121842')).toBe(false);
+    });
+});
+
+describe('douyin stats fetching', () => {
+    beforeEach(() => {
+        browserFetchMock.mockReset();
+    });
+
+    it('returns the full metric set as metric/value rows', async () => {
+        browserFetchMock.mockResolvedValueOnce({
+            items: [{ id: parseId('7665918107357121842'), metrics: METRICS }],
+            has_more: false,
+        });
+        const rows = await getCommand().func({}, { aweme_id: '7665918107357121842' });
+        expect(rows).toEqual([
+            { metric: 'view_count', value: '1173' },
+            { metric: 'bounce_rate_2s', value: '0.288638' },
+            { metric: 'completion_rate_5s', value: '0.515173' },
+            { metric: 'avg_view_second', value: '22.987297' },
+            { metric: 'cover_show', value: '5' },
+        ]);
+        expect(browserFetchMock).toHaveBeenCalledTimes(1);
+        const [, method, url] = browserFetchMock.mock.calls[0];
+        expect(method).toBe('GET');
+        expect(url).toContain('/web/api/creator/item/list');
+        expect(url).toContain('fields=metrics');
+    });
+
+    it('walks the cursor until the work is found', async () => {
+        browserFetchMock
+            .mockResolvedValueOnce({ items: [{ id: parseId('1111111111111111111') }], has_more: true, max_cursor: 42 })
+            .mockResolvedValueOnce({ items: [{ id: parseId('7665918107357121842'), metrics: METRICS }], has_more: false });
+        const rows = await getCommand().func({}, { aweme_id: '7665918107357121842' });
+        expect(rows[0]).toEqual({ metric: 'view_count', value: '1173' });
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
+        expect(browserFetchMock.mock.calls[1][2]).toContain('max_cursor=42');
+    });
+
+    it('stops paging when the cursor stops advancing', async () => {
+        browserFetchMock.mockResolvedValue({ items: [], has_more: true, max_cursor: 7 });
+        await expect(getCommand().func({}, { aweme_id: '7665918107357121842' }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('was not found') });
+        // Second hop repeats max_cursor=7, so the walk must stop instead of looping to MAX_HOPS.
+        expect(browserFetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('distinguishes a missing work from a work without metrics', async () => {
+        browserFetchMock.mockResolvedValueOnce({
+            items: [{ id: parseId('7665918107357121842') }],
+            has_more: false,
+        });
+        await expect(getCommand().func({}, { aweme_id: '7665918107357121842' }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('creator metrics are unavailable') });
     });
 });


### PR DESCRIPTION
Fixes #2197.

## The failure

`douyin stats <aweme_id>` fails for every work — any age, any account:

```
Douyin API error 4 at POST https://creator.douyin.com/janus/douyin/creator/data/item_analysis/metrics_trend
```

I replayed that endpoint three ways in a logged-in creator session to check whether it had merely been re-shaped:

| request body | `status_code` |
|---|---|
| `{aweme_id, start_time, end_time, metrics[]}` (current adapter) | 4 |
| `{aweme_id, start_date, end_date}` | 4 |
| `{item_id, start_date, end_date}` | 4 |

Same code every time, so the endpoint is retired rather than moved.

## The replacement

`https://creator.douyin.com/web/api/creator/item/list?fields=metrics,...` still serves what the creator dashboard renders — **26 metrics per work**, a superset of the four counters `metrics_trend` returned:

```
avg_view_proportion, avg_view_second, bounce_rate_2s, comment_count, comment_rate,
completion_rate, completion_rate_5s, cover_click_rate, cover_show, danmaku_count,
dislike_count, dislike_rate, download_count, fan_view_proportion, favorite_count,
favorite_rate, homepage_visit_count, like_count, like_rate, share_count, share_rate,
subscribe_count, subscribe_rate, unsubscribe_count, unsubscribe_rate, view_count
```

It is cursor-paginated the same way `work_list` is, so this walks `max_cursor` and picks the requested work out of the page. Output shape (`{metric, value}` rows) and the `COOKIE` strategy are unchanged.

## Two details worth flagging

**The work id arrives already rounded.** This endpoint serializes `id` as a JSON *number*, so the browser's `JSON.parse` has pushed it past IEEE-754 integer precision before the adapter ever sees it — `7665918107357121842` becomes `7665918107357122000`. A strict string compare misses every lookup, so `sameAwemeId` falls back to a numeric comparison.

**Absent vs. metric-less are now distinguishable.** A work that exists but carries no metrics gets a different `hint` from a work that is not in the account at all, so callers can tell "wrong id / not your work" apart from "no data yet".

## Verification

`clis/douyin/stats.test.js` grows from registration-only assertions to behavioural coverage: full metric passthrough, cursor walking, the stuck-cursor guard, the rounded-id match, and both empty cases.

```
npx vitest run clis/douyin/stats.test.js     →  9 passed
npx vitest run --project adapter             →  503 files, 5338 tests passed
npm run typecheck                            →  clean
```

Also exercised live against a logged-in creator account: 26 metrics returned for a published work, `EMPTY_RESULT` for an unknown id, `ARGUMENT` for a malformed id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)