### PR TITLE
refactor(bilibili): share relation helpers

### DIFF
--- a/clis/bilibili/follow.js
+++ b/clis/bilibili/follow.js
@@ -8,25 +8,8 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { apiPost, fetchJson, getSelfUid, requireOkPayload, resolveUid } from './utils.js';
-
-const RELATION_VERIFY_TIMEOUT_MS = 5000;
-const RELATION_VERIFY_POLL_MS = 500;
-
-function parseSpaceMidUrl(raw) {
-    const trimmed = String(raw ?? '').trim();
-    if (!trimmed) return '';
-    const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-    let parsed;
-    try {
-        parsed = new URL(candidate);
-    } catch {
-        return '';
-    }
-    if (parsed.hostname.toLowerCase() !== 'space.bilibili.com') return '';
-    const match = parsed.pathname.match(/^\/(\d+)\/?$/);
-    return match ? match[1] : '';
-}
+import { parseSpaceMidUrl, fetchRelationAttribute, waitForRelation } from './relation.js';
+import { apiPost, getSelfUid, requireOkPayload, resolveUid } from './utils.js';
 
 /**
  * Pull a uid out of a `space.bilibili.com/<uid>` URL before falling back to the
@@ -55,35 +38,6 @@ async function resolveTargetMid(page, raw) {
             error instanceof Error ? error.message : String(error),
         );
     }
-}
-
-/**
- * `attribute` from /x/relation encodes the viewer→target relation:
- *   0 = no relation, 2 = following, 6 = mutual follow, 128 = blocked.
- * `2` and `6` both count as "already following" from the follow command's POV.
- */
-async function fetchRelationAttribute(page, mid) {
-    const payload = await fetchJson(page, `https://api.bilibili.com/x/relation?fid=${mid}`);
-    requireOkPayload(payload, 'relation query');
-    const attribute = payload?.data?.attribute;
-    if (typeof attribute !== 'number') {
-        throw new CommandExecutionError('Bilibili relation query returned a malformed attribute');
-    }
-    return attribute;
-}
-
-async function waitForRelation(page, mid, predicate, expectedLabel) {
-    const deadline = Date.now() + RELATION_VERIFY_TIMEOUT_MS;
-    let lastAttribute;
-    while (Date.now() <= deadline) {
-        lastAttribute = await fetchRelationAttribute(page, mid);
-        if (predicate(lastAttribute)) return lastAttribute;
-        if (typeof page.wait !== 'function') break;
-        await page.wait({ time: RELATION_VERIFY_POLL_MS / 1000 });
-    }
-    throw new CommandExecutionError(
-        `Bilibili relation modify did not verify ${expectedLabel}; last attribute=${lastAttribute}`,
-    );
 }
 
 cli({
@@ -132,9 +86,3 @@ cli({
         return [{ mid, name: '', status: 'followed', url }];
     },
 });
-
-export const __test__ = {
-    resolveTargetMid,
-    fetchRelationAttribute,
-    waitForRelation,
-};

--- a/clis/bilibili/follow.test.js
+++ b/clis/bilibili/follow.test.js
@@ -20,6 +20,17 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import './follow.js';
 import './unfollow.js';
 
+async function expectRejectsWithMessage(promise, type, message) {
+    try {
+        await promise;
+    } catch (error) {
+        expect(error).toBeInstanceOf(type);
+        expect(error.message).toBe(message);
+        return;
+    }
+    throw new Error(`Expected rejection with message: ${message}`);
+}
+
 describe('bilibili follow', () => {
     const command = getRegistry().get('bilibili/follow');
 
@@ -101,12 +112,20 @@ describe('bilibili follow', () => {
     });
 
     it('rejects an empty target before touching the API', async () => {
-        await expect(command.func({}, { target: '   ' })).rejects.toBeInstanceOf(ArgumentError);
+        await expectRejectsWithMessage(
+            command.func({}, { target: '   ' }),
+            ArgumentError,
+            'bilibili follow target cannot be empty',
+        );
         expect(mockGetSelfUid).not.toHaveBeenCalled();
     });
 
     it('rejects malformed Bilibili profile URLs instead of searching the whole URL', async () => {
-        await expect(command.func({}, { target: 'https://space.bilibili.com/not-a-uid' })).rejects.toBeInstanceOf(ArgumentError);
+        await expectRejectsWithMessage(
+            command.func({}, { target: 'https://space.bilibili.com/not-a-uid' }),
+            ArgumentError,
+            'bilibili follow target must be a valid space.bilibili.com/<uid> URL',
+        );
         expect(mockResolveUid).not.toHaveBeenCalled();
         expect(mockFetchJson).not.toHaveBeenCalled();
     });
@@ -199,5 +218,24 @@ describe('bilibili unfollow', () => {
         mockFetchJson.mockResolvedValueOnce({ code: 0, data: { attribute: 6 } });
 
         await expect(command.func({}, { target: '9617619' })).rejects.toThrow(/did not verify not following/);
+    });
+
+    it('rejects an empty target with unfollow-specific text before touching the API', async () => {
+        await expectRejectsWithMessage(
+            command.func({}, { target: '   ' }),
+            ArgumentError,
+            'bilibili unfollow target cannot be empty',
+        );
+        expect(mockGetSelfUid).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed profile URLs with unfollow-specific text', async () => {
+        await expectRejectsWithMessage(
+            command.func({}, { target: 'https://space.bilibili.com/not-a-uid' }),
+            ArgumentError,
+            'bilibili unfollow target must be a valid space.bilibili.com/<uid> URL',
+        );
+        expect(mockResolveUid).not.toHaveBeenCalled();
+        expect(mockFetchJson).not.toHaveBeenCalled();
     });
 });

--- a/clis/bilibili/relation.js
+++ b/clis/bilibili/relation.js
@@ -1,0 +1,44 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { fetchJson, requireOkPayload } from './utils.js';
+
+const RELATION_VERIFY_TIMEOUT_MS = 5000;
+const RELATION_VERIFY_POLL_MS = 500;
+
+export function parseSpaceMidUrl(raw) {
+    const trimmed = String(raw ?? '').trim();
+    if (!trimmed) return '';
+    const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    let parsed;
+    try {
+        parsed = new URL(candidate);
+    } catch {
+        return '';
+    }
+    if (parsed.hostname.toLowerCase() !== 'space.bilibili.com') return '';
+    const match = parsed.pathname.match(/^\/(\d+)\/?$/);
+    return match ? match[1] : '';
+}
+
+export async function fetchRelationAttribute(page, mid) {
+    const payload = await fetchJson(page, `https://api.bilibili.com/x/relation?fid=${mid}`);
+    requireOkPayload(payload, 'relation query');
+    const attribute = payload?.data?.attribute;
+    if (typeof attribute !== 'number') {
+        throw new CommandExecutionError('Bilibili relation query returned a malformed attribute');
+    }
+    return attribute;
+}
+
+export async function waitForRelation(page, mid, predicate, expectedLabel) {
+    const deadline = Date.now() + RELATION_VERIFY_TIMEOUT_MS;
+    let lastAttribute;
+    while (Date.now() <= deadline) {
+        lastAttribute = await fetchRelationAttribute(page, mid);
+        if (predicate(lastAttribute)) return lastAttribute;
+        if (typeof page.wait !== 'function') break;
+        await page.wait({ time: RELATION_VERIFY_POLL_MS / 1000 });
+    }
+    throw new CommandExecutionError(
+        `Bilibili relation modify did not verify ${expectedLabel}; last attribute=${lastAttribute}`,
+    );
+}

--- a/clis/bilibili/unfollow.js
+++ b/clis/bilibili/unfollow.js
@@ -6,25 +6,8 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { apiPost, fetchJson, getSelfUid, requireOkPayload, resolveUid } from './utils.js';
-
-const RELATION_VERIFY_TIMEOUT_MS = 5000;
-const RELATION_VERIFY_POLL_MS = 500;
-
-function parseSpaceMidUrl(raw) {
-    const trimmed = String(raw ?? '').trim();
-    if (!trimmed) return '';
-    const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-    let parsed;
-    try {
-        parsed = new URL(candidate);
-    } catch {
-        return '';
-    }
-    if (parsed.hostname.toLowerCase() !== 'space.bilibili.com') return '';
-    const match = parsed.pathname.match(/^\/(\d+)\/?$/);
-    return match ? match[1] : '';
-}
+import { parseSpaceMidUrl, fetchRelationAttribute, waitForRelation } from './relation.js';
+import { apiPost, getSelfUid, requireOkPayload, resolveUid } from './utils.js';
 
 async function resolveTargetMid(page, raw) {
     const trimmed = String(raw ?? '').trim();
@@ -47,30 +30,6 @@ async function resolveTargetMid(page, raw) {
             error instanceof Error ? error.message : String(error),
         );
     }
-}
-
-async function fetchRelationAttribute(page, mid) {
-    const payload = await fetchJson(page, `https://api.bilibili.com/x/relation?fid=${mid}`);
-    requireOkPayload(payload, 'relation query');
-    const attribute = payload?.data?.attribute;
-    if (typeof attribute !== 'number') {
-        throw new CommandExecutionError('Bilibili relation query returned a malformed attribute');
-    }
-    return attribute;
-}
-
-async function waitForRelation(page, mid, predicate, expectedLabel) {
-    const deadline = Date.now() + RELATION_VERIFY_TIMEOUT_MS;
-    let lastAttribute;
-    while (Date.now() <= deadline) {
-        lastAttribute = await fetchRelationAttribute(page, mid);
-        if (predicate(lastAttribute)) return lastAttribute;
-        if (typeof page.wait !== 'function') break;
-        await page.wait({ time: RELATION_VERIFY_POLL_MS / 1000 });
-    }
-    throw new CommandExecutionError(
-        `Bilibili relation modify did not verify ${expectedLabel}; last attribute=${lastAttribute}`,
-    );
 }
 
 cli({
@@ -113,9 +72,3 @@ cli({
         return [{ mid, name: '', status: 'unfollowed', url }];
     },
 });
-
-export const __test__ = {
-    resolveTargetMid,
-    fetchRelationAttribute,
-    waitForRelation,
-};


### PR DESCRIPTION
## Summary
- add site-local `clis/bilibili/relation.js` for the duplicated follow/unfollow relation helpers
- keep `resolveTargetMid` command-local so follow/unfollow empty and malformed target messages stay distinct
- remove the unused follow/unfollow `__test__` exports instead of re-exporting imported shared helpers
- add exact full-message assertions for the follow/unfollow target validation split

## Boundary
- `relation.js` imports `fetchJson` / `requireOkPayload` from `utils.js` rather than moving helpers into `utils.js`; this preserves the existing `vi.mock('./utils.js')` boundary in `follow.test.js`
- no cross-site or configurable action abstraction
- no changes outside `clis/bilibili/{follow.js,unfollow.js,relation.js,follow.test.js}`

## Local gates
- `npx vitest run clis/bilibili/follow.test.js clis/bilibili/utils.test.js` — PASS, 2 files / 33 tests
- `npm run typecheck` — PASS
- `npm run build` — PASS, manifest 1331 entries
- `node dist/src/main.js validate bilibili` — PASS, 21 commands, 0 errors, existing 1 warning (`bilibili/video` missing domain)
- `git diff --check --cached` — PASS

## Scans
- shared relation helpers defined only in `relation.js` and imported by follow/unfollow
- `resolveTargetMid` remains command-local in both commands
- follow/unfollow no longer export `__test__`
