### PR TITLE
fix(adapter): copy shared deps on eject

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
 import { cli, getRegistry, Strategy } from './registry.js';
 import { BrowserCommandError } from './browser/daemon-client.js';
@@ -1036,6 +1037,62 @@ describe('browser verify', () => {
       if (originalUserProfile === undefined) delete process.env.USERPROFILE;
       else process.env.USERPROFILE = originalUserProfile;
       fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('adapter eject', () => {
+  it('copies repo-level shared imports so an ejected adapter can load', async () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-adapter-eject-home-'));
+    const fakePackage = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-adapter-eject-package-'));
+    const builtinClis = path.join(fakePackage, 'clis');
+    const userClis = path.join(fakeHome, '.opencli', 'clis');
+    vi.mocked(console.log).mockClear();
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+
+    try {
+      fs.mkdirSync(path.join(builtinClis, '_shared'), { recursive: true });
+      fs.mkdirSync(path.join(builtinClis, 'demo'), { recursive: true });
+      fs.writeFileSync(
+        path.join(builtinClis, '_shared', 'helper.js'),
+        "import { nestedValue } from './nested.js';\nexport const sharedValue = nestedValue;\n",
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(builtinClis, '_shared', 'nested.js'),
+        'export const nestedValue = 42;\n',
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(builtinClis, '_shared', 'unused.js'),
+        'export const unused = true;\n',
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(builtinClis, 'demo', 'command.js'),
+        "export * as shared from '../_shared/helper.js';\n",
+        'utf-8',
+      );
+
+      const program = createProgram(builtinClis, userClis);
+      await program.parseAsync(['node', 'opencli', 'adapter', 'eject', 'demo']);
+
+      const ejectedCommand = path.join(userClis, 'demo', 'command.js');
+      const module = await import(`${pathToFileURL(ejectedCommand).href}?t=${Date.now()}`);
+      expect(module.shared.sharedValue).toBe(42);
+      expect(fs.existsSync(path.join(userClis, '_shared', 'helper.js'))).toBe(true);
+      expect(fs.existsSync(path.join(userClis, '_shared', 'nested.js'))).toBe(true);
+      expect(fs.existsSync(path.join(userClis, '_shared', 'unused.js'))).toBe(false);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+      fs.rmSync(fakePackage, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,6 +104,80 @@ export function selectFreshByTimestamp<T extends { timestamp?: unknown }>(
   return { fresh, lastSeenTs: nextSeenTs };
 }
 
+const STATIC_IMPORT_SPECIFIER_RE = /^\s*(?:import\s+(?:[^;]*?\s+from\s*)?|export\s+(?:\*(?:\s+as\s+[\w$]+)?|{[^;]*?})\s+from\s*)['"]([^'"]+)['"]/gm;
+const DYNAMIC_IMPORT_SPECIFIER_RE = /(?:^|[^\w$])import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function isPathInside(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function listJsFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listJsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function extractImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const pattern of [STATIC_IMPORT_SPECIFIER_RE, DYNAMIC_IMPORT_SPECIFIER_RE]) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      specifiers.push(match[1]);
+    }
+  }
+  return specifiers;
+}
+
+function resolveImportTarget(importerPath: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(importerPath), specifier);
+  const candidates = path.extname(base) ? [base] : [base, `${base}.js`, path.join(base, 'index.js')];
+  return candidates.find(candidate => fs.existsSync(candidate)) ?? base;
+}
+
+function collectRepoSharedDependencies(entryDir: string, sharedDir: string): string[] {
+  const pending = listJsFiles(entryDir);
+  const seenFiles = new Set<string>();
+  const sharedDeps = new Set<string>();
+
+  for (let index = 0; index < pending.length; index += 1) {
+    const filePath = pending[index];
+    if (seenFiles.has(filePath)) continue;
+    seenFiles.add(filePath);
+
+    const source = fs.readFileSync(filePath, 'utf-8');
+    for (const specifier of extractImportSpecifiers(source)) {
+      const resolved = resolveImportTarget(filePath, specifier);
+      if (!resolved || !isPathInside(resolved, sharedDir)) continue;
+      sharedDeps.add(resolved);
+      if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) pending.push(resolved);
+      else if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) pending.push(...listJsFiles(resolved));
+    }
+  }
+
+  return [...sharedDeps].sort();
+}
+
+function copyEjectedRepoSharedDependencies(builtinSiteDir: string, builtinSharedDir: string, userClisDir: string): void {
+  const sharedDeps = collectRepoSharedDependencies(builtinSiteDir, builtinSharedDir);
+  for (const source of sharedDeps) {
+    const relative = path.relative(builtinSharedDir, source);
+    const target = path.join(userClisDir, '_shared', relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.cpSync(source, target, { recursive: true });
+  }
+}
+
 /**
  * Normalize raw capture entries (from daemon/CDP `readNetworkCapture` or
  * the JS interceptor's `window.__opencli_net`) into a consistent shape.
@@ -3237,6 +3311,7 @@ cli({
       const os = await import('node:os');
       const userClisDir = path.join(os.homedir(), '.opencli', 'clis');
       const builtinSiteDir = path.join(BUILTIN_CLIS, site);
+      const builtinSharedDir = path.join(BUILTIN_CLIS, '_shared');
       const userSiteDir = path.join(userClisDir, site);
 
       try {
@@ -3255,6 +3330,7 @@ cli({
       } catch { /* good, doesn't exist yet */ }
 
       fs.cpSync(builtinSiteDir, userSiteDir, { recursive: true });
+      copyEjectedRepoSharedDependencies(builtinSiteDir, builtinSharedDir, userClisDir);
       console.log(`✅ Ejected "${site}" to ~/.opencli/clis/${site}/`);
       console.log('You can now edit the adapter files. Changes take effect immediately.');
       console.log('Note: Official updates to this adapter will overwrite your changes.');


### PR DESCRIPTION
## Summary
- fix `opencli adapter eject <site>` so ejected adapters copy the repo-level `clis/_shared` files they actually import
- resolve shared dependencies from real static/dynamic import specifiers instead of copying all `_shared` files
- recurse through shared-file imports so transitive `_shared -> _shared` dependencies are copied too
- cover namespace re-export syntax (`export * as ns from ...`) and add a regression that ejects into an isolated HOME and dynamically imports the ejected adapter, proving module resolution works after eject

Fixes #2320.

## Validation
- `npx vitest run src/cli.test.ts -t "adapter eject"`
- `HOME=/tmp/opencli-cli-test-home-307 USERPROFILE=/tmp/opencli-cli-test-home-307 OPENCLI_CACHE_DIR=/tmp/opencli-cli-test-cache-307b npx vitest run src/cli.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `node dist/src/main.js validate`

Note: running `npx vitest run src/cli.test.ts` without an isolated HOME on this machine picks up my local default browser profile and fails six pre-existing browser-tab expectations around `preferredContextId`; the same file passes 167/167 with isolated HOME/cache.