### PR TITLE
feat(twitter): add muted word command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -40021,6 +40021,33 @@
   },
   {
     "site": "twitter",
+    "name": "mute-word",
+    "description": "Add a muted word or phrase on Twitter/X",
+    "access": "write",
+    "domain": "x.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "keyword",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Word or phrase to mute"
+      }
+    ],
+    "columns": [
+      "keyword",
+      "status",
+      "message"
+    ],
+    "type": "js",
+    "modulePath": "twitter/mute-word.js",
+    "sourceFile": "twitter/mute-word.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "twitter",
     "name": "notifications",
     "description": "Get your Twitter/X notifications (the logged-in user's likes/replies/follows feed, newest first)",
     "access": "read",

--- a/clis/twitter/mute-word.js
+++ b/clis/twitter/mute-word.js
@@ -1,0 +1,188 @@
+import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+function parseKeyword(value) {
+    const keyword = String(value ?? '').trim();
+    if (!keyword) {
+        throw new ArgumentError('twitter mute-word keyword cannot be empty');
+    }
+    return keyword;
+}
+
+cli({
+    site: 'twitter',
+    name: 'mute-word',
+    access: 'write',
+    description: 'Add a muted word or phrase on Twitter/X',
+    domain: 'x.com',
+    strategy: Strategy.UI,
+    browser: true,
+    args: [
+        { name: 'keyword', type: 'string', positional: true, required: true, help: 'Word or phrase to mute' },
+    ],
+    columns: ['keyword', 'status', 'message'],
+    func: async (page, kwargs) => {
+        if (!page) {
+            throw new CommandExecutionError('Browser session required for twitter mute-word');
+        }
+        const keyword = parseKeyword(kwargs.keyword);
+
+        await page.goto('https://x.com/settings/add_muted_keyword');
+        await page.wait({ selector: '[data-testid="primaryColumn"]' }).catch(() => {});
+
+        const result = await page.evaluate(`(async () => {
+            const keyword = ${JSON.stringify(keyword)};
+            let writeStarted = false;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const visible = (node) => {
+                if (!node) return false;
+                const style = window.getComputedStyle ? window.getComputedStyle(node) : null;
+                return !style || (style.visibility !== 'hidden' && style.display !== 'none');
+            };
+            const textOf = (node) => String(node?.innerText || node?.textContent || '').trim();
+            const lowerTextOf = (node) => textOf(node).toLowerCase();
+            const exactTextOf = (node) => lowerTextOf(node).replace(/\\s+/g, ' ');
+            const setNativeValue = (node, value) => {
+                if ('value' in node) {
+                    const prototype = Object.getPrototypeOf(node);
+                    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+                    if (setter) setter.call(node, value);
+                    else node.value = value;
+                } else {
+                    node.textContent = value;
+                }
+                let inputEvent;
+                try {
+                    inputEvent = new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value });
+                } catch {
+                    inputEvent = new Event('input', { bubbles: true });
+                }
+                node.dispatchEvent(inputEvent);
+                node.dispatchEvent(new Event('change', { bubbles: true }));
+            };
+            const settingsSurface = () => document.querySelector('[data-testid="primaryColumn"]')
+                || document.querySelector('main');
+            const scopeFor = (node) => node?.closest('form, [data-testid="primaryColumn"], main') || settingsSurface();
+            const keywordRows = () => {
+                const surface = settingsSurface();
+                if (!surface) return [];
+                return Array.from(surface.querySelectorAll('[data-testid*="muted"], [data-testid*="keyword"], [role="listitem"], li'))
+                    .filter((node) => visible(node) && !node.querySelector('input, textarea, [role="textbox"]'));
+            };
+            const rowSnapshot = () => keywordRows().map(textOf).filter(Boolean);
+            const exactKeywordRows = () => keywordRows().filter((node) => textOf(node) === keyword);
+            const hasNewExactKeywordRow = (beforeRows) => {
+                const beforeExactCount = beforeRows.filter((text) => text === keyword).length;
+                return exactKeywordRows().length > beforeExactCount;
+            };
+            const matchingToastTexts = () => Array.from(document.querySelectorAll('[role="status"], [data-testid="toast"], [data-testid*="toast"], [aria-live]'))
+                .filter((node) => {
+                    if (!visible(node)) return false;
+                    const text = lowerTextOf(node);
+                    return (text.includes('muted') || text.includes('added') || text.includes('saved') || text.includes('已') || text.includes('保存') || text.includes('添加'))
+                        && text.includes(keyword.toLowerCase());
+                })
+                .map(exactTextOf);
+            const hasNewSuccessToast = (beforeToasts) => {
+                const beforeCounts = new Map();
+                for (const text of beforeToasts) {
+                    beforeCounts.set(text, (beforeCounts.get(text) || 0) + 1);
+                }
+                for (const text of matchingToastTexts()) {
+                    const count = beforeCounts.get(text) || 0;
+                    if (count > 0) {
+                        beforeCounts.set(text, count - 1);
+                    } else {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            const findKeywordField = () => {
+                const surface = settingsSurface();
+                if (!surface) return null;
+                const exact = Array.from(surface.querySelectorAll('input[name="keyword"], textarea[name="keyword"]'))
+                    .filter(visible);
+                if (exact.length > 0) return exact[0];
+                const candidates = Array.from(surface.querySelectorAll('input[aria-label], textarea[aria-label], [role="textbox"]'))
+                    .filter(visible);
+                const semantic = candidates.find((node) => {
+                    if (!visible(node)) return false;
+                    const aria = String(node.getAttribute('aria-label') || '').trim().toLowerCase();
+                    const placeholder = String(node.getAttribute('placeholder') || '').trim().toLowerCase();
+                    return ['word or phrase', 'word', 'phrase', '关键词', '屏蔽词'].includes(aria)
+                        || ['word or phrase', 'word', 'phrase', '关键词', '屏蔽词'].includes(placeholder);
+                });
+                return semantic || null;
+            };
+            const findSaveButton = (field) => {
+                const labels = new Set(['save', 'add', 'done', '保存', '添加', '完成']);
+                const scope = scopeFor(field);
+                if (!scope) return null;
+                return Array.from(scope.querySelectorAll('button, [role="button"]')).find((node) => {
+                    if (!visible(node)) return false;
+                    if (node.disabled || node.getAttribute('aria-disabled') === 'true') return false;
+                    const text = exactTextOf(node);
+                    const aria = String(node.getAttribute('aria-label') || '').trim().toLowerCase();
+                    return labels.has(text) || labels.has(aria);
+                }) || null;
+            };
+
+            try {
+                const field = findKeywordField();
+                if (!field) {
+                    return { ok: false, message: 'Could not find muted word input. Are you logged in?' };
+                }
+                field.focus?.();
+                setNativeValue(field, keyword);
+                await sleep(100);
+
+                const beforePath = location.pathname;
+                const beforeRows = rowSnapshot();
+                const beforeToasts = matchingToastTexts();
+                const saveButton = findSaveButton(field);
+                if (!saveButton) {
+                    return { ok: false, message: 'Could not find muted word Save button.' };
+                }
+                writeStarted = true;
+                saveButton.click();
+
+                for (let attempt = 0; attempt < 20; attempt += 1) {
+                    await sleep(250);
+                    if (beforePath !== '/settings/muted_keywords' && location.pathname === '/settings/muted_keywords') {
+                        return { ok: true, message: 'Muted word added.' };
+                    }
+                    if (hasNewSuccessToast(beforeToasts)) {
+                        return { ok: true, message: 'Muted word added.' };
+                    }
+                    if (hasNewExactKeywordRow(beforeRows)) {
+                        return { ok: true, message: 'Muted word added.' };
+                    }
+                }
+                return { ok: false, unconfirmed: true, message: 'Muted word submission did not show confirmation.' };
+            } catch (error) {
+                return { ok: false, unconfirmed: writeStarted, message: String(error?.message || error) };
+            }
+        })()`);
+
+        if (result?.unconfirmed) {
+            throw new TimeoutError(
+                'twitter mute-word confirmation',
+                5,
+                `${result.message} Check muted words before retrying; the word may already have been added.`,
+            );
+        }
+        if (!result?.ok) {
+            throw new CommandExecutionError(
+                result?.message || 'Could not add muted word.',
+                'Nothing changed. Open Twitter/X muted word settings in the browser and retry.',
+            );
+        }
+
+        return [{
+            keyword,
+            status: 'success',
+            message: result.message || 'Muted word added.',
+        }];
+    },
+});

--- a/clis/twitter/mute-word.test.js
+++ b/clis/twitter/mute-word.test.js
@@ -1,0 +1,226 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './mute-word.js';
+import { createPageMock } from '../test-utils.js';
+import { createTwitterDomPage } from './test-dom-utils.js';
+
+function createTransformedTwitterDomPage(html, transform, url = 'https://x.com/settings/add_muted_keyword') {
+    return createInspectableTransformedTwitterDomPage(html, transform, url).page;
+}
+
+function createInspectableTransformedTwitterDomPage(html, transform, url = 'https://x.com/settings/add_muted_keyword') {
+    const dom = new JSDOM(html, {
+        url,
+        runScripts: 'outside-only',
+    });
+    dom.window.setTimeout = (callback) => {
+        callback();
+        return 0;
+    };
+    const page = createPageMock([], {
+        evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(transform(String(script))))),
+    });
+    return { page, dom };
+}
+
+describe('twitter mute-word command', () => {
+    it('navigates to the muted-word form and reports success when the script confirms', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createPageMock([{ ok: true, message: 'Muted word added.' }]);
+
+        const result = await cmd.func(page, { keyword: '  opencli-muted-token  ' });
+
+        expect(page.goto).toHaveBeenCalledWith('https://x.com/settings/add_muted_keyword');
+        expect(page.wait).toHaveBeenCalledWith({ selector: '[data-testid="primaryColumn"]' });
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain('input[name="keyword"]');
+        expect(script).toContain("labels = new Set(['save', 'add', 'done', '保存', '添加', '完成'])");
+        expect(result).toEqual([{
+            keyword: 'opencli-muted-token',
+            status: 'success',
+            message: 'Muted word added.',
+        }]);
+    });
+
+    it('embeds the keyword safely in the browser script', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createPageMock([{ ok: true, message: 'Muted word added.' }]);
+        const keyword = '"); window.__opencliInjected = true; //';
+
+        await cmd.func(page, { keyword });
+
+        const script = page.evaluate.mock.calls[0][0];
+        expect(script).toContain(JSON.stringify(keyword));
+        expect(script).not.toContain('const keyword = ""); window.__opencliInjected = true; //";');
+    });
+
+    it('throws ArgumentError for an empty keyword before browser work', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createPageMock();
+
+        await expect(cmd.func(page, { keyword: '   ' })).rejects.toMatchObject({
+            name: 'ArgumentError',
+            message: 'twitter mute-word keyword cannot be empty',
+        });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('typed-fails before write when the muted-word input is missing', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find muted word input. Are you logged in?',
+        });
+    });
+
+    it('typed-fails before write when the save button is missing', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <input name="keyword" />
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find muted word Save button.',
+        });
+    });
+
+    it('treats a missing post-submit confirmation as unconfirmed', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <input name="keyword" />
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+            hint: expect.stringContaining('may already have been added'),
+        });
+    });
+
+    it('does not treat pre-existing page text as post-submit confirmation', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <p>spoilers</p>
+                <input name="keyword" />
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+        });
+    });
+
+    it('confirms success when the click transitions to the muted keywords list', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTransformedTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <input name="keyword" />
+                <button>Save</button>
+            </main>
+        `, (script) => script.replace('saveButton.click();', "history.pushState({}, '', '/settings/muted_keywords'); saveButton.click();"));
+
+        const result = await cmd.func(page, { keyword: 'spoilers' });
+
+        expect(result).toEqual([{
+            keyword: 'spoilers',
+            status: 'success',
+            message: 'Muted word added.',
+        }]);
+    });
+
+    it('does not treat an already-present success toast as post-submit confirmation', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <div role="status">spoilers added</div>
+                <input name="keyword" />
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+        });
+    });
+
+    it('does not treat an already-open muted keywords route as a transition', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <input name="keyword" />
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/muted_keywords');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+        });
+    });
+
+    it('typed-fails before clicking body-only unrelated controls', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const { page, dom } = createInspectableTransformedTwitterDomPage(`
+            <input aria-label="Word" />
+            <button>Add</button>
+        `, (script) => script.replace(
+            'saveButton.click();',
+            'window.__clicked = (window.__clicked || 0) + 1; saveButton.click();',
+        ));
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find muted word input. Are you logged in?',
+        });
+        expect(dom.window.__clicked || 0).toBe(0);
+    });
+
+    it('does not treat the edited textbox value itself as confirmation', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        const page = createTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <div role="textbox" aria-label="Word"></div>
+                <button>Save</button>
+            </main>
+        `, 'https://x.com/settings/add_muted_keyword');
+
+        await expect(cmd.func(page, { keyword: 'spoilers' })).rejects.toMatchObject({
+            name: 'TimeoutError',
+            code: 'TIMEOUT',
+            exitCode: 75,
+        });
+    });
+
+    it('throws CommandExecutionError when no page is provided', async () => {
+        const cmd = getRegistry().get('twitter/mute-word');
+        await expect(cmd.func(undefined, { keyword: 'spoilers' })).rejects.toThrow(CommandExecutionError);
+    });
+});


### PR DESCRIPTION
## Summary
- add `twitter mute-word <keyword>` to add a muted word or phrase through the visible X/Twitter settings flow
- validate empty keywords before browser work and return `keyword,status,message`
- treat missing input/save controls as definite typed failures, but post-submit no-confirmation as `TimeoutError` because the write may have landed
- regenerate `cli-manifest.json`

## Strategy note
Strategy: `UI_SELECTOR`
Contract: `visible-ui`
Evidence:
- target route: `https://x.com/settings/add_muted_keyword`
- auth source: live browser session/cookies via existing UI command pattern
- write evidence: visible muted-word form textbox + Save/Add/Done button, followed by route/list/confirmation check

The older private muted-keyword API has conflicting evidence for the web client and would require brittle internal auth/request details. For a single write action, the visible settings UI is the simpler and safer contract.

## Local gates
- `npx vitest run clis/twitter/mute-word.test.js clis/twitter/block.test.js clis/twitter/unblock.test.js` — PASS, 17/17
- `npx vitest run clis/twitter/*.test.js` — PASS, 44 files / 519 tests
- `npm run typecheck` — PASS
- `npm run build` — PASS, manifest 1332 entries
- `node dist/src/main.js validate twitter` — PASS, 46 commands, 0 errors / 0 warnings
- `git diff --cached --check` — PASS

## Notes
- I did not run a live write smoke because this machine's browser bridge currently returns `No SW` for `twitter whoami`, and a live muted-word write would mutate the signed-in account. The command has JSDOM coverage for pre-write failure and unconfirmed post-write behavior, plus full Twitter adapter suite coverage.
