### PR TITLE
chore: remove orphan internal test hooks

### DIFF
--- a/src/browser/extract.ts
+++ b/src/browser/extract.ts
@@ -162,9 +162,3 @@ export function runExtractFromHtml(opts: RunExtractOptions): RunExtractResult {
         content: chunk.content,
     };
 }
-
-export const __extractInternals = {
-    DEFAULT_CHUNK_SIZE,
-    MIN_CHUNK_SIZE,
-    MAX_CHUNK_SIZE,
-};

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -116,8 +116,3 @@ export function isElectronApp(site: string): boolean {
 export function getAllElectronApps(): Record<string, ElectronAppEntry> {
   return ensureLoaded();
 }
-
-/** Reset loaded apps (for testing). */
-export function _resetRegistry(): void {
-  _apps = null;
-}

--- a/src/package-paths.ts
+++ b/src/package-paths.ts
@@ -52,7 +52,3 @@ export function getBuiltEntryCandidates(
 export function getCliManifestPath(clisDir: string): string {
   return path.resolve(clisDir, '..', 'cli-manifest.json');
 }
-
-export function getFetchAdaptersScriptPath(packageRoot: string): string {
-  return path.join(packageRoot, 'scripts', 'fetch-adapters.js');
-}


### PR DESCRIPTION
## Summary
- Remove the orphan `__extractInternals` export object from `src/browser/extract.ts` while keeping the chunk constants and extract pipeline helpers.
- Remove the orphan `_resetRegistry` test hook from `src/electron-apps.ts` while keeping registry state and public helpers.
- Remove the orphan `getFetchAdaptersScriptPath` helper from `src/package-paths.ts` while keeping package-root, built-entry, and manifest path helpers.

## Boundary evidence
- Diff files are exactly `src/browser/extract.ts`, `src/electron-apps.ts`, and `src/package-paths.ts`.
- No `src/browser/article-extract*` file is touched.
- `__extractInternals`, `_resetRegistry`, and `getFetchAdaptersScriptPath` are zero after deletion.
- Chunk constants retain definition -> production-use chains; Electron registry helpers retain launcher/execution/runtime/CDP/test callers; package-path helpers retain CLI/main/skills/discovery/build-manifest/browser-verify callers.
- These three modules are not package-exported.
- No Adapter clone, #2322 proxy, or article-extract changes included.

## Local gates
- `npx vitest run src/browser/extract.test.ts src/electron-apps.test.ts`: PASS, 24/24
- `npx vitest run src/cli.test.ts -t "resolveBrowserVerifyInvocation|findPackageRoot"`: PASS, 6/6
- `npm run typecheck`: PASS
- `npm run build`: PASS
- `node dist/src/main.js validate`: PASS, 1331 commands, 0 errors, existing 8 warnings
- `git diff --check`: PASS
- fresh merge-tree vs origin/main: clean

Note: an initial broad `src/cli.test.ts` run was too wide for this gate and failed six unrelated browser tab-targeting expectations around persisted preferredContextId/default target state. The requested package-path CLI groups above pass.
