### PR TITLE
chore(grok): share site identity helpers

### DIFF
--- a/clis/grok/export-all.js
+++ b/clis/grok/export-all.js
@@ -7,9 +7,7 @@ import {
   requireBooleanEvaluateResult,
   requireObjectEvaluateResult,
 } from './export-utils.js';
-
-const GROK_DOMAIN = 'grok.com';
-const GROK_URL = 'https://grok.com/';
+import { GROK_DOMAIN, GROK_URL } from './utils.js';
 
 function normalizeInteger(value, defaultValue, label, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
   const raw = value ?? defaultValue;

--- a/clis/grok/export.js
+++ b/clis/grok/export.js
@@ -1,9 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import { normalizeConversationRows, requireObjectEvaluateResult } from './export-utils.js';
-
-const GROK_DOMAIN = 'grok.com';
-const GROK_URL = 'https://grok.com/';
+import { GROK_DOMAIN, GROK_URL } from './utils.js';
 
 function normalizeLimit(value) {
   const raw = value ?? 0;

--- a/clis/grok/image.js
+++ b/clis/grok/image.js
@@ -3,15 +3,9 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { GROK_URL, isOnGrok, normalizeBooleanFlag } from './utils.js';
 
-const GROK_URL = 'https://grok.com/';
 const SESSION_HINT = 'Likely login/auth/challenge/session issue in the existing grok.com browser session.';
-
-function normalizeBooleanFlag(value) {
-  if (typeof value === 'boolean') return value;
-  const normalized = String(value ?? '').trim().toLowerCase();
-  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
-}
 
 /**
  * Validate a positive-integer arg without silently flooring/clamping.
@@ -53,18 +47,6 @@ function buildFilename(src, ct) {
   const ext = extFromContentType(ct);
   const hash = crypto.createHash('sha1').update(src).digest('hex').slice(0, 12);
   return `grok-${Date.now()}-${hash}.${ext}`;
-}
-
-/** Check whether the tab is already on grok.com (any path). */
-async function isOnGrok(page) {
-  const url = await page.evaluate('window.location.href').catch(() => '');
-  if (typeof url !== 'string' || !url) return false;
-  try {
-    const hostname = new URL(url).hostname;
-    return hostname === 'grok.com' || hostname.endsWith('.grok.com');
-  } catch {
-    return false;
-  }
 }
 
 async function tryStartFreshChat(page) {
@@ -332,9 +314,7 @@ export const imageCommand = cli({
 });
 
 export const __test__ = {
-  normalizeBooleanFlag,
   normalizePositiveInteger,
-  isOnGrok,
   dedupeBySrc,
   imagesSignature,
   extFromContentType,

--- a/clis/grok/image.test.ts
+++ b/clis/grok/image.test.ts
@@ -1,44 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { IPage } from '@jackwener/opencli/types';
 import { ArgumentError } from '@jackwener/opencli/errors';
 import { __test__ } from './image.js';
 
 describe('grok image helpers', () => {
-  describe('isOnGrok', () => {
-    const fakePage = (url: string | Error): IPage =>
-      ({ evaluate: () => url instanceof Error ? Promise.reject(url) : Promise.resolve(url) }) as unknown as IPage;
-
-    it('returns true for grok.com URLs', async () => {
-      expect(await __test__.isOnGrok(fakePage('https://grok.com/'))).toBe(true);
-      expect(await __test__.isOnGrok(fakePage('https://grok.com/chat/abc123'))).toBe(true);
-    });
-
-    it('returns true for grok.com subdomains', async () => {
-      expect(await __test__.isOnGrok(fakePage('https://assets.grok.com/foo'))).toBe(true);
-    });
-
-    it('returns false for non-grok domains', async () => {
-      expect(await __test__.isOnGrok(fakePage('https://fakegrok.com/'))).toBe(false);
-      expect(await __test__.isOnGrok(fakePage('about:blank'))).toBe(false);
-    });
-
-    it('returns false when evaluate throws (detached tab)', async () => {
-      expect(await __test__.isOnGrok(fakePage(new Error('detached')))).toBe(false);
-    });
-  });
-
-  it('normalizes boolean flags', () => {
-    expect(__test__.normalizeBooleanFlag(true)).toBe(true);
-    expect(__test__.normalizeBooleanFlag('true')).toBe(true);
-    expect(__test__.normalizeBooleanFlag('1')).toBe(true);
-    expect(__test__.normalizeBooleanFlag('yes')).toBe(true);
-    expect(__test__.normalizeBooleanFlag('on')).toBe(true);
-
-    expect(__test__.normalizeBooleanFlag(false)).toBe(false);
-    expect(__test__.normalizeBooleanFlag('false')).toBe(false);
-    expect(__test__.normalizeBooleanFlag(undefined)).toBe(false);
-  });
-
   it('dedupes images by src', () => {
     const deduped = __test__.dedupeBySrc([
       { src: 'https://a.example/1.jpg', w: 500, h: 500 },


### PR DESCRIPTION
## Summary
- reuse Grok site identity constants and helpers from clis/grok/utils.js in image/export/export-all
- remove image.js local isOnGrok and normalizeBooleanFlag copies plus imported-helper __test__ keys
- delete five duplicate image helper tests already covered by utils.test.js

## Scope / negative boundaries
- 4-file diff only: clis/grok/image.js, image.test.ts, export.js, export-all.js
- no utils.js or utils.test.js changes
- no changes to image normalizePositiveInteger, navigation timing, prompt/image polling, download, or error semantics
- no changes to export/export-all auth/history/manifest/scroll logic or __test__

## Validation
- npx vitest run clis/grok = 4 files / 43 tests PASS
- npm run typecheck PASS
- npm run build PASS, manifest 1332 entries and no tracked generated diff
- node dist/src/main.js validate grok PASS, 15 commands / 0 errors / 0 warnings
- npm run check:typed-error-lint PASS, new=0
- npm run check:silent-column-drop PASS, new=0
- git diff --check PASS