### PR TITLE
refactor(linkedin-learning): share API fetch helpers

### DIFF
--- a/clis/linkedin-learning/course.js
+++ b/clis/linkedin-learning/course.js
@@ -2,18 +2,8 @@
  * LinkedIn Learning course detail by slug, via /learning-api/courses?q=slug.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-
-const DOMAIN = 'www.linkedin.com';
-
-function normalizeWhitespace(value) {
-    return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
-}
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, fetchLinkedInLearningApi, normalizeWhitespace } from './shared.js';
 
 function parseSlug(value) {
     const s = normalizeWhitespace(value);
@@ -41,26 +31,6 @@ function parseSlug(value) {
         throw new ArgumentError(`Invalid LinkedIn Learning slug: "${slug}"`);
     }
     return slug;
-}
-
-function buildFetchScript(url, csrf) {
-    return String.raw`(async () => {
-    try {
-      const res = await fetch(${JSON.stringify(url)}, {
-        credentials: 'include',
-        headers: {
-          'csrf-token': ${JSON.stringify(csrf)},
-          'x-restli-protocol-version': '2.0.0',
-          accept: 'application/json',
-        },
-      });
-      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
-      if (!res.ok) return { error: 'HTTP ' + res.status };
-      return { json: await res.json() };
-    } catch (e) {
-      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
-    }
-  })()`;
 }
 
 function parseCourse(el, slug) {
@@ -101,21 +71,8 @@ cli({
         if (!page) throw new CommandExecutionError('Browser session required for linkedin-learning course');
         const slug = parseSlug(args.slug);
 
-        await page.goto('https://www.linkedin.com/learning/');
-        await page.wait(3);
-
-        const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
-        const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
-        if (!jsession) {
-            throw new AuthRequiredError(DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');
-        }
-        const csrf = jsession.replace(/^"|"$/g, '');
-
         const url = `https://www.linkedin.com/learning-api/courses?q=slug&slug=${encodeURIComponent(slug)}`;
-        const result = unwrapEvaluateResult(await page.evaluate(buildFetchScript(url, csrf)));
-        if (result?.authRequired) {
-            throw new AuthRequiredError(DOMAIN, `LinkedIn Learning auth failed (HTTP ${result.status ?? ''}).`);
-        }
+        const result = await fetchLinkedInLearningApi(page, url);
         if (!result?.json) {
             throw new CommandExecutionError(`LinkedIn Learning courses lookup failed: ${result?.error ?? 'no payload'}`);
         }

--- a/clis/linkedin-learning/course.test.js
+++ b/clis/linkedin-learning/course.test.js
@@ -1,18 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { expectRejectsWithMessage, makePage } from './test-helpers.js';
 import './course.js';
 
 const { parseSlug, parseCourse } = await import('./course.js').then((m) => m.__test__);
-
-function makePage({ evaluateResult, cookies = [{ name: 'JSESSIONID', value: '"ajax:abc"' }] } = {}) {
-    return {
-        goto: vi.fn().mockResolvedValue(undefined),
-        wait: vi.fn().mockResolvedValue(undefined),
-        getCookies: vi.fn().mockResolvedValue(cookies),
-        evaluate: vi.fn().mockResolvedValue(evaluateResult),
-    };
-}
 
 describe('linkedin-learning course', () => {
     it('accepts a bare slug', () => {
@@ -88,6 +80,15 @@ describe('linkedin-learning course', () => {
         await expect(cmd.func(page, { slug: 'agentic-ai-build' })).rejects.toBeInstanceOf(AuthRequiredError);
     });
 
+    it('keeps the exact page-required message local to course', async () => {
+        const cmd = getRegistry().get('linkedin-learning/course');
+        await expectRejectsWithMessage(
+            cmd.func(undefined, { slug: 'agentic-ai-build' }),
+            CommandExecutionError,
+            'Browser session required for linkedin-learning course'
+        );
+    });
+
     it('throws EmptyResultError when no element matches the slug', async () => {
         const cmd = getRegistry().get('linkedin-learning/course');
         const page = makePage({ evaluateResult: { json: { elements: [] } } });
@@ -97,7 +98,11 @@ describe('linkedin-learning course', () => {
     it('throws CommandExecutionError when the elements array is missing', async () => {
         const cmd = getRegistry().get('linkedin-learning/course');
         const page = makePage({ evaluateResult: { json: { data: {} } } });
-        await expect(cmd.func(page, { slug: 'agentic-ai-build' })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expectRejectsWithMessage(
+            cmd.func(page, { slug: 'agentic-ai-build' }),
+            CommandExecutionError,
+            'LinkedIn Learning courses lookup returned malformed payload: missing elements array'
+        );
     });
 
     it('throws CommandExecutionError when the first detail element is malformed', async () => {
@@ -109,6 +114,10 @@ describe('linkedin-learning course', () => {
     it('throws CommandExecutionError on fetch errors', async () => {
         const cmd = getRegistry().get('linkedin-learning/course');
         const page = makePage({ evaluateResult: { error: 'HTTP 500' } });
-        await expect(cmd.func(page, { slug: 'agentic-ai-build' })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expectRejectsWithMessage(
+            cmd.func(page, { slug: 'agentic-ai-build' }),
+            CommandExecutionError,
+            'LinkedIn Learning courses lookup failed: HTTP 500'
+        );
     });
 });

--- a/clis/linkedin-learning/search.js
+++ b/clis/linkedin-learning/search.js
@@ -3,48 +3,8 @@
  * Shares cookie session with linkedin.com; no Commercial Use Limit.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-
-const DOMAIN = 'www.linkedin.com';
-const MAX_LIMIT = 50;
-
-function normalizeWhitespace(value) {
-    return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-function parseLimit(value) {
-    if (value === undefined || value === null || value === '') return 10;
-    const limit = Number(value);
-    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
-        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
-    }
-    return limit;
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
-}
-
-function buildFetchScript(url, csrf) {
-    return String.raw`(async () => {
-    try {
-      const res = await fetch(${JSON.stringify(url)}, {
-        credentials: 'include',
-        headers: {
-          'csrf-token': ${JSON.stringify(csrf)},
-          'x-restli-protocol-version': '2.0.0',
-          accept: 'application/json',
-        },
-      });
-      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
-      if (!res.ok) return { error: 'HTTP ' + res.status };
-      return { json: await res.json() };
-    } catch (e) {
-      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
-    }
-  })()`;
-}
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, MAX_LIMIT, fetchLinkedInLearningApi, normalizeWhitespace, parseLimit } from './shared.js';
 
 function parseAuthors(authors) {
     if (!Array.isArray(authors)) return '';
@@ -106,21 +66,8 @@ cli({
         if (!keywords) throw new ArgumentError('--keywords is required');
         const limit = parseLimit(args.limit);
 
-        await page.goto('https://www.linkedin.com/learning/');
-        await page.wait(3);
-
-        const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
-        const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
-        if (!jsession) {
-            throw new AuthRequiredError(DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');
-        }
-        const csrf = jsession.replace(/^"|"$/g, '');
-
         const url = `https://www.linkedin.com/learning-api/searchV2?keywords=${encodeURIComponent(keywords)}&q=keywords`;
-        const result = unwrapEvaluateResult(await page.evaluate(buildFetchScript(url, csrf)));
-        if (result?.authRequired) {
-            throw new AuthRequiredError(DOMAIN, `LinkedIn Learning auth failed (HTTP ${result.status ?? ''}).`);
-        }
+        const result = await fetchLinkedInLearningApi(page, url);
         if (!result?.json) {
             throw new CommandExecutionError(`LinkedIn Learning searchV2 failed: ${result?.error ?? 'no payload'}`);
         }
@@ -145,11 +92,8 @@ cli({
 });
 
 export const __test__ = {
-    normalizeWhitespace,
-    parseLimit,
     parseAuthors,
     durationSeconds,
     averageRating,
     parseRow,
-    buildFetchScript,
 };

--- a/clis/linkedin-learning/search.test.js
+++ b/clis/linkedin-learning/search.test.js
@@ -1,30 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { expectRejectsWithMessage, makePage } from './test-helpers.js';
 import './search.js';
 
-const { parseLimit, parseAuthors, durationSeconds, averageRating, parseRow, buildFetchScript } = await import('./search.js').then((m) => m.__test__);
-
-function makePage({ evaluateResult, cookies = [{ name: 'JSESSIONID', value: '"ajax:abc"' }] } = {}) {
-    return {
-        goto: vi.fn().mockResolvedValue(undefined),
-        wait: vi.fn().mockResolvedValue(undefined),
-        getCookies: vi.fn().mockResolvedValue(cookies),
-        evaluate: vi.fn().mockResolvedValue(evaluateResult),
-    };
-}
+const { parseAuthors, durationSeconds, averageRating, parseRow } = await import('./search.js').then((m) => m.__test__);
 
 describe('linkedin-learning search', () => {
-    it('validates --limit without silent clamping', () => {
-        expect(parseLimit(undefined)).toBe(10);
-        expect(parseLimit(1)).toBe(1);
-        expect(parseLimit(50)).toBe(50);
-        expect(() => parseLimit(0)).toThrow(ArgumentError);
-        expect(() => parseLimit(51)).toThrow(ArgumentError);
-        expect(() => parseLimit('abc')).toThrow(ArgumentError);
-        expect(() => parseLimit(1.5)).toThrow(ArgumentError);
-    });
-
     it('joins author first/last names', () => {
         expect(parseAuthors([{ firstName: 'Jane', lastName: 'Doe' }])).toBe('Jane Doe');
         expect(parseAuthors([{ firstName: 'A', lastName: 'B' }, { firstName: 'C', lastName: 'D' }])).toBe('A B, C D');
@@ -75,14 +57,6 @@ describe('linkedin-learning search', () => {
         expect(row).toBeNull();
     });
 
-    it('escapes the URL and csrf into the fetch script as literal strings', () => {
-        const s = buildFetchScript('https://www.linkedin.com/learning-api/searchV2?keywords=AI', 'csrf-token-value');
-        expect(s).toContain('"https://www.linkedin.com/learning-api/searchV2?keywords=AI"');
-        expect(s).toContain('"csrf-token-value"');
-        expect(s).toContain("'x-restli-protocol-version': '2.0.0'");
-        expect(s).toContain('authRequired: true');
-    });
-
     it('throws AuthRequiredError when JSESSIONID cookie is missing', async () => {
         const cmd = getRegistry().get('linkedin-learning/search');
         const page = makePage({ cookies: [], evaluateResult: { json: { elements: [] } } });
@@ -95,10 +69,23 @@ describe('linkedin-learning search', () => {
         await expect(cmd.func(page, { keywords: 'x', limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
     });
 
+    it('keeps the exact page-required message local to search', async () => {
+        const cmd = getRegistry().get('linkedin-learning/search');
+        await expectRejectsWithMessage(
+            cmd.func(undefined, { keywords: 'x', limit: 5 }),
+            CommandExecutionError,
+            'Browser session required for linkedin-learning search'
+        );
+    });
+
     it('throws CommandExecutionError when the upstream payload is empty', async () => {
         const cmd = getRegistry().get('linkedin-learning/search');
         const page = makePage({ evaluateResult: { error: 'fetch failed: socket' } });
-        await expect(cmd.func(page, { keywords: 'x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expectRejectsWithMessage(
+            cmd.func(page, { keywords: 'x', limit: 5 }),
+            CommandExecutionError,
+            'LinkedIn Learning searchV2 failed: fetch failed: socket'
+        );
     });
 
     it('throws EmptyResultError when zero elements come back', async () => {
@@ -110,7 +97,11 @@ describe('linkedin-learning search', () => {
     it('throws CommandExecutionError when the elements array is missing', async () => {
         const cmd = getRegistry().get('linkedin-learning/search');
         const page = makePage({ evaluateResult: { json: { data: {} } } });
-        await expect(cmd.func(page, { keywords: 'x', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expectRejectsWithMessage(
+            cmd.func(page, { keywords: 'x', limit: 5 }),
+            CommandExecutionError,
+            'LinkedIn Learning searchV2 returned malformed payload: missing elements array'
+        );
     });
 
     it('throws CommandExecutionError when elements lack slug identity', async () => {
@@ -123,6 +114,13 @@ describe('linkedin-learning search', () => {
         const cmd = getRegistry().get('linkedin-learning/search');
         const page = makePage({ evaluateResult: { json: { elements: [] } } });
         await expect(cmd.func(page, { keywords: '   ', limit: 5 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid --limit before navigation', async () => {
+        const cmd = getRegistry().get('linkedin-learning/search');
+        const page = makePage({ evaluateResult: { json: { elements: [] } } });
+        await expect(cmd.func(page, { keywords: 'x', limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
     });
 

--- a/clis/linkedin-learning/shared.js
+++ b/clis/linkedin-learning/shared.js
@@ -1,0 +1,60 @@
+import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
+
+export const DOMAIN = 'www.linkedin.com';
+export const MAX_LIMIT = 50;
+
+export function normalizeWhitespace(value) {
+    return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function parseLimit(value) {
+    if (value === undefined || value === null || value === '') return 10;
+    const limit = Number(value);
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
+export function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
+    return payload;
+}
+
+export function buildFetchScript(url, csrf) {
+    return String.raw`(async () => {
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        credentials: 'include',
+        headers: {
+          'csrf-token': ${JSON.stringify(csrf)},
+          'x-restli-protocol-version': '2.0.0',
+          accept: 'application/json',
+        },
+      });
+      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
+      if (!res.ok) return { error: 'HTTP ' + res.status };
+      return { json: await res.json() };
+    } catch (e) {
+      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
+    }
+  })()`;
+}
+
+export async function fetchLinkedInLearningApi(page, url) {
+    await page.goto('https://www.linkedin.com/learning/');
+    await page.wait(3);
+
+    const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
+    const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
+    if (!jsession) {
+        throw new AuthRequiredError(DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');
+    }
+    const csrf = jsession.replace(/^"|"$/g, '');
+
+    const result = unwrapEvaluateResult(await page.evaluate(buildFetchScript(url, csrf)));
+    if (result?.authRequired) {
+        throw new AuthRequiredError(DOMAIN, `LinkedIn Learning auth failed (HTTP ${result.status ?? ''}).`);
+    }
+    return result;
+}

--- a/clis/linkedin-learning/shared.test.js
+++ b/clis/linkedin-learning/shared.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
+import { expectRejectsWithMessage, makePage } from './test-helpers.js';
+import {
+    buildFetchScript,
+    fetchLinkedInLearningApi,
+    normalizeWhitespace,
+    parseLimit,
+    unwrapEvaluateResult,
+} from './shared.js';
+
+describe('linkedin-learning shared helpers', () => {
+    it('normalizes whitespace consistently', () => {
+        expect(normalizeWhitespace('  A\tB\nC  ')).toBe('A B C');
+        expect(normalizeWhitespace(null)).toBe('');
+    });
+
+    it('validates --limit without silent clamping', () => {
+        expect(parseLimit(undefined)).toBe(10);
+        expect(parseLimit(null)).toBe(10);
+        expect(parseLimit('')).toBe(10);
+        expect(parseLimit(1)).toBe(1);
+        expect(parseLimit(50)).toBe(50);
+        expect(() => parseLimit(0)).toThrow(ArgumentError);
+        expect(() => parseLimit(51)).toThrow(ArgumentError);
+        expect(() => parseLimit('abc')).toThrow(ArgumentError);
+        expect(() => parseLimit(1.5)).toThrow(ArgumentError);
+    });
+
+    it('unwraps bridge evaluate envelopes', () => {
+        expect(unwrapEvaluateResult({ data: { json: true }, session: { id: 's' } })).toEqual({ json: true });
+        expect(unwrapEvaluateResult({ json: true })).toEqual({ json: true });
+    });
+
+    it('escapes the URL and csrf into the fetch script as literal strings', () => {
+        const script = buildFetchScript('https://www.linkedin.com/learning-api/searchV2?keywords=AI', 'csrf-token-value');
+        expect(script).toContain('"https://www.linkedin.com/learning-api/searchV2?keywords=AI"');
+        expect(script).toContain('"csrf-token-value"');
+        expect(script).toContain("'x-restli-protocol-version': '2.0.0'");
+        expect(script).toContain('authRequired: true');
+    });
+
+    it('navigates to learning home and strips quoted JSESSIONID before fetch', async () => {
+        const page = makePage({ evaluateResult: { json: { ok: true } } });
+        const result = await fetchLinkedInLearningApi(page, 'https://www.linkedin.com/learning-api/example');
+        expect(result).toEqual({ json: { ok: true } });
+        expect(page.goto).toHaveBeenCalledWith('https://www.linkedin.com/learning/');
+        expect(page.wait).toHaveBeenCalledWith(3);
+        expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://www.linkedin.com' });
+        expect(page.evaluate.mock.calls[0][0]).toContain('"ajax:abc"');
+    });
+
+    it('throws the shared exact message when JSESSIONID cookie is missing', async () => {
+        const page = makePage({ cookies: [], evaluateResult: { json: { elements: [] } } });
+        await expectRejectsWithMessage(
+            fetchLinkedInLearningApi(page, 'https://www.linkedin.com/learning-api/example'),
+            AuthRequiredError,
+            'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.'
+        );
+    });
+
+    it('throws the shared exact message when the fetch returns 401 or 403', async () => {
+        const page401 = makePage({ evaluateResult: { authRequired: true, status: 401 } });
+        await expectRejectsWithMessage(
+            fetchLinkedInLearningApi(page401, 'https://www.linkedin.com/learning-api/example'),
+            AuthRequiredError,
+            'LinkedIn Learning auth failed (HTTP 401).'
+        );
+
+        const page403 = makePage({ evaluateResult: { authRequired: true, status: 403 } });
+        await expectRejectsWithMessage(
+            fetchLinkedInLearningApi(page403, 'https://www.linkedin.com/learning-api/example'),
+            AuthRequiredError,
+            'LinkedIn Learning auth failed (HTTP 403).'
+        );
+    });
+});

--- a/clis/linkedin-learning/test-helpers.js
+++ b/clis/linkedin-learning/test-helpers.js
@@ -1,0 +1,21 @@
+import { expect, vi } from 'vitest';
+
+export function makePage({ evaluateResult, cookies = [{ name: 'JSESSIONID', value: '"ajax:abc"' }] } = {}) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue(cookies),
+        evaluate: vi.fn().mockResolvedValue(evaluateResult),
+    };
+}
+
+export async function expectRejectsWithMessage(promise, ErrorClass, message) {
+    let error;
+    try {
+        await promise;
+    } catch (e) {
+        error = e;
+    }
+    expect(error).toBeInstanceOf(ErrorClass);
+    expect(error.message).toBe(message);
+}

--- a/clis/linkedin-learning/trending.js
+++ b/clis/linkedin-learning/trending.js
@@ -5,45 +5,10 @@
  * command flattens the cards across them into a ranked list.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { DOMAIN, MAX_LIMIT, fetchLinkedInLearningApi, parseLimit } from './shared.js';
 
-const DOMAIN = 'www.linkedin.com';
-const MAX_LIMIT = 50;
 const MAX_PER_CAROUSEL = 25;
-
-function parseLimit(value) {
-    if (value === undefined || value === null || value === '') return 10;
-    const limit = Number(value);
-    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
-        throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
-    }
-    return limit;
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
-}
-
-function buildFetchScript(url, csrf) {
-    return String.raw`(async () => {
-    try {
-      const res = await fetch(${JSON.stringify(url)}, {
-        credentials: 'include',
-        headers: {
-          'csrf-token': ${JSON.stringify(csrf)},
-          'x-restli-protocol-version': '2.0.0',
-          accept: 'application/json',
-        },
-      });
-      if (res.status === 401 || res.status === 403) return { authRequired: true, status: res.status };
-      if (!res.ok) return { error: 'HTTP ' + res.status };
-      return { json: await res.json() };
-    } catch (e) {
-      return { error: 'fetch failed: ' + ((e && e.message) || String(e)) };
-    }
-  })()`;
-}
 
 function parseCard(card, group, rank) {
     const slug = card?.slug || '';
@@ -75,21 +40,8 @@ cli({
         if (!page) throw new CommandExecutionError('Browser session required for linkedin-learning trending');
         const limit = parseLimit(args.limit);
 
-        await page.goto('https://www.linkedin.com/learning/');
-        await page.wait(3);
-
-        const cookies = await page.getCookies({ url: 'https://www.linkedin.com' });
-        const jsession = cookies.find((c) => c.name === 'JSESSIONID')?.value;
-        if (!jsession) {
-            throw new AuthRequiredError(DOMAIN, 'LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn in the browser.');
-        }
-        const csrf = jsession.replace(/^"|"$/g, '');
-
         const url = `https://www.linkedin.com/learning-api/feedRecommendationGroups?countPerCarousel=${MAX_PER_CAROUSEL}&q=learner`;
-        const result = unwrapEvaluateResult(await page.evaluate(buildFetchScript(url, csrf)));
-        if (result?.authRequired) {
-            throw new AuthRequiredError(DOMAIN, `LinkedIn Learning auth failed (HTTP ${result.status ?? ''}).`);
-        }
+        const result = await fetchLinkedInLearningApi(page, url);
         if (!result?.json) {
             throw new CommandExecutionError(`LinkedIn Learning feedRecommendationGroups failed: ${result?.error ?? 'no payload'}`);
         }
@@ -130,4 +82,4 @@ cli({
     },
 });
 
-export const __test__ = { parseLimit, parseCard };
+export const __test__ = { parseCard };

--- a/clis/linkedin-learning/trending.test.js
+++ b/clis/linkedin-learning/trending.test.js
@@ -1,27 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { expectRejectsWithMessage, makePage } from './test-helpers.js';
 import './trending.js';
 
-const { parseLimit, parseCard } = await import('./trending.js').then((m) => m.__test__);
-
-function makePage({ evaluateResult, cookies = [{ name: 'JSESSIONID', value: '"ajax:abc"' }] } = {}) {
-    return {
-        goto: vi.fn().mockResolvedValue(undefined),
-        wait: vi.fn().mockResolvedValue(undefined),
-        getCookies: vi.fn().mockResolvedValue(cookies),
-        evaluate: vi.fn().mockResolvedValue(evaluateResult),
-    };
-}
+const { parseCard } = await import('./trending.js').then((m) => m.__test__);
 
 describe('linkedin-learning trending', () => {
-    it('validates --limit without silent clamping', () => {
-        expect(parseLimit(undefined)).toBe(10);
-        expect(parseLimit(50)).toBe(50);
-        expect(() => parseLimit(0)).toThrow(ArgumentError);
-        expect(() => parseLimit(51)).toThrow(ArgumentError);
-    });
-
     it('maps a carousel card to the canonical row shape', () => {
         const card = {
             entityType: 'COURSE',
@@ -93,10 +78,36 @@ describe('linkedin-learning trending', () => {
         expect(rows).toHaveLength(3);
     });
 
+    it('rejects invalid --limit before navigation', async () => {
+        const cmd = getRegistry().get('linkedin-learning/trending');
+        const page = makePage({ evaluateResult: { json: { elements: [] } } });
+        await expect(cmd.func(page, { limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
     it('throws AuthRequiredError when JSESSIONID is missing', async () => {
         const cmd = getRegistry().get('linkedin-learning/trending');
         const page = makePage({ cookies: [], evaluateResult: { json: { elements: [] } } });
         await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('keeps the exact page-required message local to trending', async () => {
+        const cmd = getRegistry().get('linkedin-learning/trending');
+        await expectRejectsWithMessage(
+            cmd.func(undefined, { limit: 5 }),
+            CommandExecutionError,
+            'Browser session required for linkedin-learning trending'
+        );
+    });
+
+    it('keeps the exact feedRecommendationGroups failure message local to trending', async () => {
+        const cmd = getRegistry().get('linkedin-learning/trending');
+        const page = makePage({ evaluateResult: { error: 'HTTP 500' } });
+        await expectRejectsWithMessage(
+            cmd.func(page, { limit: 5 }),
+            CommandExecutionError,
+            'LinkedIn Learning feedRecommendationGroups failed: HTTP 500'
+        );
     });
 
     it('throws EmptyResultError when no carousels yield cards', async () => {
@@ -108,7 +119,11 @@ describe('linkedin-learning trending', () => {
     it('throws CommandExecutionError when the elements array is missing', async () => {
         const cmd = getRegistry().get('linkedin-learning/trending');
         const page = makePage({ evaluateResult: { json: { data: {} } } });
-        await expect(cmd.func(page, { limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        await expectRejectsWithMessage(
+            cmd.func(page, { limit: 5 }),
+            CommandExecutionError,
+            'LinkedIn Learning feedRecommendationGroups returned malformed payload: missing elements array'
+        );
     });
 
     it('throws CommandExecutionError when cards lack slug identity', async () => {


### PR DESCRIPTION
## Summary
- add `clis/linkedin-learning/shared.js` for the byte-identical LinkedIn Learning helpers: `normalizeWhitespace`, `parseLimit`, `unwrapEvaluateResult`, `buildFetchScript`, and the common learning-home/cookie/fetch/401-403 auth envelope
- keep command-owned behavior in `search`, `trending`, and `course`: page-required messages, arg validation, endpoint URL construction, endpoint-specific no-payload failures, malformed/empty parsing, and row/card/course parsing
- add exact full-message assertions so command-specific messages cannot drift into a generic shared template
- add `clis/linkedin-learning/test-helpers.js` for pure test scaffolding instead of duplicating test helpers or adding command-module test-only re-exports

## Safety boundaries
- production shared fetch helper accepts only `(page, url)`; it does not take command names, endpoint labels, or error-message template params
- common exact auth messages are covered in `shared.test.js`
- command-local exact messages are covered in each command test for page-required, endpoint failure, and malformed payload
- `parseLimit` and `buildFetchScript` direct-helper tests live only in `shared.test.js`; command tests cover command behavior such as invalid limit before navigation
- touched only `clis/linkedin-learning/*`; no main LinkedIn adapter, other adapters, core, proxy behavior, or article-extract files

## Local gates
- `npx vitest run clis/linkedin-learning/*.test.js` — 4 files / 48 tests pass
- `npm run typecheck` — pass
- `npm run build` — pass, manifest 1331 entries unchanged in git
- `node dist/src/main.js validate linkedin-learning` — PASS, 5 commands, 0 errors / 0 warnings
- `git diff --check` — clean
