### PR TITLE
fix(xiaohongshu): scope note title/desc/author to #noteContainer

### DIFF
--- a/clis/xiaohongshu/note.js
+++ b/clis/xiaohongshu/note.js
@@ -32,11 +32,16 @@ export const NOTE_EXTRACT_JS = `
         // .title and reported an unrelated recommendation card's title as this
         // note's title. Same class of bug as the .interact-container scoping
         // below.
-        const scope = document.querySelector('#noteContainer') || document
-
-        const title = clean(scope.querySelector('#detail-title, .title'))
-        const desc = clean(scope.querySelector('#detail-desc, .desc, .note-text'))
-        const author = clean(scope.querySelector('.username, .author-wrapper .name'))
+        const scope = document.querySelector('#noteContainer')
+        const title = scope
+          ? clean(scope.querySelector('#detail-title, .title'))
+          : clean(document.querySelector('#detail-title'))
+        const desc = scope
+          ? clean(scope.querySelector('#detail-desc, .desc, .note-text'))
+          : clean(document.querySelector('#detail-desc, .note-text'))
+        const author = scope
+          ? clean(scope.querySelector('.username, .author-wrapper .name'))
+          : clean(document.querySelector('.username, .author-wrapper .name'))
         // Scope to .interact-container — the post's main interaction bar.
         // Without scoping, .like-wrapper / .chat-wrapper also match each
         // comment's like/reply buttons in the comment section, and

--- a/clis/xiaohongshu/note.js
+++ b/clis/xiaohongshu/note.js
@@ -24,9 +24,19 @@ export const NOTE_EXTRACT_JS = `
 
         const clean = (el) => (el?.textContent || '').replace(/\\s+/g, ' ').trim()
 
-        const title = clean(document.querySelector('#detail-title, .title'))
-        const desc = clean(document.querySelector('#detail-desc, .desc, .note-text'))
-        const author = clean(document.querySelector('.username, .author-wrapper .name'))
+        // Scope the note's own fields to #noteContainer — the detail panel.
+        // The page also renders a recommendation feed next to the note, and
+        // every card in that feed carries a .title. querySelector returns the
+        // FIRST match in document order, so for a note that has no title of
+        // its own (#detail-title absent) the unscoped selector fell through to
+        // .title and reported an unrelated recommendation card's title as this
+        // note's title. Same class of bug as the .interact-container scoping
+        // below.
+        const scope = document.querySelector('#noteContainer') || document
+
+        const title = clean(scope.querySelector('#detail-title, .title'))
+        const desc = clean(scope.querySelector('#detail-desc, .desc, .note-text'))
+        const author = clean(scope.querySelector('.username, .author-wrapper .name'))
         // Scope to .interact-container — the post's main interaction bar.
         // Without scoping, .like-wrapper / .chat-wrapper also match each
         // comment's like/reply buttons in the comment section, and
@@ -83,8 +93,8 @@ export const command = cli({
         // XHS renders placeholder text like "赞"/"收藏"/"评论" when count is 0;
         // normalize to '0' unless the value looks numeric.
         const numOrZero = (v) => /^\d+/.test(v) ? v : '0';
-        // Title + author are always present on a real note page.
-        // If both are missing, the page likely failed to load properly.
+        // A note may legitimately have no title, but a real note page always
+        // renders an author. If both are missing, the page failed to load.
         if (!d.title && !d.author) {
             throw new EmptyResultError('xiaohongshu/note', 'The note page loaded without visible content. The note may be deleted or restricted.');
         }

--- a/clis/xiaohongshu/note.test.js
+++ b/clis/xiaohongshu/note.test.js
@@ -1,7 +1,38 @@
+import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { parseNoteId, buildNoteUrl } from './note-helpers.js';
-import './note.js';
+import { NOTE_EXTRACT_JS } from './note.js';
+
+function runExtract(html) {
+    const dom = new JSDOM(html, {
+        url: 'https://www.xiaohongshu.com/explore/69c131c9000000002800be4c?xsec_token=abc',
+        runScripts: 'outside-only',
+    });
+    return dom.window.eval(NOTE_EXTRACT_JS);
+}
+
+const RECOMMEND_FEED = `
+    <div class="feeds-container">
+      <section class="note-item"><a class="title"><span>不懂为什么...</span></a></section>
+      <section class="note-item"><a class="title"><span>另一篇推荐笔记</span></a></section>
+    </div>`;
+
+function notePage({ title = '', desc = '正文在这里', author = '芭比 Q' } = {}) {
+    return `<!doctype html><html><body>
+      <div id="noteContainer">
+        <div class="author-wrapper"><span class="username">${author}</span></div>
+        ${title ? `<div id="detail-title">${title}</div>` : ''}
+        <div id="detail-desc">${desc}</div>
+        <div class="interact-container">
+          <span class="like-wrapper"><span class="count">10</span></span>
+          <span class="collect-wrapper"><span class="count">1</span></span>
+          <span class="chat-wrapper"><span class="count">15</span></span>
+        </div>
+      </div>
+      ${RECOMMEND_FEED}
+    </body></html>`;
+}
 function createPageMock(evaluateResult) {
     return {
         goto: vi.fn().mockResolvedValue(undefined),
@@ -245,5 +276,35 @@ describe('xiaohongshu note', () => {
         }));
         expect(result.find((r) => r.field === 'tags')).toBeUndefined();
         expect(result).toHaveLength(6);
+    });
+});
+
+describe('NOTE_EXTRACT_JS', () => {
+    it('reports an empty title for a note that has none, ignoring recommendation cards', () => {
+        const d = runExtract(notePage());
+        // Regression: the unscoped '#detail-title, .title' selector used to fall
+        // through to the recommendation feed and return '不懂为什么...' here.
+        expect(d.title).toBe('');
+        expect(d.desc).toBe('正文在这里');
+        expect(d.author).toBe('芭比 Q');
+        expect(d.likes).toBe('10');
+        expect(d.collects).toBe('1');
+        expect(d.comments).toBe('15');
+    });
+
+    it('still reads the note title when the note has one', () => {
+        const d = runExtract(notePage({ title: '尚界Z7实车体验' }));
+        expect(d.title).toBe('尚界Z7实车体验');
+        expect(d.author).toBe('芭比 Q');
+    });
+
+    it('falls back to document scope when #noteContainer is absent', () => {
+        const d = runExtract(`<!doctype html><html><body>
+          <div id="detail-title">老版布局</div>
+          <div id="detail-desc">正文</div>
+          <div class="author-wrapper"><span class="username">作者</span></div>
+        </body></html>`);
+        expect(d.title).toBe('老版布局');
+        expect(d.author).toBe('作者');
     });
 });

--- a/clis/xiaohongshu/note.test.js
+++ b/clis/xiaohongshu/note.test.js
@@ -307,4 +307,19 @@ describe('NOTE_EXTRACT_JS', () => {
         expect(d.title).toBe('老版布局');
         expect(d.author).toBe('作者');
     });
+
+    it('does not use document-level recommendation title or desc when #noteContainer is absent', () => {
+        const d = runExtract(`<!doctype html><html><body>
+          <div class="feeds-container">
+            <section class="note-item">
+              <a class="title"><span>推荐卡片标题</span></a>
+              <div class="desc">推荐卡片正文</div>
+            </section>
+          </div>
+          <div class="author-wrapper"><span class="username">作者</span></div>
+        </body></html>`);
+        expect(d.title).toBe('');
+        expect(d.desc).toBe('');
+        expect(d.author).toBe('作者');
+    });
 });


### PR DESCRIPTION
## The bug

`xiaohongshu note` can report a title that belongs to a completely different note.

Running it twice on the same note (`6a872390000000001d01dbdc`, which has no title of its own) returned two different, unrelated titles:

```text
run 1 -> title: 以后还能用什么。？
run 2 -> title: 粉笔能不能和qingqu用品一样保密发货
```

Neither belongs to that note. Both are titles of cards in the recommendation feed rendered next to the note.

## Root cause

```js
const title = clean(document.querySelector('#detail-title, .title'))
```

The selector runs against the whole document. On a note detail page I counted 50 elements matching `.title` - the recommendation feed cards. When the note has no title, `#detail-title` is absent, the selector falls through to `.title`, and `querySelector` returns the first match in document order: a recommendation card.

This is the same class of bug already fixed a few lines below for the counts, with the reasoning spelled out in the existing comment:

```js
// Scope to .interact-container - the post's main interaction bar.
// Without scoping, .like-wrapper / .chat-wrapper also match each
// comment's like/reply buttons in the comment section ...
```

`title` / `desc` / `author` were left unscoped.

## Fix

Scope those three to `#noteContainer`, the note detail panel. For older layouts without `#noteContainer`, keep a narrow document fallback for stable detail selectors, but do **not** allow document-level `.title` or `.desc` to match recommendation cards.

`clis/rednote/note.js` reuses `NOTE_EXTRACT_JS`, so it picks up the same fix.

## Tests

Adds JSDOM regression tests for `NOTE_EXTRACT_JS`:

- untitled note + recommendation feed -> `title === ''`
- titled note -> title still read correctly
- page without `#noteContainer` -> safe detail ID fallback still works
- page without `#noteContainer` + recommendation `.title/.desc` -> title/content stay empty rather than leaking recommendation data

Verification:

- `npx vitest run clis/xiaohongshu/note.test.js` -> 28/28 passing.
- `npm run build` -> PASS, manifest 1331 entries.
- `node dist/src/main.js validate xiaohongshu` -> PASS, 25 commands.
- `git diff --check` -> PASS.
