### PR TITLE
chore(12306): share limit normalization helper

### DIFF
--- a/clis/12306/passengers.js
+++ b/clis/12306/passengers.js
@@ -7,19 +7,11 @@
  * `--include-sensitive` to surface the unmasked-by-12306 fields.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { isAuthLikePayload, maskChineseName, require12306Login, requireEvaluateObject } from './utils.js';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { isAuthLikePayload, maskChineseName, normalizeLimit, require12306Login, requireEvaluateObject } from './utils.js';
 
 const PASSENGER_QUERY_URL = 'https://kyfw.12306.cn/otn/passengers/query';
 const MAX_PAGE_SIZE = 50;
-
-function normalizeLimit(value, defaultValue, max) {
-    if (value === undefined || value === null || value === '') return defaultValue;
-    const n = Number(value);
-    if (!Number.isInteger(n) || n < 1) throw new ArgumentError(`limit must be a positive integer (1-${max})`);
-    if (n > max) throw new ArgumentError(`limit must be <= ${max}`);
-    return n;
-}
 
 cli({
     site: '12306',
@@ -86,5 +78,3 @@ cli({
         }));
     },
 });
-
-export const __test__ = { normalizeLimit };

--- a/clis/12306/stations.js
+++ b/clis/12306/stations.js
@@ -6,21 +6,9 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
-import { fetchStationBundle } from './utils.js';
+import { fetchStationBundle, normalizeLimit } from './utils.js';
 
 const MAX_LIMIT = 50;
-
-function normalizeLimit(value, defaultValue, max) {
-    if (value === undefined || value === null || value === '') return defaultValue;
-    const n = Number(value);
-    if (!Number.isInteger(n) || n < 1) {
-        throw new ArgumentError(`limit must be a positive integer (1-${max})`);
-    }
-    if (n > max) {
-        throw new ArgumentError(`limit must be <= ${max}`);
-    }
-    return n;
-}
 
 cli({
     site: '12306',
@@ -62,5 +50,3 @@ cli({
         }));
     },
 });
-
-export const __test__ = { normalizeLimit };

--- a/clis/12306/trains.js
+++ b/clis/12306/trains.js
@@ -11,24 +11,12 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { fetchStationBundle, mintSession, resolveStation, validateDate, parseTrainRecord } from './utils.js';
+import { fetchStationBundle, mintSession, normalizeLimit, resolveStation, validateDate, parseTrainRecord } from './utils.js';
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0 Safari/537.36';
 const QUERY_ENDPOINTS = ['queryG', 'queryO', 'queryZ', 'queryA'];
 const MAX_LIMIT = 100;
 const QUERY_ENDPOINT_RE = /^query[A-Z]$/;
-
-function normalizeLimit(value, defaultValue, max) {
-    if (value === undefined || value === null || value === '') return defaultValue;
-    const n = Number(value);
-    if (!Number.isInteger(n) || n < 1) {
-        throw new ArgumentError(`limit must be a positive integer (1-${max})`);
-    }
-    if (n > max) {
-        throw new ArgumentError(`limit must be <= ${max}`);
-    }
-    return n;
-}
 
 function extractQueryEndpoint(value) {
     const raw = String(value ?? '').trim();
@@ -163,4 +151,4 @@ cli({
     },
 });
 
-export const __test__ = { normalizeLimit, extractQueryEndpoint, queryLeftTickets };
+export const __test__ = { extractQueryEndpoint, queryLeftTickets };

--- a/clis/12306/utils.js
+++ b/clis/12306/utils.js
@@ -101,6 +101,18 @@ export function validateDate(value) {
     return value;
 }
 
+export function normalizeLimit(value, defaultValue, max) {
+    if (value === undefined || value === null || value === '') return defaultValue;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new ArgumentError(`limit must be a positive integer (1-${max})`);
+    }
+    if (n > max) {
+        throw new ArgumentError(`limit must be <= ${max}`);
+    }
+    return n;
+}
+
 /** Extract Set-Cookie header values into a single `Cookie:` header string. */
 export function buildCookieHeader(setCookieHeaders) {
     if (!Array.isArray(setCookieHeaders) || setCookieHeaders.length === 0) return '';

--- a/clis/12306/utils.test.js
+++ b/clis/12306/utils.test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { __test__ } from './utils.js';
+import { __test__, normalizeLimit } from './utils.js';
 import { __test__ as priceTest } from './price.js';
 import { __test__ as trainTest } from './train.js';
 import { __test__ as trainsTest } from './trains.js';
@@ -89,6 +89,34 @@ describe('12306 utils - validateDate', () => {
     it('throws ArgumentError on impossible calendar dates', () => {
         expect(() => validateDate('2026-02-30')).toThrow(ArgumentError);
         expect(() => validateDate('2026-13-01')).toThrow(ArgumentError);
+    });
+});
+
+describe('12306 utils - normalizeLimit', () => {
+    it('uses the default for omitted, null, and empty values', () => {
+        expect(normalizeLimit(undefined, 20, 50)).toBe(20);
+        expect(normalizeLimit(null, 30, 80)).toBe(30);
+        expect(normalizeLimit('', 50, 100)).toBe(50);
+    });
+
+    it('accepts numeric values and numeric strings at legal boundaries', () => {
+        expect(normalizeLimit(1, 20, 50)).toBe(1);
+        expect(normalizeLimit('25', 20, 50)).toBe(25);
+        expect(normalizeLimit(50, 20, 50)).toBe(50);
+    });
+
+    it('rejects non-integer and non-positive values with the positive integer message', () => {
+        expect(() => normalizeLimit('abc', 20, 50)).toThrow(ArgumentError);
+        expect(() => normalizeLimit('abc', 20, 50)).toThrow('limit must be a positive integer (1-50)');
+        expect(() => normalizeLimit(1.5, 20, 50)).toThrow('limit must be a positive integer (1-50)');
+        expect(() => normalizeLimit(0, 20, 50)).toThrow('limit must be a positive integer (1-50)');
+        expect(() => normalizeLimit(-1, 20, 50)).toThrow('limit must be a positive integer (1-50)');
+    });
+
+    it('rejects values over the command max with the max message', () => {
+        expect(() => normalizeLimit(51, 20, 50)).toThrow(ArgumentError);
+        expect(() => normalizeLimit(51, 20, 50)).toThrow('limit must be <= 50');
+        expect(() => normalizeLimit('101', 50, 100)).toThrow('limit must be <= 100');
     });
 });
 


### PR DESCRIPTION
## Summary
- add `normalizeLimit(value, defaultValue, max)` to `clis/12306/utils.js`
- remove the three command-local `normalizeLimit` copies from `stations.js`, `passengers.js`, and `trains.js`
- clean test shims: remove orphan `stations.__test__` / `passengers.__test__`; keep `trains.__test__` with only `extractQueryEndpoint` and `queryLeftTickets`
- add direct `utils.test.js` coverage for omitted/default, legal boundaries, numeric strings, non-integer/non-positive errors, over-max errors, and exact error messages

## Negative boundaries
- no changes to command max constants or help text: `stations MAX_LIMIT=50`, `passengers MAX_PAGE_SIZE=50`, `trains MAX_LIMIT=100`
- call sites remain equivalent: `normalizeLimit(kwargs.limit, 20, MAX_LIMIT)`, `normalizeLimit(kwargs.limit, 20, MAX_PAGE_SIZE)`, and `normalizeLimit(kwargs.limit, 50, MAX_LIMIT)`
- no changes to 12306 login, session, endpoint rotation, PII masking, station/date parsing, train parsing, package exports, or cross-site utilities
- closure check: the moved helper only depends on `ArgumentError`, which resolves to the same `@jackwener/opencli/errors` import in all source/target modules

## Verification
- `npx vitest run clis/12306` (1 file / 48 tests)
- `npm run typecheck`
- `npm run build` (manifest 1332 entries)
- `node dist/src/main.js validate 12306` (9 commands, 0 errors / 0 warnings)
- `npm run check:typed-error-lint` (new=0; resolved baseline entries only)
- `npm run check:silent-column-drop` (new=0; resolved baseline entries only)
- `git diff --check`
