### PR TITLE
chore(twitter): share archive JSONL helpers

### DIFF
--- a/clis/twitter/archive.js
+++ b/clis/twitter/archive.js
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+// Safety cap only. Full-archive runs can set a higher page budget via --max-pages.
+export const DEFAULT_MAX_PAGINATION_PAGES = 100;
+const HARD_MAX_PAGINATION_PAGES = 100000;
+
+export function resolveOptionalFilePath(raw, label) {
+    if (raw === undefined || raw === null || raw === '')
+        return '';
+    const value = String(raw).trim();
+    if (!value)
+        throw new ArgumentError(`${label} cannot be empty`);
+    return path.resolve(value);
+}
+
+export function ensureParentDir(filePath) {
+    if (!filePath)
+        return;
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function removeFile(filePath) {
+    if (!filePath)
+        return;
+    try {
+        fs.rmSync(filePath, { force: true });
+    }
+    catch {
+    }
+}
+
+export function loadJsonlArchiveState(filePath) {
+    const seen = new Set();
+    let count = 0;
+    if (!filePath || !fs.existsSync(filePath))
+        return { seen, count };
+    const text = fs.readFileSync(filePath, 'utf8');
+    for (const [index, line] of text.split('\n').entries()) {
+        const trimmed = line.trim();
+        if (!trimmed)
+            continue;
+        try {
+            const row = JSON.parse(trimmed);
+            if (!row?.id)
+                throw new Error('missing id');
+            const id = String(row.id);
+            if (seen.has(id))
+                throw new Error(`duplicate id ${id}`);
+            seen.add(id);
+            count += 1;
+        }
+        catch (error) {
+            throw new CommandExecutionError(`Invalid JSONL record in ${filePath} at line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+    return { seen, count };
+}
+
+export function appendJsonlRows(filePath, rows) {
+    if (!filePath || !Array.isArray(rows) || rows.length === 0)
+        return;
+    ensureParentDir(filePath);
+    // Escape LS/PS so JSONL stays one physical line even when tweet text contains them.
+    const text = rows
+        .map((row) => JSON.stringify(row).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029'))
+        .join('\n') + '\n';
+    fs.appendFileSync(filePath, text, 'utf8');
+}
+
+export function removeResumeFile(filePath) {
+    removeFile(filePath);
+}
+
+export function resolveMaxPages(kwargs, fetchAll) {
+    const raw = kwargs['max-pages'];
+    if (raw === undefined || raw === null || raw === '') {
+        return fetchAll ? HARD_MAX_PAGINATION_PAGES : DEFAULT_MAX_PAGINATION_PAGES;
+    }
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value < 1 || value > HARD_MAX_PAGINATION_PAGES) {
+        throw new ArgumentError(`--max-pages must be an integer between 1 and ${HARD_MAX_PAGINATION_PAGES}`);
+    }
+    return value;
+}

--- a/clis/twitter/archive.test.js
+++ b/clis/twitter/archive.test.js
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DEFAULT_MAX_PAGINATION_PAGES,
+    appendJsonlRows,
+    ensureParentDir,
+    loadJsonlArchiveState,
+    removeResumeFile,
+    resolveMaxPages,
+    resolveOptionalFilePath,
+} from './archive.js';
+
+function makeTempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-twitter-archive-'));
+}
+
+describe('twitter archive helpers', () => {
+    it('resolves optional file paths and rejects blank explicit values', () => {
+        expect(resolveOptionalFilePath(undefined, '--output-file')).toBe('');
+        expect(resolveOptionalFilePath(null, '--output-file')).toBe('');
+        expect(resolveOptionalFilePath('', '--output-file')).toBe('');
+        expect(resolveOptionalFilePath('archive.jsonl', '--output-file')).toBe(path.resolve('archive.jsonl'));
+        expect(() => resolveOptionalFilePath('   ', '--output-file')).toThrow(ArgumentError);
+    });
+
+    it('creates parent directories recursively', () => {
+        const root = makeTempDir();
+        try {
+            const filePath = path.join(root, 'nested', 'archive', 'out.jsonl');
+            ensureParentDir(filePath);
+            expect(fs.statSync(path.dirname(filePath)).isDirectory()).toBe(true);
+        }
+        finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('loads JSONL state while ignoring blank lines and stringifying ids', () => {
+        const root = makeTempDir();
+        try {
+            const filePath = path.join(root, 'archive.jsonl');
+            fs.writeFileSync(filePath, '\n{"id":123}\n  \n{"id":"abc"}\n', 'utf8');
+            const state = loadJsonlArchiveState(filePath);
+            expect(state.count).toBe(2);
+            expect([...state.seen]).toEqual(['123', 'abc']);
+        }
+        finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('fails JSONL loading with 1-based line errors for malformed records', () => {
+        const root = makeTempDir();
+        try {
+            const missingId = path.join(root, 'missing-id.jsonl');
+            fs.writeFileSync(missingId, '{"id":"ok"}\n{"text":"no id"}\n', 'utf8');
+            expect(() => loadJsonlArchiveState(missingId)).toThrow(/line 2: missing id/);
+
+            const badJson = path.join(root, 'bad-json.jsonl');
+            fs.writeFileSync(badJson, '{"id":"ok"}\n{broken}\n', 'utf8');
+            expect(() => loadJsonlArchiveState(badJson)).toThrow(CommandExecutionError);
+            expect(() => loadJsonlArchiveState(badJson)).toThrow(/line 2:/);
+
+            const duplicate = path.join(root, 'duplicate.jsonl');
+            fs.writeFileSync(duplicate, '{"id":"same"}\n{"id":"same"}\n', 'utf8');
+            expect(() => loadJsonlArchiveState(duplicate)).toThrow(/line 2: duplicate id same/);
+        }
+        finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('appends one physical JSONL line per row and escapes LS/PS', () => {
+        const root = makeTempDir();
+        try {
+            const filePath = path.join(root, 'nested', 'archive.jsonl');
+            appendJsonlRows(filePath, [
+                { id: '1', text: 'line separator \u2028 paragraph \u2029 done' },
+                { id: '2', text: 'second' },
+            ]);
+            appendJsonlRows(filePath, [{ id: '3', text: 'third' }]);
+            const text = fs.readFileSync(filePath, 'utf8');
+            const lines = text.split('\n');
+            expect(lines).toHaveLength(4);
+            expect(lines[3]).toBe('');
+            expect(lines[0]).toContain('\\u2028');
+            expect(lines[0]).toContain('\\u2029');
+            expect(JSON.parse(lines[0])).toEqual({ id: '1', text: 'line separator \u2028 paragraph \u2029 done' });
+            expect(JSON.parse(lines[2])).toEqual({ id: '3', text: 'third' });
+        }
+        finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('removes resume files and ignores empty paths', () => {
+        const root = makeTempDir();
+        try {
+            const filePath = path.join(root, 'resume.json');
+            fs.writeFileSync(filePath, '{}\n', 'utf8');
+            removeResumeFile(filePath);
+            removeResumeFile('');
+            expect(fs.existsSync(filePath)).toBe(false);
+        }
+        finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('resolves default and explicit max page bounds', () => {
+        expect(resolveMaxPages({}, false)).toBe(DEFAULT_MAX_PAGINATION_PAGES);
+        expect(resolveMaxPages({}, true)).toBe(100000);
+        expect(resolveMaxPages({ 'max-pages': '' }, true)).toBe(100000);
+        expect(resolveMaxPages({ 'max-pages': 1 }, false)).toBe(1);
+        expect(resolveMaxPages({ 'max-pages': 100000 }, false)).toBe(100000);
+        expect(() => resolveMaxPages({ 'max-pages': 0 }, false)).toThrow(ArgumentError);
+        expect(() => resolveMaxPages({ 'max-pages': 1.5 }, false)).toThrow(ArgumentError);
+        expect(() => resolveMaxPages({ 'max-pages': 100001 }, true)).toThrow(
+            '--max-pages must be an integer between 1 and 100000',
+        );
+    });
+});

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -3,11 +3,9 @@ import path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { extractMedia, describeTwitterApiError, resolveTwitterQueryId, unwrapBrowserResult } from './shared.js';
+import { DEFAULT_MAX_PAGINATION_PAGES, appendJsonlRows, ensureParentDir, loadJsonlArchiveState, removeResumeFile, resolveMaxPages, resolveOptionalFilePath } from './archive.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const BOOKMARKS_QUERY_ID = 'Fy0QMy4q_aZCpkO0PnyLYw';
-// Safety cap only. Full-archive runs can set a higher page budget via --max-pages.
-const DEFAULT_MAX_PAGINATION_PAGES = 100;
-const HARD_MAX_PAGINATION_PAGES = 100000;
 const FEATURES = {
     rweb_video_screen_enabled: false,
     profile_label_improvements_pcf_label_in_post_enabled: true,
@@ -104,14 +102,6 @@ export function parseBookmarks(data, seen) {
     }
     return { tweets, nextCursor };
 }
-function resolveOptionalFilePath(raw, label) {
-    if (raw === undefined || raw === null || raw === '')
-        return '';
-    const value = String(raw).trim();
-    if (!value)
-        throw new ArgumentError(`${label} cannot be empty`);
-    return path.resolve(value);
-}
 function readResumeFile(filePath, expected = null) {
     if (!filePath || !fs.existsSync(filePath))
         return null;
@@ -153,56 +143,9 @@ function readResumeFile(filePath, expected = null) {
         updatedAt: parsed.updatedAt || null,
     };
 }
-function ensureParentDir(filePath) {
-    if (!filePath)
-        return;
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-}
-function removeFile(filePath) {
-    if (!filePath)
-        return;
-    try {
-        fs.rmSync(filePath, { force: true });
-    }
-    catch {
-    }
-}
-function loadJsonlArchiveState(filePath) {
-    const seen = new Set();
-    let count = 0;
-    if (!filePath || !fs.existsSync(filePath))
-        return { seen, count };
-    const text = fs.readFileSync(filePath, 'utf8');
-    for (const [index, line] of text.split('\n').entries()) {
-        const trimmed = line.trim();
-        if (!trimmed)
-            continue;
-        try {
-            const row = JSON.parse(trimmed);
-            if (!row?.id)
-                throw new Error('missing id');
-            const id = String(row.id);
-            if (seen.has(id))
-                throw new Error(`duplicate id ${id}`);
-            seen.add(id);
-            count += 1;
-        }
-        catch (error) {
-            throw new CommandExecutionError(`Invalid JSONL record in ${filePath} at line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-    }
-    return { seen, count };
-}
-function appendJsonlRows(filePath, rows) {
-    if (!filePath || !Array.isArray(rows) || rows.length === 0)
-        return;
-    ensureParentDir(filePath);
-    // Escape LS/PS so JSONL stays one physical line even when tweet text contains them.
-    const text = rows
-        .map((row) => JSON.stringify(row).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029'))
-        .join('\n') + '\n';
-    fs.appendFileSync(filePath, text, 'utf8');
-}
+
+// Keep this in sync with twitter/likes; wording is command-specific, so the
+// atomic tmp-write/rename cleanup sequence intentionally remains local.
 function writeResumeFile(filePath, payload) {
     if (!filePath)
         return;
@@ -220,20 +163,6 @@ function writeResumeFile(filePath, payload) {
         }
         throw new CommandExecutionError(`Could not persist Twitter bookmarks resume state: ${error instanceof Error ? error.message : String(error)}`);
     }
-}
-function removeResumeFile(filePath) {
-    removeFile(filePath);
-}
-function resolveMaxPages(kwargs, fetchAll) {
-    const raw = kwargs['max-pages'];
-    if (raw === undefined || raw === null || raw === '') {
-        return fetchAll ? HARD_MAX_PAGINATION_PAGES : DEFAULT_MAX_PAGINATION_PAGES;
-    }
-    const value = Number(raw);
-    if (!Number.isInteger(value) || value < 1 || value > HARD_MAX_PAGINATION_PAGES) {
-        throw new ArgumentError(`--max-pages must be an integer between 1 and ${HARD_MAX_PAGINATION_PAGES}`);
-    }
-    return value;
 }
 cli({
     site: 'twitter',
@@ -385,6 +314,5 @@ cli({
 export const __test__ = {
     parseBookmarks,
     extractBookmarkTweet,
-    appendJsonlRows,
     readResumeFile,
 };

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -3,12 +3,10 @@ import path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { buildUserByScreenNameQueryUrl, looksLikePrivateTwitterTimeline, normalizeTwitterScreenName, resolveTwitterQueryId, sanitizeQueryId, extractMedia, unwrapBrowserResult, describeTwitterApiError } from './shared.js';
+import { DEFAULT_MAX_PAGINATION_PAGES, appendJsonlRows, ensureParentDir, loadJsonlArchiveState, removeResumeFile, resolveMaxPages, resolveOptionalFilePath } from './archive.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 const LIKES_QUERY_ID = 'CDWHmpZeSdIJ3HGeRbNm0w';
 const USER_BY_SCREEN_NAME_QUERY_ID = 'IGgvgiOx4QZndDHuD3x9TQ';
-// Safety cap only. Full-archive runs can set a higher page budget via --max-pages.
-const DEFAULT_MAX_PAGINATION_PAGES = 100;
-const HARD_MAX_PAGINATION_PAGES = 100000;
 const FEATURES = {
     rweb_video_screen_enabled: false,
     profile_label_improvements_pcf_label_in_post_enabled: true,
@@ -119,14 +117,6 @@ function parseLikes(data, seen) {
     }
     return { tweets, nextCursor };
 }
-function resolveOptionalFilePath(raw, label) {
-    if (raw === undefined || raw === null || raw === '')
-        return '';
-    const value = String(raw).trim();
-    if (!value)
-        throw new ArgumentError(`${label} cannot be empty`);
-    return path.resolve(value);
-}
 function readResumeFile(filePath, expected = null) {
     if (!filePath || !fs.existsSync(filePath))
         return null;
@@ -171,56 +161,9 @@ function readResumeFile(filePath, expected = null) {
         updatedAt: parsed.updatedAt || null,
     };
 }
-function ensureParentDir(filePath) {
-    if (!filePath)
-        return;
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-}
-function removeFile(filePath) {
-    if (!filePath)
-        return;
-    try {
-        fs.rmSync(filePath, { force: true });
-    }
-    catch {
-    }
-}
-function loadJsonlArchiveState(filePath) {
-    const seen = new Set();
-    let count = 0;
-    if (!filePath || !fs.existsSync(filePath))
-        return { seen, count };
-    const text = fs.readFileSync(filePath, 'utf8');
-    for (const [index, line] of text.split('\n').entries()) {
-        const trimmed = line.trim();
-        if (!trimmed)
-            continue;
-        try {
-            const row = JSON.parse(trimmed);
-            if (!row?.id)
-                throw new Error('missing id');
-            const id = String(row.id);
-            if (seen.has(id))
-                throw new Error(`duplicate id ${id}`);
-            seen.add(id);
-            count += 1;
-        }
-        catch (error) {
-            throw new CommandExecutionError(`Invalid JSONL record in ${filePath} at line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-    }
-    return { seen, count };
-}
-function appendJsonlRows(filePath, rows) {
-    if (!filePath || !Array.isArray(rows) || rows.length === 0)
-        return;
-    ensureParentDir(filePath);
-    // Escape LS/PS so JSONL stays one physical line even when tweet text contains them.
-    const text = rows
-        .map((row) => JSON.stringify(row).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029'))
-        .join('\n') + '\n';
-    fs.appendFileSync(filePath, text, 'utf8');
-}
+
+// Keep this in sync with twitter/bookmarks; wording is command-specific, so the
+// atomic tmp-write/rename cleanup sequence intentionally remains local.
 function writeResumeFile(filePath, payload) {
     if (!filePath)
         return;
@@ -238,20 +181,6 @@ function writeResumeFile(filePath, payload) {
         }
         throw new CommandExecutionError(`Could not persist Twitter likes resume state: ${error instanceof Error ? error.message : String(error)}`);
     }
-}
-function removeResumeFile(filePath) {
-    removeFile(filePath);
-}
-function resolveMaxPages(kwargs, fetchAll) {
-    const raw = kwargs['max-pages'];
-    if (raw === undefined || raw === null || raw === '') {
-        return fetchAll ? HARD_MAX_PAGINATION_PAGES : DEFAULT_MAX_PAGINATION_PAGES;
-    }
-    const value = Number(raw);
-    if (!Number.isInteger(value) || value < 1 || value > HARD_MAX_PAGINATION_PAGES) {
-        throw new ArgumentError(`--max-pages must be an integer between 1 and ${HARD_MAX_PAGINATION_PAGES}`);
-    }
-    return value;
 }
 cli({
     site: 'twitter',
@@ -453,6 +382,5 @@ export const __test__ = {
     sanitizeQueryId,
     buildLikesUrl,
     parseLikes,
-    appendJsonlRows,
     readResumeFile,
 };


### PR DESCRIPTION
## Summary
- add site-local `clis/twitter/archive.js` for the seven byte-identical bookmarks/likes archive helpers: `resolveOptionalFilePath`, `ensureParentDir`, `removeFile` (private), `loadJsonlArchiveState`, `appendJsonlRows`, `removeResumeFile`, and `resolveMaxPages`
- move the shared pagination caps into the archive helper module; only `DEFAULT_MAX_PAGINATION_PAGES` is exported because command help text consumes it, while the hard cap remains module-private
- keep `readResumeFile` and `writeResumeFile` command-local; the raw `getText()` node hashes for both functions in both commands are unchanged from base
- remove only the orphan `__test__.appendJsonlRows` keys; existing command-local `__test__` entries remain

## Negative boundaries
- no changes to pagination loops, existing/missing output checks, resume count validation, repeated-cursor fail-closed behavior, incomplete resume retention, exhausted-only delete behavior, receipt fields, resume schema, `shared.js`, manifest, or other Twitter commands
- `writeResumeFile` now has function-external sync comments only; the tmp-write -> rename -> failed-cleanup function bodies are untouched
- exact-head function gate: bookmarks/likes top-level same-name intersection is now only `readResumeFile` and `writeResumeFile`; same-body intersection is 0
- no imported-helper `__test__` shim and no test-only export for the hard pagination cap

## Verification
- `npx vitest run clis/twitter/archive.test.js clis/twitter/bookmarks.test.js clis/twitter/likes.test.js` (39/39)
- `npx vitest run clis/twitter` (45 files / 539 tests)
- `npm run typecheck`
- `npm run build` (manifest 1332 entries, no tracked manifest diff)
- `node dist/src/main.js validate twitter` (46 commands, 0 errors / 0 warnings)
- `npm run check:typed-error-lint` (new=0; resolved baseline entries only)
- `npm run check:silent-column-drop` (new=0; resolved baseline entries only)
- `git diff --check`

Post-blocker narrow rerun after `HARD_MAX_PAGINATION_PAGES` was made private:
- `npx vitest run clis/twitter/archive.test.js clis/twitter/bookmarks.test.js clis/twitter/likes.test.js` (39/39)
- `npm run typecheck`
- `git diff --check`
