### PR TITLE
chore(core): remove dead internal symbols

### DIFF
--- a/src/browser/bridge.ts
+++ b/src/browser/bridge.ts
@@ -2,7 +2,6 @@
  * Browser session manager — auto-spawns daemon and provides IPage.
  */
 
-import type { ChildProcess } from 'node:child_process';
 import type { IPage } from '../types.js';
 import type { IBrowserFactory } from '../runtime.js';
 import { Page } from './page.js';
@@ -19,7 +18,6 @@ export type BrowserBridgeState = 'idle' | 'connecting' | 'connected' | 'closing'
 export class BrowserBridge implements IBrowserFactory {
   private _state: BrowserBridgeState = 'idle';
   private _page: Page | null = null;
-  private _daemonProc: ChildProcess | null = null;
 
   get state(): BrowserBridgeState {
     return this._state;
@@ -62,11 +60,10 @@ export class BrowserBridge implements IBrowserFactory {
   }
 
   private async _ensureDaemon(timeoutSeconds?: number, contextId?: string, preferredContextId?: string): Promise<void> {
-    const result = await ensureBrowserBridgeReady({
+    await ensureBrowserBridgeReady({
       timeoutSeconds: timeoutSeconds ?? Math.ceil(DAEMON_SPAWN_TIMEOUT / 1000),
       contextId,
       preferredContextId,
     });
-    this._daemonProc = result.spawnedProcess;
   }
 }

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -428,20 +428,17 @@ describe('daemon-client', () => {
 
   function mockEnsureReady(extensionVersion?: string) {
     return vi.spyOn(daemonLifecycle, 'ensureBrowserBridgeReady').mockResolvedValue({
-      health: {
-        state: 'ready',
-        status: {
-          ok: true,
-          pid: 1,
-          uptime: 1,
-          extensionConnected: true,
-          ...(extensionVersion && { extensionVersion }),
-          pending: 0,
-          memoryMB: 0,
-          port: 19825,
-        },
+      state: 'ready',
+      status: {
+        ok: true,
+        pid: 1,
+        uptime: 1,
+        extensionConnected: true,
+        ...(extensionVersion && { extensionVersion }),
+        pending: 0,
+        memoryMB: 0,
+        port: 19825,
       },
-      spawnedProcess: null,
     });
   }
 

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -350,7 +350,7 @@ async function sendCommandRaw(
     // Bound the connect wait by the command's remaining budget so repeated
     // daemon failures cannot stretch the total wall time far past --timeout.
     const remainingSeconds = Math.ceil((deadlineAt - Date.now()) / 1000);
-    const ready = await ensureBrowserBridgeReady({
+    const health = await ensureBrowserBridgeReady({
       timeoutSeconds: Math.max(1, Math.min(DEFAULT_BROWSER_CONNECT_TIMEOUT, remainingSeconds)),
       // Only an explicit requirement pins readiness to a specific profile; a
       // preferred one is arbitrated against live connections on every poll,
@@ -360,7 +360,7 @@ async function sendCommandRaw(
       preferredContextId,
       verbose: false,
     });
-    executorJournaled = versionAtLeast(ready.health.status?.extensionVersion, MIN_JOURNAL_EXTENSION_VERSION);
+    executorJournaled = versionAtLeast(health.status?.extensionVersion, MIN_JOURNAL_EXTENSION_VERSION);
   };
 
   for (let attempt = 1; attempt <= TRANSPORT_MAX_ATTEMPTS; attempt++) {

--- a/src/browser/daemon-lifecycle.ts
+++ b/src/browser/daemon-lifecycle.ts
@@ -21,11 +21,6 @@ export interface DaemonRestartResult {
   spawned: boolean;
 }
 
-export interface EnsureBrowserBridgeReadyResult {
-  health: DaemonHealth;
-  spawnedProcess: ChildProcess | null;
-}
-
 export function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const parentDir = path.resolve(__dirname, '..');
@@ -95,7 +90,7 @@ export async function restartDaemon(opts: { stopTimeoutMs?: number; startTimeout
 
 export async function ensureBrowserBridgeReady(
   opts: { timeoutSeconds?: number; contextId?: string; preferredContextId?: string; verbose?: boolean } = {},
-): Promise<EnsureBrowserBridgeReadyResult> {
+): Promise<DaemonHealth> {
   const timeoutSeconds = opts.timeoutSeconds && opts.timeoutSeconds > 0 ? opts.timeoutSeconds : 10;
   const timeoutMs = timeoutSeconds * 1000;
   const verbose = opts.verbose ?? true;
@@ -106,7 +101,6 @@ export async function ensureBrowserBridgeReady(
   const daemonVersion = health.status?.daemonVersion;
   const isStale = !!health.status && (!daemonVersion || daemonVersion !== PKG_VERSION);
   let staleDaemonReplaced = false;
-  let spawnedProcess: ChildProcess | null = null;
 
   if (isStale) {
     const reason = daemonVersion
@@ -142,7 +136,7 @@ export async function ensureBrowserBridgeReady(
   }
 
   if (!staleDaemonReplaced && health.state === 'ready') {
-    return { health, spawnedProcess };
+    return health;
   }
 
   if (!staleDaemonReplaced && health.state === 'profile-required') {
@@ -153,14 +147,14 @@ export async function ensureBrowserBridgeReady(
     if (verbose && (process.env.OPENCLI_VERBOSE || process.stderr.isTTY)) {
       process.stderr.write('⏳ Starting daemon...\n');
     }
-    spawnedProcess = daemonLifecycleHooks.spawnDaemonProcess();
+    daemonLifecycleHooks.spawnDaemonProcess();
   } else if (verbose && (process.env.OPENCLI_VERBOSE || process.stderr.isTTY)) {
     process.stderr.write('⏳ Waiting for Chrome/Chromium extension to connect...\n');
     process.stderr.write('   Make sure Chrome or Chromium is open and the OpenCLI extension is enabled.\n');
   }
 
   const finalHealth = await waitForBridgeReady(getDaemonHealth, { timeoutMs, contextId, preferredContextId });
-  if (finalHealth.state === 'ready') return { health: finalHealth, spawnedProcess };
+  if (finalHealth.state === 'ready') return finalHealth;
   throw browserConnectErrorFromHealth(finalHealth, contextId);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -884,7 +884,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     .argument('[target]', 'site or site/name')
     .action(async (target) => {
       const { validateClisWithTarget, renderValidationReport } = await import('./validate.js');
-      console.log(renderValidationReport(validateClisWithTarget([BUILTIN_CLIS, USER_CLIS], target)));
+      console.log(renderValidationReport(validateClisWithTarget(target)));
     });
 
   program
@@ -1233,7 +1233,7 @@ Examples:
   // ── Navigation ──
 
   addBrowserTabOption(browser.command('open').argument('<url>').description('Open URL in the browser session'))
-    .action(browserAction(async (page, url, opts) => {
+    .action(browserAction(async (page, url) => {
       // Start session-level capture before navigation (catches initial requests)
       const hasSessionCapture = await page.startNetworkCapture?.() ?? false;
       await page.goto(url);
@@ -1252,7 +1252,7 @@ Examples:
     }));
 
   addBrowserTabOption(browser.command('back').description('Go back in browser history'))
-    .action(browserAction(async (page, opts) => {
+    .action(browserAction(async (page) => {
       await page.evaluate('history.back()');
       await page.wait(2);
       console.log('Navigated back');

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -23,7 +23,6 @@ import {
   formatSiteCommandDescription,
   formatSiteHelpText,
   getRequestedHelpFormat,
-  installStructuredHelp,
   renderStructuredHelp,
   siteHelpData,
 } from './help.js';

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -10,7 +10,6 @@ import { Readable, Transform } from 'node:stream';
 import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import { pipeline } from 'node:stream/promises';
 import { URL } from 'node:url';
-import type { ProgressBar } from './progress.js';
 import { isBinaryInstalled } from '../external.js';
 import type { BrowserCookie } from '../types.js';
 import { getErrorMessage } from '../errors.js';

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,6 @@ import { isSupportedNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './runtime-dete
 import { isIgnorableDaemonPortEnv, unsupportedDaemonPortEnvMessage } from './constants.js';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 // Adapters are JS-first and live at <package-root>/clis/.
 // Use findPackageRoot so the path works both in dev (src/main.ts) and prod (dist/src/main.js).
 const BUILTIN_CLIS = path.join(findPackageRoot(__filename), 'clis');

--- a/src/node-network.ts
+++ b/src/node-network.ts
@@ -185,7 +185,7 @@ export function decideProxy(url: URL, env: NodeJS.ProcessEnv = process.env): Pro
   return { mode: 'proxy', proxyUrl };
 }
 
-export function getDispatcherForUrl(url: URL, env: NodeJS.ProcessEnv = process.env): Dispatcher {
+export function getNetworkDispatcher(env: NodeJS.ProcessEnv = process.env): Dispatcher {
   const config = resolveProxyConfig(env);
   if (!config.httpProxy && !config.httpsProxy) return directDispatcher;
   return createProxyDispatcher(config);
@@ -199,7 +199,7 @@ export async function fetchWithNodeNetwork(input: RequestInfo | URL, init: Reque
 
   return (await undiciFetch(input as Parameters<typeof undiciFetch>[0], {
     ...init,
-    dispatcher: getDispatcherForUrl(url),
+    dispatcher: getNetworkDispatcher(),
   } as Parameters<typeof undiciFetch>[1])) as unknown as Response;
 }
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -38,7 +38,7 @@ export function render(data: unknown, opts: RenderOptions = {}): void {
   }
   switch (fmt) {
     case 'json': renderJson(data); break;
-    case 'plain': renderPlain(data, opts); break;
+    case 'plain': renderPlain(data); break;
     case 'md': case 'markdown': renderMarkdown(data, opts); break;
     case 'csv': renderCsv(data, opts); break;
     case 'yaml': case 'yml': renderYaml(data); break;
@@ -80,7 +80,7 @@ function renderTable(data: unknown, opts: RenderOptions): void {
 function renderJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
 }
-function renderPlain(data: unknown, opts: RenderOptions): void {
+function renderPlain(data: unknown): void {
   const rows = normalizeRows(data);
   if (!rows.length) return;
 

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -44,7 +44,7 @@ export async function executePipeline(
           );
         }
 
-        if (debug) debugStepResult(op, data);
+        if (debug) debugStepResult(data);
       }
     }
   } catch (err) {
@@ -93,7 +93,7 @@ function debugStepStart(stepNum: number, total: number, op: string, params: unkn
   log.step(stepNum, total, op, preview);
 }
 
-function debugStepResult(op: string, data: unknown): void {
+function debugStepResult(data: unknown): void {
   if (data === null || data === undefined) {
     log.stepResult('(no data)');
   } else if (Array.isArray(data)) {

--- a/src/pipeline/steps/download.ts
+++ b/src/pipeline/steps/download.ts
@@ -10,7 +10,6 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import type { IPage } from '../../types.js';
 import { render } from '../template.js';
 import { getErrorMessage } from '../../errors.js';

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -42,7 +42,7 @@ describe('validate.ts pipeline step allowlist', () => {
     });
 
     try {
-      const report = validateClisWithTarget([], 'validate-allowlist-test/all-steps');
+      const report = validateClisWithTarget('validate-allowlist-test/all-steps');
       const r = report.results[0];
       const unknownStepWarning = r.warnings.find(w => w.startsWith('Pipeline step '));
       expect(unknownStepWarning).toBeUndefined();
@@ -77,7 +77,7 @@ describe('validate.ts pipeline step allowlist', () => {
       });
 
       try {
-        const report = validateClisWithTarget([], 'validate-dynamic-test/uses-custom');
+        const report = validateClisWithTarget('validate-dynamic-test/uses-custom');
         const r = report.results[0];
         const unknownStepWarning = r.warnings.find(w => w.includes(customStep));
         expect(unknownStepWarning).toBeUndefined();

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -29,11 +29,8 @@ export interface ValidationReport {
 
 /**
  * Validate registered CLI commands from the in-memory registry.
- *
- * The `_dirs` parameter is kept for call-site compatibility but is no longer
- * used — validation now operates on the registry populated by `discoverClis()`.
  */
-export function validateClisWithTarget(_dirs: string[], target?: string): ValidationReport {
+export function validateClisWithTarget(target?: string): ValidationReport {
   const registry = getRegistry();
   const results: CommandValidationResult[] = [];
   let errors = 0; let warnings = 0;

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -30,7 +30,7 @@ export interface VerifyReport {
 }
 
 export async function verifyClis(opts: VerifyOptions): Promise<VerifyReport> {
-  const report = validateClisWithTarget([opts.builtinClis, opts.userClis], opts.target);
+  const report = validateClisWithTarget(opts.target);
   let smoke: VerifyReport['smoke'] = null;
   if (opts.smoke) {
     smoke = await runSmokeTests(opts.builtinClis);


### PR DESCRIPTION
## Summary
- remove the unused BrowserBridge daemon process handle and make `ensureBrowserBridgeReady` return `DaemonHealth` directly
- remove production no-unused imports/parameters in CLI, output, pipeline, download, commander adapter, main, and node-network
- drop the stale `validateClisWithTarget(_dirs, target)` compatibility parameter and update internal call sites/tests

This intentionally does not touch `src/errors.ts`, `src/browser/errors.ts`, `src/browser/bridge-readiness.ts`, `src/launcher.ts`, article-extract, or the orphan subsystem batch. Proxy behavior/test realignment is tracked separately in #2322.

## Validation
- `npx vitest run src/browser.test.ts src/browser/daemon-client.test.ts src/browser/bridge-readiness.test.ts`
- `npx vitest run src/validate.test.ts src/output.test.ts src/pipeline/executor.test.ts src/node-network.test.ts`
- `HOME=/tmp/opencli-cli-test-home-p1b USERPROFILE=/tmp/opencli-cli-test-home-p1b OPENCLI_CACHE_DIR=/tmp/opencli-cli-test-cache-p1b npx vitest run src/cli.test.ts`
- `npx vitest run src/commands/daemon.test.ts src/doctor.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `node dist/src/main.js validate`
- `node dist/src/main.js daemon restart` then `node dist/src/main.js daemon status` (daemon restarted to v1.8.6 and extension reconnected)
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false` now has no production runtime hits after filtering the known out-of-scope `autoresearch/` and `src/*.test.ts` entries
