### PR TITLE
fix(twitter): repair block and hide reply flows

### DIFF
--- a/clis/twitter/block.js
+++ b/clis/twitter/block.js
@@ -22,22 +22,38 @@ cli({
         let writeStarted = false;
         try {
             let attempts = 0;
+            const getPrimary = () => document.querySelector('[data-testid="primaryColumn"]');
+            const isBlockMenuItem = (item) => {
+                const text = String(item.textContent || '');
+                const lower = text.toLowerCase();
+                const isUnblockText = lower.includes('unblock') || text.includes('取消屏蔽') || text.includes('解除屏蔽');
+                const isBlockText = (lower.includes('block') || text.includes('屏蔽')) && !isUnblockText;
+                return item.getAttribute('data-testid') === 'block' || isBlockText;
+            };
+            if (!getPrimary()) {
+                return { ok: false, message: 'Could not find profile surface. Are you logged in?' };
+            }
 
             // Check if already blocked (profile shows "Blocked" / unblock button)
             while (attempts < 20) {
-                const blockedIndicator = document.querySelector('[data-testid$="-unblock"]');
+                const primary = getPrimary();
+                if (!primary) {
+                    return { ok: false, message: 'Could not find profile surface. Are you logged in?' };
+                }
+                const blockedIndicator = primary.querySelector('[data-testid$="-unblock"]');
                 if (blockedIndicator) {
                     return { ok: true, message: 'Already blocking @${username}.' };
                 }
 
-                const moreBtn = document.querySelector('[data-testid="userActions"]');
+                const moreBtn = primary.querySelector('[data-testid="userActions"]');
                 if (moreBtn) break;
 
                 await new Promise(r => setTimeout(r, 500));
                 attempts++;
             }
 
-            const moreBtn = document.querySelector('[data-testid="userActions"]');
+            const primary = getPrimary();
+            const moreBtn = primary?.querySelector('[data-testid="userActions"]');
             if (!moreBtn) {
                 return { ok: false, message: 'Could not find user actions menu. Are you logged in?' };
             }
@@ -50,7 +66,7 @@ cli({
             const menuItems = document.querySelectorAll('[role="menuitem"]');
             let blockItem = null;
             for (const item of menuItems) {
-                if (item.textContent && item.textContent.includes('Block')) {
+                if (isBlockMenuItem(item)) {
                     blockItem = item;
                     break;
                 }
@@ -73,7 +89,7 @@ cli({
             await new Promise(r => setTimeout(r, 1500));
 
             // Verify
-            const verify = document.querySelector('[data-testid$="-unblock"]');
+            const verify = getPrimary()?.querySelector('[data-testid$="-unblock"]');
             if (verify) {
                 return { ok: true, message: 'Successfully blocked @${username}.' };
             } else {

--- a/clis/twitter/block.test.js
+++ b/clis/twitter/block.test.js
@@ -3,7 +3,7 @@ import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './block.js';
 import { createPageMock } from '../test-utils.js';
-import { createTwitterDomPage } from './test-dom-utils.js';
+import { createInteractiveTwitterDomPage, createTwitterDomPage } from './test-dom-utils.js';
 
 describe('twitter block command', () => {
     it('navigates to the profile URL and reports success when the block script confirms', async () => {
@@ -23,7 +23,10 @@ describe('twitter block command', () => {
         // the script returns ok:true with an "already blocking" message.
         expect(script).toContain('[data-testid$="-unblock"]');
         expect(script).toContain('[data-testid="userActions"]');
-        expect(script).toContain("includes('Block')");
+        expect(script).toContain("lower.includes('block')");
+        expect(script).toContain("text.includes('屏蔽')");
+        expect(script).toContain("text.includes('取消屏蔽')");
+        expect(script).toContain("item.getAttribute('data-testid') === 'block'");
         expect(script).toContain('blockItem.click()');
         expect(script).toContain('[data-testid="confirmationSheetConfirm"]');
         expect(result).toEqual([
@@ -53,7 +56,9 @@ describe('twitter block command', () => {
     it('keeps a missing confirmation dialog a definite pre-write failure', async () => {
         const cmd = getRegistry().get('twitter/block');
         const page = createTwitterDomPage(`
-            <button data-testid="userActions">More</button>
+            <main data-testid="primaryColumn">
+                <button data-testid="userActions">More</button>
+            </main>
             <button role="menuitem">Block @alice</button>
         `, 'https://x.com/alice');
 
@@ -68,7 +73,9 @@ describe('twitter block command', () => {
     it('treats a missing post-confirm profile state change as unconfirmed', async () => {
         const cmd = getRegistry().get('twitter/block');
         const page = createTwitterDomPage(`
-            <button data-testid="userActions">More</button>
+            <main data-testid="primaryColumn">
+                <button data-testid="userActions">More</button>
+            </main>
             <button role="menuitem">Block @alice</button>
             <button data-testid="confirmationSheetConfirm">Confirm</button>
         `, 'https://x.com/alice');
@@ -79,6 +86,86 @@ describe('twitter block command', () => {
             exitCode: 75,
             hint: expect.stringContaining('may already have succeeded'),
         });
+    });
+
+    it('blocks via localized menu text and data-testid="block"', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const { page, dom } = createInteractiveTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button data-testid="userActions">更多</button>
+            </main>
+            <div role="menuitem" data-testid="block">屏蔽 @alice</div>
+            <button data-testid="confirmationSheetConfirm">确认</button>
+        `, 'https://x.com/alice');
+        dom.window.document
+            .querySelector('[data-testid="confirmationSheetConfirm"]')
+            .addEventListener('click', () => {
+                dom.window.document
+                    .querySelector('[data-testid="primaryColumn"]')
+                    .insertAdjacentHTML('beforeend', '<button data-testid="alice-unblock">已屏蔽</button>');
+            });
+
+        const result = await cmd.func(page, { username: 'alice' });
+
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully blocked @alice.' },
+        ]);
+    });
+
+    it('does not click localized unblock menu items while looking for Block', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const { page, dom } = createInteractiveTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button data-testid="userActions">更多</button>
+            </main>
+            <div role="menuitem">取消屏蔽 @alice</div>
+            <button data-testid="confirmationSheetConfirm">确认</button>
+        `, 'https://x.com/alice');
+        let cancelClicked = false;
+        let confirmClicked = false;
+        dom.window.document
+            .querySelector('[role="menuitem"]')
+            .addEventListener('click', () => {
+                cancelClicked = true;
+            });
+        dom.window.document
+            .querySelector('[data-testid="confirmationSheetConfirm"]')
+            .addEventListener('click', () => {
+                confirmClicked = true;
+            });
+
+        await expect(cmd.func(page, { username: 'alice' })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find Block option in menu.',
+        });
+        expect(cancelClicked).toBe(false);
+        expect(confirmClicked).toBe(false);
+    });
+
+    it('verifies against the current primary column after confirmation replaces the profile surface', async () => {
+        const cmd = getRegistry().get('twitter/block');
+        const { page, dom } = createInteractiveTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button data-testid="userActions">More</button>
+            </main>
+            <div role="menuitem">Block @alice</div>
+            <button data-testid="confirmationSheetConfirm">Confirm</button>
+        `, 'https://x.com/alice');
+        dom.window.document
+            .querySelector('[data-testid="confirmationSheetConfirm"]')
+            .addEventListener('click', () => {
+                dom.window.document
+                    .querySelector('[data-testid="primaryColumn"]')
+                    .outerHTML = '<main data-testid="primaryColumn"><button data-testid="alice-unblock">Blocked</button></main>';
+            });
+
+        const result = await cmd.func(page, { username: 'alice' });
+
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully blocked @alice.' },
+        ]);
     });
 
     it('throws CommandExecutionError when no page is provided', async () => {

--- a/clis/twitter/hide-reply.js
+++ b/clis/twitter/hide-reply.js
@@ -20,10 +20,31 @@ cli({
         const target = parseTweetUrl(kwargs.url);
         await page.goto(target.url);
         await page.wait({ selector: '[data-testid="primaryColumn"]' });
-        const result = await page.evaluate(`(async () => {
+        const runHideAttempt = (allowParentDiscovery) => page.evaluate(`(async () => {
         try {
             ${buildTwitterArticleScopeSource(target.id)}
             const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
+            const moreLabels = new Set(['More', '更多']);
+            const findParentConversationUrl = (targetArticle) => {
+                const primary = document.querySelector('[data-testid="primaryColumn"]') || document;
+                const articles = Array.from(primary.querySelectorAll('article'));
+                const targetIndex = articles.indexOf(targetArticle);
+                if (targetIndex <= 0) return null;
+                for (let index = targetIndex - 1; index >= 0; index -= 1) {
+                    const links = Array.from(articles[index].querySelectorAll('a[href*="/status/"]'))
+                        .filter((link) => link.querySelector('time'));
+                    for (const link of links) {
+                        const statusId = __twGetStatusIdFromHref(link.href);
+                        if (statusId && statusId !== tweetId) {
+                            const parsed = new URL(link.href, window.location.origin);
+                            if (parsed.origin === window.location.origin) {
+                                return parsed.toString();
+                            }
+                        }
+                    }
+                }
+                return null;
+            };
             // Locate the article matching the requested status id, then find
             // its More menu. Without article scoping we'd grab whatever the
             // first "More" button on the page is — usually the parent tweet
@@ -37,7 +58,7 @@ cli({
                 targetArticle = findTargetArticle();
                 if (targetArticle) {
                     const buttons = Array.from(targetArticle.querySelectorAll('button,[role="button"]'));
-                    moreMenu = buttons.find((el) => visible(el) && (el.getAttribute('aria-label') || '').trim() === 'More');
+                    moreMenu = buttons.find((el) => visible(el) && moreLabels.has((el.getAttribute('aria-label') || '').trim()));
                     if (moreMenu) break;
                 }
                 await new Promise(r => setTimeout(r, 500));
@@ -59,13 +80,26 @@ cli({
             const items = document.querySelectorAll('[role="menuitem"]');
             let hideItem = null;
             for (const item of items) {
-                if (item.textContent && item.textContent.includes('Hide reply')) {
+                const text = String(item.textContent || '');
+                const testId = item.getAttribute('data-testid');
+                if (
+                    testId === 'hideReply'
+                    || text.includes('Hide reply')
+                    || text.includes('隐藏回复')
+                    || (text.includes('隐藏') && text.includes('回复') && !text.includes('取消'))
+                ) {
                     hideItem = item;
                     break;
                 }
             }
 
             if (!hideItem) {
+                if (${allowParentDiscovery ? 'true' : 'false'}) {
+                    const parentUrl = findParentConversationUrl(targetArticle);
+                    if (parentUrl) {
+                        return { ok: false, retryOnParent: true, parentUrl, message: 'Hide reply option is not present on standalone reply page; retrying in parent conversation.' };
+                    }
+                }
                 return { ok: false, message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.' };
             }
 
@@ -77,6 +111,12 @@ cli({
             return { ok: false, message: e.toString() };
         }
     })()`);
+        let result = await runHideAttempt(true);
+        if (result?.retryOnParent && result.parentUrl) {
+            await page.goto(result.parentUrl);
+            await page.wait({ selector: '[data-testid="primaryColumn"]' });
+            result = await runHideAttempt(false);
+        }
         if (!result.ok) {
             throw new CommandExecutionError(result.message, 'Nothing changed. Open the tweet in the browser and retry.');
         }

--- a/clis/twitter/hide-reply.test.js
+++ b/clis/twitter/hide-reply.test.js
@@ -1,8 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './hide-reply.js';
 import { createPageMock } from '../test-utils.js';
+
+function makeVisibleDom(html, url) {
+    const dom = new JSDOM(html, {
+        url,
+        runScripts: 'outside-only',
+    });
+    dom.window.setTimeout = (callback) => {
+        callback();
+        return 0;
+    };
+    dom.window.HTMLElement.prototype.getClientRects = function getClientRects() {
+        return [{ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }];
+    };
+    return dom;
+}
+
+function createMultiPageDomPage(pages, initialUrl) {
+    let current = pages[initialUrl];
+    return {
+        goto: vi.fn(async (url) => {
+            current = pages[url];
+            if (!current) throw new Error(`Unexpected navigation: ${url}`);
+        }),
+        wait: vi.fn(async () => undefined),
+        evaluate: vi.fn(async (script) => current.window.eval(String(script))),
+    };
+}
 
 describe('twitter hide-reply command', () => {
     it('navigates to the reply URL and reports success when the hide-reply script confirms', async () => {
@@ -23,8 +51,12 @@ describe('twitter hide-reply command', () => {
         // silently hides the wrong reply (or fails because the parent is not a
         // reply you authored).
         expect(script).toContain('moreMenu.click()');
+        expect(script).toContain("new Set(['More', '更多'])");
+        expect(script).toContain('findParentConversationUrl');
         expect(script).toContain('[role="menuitem"]');
         expect(script).toContain("'Hide reply'");
+        expect(script).toContain("'hideReply'");
+        expect(script).toContain("'隐藏回复'");
         expect(script).toContain('hideItem.click()');
         // Article scoping comes from the shared helper (buildTwitterArticleScopeSource):
         // emits __twHasLinkToTarget + __twGetStatusIdFromHref + the anchored
@@ -35,6 +67,112 @@ describe('twitter hide-reply command', () => {
         expect(result).toEqual([
             { status: 'success', message: 'Reply successfully hidden.' },
         ]);
+    });
+
+    it('retries in the parent conversation when standalone reply page lacks the hide menu item', async () => {
+        const cmd = getRegistry().get('twitter/hide-reply');
+        const replyUrl = 'https://x.com/bob/status/222';
+        const parentUrl = 'https://x.com/alice/status/111';
+        const pages = {
+            [replyUrl]: makeVisibleDom(`
+                <main data-testid="primaryColumn">
+                    <article id="parent"><a href="${parentUrl}"><time datetime="2026-08-23">parent</time></a></article>
+                    <article id="reply">
+                        <a href="${replyUrl}">reply</a>
+                        <button aria-label="更多">menu</button>
+                    </article>
+                </main>
+            `, replyUrl),
+            [parentUrl]: makeVisibleDom(`
+                <main data-testid="primaryColumn">
+                    <article id="parent"><a href="${parentUrl}"><time datetime="2026-08-23">parent</time></a></article>
+                    <article id="reply">
+                        <a href="${replyUrl}">reply</a>
+                        <button aria-label="更多">menu</button>
+                    </article>
+                </main>
+                <div role="menuitem" data-testid="hideReply">隐藏回复</div>
+            `, parentUrl),
+        };
+        const page = createMultiPageDomPage(pages, replyUrl);
+
+        const result = await cmd.func(page, { url: replyUrl });
+
+        expect(page.goto).toHaveBeenNthCalledWith(1, replyUrl);
+        expect(page.goto).toHaveBeenNthCalledWith(2, parentUrl);
+        expect(page.wait).toHaveBeenCalledTimes(3);
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([
+            { status: 'success', message: 'Reply successfully hidden.' },
+        ]);
+    });
+
+    it('uses the parent tweet time permalink instead of an earlier quoted status link', async () => {
+        const cmd = getRegistry().get('twitter/hide-reply');
+        const replyUrl = 'https://x.com/bob/status/222';
+        const parentUrl = 'https://x.com/alice/status/111';
+        const quotedUrl = 'https://x.com/quoted/status/999';
+        const pages = {
+            [replyUrl]: makeVisibleDom(`
+                <main data-testid="primaryColumn">
+                    <article id="parent">
+                        <a href="${quotedUrl}">quoted card</a>
+                        <a href="${parentUrl}"><time datetime="2026-08-23">parent</time></a>
+                    </article>
+                    <article id="reply">
+                        <a href="${replyUrl}">reply</a>
+                        <button aria-label="More">menu</button>
+                    </article>
+                </main>
+            `, replyUrl),
+            [parentUrl]: makeVisibleDom(`
+                <main data-testid="primaryColumn">
+                    <article id="parent"><a href="${parentUrl}"><time datetime="2026-08-23">parent</time></a></article>
+                    <article id="reply">
+                        <a href="${replyUrl}">reply</a>
+                        <button aria-label="More">menu</button>
+                    </article>
+                </main>
+                <div role="menuitem">Hide reply</div>
+            `, parentUrl),
+        };
+        const page = createMultiPageDomPage(pages, replyUrl);
+
+        const result = await cmd.func(page, { url: replyUrl });
+
+        expect(page.goto).toHaveBeenNthCalledWith(1, replyUrl);
+        expect(page.goto).toHaveBeenNthCalledWith(2, parentUrl);
+        expect(page.goto).not.toHaveBeenCalledWith(quotedUrl);
+        expect(result).toEqual([
+            { status: 'success', message: 'Reply successfully hidden.' },
+        ]);
+    });
+
+    it('does not retry a parent conversation URL from a different Twitter/X origin', async () => {
+        const cmd = getRegistry().get('twitter/hide-reply');
+        const replyUrl = 'https://x.com/bob/status/222';
+        const crossOriginParentUrl = 'https://twitter.com/alice/status/111';
+        const pages = {
+            [replyUrl]: makeVisibleDom(`
+                <main data-testid="primaryColumn">
+                    <article id="parent"><a href="${crossOriginParentUrl}"><time datetime="2026-08-23">parent</time></a></article>
+                    <article id="reply">
+                        <a href="${replyUrl}">reply</a>
+                        <button aria-label="More">menu</button>
+                    </article>
+                </main>
+            `, replyUrl),
+        };
+        const page = createMultiPageDomPage(pages, replyUrl);
+
+        await expect(cmd.func(page, { url: replyUrl })).rejects.toMatchObject({
+            name: 'CommandExecutionError',
+            code: 'COMMAND_EXEC',
+            exitCode: 1,
+            message: 'Could not find "Hide reply" option. This may not be a reply on your tweet.',
+        });
+        expect(page.goto).toHaveBeenCalledTimes(1);
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
     });
 
     it('typed-fails without re-waiting when the hide-reply script reports a UI mismatch', async () => {

--- a/clis/twitter/test-dom-utils.js
+++ b/clis/twitter/test-dom-utils.js
@@ -15,3 +15,21 @@ export function createTwitterDomPage(html, url = 'https://x.com/alice/status/204
         evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
     });
 }
+
+export function createInteractiveTwitterDomPage(html, url = 'https://x.com/alice/status/2040254679301718161') {
+    const dom = new JSDOM(html, {
+        url,
+        runScripts: 'outside-only',
+    });
+    dom.window.setTimeout = (callback) => {
+        callback();
+        return 0;
+    };
+    dom.window.HTMLElement.prototype.getClientRects = function getClientRects() {
+        return [{ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }];
+    };
+    const page = createPageMock([], {
+        evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
+    });
+    return { page, dom };
+}

--- a/clis/twitter/unblock.js
+++ b/clis/twitter/unblock.js
@@ -23,15 +23,23 @@ cli({
         try {
             let attempts = 0;
             let unblockBtn = null;
+            const getPrimary = () => document.querySelector('[data-testid="primaryColumn"]');
+            if (!getPrimary()) {
+                return { ok: false, message: 'Could not find profile surface. Are you logged in?' };
+            }
 
             while (attempts < 20) {
+                const primary = getPrimary();
+                if (!primary) {
+                    return { ok: false, message: 'Could not find profile surface. Are you logged in?' };
+                }
                 // Check if not blocked (follow button visible means not blocked)
-                const followBtn = document.querySelector('[data-testid$="-follow"]');
+                const followBtn = primary.querySelector('[data-testid$="-follow"]');
                 if (followBtn) {
                     return { ok: true, message: 'Not blocking @${username} (already unblocked).' };
                 }
 
-                unblockBtn = document.querySelector('[data-testid$="-unblock"]');
+                unblockBtn = primary.querySelector('[data-testid$="-unblock"]');
                 if (unblockBtn) break;
 
                 await new Promise(r => setTimeout(r, 500));
@@ -56,7 +64,7 @@ cli({
             await new Promise(r => setTimeout(r, 1000));
 
             // Verify
-            const verify = document.querySelector('[data-testid$="-follow"]');
+            const verify = getPrimary()?.querySelector('[data-testid$="-follow"]');
             if (verify) {
                 return { ok: true, message: 'Successfully unblocked @${username}.' };
             } else {

--- a/clis/twitter/unblock.test.js
+++ b/clis/twitter/unblock.test.js
@@ -3,6 +3,7 @@ import { CommandExecutionError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './unblock.js';
 import { createPageMock } from '../test-utils.js';
+import { createInteractiveTwitterDomPage } from './test-dom-utils.js';
 
 describe('twitter unblock command', () => {
     it('navigates to the profile URL and reports success when the unblock script confirms', async () => {
@@ -20,6 +21,7 @@ describe('twitter unblock command', () => {
         const script = page.evaluate.mock.calls[0][0];
         // Idempotency probe: when the Follow button is visible ([data-testid$="-follow"]
         // present, so not blocked), the script returns ok:true with an "already unblocked" message.
+        expect(script).toContain("document.querySelector('[data-testid=\"primaryColumn\"]')");
         expect(script).toContain('[data-testid$="-follow"]');
         expect(script).toContain('[data-testid$="-unblock"]');
         expect(script).toContain('unblockBtn.click()');
@@ -46,6 +48,55 @@ describe('twitter unblock command', () => {
             message: 'Could not find Unblock button. Are you logged in?',
         });
         expect(page.wait).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores sidebar follow buttons when deciding whether the profile is already unblocked', async () => {
+        const cmd = getRegistry().get('twitter/unblock');
+        const { page, dom } = createInteractiveTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button data-testid="alice-unblock">Unblock</button>
+            </main>
+            <aside>
+                <button data-testid="370654420-follow">Follow suggested account</button>
+            </aside>
+            <button data-testid="confirmationSheetConfirm">Confirm</button>
+        `, 'https://x.com/alice');
+        dom.window.document
+            .querySelector('[data-testid="confirmationSheetConfirm"]')
+            .addEventListener('click', () => {
+                dom.window.document
+                    .querySelector('[data-testid="primaryColumn"]')
+                    .insertAdjacentHTML('beforeend', '<button data-testid="alice-follow">Follow</button>');
+            });
+
+        const result = await cmd.func(page, { username: 'alice' });
+
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully unblocked @alice.' },
+        ]);
+    });
+
+    it('verifies against the current primary column after confirmation replaces the profile surface', async () => {
+        const cmd = getRegistry().get('twitter/unblock');
+        const { page, dom } = createInteractiveTwitterDomPage(`
+            <main data-testid="primaryColumn">
+                <button data-testid="alice-unblock">Unblock</button>
+            </main>
+            <button data-testid="confirmationSheetConfirm">Confirm</button>
+        `, 'https://x.com/alice');
+        dom.window.document
+            .querySelector('[data-testid="confirmationSheetConfirm"]')
+            .addEventListener('click', () => {
+                dom.window.document
+                    .querySelector('[data-testid="primaryColumn"]')
+                    .outerHTML = '<main data-testid="primaryColumn"><button data-testid="alice-follow">Follow</button></main>';
+            });
+
+        const result = await cmd.func(page, { username: 'alice' });
+
+        expect(result).toEqual([
+            { status: 'success', message: 'Successfully unblocked @alice.' },
+        ]);
     });
 
     it('throws CommandExecutionError when no page is provided', async () => {


### PR DESCRIPTION
Fixes #2334.
Fixes #2335.
Fixes #2336.

## Summary
- match Twitter/X block menu items by `data-testid="block"` and localized Chinese text in addition to English text, while explicitly excluding unblock/cancel-unblock text
- scope block/unblock profile-state probes to the current `[data-testid="primaryColumn"]` on every read, so sidebar follow buttons and replaced React roots cannot corrupt post-click verification
- make `hide-reply` tolerate localized More / hide-reply labels, and when the standalone reply page has no Hide reply option, derive the closest parent tweet URL from the preceding article's `<time>` permalink and retry in the same-origin parent conversation view
- add production-script JSDOM regressions for localized block, cancel-unblock no-click, current-primary verification after root replacement, sidebar follow false-positive unblock, and standalone reply -> parent conversation hide-reply retry with quote/status traps

## Validation
- `npx vitest run clis/twitter/block.test.js clis/twitter/unblock.test.js clis/twitter/hide-reply.test.js` PASS, 20/20
- `npx vitest run clis/twitter/*.test.js` PASS, 44 files / 531 tests
- `npm run typecheck` PASS
- `npm run build` PASS, manifest 1332 entries
- `node dist/src/main.js validate twitter` PASS, 46 commands, 0 errors / 0 warnings
- `npm run check:typed-error-lint` PASS, new=0
- `npm run check:silent-column-drop` PASS, new=0
- `git diff --check` PASS

Live write smoke was not run: these commands mutate Twitter/X account state, and the issue bodies already contain local live autofix evidence for the original #2334/#2335 failures.
