### PR TITLE
harden: sanitize child_process call in spotify.js...

### DIFF
--- a/clis/spotify/spotify.js
+++ b/clis/spotify/spotify.js
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { createServer } from 'http';
 import { homedir } from 'os';
 import { join } from 'path';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { assertSpotifyCredentialsConfigured, getFirstSpotifyTrack, mapSpotifyTrackResults, parseDotEnv, resolveSpotifyCredentials, } from './utils.js';
 // ── Credentials ───────────────────────────────────────────────────────────────
 // Set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET as environment variables,
@@ -99,8 +99,13 @@ async function findTrackUri(query) {
     return track;
 }
 function openBrowser(url) {
-    const cmd = process.platform === 'win32' ? `start "" "${url}"` : process.platform === 'darwin' ? `open "${url}"` : `xdg-open "${url}"`;
-    exec(cmd);
+    if (process.platform === 'win32') {
+        execFile('cmd', ['/c', 'start', '', url]);
+    } else if (process.platform === 'darwin') {
+        execFile('open', [url]);
+    } else {
+        execFile('xdg-open', [url]);
+    }
 }
 // ── Commands ──────────────────────────────────────────────────────────────────
 cli({


### PR DESCRIPTION
## Summary
Harden input handling in `clis/spotify/spotify.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `clis/spotify/spotify.js:103` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `url`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `clis/spotify/spotify.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
