### PR TITLE
chore(browser): remove dead internal error exports

### DIFF
--- a/src/browser/bridge-readiness.ts
+++ b/src/browser/bridge-readiness.ts
@@ -28,8 +28,6 @@ export const PRE_DISPATCH_ERROR_CODES = new Set([
   'profile_disconnected',
 ] as const);
 
-export type PreDispatchErrorCode = typeof PRE_DISPATCH_ERROR_CODES extends Set<infer T> ? T : never;
-
 export function isPreDispatchError(errorCode: string | undefined): boolean {
   if (!errorCode) return false;
   return (PRE_DISPATCH_ERROR_CODES as Set<string>).has(errorCode);

--- a/src/browser/errors.ts
+++ b/src/browser/errors.ts
@@ -5,9 +5,6 @@
  * The daemon architecture has a single failure mode: daemon not reachable or extension not connected.
  */
 
-import { BrowserConnectError, type BrowserConnectKind } from '../errors.js';
-import { DEFAULT_DAEMON_PORT } from '../constants.js';
-
 /**
  * Unified browser error classification.
  *
@@ -122,36 +119,4 @@ export function classifyBrowserError(err: unknown): RetryAdvice {
  */
 export function isTransientBrowserError(err: unknown): boolean {
   return classifyBrowserError(err).retryable;
-}
-
-// Re-export so callers don't need to import from two places
-export type ConnectFailureKind = BrowserConnectKind;
-
-export function formatBrowserConnectError(kind: ConnectFailureKind, detail?: string): BrowserConnectError {
-  switch (kind) {
-    case 'daemon-not-running':
-      return new BrowserConnectError(
-        'Cannot connect to opencli daemon.' + (detail ? `\n\n${detail}` : ''),
-        `Run \`opencli doctor\` to diagnose, or \`opencli daemon restart\` to force a fresh daemon. Default port is ${DEFAULT_DAEMON_PORT}.`,
-        kind,
-      );
-    case 'extension-not-connected':
-      return new BrowserConnectError(
-        'Browser Bridge extension is not connected.' + (detail ? `\n\n${detail}` : ''),
-        'Install the extension from GitHub Releases, then reload.',
-        kind,
-      );
-    case 'command-failed':
-      return new BrowserConnectError(
-        `Browser command failed: ${detail ?? 'unknown error'}`,
-        undefined,
-        kind,
-      );
-    default:
-      return new BrowserConnectError(
-        detail ?? 'Failed to connect to browser',
-        undefined,
-        kind,
-      );
-  }
 }


### PR DESCRIPTION
## Summary
- Remove dead internal browser error exports: formatBrowserConnectError, ConnectFailureKind, and PreDispatchErrorCode.
- Trim only the now-unused BrowserConnectError, BrowserConnectKind, and DEFAULT_DAEMON_PORT imports from src/browser/errors.ts.
- Preserve live browser error classification and pre-dispatch retry predicates.

## Boundary evidence
- Diff files are only src/browser/errors.ts and src/browser/bridge-readiness.ts.
- Public src/errors.ts is untouched; package exports still expose ./errors but not ./browser/errors or ./browser/bridge-readiness.
- formatBrowserConnectError / ConnectFailureKind / PreDispatchErrorCode are zero after deletion.
- classifyBrowserError / isTransientBrowserError, PRE_DISPATCH_ERROR_CODES / isPreDispatchError, and daemon-client callers remain.
- No extract/electron/package-paths/article-extract/#2322/adapter-clone changes included.

## Local gates
- npx vitest run src/browser/errors.test.ts src/browser/bridge-readiness.test.ts src/browser/daemon-client.test.ts src/browser.test.ts: PASS, 77/77
- npm run typecheck: PASS
- npm run build: PASS
- node dist/src/main.js validate: PASS, 1331 commands, 0 errors, existing 8 warnings
- git diff --check: PASS
- fresh merge-tree vs origin/main: clean
