### PR TITLE
feat(adapters): add Behance search and stabilize Xiaohongshu

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ When the site you need is not yet covered, use the `opencli-adapter-author` skil
 
 | Site | Commands |
 |------|----------|
+| **behance** | `search` |
 | **xiaohongshu** | `search` `ask` `note` `comments` `feed` `user` `download` `publish` `follow` `unfollow` `notifications` `creator-notes` `creator-notes-summary` `creator-note-detail` `creator-profile` `creator-stats` |
 | **bilibili** | `hot` `search` `history` `feed` `ranking` `download` `comments` `dynamic` `favorite` `following` `follow` `unfollow` `me` `subtitle` `summary` `video` `user-videos` |
 | **zhihu** | `hot` `search` `question` `download` `follow` `like` `favorite` `comment` `answer` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,6 +173,7 @@ Browser Bridge daemon 与扩展的通信端口固定为 `localhost:19825`，不�
 
 | 站点 | 命令 |
 |------|------|
+| **behance** | `search` |
 | **xiaohongshu** | `search` `ask` `note` `comments` `notifications` `feed` `user` `saved` `liked` `download` `publish` `follow` `unfollow` `creator-notes` `creator-note-detail` `creator-notes-summary` `creator-profile` `creator-stats` |
 | **bilibili** | `hot` `search` `me` `favorite` `history` `feed` `subtitle` `summary` `video` `comments` `dynamic` `ranking` `following` `follow` `unfollow` `user-videos` `download` |
 | **zhihu** | `hot` `search` `question` `download` `follow` `like` `favorite` `comment` `answer` |

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3483,6 +3483,45 @@
     "sourceFile": "bbc/topic.js"
   },
   {
+    "site": "behance",
+    "name": "search",
+    "description": "搜索 Behance 公开项目案例，返回标题、作者、可见统计、封面与项目链接",
+    "access": "read",
+    "example": "opencli behance search \"industrial brand identity\" --limit 12 -f json",
+    "domain": "www.behance.net",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "设计检索关键词，例如 \"industrial brand identity\""
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "返回项目数量（1-50）"
+      }
+    ],
+    "columns": [
+      "rank",
+      "projectId",
+      "title",
+      "author",
+      "appreciations",
+      "views",
+      "thumbnailUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "behance/search.js",
+    "sourceFile": "behance/search.js"
+  },
+  {
     "site": "bilibili",
     "name": "comment",
     "description": "在 B站视频下发表评论或回复（官方 API，需登录；消息里的 @用户 会被解析为真实提及）",
@@ -44762,6 +44801,7 @@
       "author",
       "likes",
       "published_at",
+      "thumbnailUrl",
       "url"
     ],
     "type": "js",

--- a/clis/behance/search.js
+++ b/clis/behance/search.js
@@ -1,0 +1,252 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+  ArgumentError,
+  CommandExecutionError,
+  EmptyResultError,
+  TimeoutError,
+} from '@jackwener/opencli/errors';
+
+const BASE = 'https://www.behance.net';
+const USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138 Safari/537.36';
+
+function decodeEntities(value) {
+  return String(value ?? '')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function cleanText(value) {
+  return decodeEntities(String(value ?? '').replace(/<[^>]*>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function firstMatch(value, pattern, group = 1) {
+  const match = String(value ?? '').match(pattern);
+  return match ? match[group] : null;
+}
+
+function attributeValue(attributes, name) {
+  const match = String(attributes ?? '').match(
+    new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i'),
+  );
+  return match ? decodeEntities(match[1] ?? match[2] ?? '') : null;
+}
+
+function anchorsIn(html) {
+  return [...String(html ?? '').matchAll(/<a\b([^>]*)>([\s\S]*?)<\/a>/gi)]
+    .map((match) => ({
+      attributes: match[1],
+      body: match[2],
+      href: attributeValue(match[1], 'href'),
+      ariaLabel: attributeValue(match[1], 'aria-label'),
+      titleAttribute: attributeValue(match[1], 'title'),
+      className: attributeValue(match[1], 'class'),
+    }));
+}
+
+function projectTitle(anchor) {
+  const label = cleanText(anchor.ariaLabel || anchor.titleAttribute);
+  if (label && !/^title$/i.test(label)) {
+    const unprefixed = label.replace(
+      /^(?:(?:project\s+link|link\s+to\s+project)|项目的链接)\s*[-—:：]\s*/iu,
+      '',
+    );
+    if (unprefixed !== label || !cleanText(anchor.body)) return unprefixed;
+  }
+  return cleanText(anchor.body);
+}
+
+function toCount(value) {
+  if (!value) return null;
+  const number = Number(String(value).replace(/,/g, ''));
+  return Number.isFinite(number) ? number : null;
+}
+
+function splitProjectCards(html) {
+  const markers = [];
+  const markerPattern = /\brole=["']article["']/gi;
+  let match;
+  while ((match = markerPattern.exec(html)) !== null) markers.push(match.index);
+  return markers.map((start, index) => {
+    const end = index + 1 < markers.length ? markers[index + 1] : html.length;
+    return html.slice(start, end);
+  });
+}
+
+function extractProjectTuples(html) {
+  const tuples = [];
+  const seen = new Set();
+
+  for (const card of splitProjectCards(html)) {
+    const anchors = anchorsIn(card);
+    const projectAnchors = anchors.filter((anchor) =>
+      /(?:^https:\/\/www\.behance\.net)?\/gallery\/\d+\//i.test(anchor.href || ''),
+    );
+    const linkAnchor = projectAnchors[0];
+    const titleAnchor = projectAnchors.find((anchor) => projectTitle(anchor));
+    const href = linkAnchor?.href || '';
+    const path = firstMatch(
+      href,
+      /^(?:https:\/\/www\.behance\.net)?(\/gallery\/(\d+)\/[^?#]+)(?:[?#].*)?$/i,
+      1,
+    );
+    const projectId = firstMatch(href, /\/gallery\/(\d+)\//i);
+    const title = titleAnchor ? projectTitle(titleAnchor) : '';
+    const authorAnchor = anchors.find((anchor) => {
+      if (!anchor.href || /\/gallery\//i.test(anchor.href)) return false;
+      return /\bOwners-owner-/i.test(anchor.className || '')
+        || /(?:\?|&)tracking_source=search_projects(?:%7C|\|)/i.test(anchor.href);
+    });
+
+    if (!path || !projectId || !title || seen.has(projectId)) continue;
+    seen.add(projectId);
+
+    const visibleCounts = [...card.matchAll(
+      /<span[^>]*\btitle=["']([\d,]+)["'][^>]*>/gi,
+    )].map((match) => match[1]);
+    const appreciations = visibleCounts[0] ?? firstMatch(
+      card,
+      /<span[^>]*class="screenReaderOnly"[^>]*>([\d,]+)\s+appreciations?\s+for\b/i,
+    );
+    const views = visibleCounts[1] ?? firstMatch(
+      card,
+      /<span[^>]*class="screenReaderOnly"[^>]*>([\d,]+)\s+views?\s+for\b/i,
+    );
+    const thumbnailUrl = firstMatch(
+      card,
+      /(https:\/\/mir-s3-cdn-cf\.behance\.net\/projects\/404_webp\/[^"'\s,]+)/i,
+    ) ?? firstMatch(
+      card,
+      /(https:\/\/mir-s3-cdn-cf\.behance\.net\/projects\/404\/[^"'\s,]+)/i,
+    );
+
+    tuples.push([
+      projectId,
+      title,
+      authorAnchor ? cleanText(authorAnchor.body) : null,
+      toCount(appreciations),
+      toCount(views),
+      thumbnailUrl ? decodeEntities(thumbnailUrl) : null,
+      new URL(decodeEntities(path), BASE).toString(),
+    ]);
+  }
+
+  return tuples;
+}
+
+const command = cli({
+  site: 'behance',
+  name: 'search',
+  description: '搜索 Behance 公开项目案例，返回标题、作者、可见统计、封面与项目链接',
+  access: 'read',
+  example: 'opencli behance search "industrial brand identity" --limit 12 -f json',
+  domain: 'www.behance.net',
+  strategy: Strategy.PUBLIC,
+  browser: false,
+  args: [
+    {
+      name: 'query',
+      type: 'string',
+      required: true,
+      positional: true,
+      help: '设计检索关键词，例如 "industrial brand identity"',
+    },
+    {
+      name: 'limit',
+      type: 'int',
+      default: 20,
+      help: '返回项目数量（1-50）',
+    },
+  ],
+  columns: [
+    'rank',
+    'projectId',
+    'title',
+    'author',
+    'appreciations',
+    'views',
+    'thumbnailUrl',
+    'url',
+  ],
+  func: async (args) => {
+    const query = String(args.query ?? '').trim();
+    if (!query) throw new ArgumentError('query is required');
+
+    const limit = Number(args.limit ?? 20);
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new ArgumentError('limit must be a positive integer');
+    }
+    if (limit > 50) throw new ArgumentError('limit must be <= 50');
+
+    const url = `${BASE}/search/projects/${encodeURIComponent(query)}`;
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: 'text/html,application/xhtml+xml',
+          'Accept-Language': 'en-US,en;q=0.9',
+          'User-Agent': USER_AGENT,
+        },
+        redirect: 'follow',
+        signal: AbortSignal.timeout(20000),
+      });
+    } catch (error) {
+      if (error?.name === 'TimeoutError' || error?.name === 'AbortError') {
+        throw new TimeoutError('behance search', 20);
+      }
+      throw new CommandExecutionError(
+        `Behance search request failed: ${error?.message || error}`,
+      );
+    }
+    if (!response.ok) {
+      throw new CommandExecutionError(
+        `Behance search request failed: HTTP ${response.status}`,
+      );
+    }
+
+    const html = await response.text();
+    if (/auth\.services\.adobe\.com\/.+profile-chooser/i.test(html)) {
+      throw new CommandExecutionError(
+        'Behance returned an Adobe profile chooser instead of public search results',
+      );
+    }
+
+    const tuples = extractProjectTuples(html);
+    if (tuples.length === 0) {
+      throw new EmptyResultError(
+        'behance search',
+        `No public projects found for "${query}", or the result-card structure changed`,
+      );
+    }
+
+    return tuples.slice(0, limit).map((item, index) => ({
+      rank: index + 1,
+      projectId: item[0],
+      title: item[1],
+      author: item[2],
+      appreciations: item[3],
+      views: item[4],
+      thumbnailUrl: item[5],
+      url: item[6],
+    }));
+  },
+});
+
+export const __test__ = {
+  anchorsIn,
+  attributeValue,
+  command,
+  cleanText,
+  extractProjectTuples,
+  projectTitle,
+  splitProjectCards,
+  toCount,
+};

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -186,6 +186,7 @@ export function buildSearchExtractJs(webHost) {
         const normalizeUrl = (href) => {
           if (!href) return '';
           if (href.startsWith('http://') || href.startsWith('https://')) return href;
+          if (href.startsWith('//')) return 'https:' + href;
           if (href.startsWith('/')) return 'https://${webHost}' + href;
           return '';
         };
@@ -240,6 +241,15 @@ export function buildSearchExtractJs(webHost) {
 
           const url = normalizeUrl(detailLinkEl?.getAttribute('href') || '');
           if (!url) continue;
+          const coverImageEl =
+            detailLinkEl?.querySelector('img[data-xhs-img]') ||
+            detailLinkEl?.querySelector('img');
+          const thumbnailUrl = normalizeUrl(
+            coverImageEl?.currentSrc ||
+            coverImageEl?.getAttribute('src') ||
+            coverImageEl?.getAttribute('data-src') ||
+            ''
+          );
 
           const key = url;
           if (seen.has(key)) continue;
@@ -258,6 +268,7 @@ export function buildSearchExtractJs(webHost) {
             title,
             author,
             likes: cleanText(likesEl?.textContent || '0'),
+            thumbnailUrl: thumbnailUrl || null,
             url,
             author_url: normalizeUrl(authorLinkEl?.getAttribute('href') || ''),
           });
@@ -279,23 +290,36 @@ export const command = cli({
         { name: 'query', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
     ],
-    columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
+    columns: ['rank', 'title', 'author', 'likes', 'published_at', 'thumbnailUrl', 'url'],
     func: async (page, kwargs) => {
         const limit = parseLimit(kwargs.limit);
         const keyword = encodeURIComponent(kwargs.query);
-        await page.goto(`https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
-        // Wait for search results to render (or login wall to appear).
-        // Uses MutationObserver to resolve as soon as content appears,
-        // instead of a fixed delay + blind retry.
-        const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
-        if (waitResult === 'login_wall') {
-            throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
-        }
+        const searchUrl = `https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`;
+        const navigateAndWait = async (url) => {
+            await page.goto(url);
+            // Wait for search results to render (or login wall to appear).
+            // Uses MutationObserver to resolve as soon as content appears,
+            // instead of a fixed delay + blind retry.
+            const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
+            if (waitResult === 'login_wall') {
+                throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
+            }
+            return waitResult;
+        };
+        const initialWaitResult = await navigateAndWait(searchUrl);
         // Extract before scrolling. Xiaohongshu uses a virtualized masonry
         // layout, so scrolling to the bottom can evict the initially visible
         // note cards from the DOM and make extraction return [] even though the
         // browser rendered results correctly.
-        const initialPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'initial extraction');
+        let initialPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'initial extraction');
+        if (initialWaitResult === 'timeout' && initialPayload.length === 0) {
+            // Reusing the same browser tab can occasionally leave Xiaohongshu
+            // on an empty intermediate render even though the same query works
+            // immediately afterward. Force one real navigation before treating
+            // the response as a legitimate empty result.
+            await navigateAndWait(`${searchUrl}&opencli_retry=${Date.now()}`);
+            initialPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'retry extraction');
+        }
         const payload = [...initialPayload];
         if (payload.length < limit) {
             // Scroll until enough rows are rendered or the lazy-load plateaus.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -106,6 +106,7 @@ export default defineConfig({
                 { text: 'Upwork', link: '/adapters/browser/upwork' },
                 { text: 'Instagram', link: '/adapters/browser/instagram' },
                 { text: 'Pinterest', link: '/adapters/browser/pinterest' },
+                { text: 'Behance', link: '/adapters/browser/behance' },
                 { text: 'JD.com', link: '/adapters/browser/jd' },
                 { text: 'Medium', link: '/adapters/browser/medium' },
                 { text: 'Mercury', link: '/adapters/browser/mercury' },

--- a/docs/adapters/browser/behance.md
+++ b/docs/adapters/browser/behance.md
@@ -1,0 +1,43 @@
+# Behance
+
+**Mode**: 🌐 Public · **Domain**: `behance.net`
+
+Search public Behance projects without a browser session or Adobe login.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli behance search <query>` | Search public projects and return visible project-card metadata |
+
+## Usage Examples
+
+```bash
+# Search for brand identity projects
+opencli behance search "brand identity" --limit 12
+
+# Machine-readable output
+opencli behance search "industrial branding" --limit 5 -f json
+```
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `rank` | 1-indexed result position |
+| `projectId` | Stable Behance project ID |
+| `title` | Project title |
+| `author` | Visible owner name when the card exposes one; otherwise `null` |
+| `appreciations` | Visible appreciation count |
+| `views` | Visible view count |
+| `thumbnailUrl` | Project cover image URL when available |
+| `url` | Canonical Behance project URL without tracking parameters |
+
+## Arguments
+
+- `<query>` is required and positional.
+- `--limit` accepts an integer from 1 to 50 and defaults to 20.
+
+## Prerequisites
+
+- No browser or login required. The adapter reads the public server-rendered search page.

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -6,7 +6,7 @@
 
 | Command | Description |
 |---------|-------------|
-| `opencli xiaohongshu search` | Search notes by keyword (returns title, author, likes, URL) |
+| `opencli xiaohongshu search` | Search notes by keyword (returns title, author, likes, thumbnail, URL) |
 | `opencli xiaohongshu ask` | Ask 点点 and return its answer with citation sources (`sources[]` in JSON) |
 | `opencli xiaohongshu note` | Read full note content (title, author, description, likes, collects, comments, tags) |
 | `opencli xiaohongshu comments` | Read comments from a note (`--with-replies` for nested 楼中楼 replies) |

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -103,6 +103,7 @@ Run `opencli list` for the live registry.
 | Site                                           | Commands                                                                                                                                       | Mode         |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | **[hackernews](./browser/hackernews.md)**         | `top` `new` `best` `ask` `show` `jobs` `search` `user`                                                                                         | 🌐 Public    |
+| **[behance](./browser/behance.md)**               | `search`                                                                                                                                       | 🌐 Public    |
 | **[bbc](./browser/bbc.md)**                       | `news`                                                                                                                                         | 🌐 Public    |
 | **[devto](./browser/devto.md)**                   | `top` `tag` `user`                                                                                                                             | 🌐 Public    |
 | **[juejin](./browser/juejin.md)**                 | `recommend` `hot`                                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
## Description

Adds a built-in public `behance/search` adapter and stabilizes `xiaohongshu/search` for Brand Desk and other design-research workflows.

- Behance now parses current SSR project cards from stable gallery links, tolerates localized labels and attribute-order changes, and returns IDs, titles, counts, thumbnails, and canonical URLs.
- Xiaohongshu now retries once only when the initial content wait times out and extraction is empty, preserving login-wall and legitimate content-empty behavior. It also normalizes protocol-relative URLs and exposes rendered thumbnails.

Closes #2314
Closes #2313

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Added doc page under `docs/adapters/`
- [x] Updated `docs/adapters/index.md` table
- [x] Updated sidebar in `docs/.vitepress/config.mts`
- [x] Updated `README.md` / `README.zh-CN.md`
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

The generated `cli-manifest.json` is committed and matches a clean `npm run build`.

## Verification

- `npm run build` — passed; manifest compiled with 1,332 entries
- `npm run typecheck` — passed
- `npm test` — 590 files passed; 6,738 tests passed; 1 skipped
- `npm run check:typed-error-lint` — no new violations
- `npm run check:silent-column-drop` — no new violations
- `bash scripts/check-doc-coverage.sh --strict` — 177/177 adapters documented
- `npm run docs:build` — passed
- `opencli validate behance/search` — passed
- `opencli validate xiaohongshu/search` — passed
- Direct upstream-source Behance query returned 3 populated rows
- Live Xiaohongshu query returned 3 populated rows including thumbnails
- Four-source Brand Desk run completed with 12/12 rows and all sources `ok`

## Strategy notes

**Behance:** public SSR HTML, no auth. The user-visible project-card contract is used because the observed internal GraphQL endpoint returned 403; no private endpoint is replayed.

**Xiaohongshu:** logged-in visible DOM via the existing COOKIE strategy. The retry is bounded to one cache-busted navigation and only triggers after a wait timeout plus empty initial extraction.
