### PR TITLE
chore(twitter): share user lookup URL builder

### DIFF
--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
+import { buildUserByScreenNameQueryUrl, looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
 const FOLLOWING_QUERY_ID = 'F42cDX8PDFxkbjjq6JrM2w';
@@ -62,27 +62,6 @@ function buildFollowingUrl(queryId, userId, count, cursor) {
     return `/i/api/graphql/${queryId}/Following`
         + `?variables=${encodeURIComponent(JSON.stringify(vars))}`
         + `&features=${encodeURIComponent(JSON.stringify(FEATURES))}`;
-}
-
-function buildUserByScreenNameUrl(queryId, screenName) {
-    const vars = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
-    const feats = JSON.stringify({
-        hidden_profile_subscriptions_enabled: true,
-        rweb_tipjar_consumption_enabled: true,
-        responsive_web_graphql_exclude_directive_enabled: true,
-        verified_phone_label_enabled: false,
-        subscriptions_verification_info_is_identity_verified_enabled: true,
-        subscriptions_verification_info_verified_since_enabled: true,
-        highlights_tweets_tab_ui_enabled: true,
-        responsive_web_twitter_article_notes_tab_enabled: true,
-        subscriptions_feature_can_gift_premium: true,
-        creator_subscriptions_tweet_preview_api_enabled: true,
-        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-        responsive_web_graphql_timeline_navigation_enabled: true,
-    });
-    return `/i/api/graphql/${queryId}/UserByScreenName`
-        + `?variables=${encodeURIComponent(vars)}`
-        + `&features=${encodeURIComponent(feats)}`;
 }
 
 function extractUser(result) {
@@ -211,7 +190,7 @@ cli({
             if (!resp.ok) return { error: resp.status };
             const d = await resp.json();
             return { userId: d.data?.user?.result?.rest_id || null };
-        }, buildUserByScreenNameUrl(userByScreenNameQueryId, targetUser), headers));
+        }, buildUserByScreenNameQueryUrl(userByScreenNameQueryId, targetUser), headers));
         if (userLookup?.error === 401 || userLookup?.error === 403) {
             throw new AuthRequiredError('x.com', `Twitter user lookup failed (HTTP ${userLookup.error})`);
         }
@@ -267,7 +246,6 @@ cli({
 export const __test__ = {
     sanitizeQueryId,
     buildFollowingUrl,
-    buildUserByScreenNameUrl,
     extractUser,
     normalizeScreenName,
     parseFollowing,

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, extractMedia, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
+import { buildUserByScreenNameQueryUrl, looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, extractMedia, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const LIKES_QUERY_ID = 'CDWHmpZeSdIJ3HGeRbNm0w';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
@@ -62,26 +62,6 @@ function buildLikesUrl(queryId, userId, count, cursor) {
     return `/i/api/graphql/${queryId}/Likes`
         + `?variables=${encodeURIComponent(JSON.stringify(vars))}`
         + `&features=${encodeURIComponent(JSON.stringify(FEATURES))}`;
-}
-function buildUserByScreenNameUrl(queryId, screenName) {
-    const vars = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
-    const feats = JSON.stringify({
-        hidden_profile_subscriptions_enabled: true,
-        rweb_tipjar_consumption_enabled: true,
-        responsive_web_graphql_exclude_directive_enabled: true,
-        verified_phone_label_enabled: false,
-        subscriptions_verification_info_is_identity_verified_enabled: true,
-        subscriptions_verification_info_verified_since_enabled: true,
-        highlights_tweets_tab_ui_enabled: true,
-        responsive_web_twitter_article_notes_tab_enabled: true,
-        subscriptions_feature_can_gift_premium: true,
-        creator_subscriptions_tweet_preview_api_enabled: true,
-        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-        responsive_web_graphql_timeline_navigation_enabled: true,
-    });
-    return `/i/api/graphql/${queryId}/UserByScreenName`
-        + `?variables=${encodeURIComponent(vars)}`
-        + `&features=${encodeURIComponent(feats)}`;
 }
 function extractLikedTweet(result, seen) {
     if (!result)
@@ -350,7 +330,7 @@ cli({
         // Get userId from screen_name
         const userId = unwrapBrowserResult(await page.evaluate(`async () => {
       const screenName = ${JSON.stringify(username)};
-      const url = ${JSON.stringify(buildUserByScreenNameUrl(userByScreenNameQueryId, username))};
+      const url = ${JSON.stringify(buildUserByScreenNameQueryUrl(userByScreenNameQueryId, username))};
       const resp = await fetch(url, { headers: ${headers}, credentials: 'include' });
       if (!resp.ok) return null;
       const d = await resp.json();
@@ -472,7 +452,6 @@ cli({
 export const __test__ = {
     sanitizeQueryId,
     buildLikesUrl,
-    buildUserByScreenNameUrl,
     parseLikes,
     appendJsonlRows,
     readResumeFile,

--- a/clis/twitter/list-add-core.js
+++ b/clis/twitter/list-add-core.js
@@ -1,5 +1,5 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+import { buildUserByScreenNameQueryUrl, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
 import { parseListsManagement } from './lists.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
@@ -42,27 +42,6 @@ const LISTS_MANAGEMENT_FEATURES = {
     responsive_web_grok_image_annotation_enabled: true,
     responsive_web_enhance_cards_enabled: false,
 };
-
-function buildUserByScreenNameUrl(queryId, screenName) {
-    const vars = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
-    const feats = JSON.stringify({
-        hidden_profile_subscriptions_enabled: true,
-        rweb_tipjar_consumption_enabled: true,
-        responsive_web_graphql_exclude_directive_enabled: true,
-        verified_phone_label_enabled: false,
-        subscriptions_verification_info_is_identity_verified_enabled: true,
-        subscriptions_verification_info_verified_since_enabled: true,
-        highlights_tweets_tab_ui_enabled: true,
-        responsive_web_twitter_article_notes_tab_enabled: true,
-        subscriptions_feature_can_gift_premium: true,
-        creator_subscriptions_tweet_preview_api_enabled: true,
-        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-        responsive_web_graphql_timeline_navigation_enabled: true,
-    });
-    return `/i/api/graphql/${queryId}/UserByScreenName`
-        + `?variables=${encodeURIComponent(vars)}`
-        + `&features=${encodeURIComponent(feats)}`;
-}
 
 function fatalGraphqlErrors(errors) {
     const list = Array.isArray(errors) ? errors : [];
@@ -150,7 +129,7 @@ export async function listAddUser(page, kwargs) {
 
         // opencli >=1.7.x wraps page.evaluate return values as { session, data }.
         // Unwrap before use so JSON.stringify of nested values doesn't become "[object Object]".
-        const userLookupUrl = buildUserByScreenNameUrl(userByScreenNameQueryId, username);
+        const userLookupUrl = buildUserByScreenNameQueryUrl(userByScreenNameQueryId, username);
         const userIdRaw = await page.evaluate(`async () => {
             const resp = await fetch(${JSON.stringify(userLookupUrl)}, { headers: ${headers}, credentials: 'include' });
             if (!resp.ok) return null;

--- a/clis/twitter/list-remove-core.js
+++ b/clis/twitter/list-remove-core.js
@@ -1,5 +1,5 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+import { buildUserByScreenNameQueryUrl, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
 import { getListsManagementInstructions, parseListsManagement } from './lists.js';
 import { TWITTER_BEARER_TOKEN } from './utils.js';
 
@@ -40,27 +40,6 @@ const LISTS_MANAGEMENT_FEATURES = {
     responsive_web_enhance_cards_enabled: false,
 };
 
-function buildUserByScreenNameUrl(queryId, screenName) {
-    const vars = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
-    const feats = JSON.stringify({
-        hidden_profile_subscriptions_enabled: true,
-        rweb_tipjar_consumption_enabled: true,
-        responsive_web_graphql_exclude_directive_enabled: true,
-        verified_phone_label_enabled: false,
-        subscriptions_verification_info_is_identity_verified_enabled: true,
-        subscriptions_verification_info_verified_since_enabled: true,
-        highlights_tweets_tab_ui_enabled: true,
-        responsive_web_twitter_article_notes_tab_enabled: true,
-        subscriptions_feature_can_gift_premium: true,
-        creator_subscriptions_tweet_preview_api_enabled: true,
-        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-        responsive_web_graphql_timeline_navigation_enabled: true,
-    });
-    return `/i/api/graphql/${queryId}/UserByScreenName`
-        + `?variables=${encodeURIComponent(vars)}`
-        + `&features=${encodeURIComponent(feats)}`;
-}
-
 export function interpretRemoveResponse(status, json) {
     if (status === 200 && json && (json.id_str || json.id || json.slug)) return { ok: true };
     if (json && Array.isArray(json.errors) && json.errors.length > 0) {
@@ -94,7 +73,7 @@ export async function listRemoveUser(page, kwargs) {
             'X-Twitter-Active-User': 'yes',
         });
 
-        const userLookupUrl = buildUserByScreenNameUrl(userByScreenNameQueryId, username);
+        const userLookupUrl = buildUserByScreenNameQueryUrl(userByScreenNameQueryId, username);
         const userId = unwrapBrowserResult(await page.evaluate(`async () => {
             const resp = await fetch(${JSON.stringify(userLookupUrl)}, { headers: ${headers}, credentials: 'include' });
             if (!resp.ok) return null;

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -5,6 +5,20 @@ const SCREEN_NAME_PATTERN = /^[A-Za-z0-9_]{1,15}$/;
 const TWEET_PATH_PATTERN = /^\/(?:[^/]+|i)\/status\/(\d+)\/?$/;
 const TWEET_HOSTS = new Set(['x.com', 'twitter.com']);
 const SCREEN_NAME_HOSTS = new Set(['x.com', 'twitter.com', 'mobile.twitter.com']);
+const USER_BY_SCREEN_NAME_FEATURES = {
+    hidden_profile_subscriptions_enabled: true,
+    rweb_tipjar_consumption_enabled: true,
+    responsive_web_graphql_exclude_directive_enabled: true,
+    verified_phone_label_enabled: false,
+    subscriptions_verification_info_is_identity_verified_enabled: true,
+    subscriptions_verification_info_verified_since_enabled: true,
+    highlights_tweets_tab_ui_enabled: true,
+    responsive_web_twitter_article_notes_tab_enabled: true,
+    subscriptions_feature_can_gift_premium: true,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+};
 const RESERVED_SCREEN_NAME_PATHS = new Set([
     'compose',
     'explore',
@@ -100,6 +114,14 @@ export function buildTwitterArticleScopeSource(tweetId) {
 
 export function sanitizeQueryId(resolved, fallbackId) {
     return typeof resolved === 'string' && QUERY_ID_PATTERN.test(resolved) ? resolved : fallbackId;
+}
+
+export function buildUserByScreenNameQueryUrl(queryId, screenName) {
+    const variables = JSON.stringify({ screen_name: screenName, withSafetyModeUserFields: true });
+    const features = JSON.stringify(USER_BY_SCREEN_NAME_FEATURES);
+    return `/i/api/graphql/${queryId}/UserByScreenName`
+        + `?variables=${encodeURIComponent(variables)}`
+        + `&features=${encodeURIComponent(features)}`;
 }
 
 export function normalizeTwitterScreenName(value) {
@@ -548,6 +570,7 @@ export function describeTwitterApiError(operation, status, extraHint) {
 
 export const __test__ = {
     sanitizeQueryId,
+    buildUserByScreenNameQueryUrl,
     normalizeTwitterOperationFlags,
     sanitizeTwitterOperationMetadata,
     unwrapBrowserResult,

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -9,6 +9,7 @@ const {
     extractQuotedTweet,
     parseTweetUrl,
     buildTwitterArticleScopeSource,
+    buildUserByScreenNameQueryUrl,
     unwrapBrowserResult,
     normalizeTwitterGraphqlPayload,
     normalizeTwitterScreenName,
@@ -40,6 +41,29 @@ function imgBinding(key, url) {
 }
 
 describe('twitter browser result helpers', () => {
+    it('builds the legacy queryId UserByScreenName URL contract', () => {
+        const url = new URL(buildUserByScreenNameQueryUrl('query_123', 'jack'), 'https://x.com');
+        expect(url.pathname).toBe('/i/api/graphql/query_123/UserByScreenName');
+        expect(JSON.parse(url.searchParams.get('variables'))).toEqual({
+            screen_name: 'jack',
+            withSafetyModeUserFields: true,
+        });
+        expect(JSON.parse(url.searchParams.get('features'))).toEqual({
+            hidden_profile_subscriptions_enabled: true,
+            rweb_tipjar_consumption_enabled: true,
+            responsive_web_graphql_exclude_directive_enabled: true,
+            verified_phone_label_enabled: false,
+            subscriptions_verification_info_is_identity_verified_enabled: true,
+            subscriptions_verification_info_verified_since_enabled: true,
+            highlights_tweets_tab_ui_enabled: true,
+            responsive_web_twitter_article_notes_tab_enabled: true,
+            subscriptions_feature_can_gift_premium: true,
+            creator_subscriptions_tweet_preview_api_enabled: true,
+            responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+            responsive_web_graphql_timeline_navigation_enabled: true,
+        });
+    });
+
     it('unwraps Browser Bridge exec envelopes', () => {
         expect(unwrapBrowserResult({ session: 'site:twitter', data: '123' })).toBe('123');
         expect(unwrapBrowserResult({ data: { user: true } })).toEqual({ data: { user: true } });


### PR DESCRIPTION
## Summary
- move the four identical legacy `(queryId, screenName)` UserByScreenName URL builders into `clis/twitter/shared.js` as `buildUserByScreenNameQueryUrl`
- update list-add, list-remove, following, and likes to import the shared helper
- remove following/likes imported-helper `__test__` shims and add one shared URL contract test

## Boundaries
- leaves `download.js` and `user-timeline.js` operation-object `buildUserByScreenNameUrl(operation, screenName)` implementations untouched
- does not touch tweets, bookmarks/likes JSONL, #2322 proxy behavior, or article-extract files

## Tests
- `npx vitest run clis/twitter/shared.test.js clis/twitter/following.test.js clis/twitter/likes.test.js clis/twitter/list-add.test.js clis/twitter/list-remove.test.js`
- `npx vitest run clis/twitter`
- `npm run typecheck`
- `npm run build`
- `node dist/src/main.js validate twitter`
- `npm run check:typed-error-lint` (new=0; reported baseline-resolved line shifts only)
- `npm run check:silent-column-drop` (new=0; reported baseline-resolved line shifts only)
- `git diff --check`