### PR TITLE
chore(zhihu): share answer target parser

### DIFF
--- a/clis/zhihu/answer-comments.js
+++ b/clis/zhihu/answer-comments.js
@@ -1,42 +1,12 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ANSWER_PATH_RE, parseAnswerTarget } from './answer-target.js';
 import { stripHtml as stripHtmlText } from './text.js';
 
 function stripHtml(html) {
     return stripHtmlText(html, { preserveBlocks: true });
 }
 
-const ANSWER_ID_RE = /^\d+$/;
-const ANSWER_TYPED_RE = /^answer:(\d+):(\d+)$/;
-const ANSWER_PATH_RE = /^\/question\/(\d+)\/answer\/(\d+)\/?$/;
-const BARE_ANSWER_PATH_RE = /^\/answer\/(\d+)\/?$/;
-
-function parseAnswerTarget(input) {
-    const value = String(input ?? '').trim();
-    if (!value) return null;
-    if (ANSWER_ID_RE.test(value)) return { answerId: value, questionId: '' };
-    const typed = value.match(ANSWER_TYPED_RE);
-    if (typed) return { questionId: typed[1], answerId: typed[2] };
-    try {
-        const url = new URL(value);
-        if (
-            url.protocol !== 'https:' ||
-            url.username ||
-            url.password ||
-            url.port ||
-            (url.hostname !== 'www.zhihu.com' && url.hostname !== 'zhihu.com')
-        ) {
-            return null;
-        }
-        let m = url.pathname.match(ANSWER_PATH_RE);
-        if (m) return { questionId: m[1], answerId: m[2] };
-        m = url.pathname.match(BARE_ANSWER_PATH_RE);
-        if (m) return { answerId: m[1], questionId: '' };
-    } catch {
-        return null;
-    }
-    return null;
-}
 
 function extractQuestionIdFromAnswerUrl(input) {
     const value = String(input ?? '').trim();
@@ -277,4 +247,4 @@ cli({
     },
 });
 
-export const __test__ = { stripHtml, parseAnswerTarget, normalizeCommentsApiUrl, buildRows };
+export const __test__ = { stripHtml, normalizeCommentsApiUrl, buildRows };

--- a/clis/zhihu/answer-comments.test.js
+++ b/clis/zhihu/answer-comments.test.js
@@ -255,14 +255,6 @@ describe('zhihu answer-comments', () => {
 });
 
 describe('zhihu answer-comments helpers', () => {
-    it('parseAnswerTarget handles exact input shapes', () => {
-        expect(helpers.parseAnswerTarget('123')).toEqual({ answerId: '123', questionId: '' });
-        expect(helpers.parseAnswerTarget('answer:10:123')).toEqual({ answerId: '123', questionId: '10' });
-        expect(helpers.parseAnswerTarget('https://www.zhihu.com/question/10/answer/123')).toEqual({ answerId: '123', questionId: '10' });
-        expect(helpers.parseAnswerTarget('https://zhihu.com/answer/123?utm=1')).toEqual({ answerId: '123', questionId: '' });
-        expect(helpers.parseAnswerTarget('https://example.com/question/10/answer/123')).toBeNull();
-    });
-
     it('normalizeCommentsApiUrl only accepts same-answer Zhihu comments API URLs', () => {
         expect(helpers.normalizeCommentsApiUrl('https://www.zhihu.com/api/v4/answers/123/comments?offset=20', '123'))
             .toBe('https://www.zhihu.com/api/v4/answers/123/comments?offset=20');

--- a/clis/zhihu/answer-detail.js
+++ b/clis/zhihu/answer-detail.js
@@ -1,54 +1,14 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ANSWER_PATH_RE, parseAnswerTarget } from './answer-target.js';
 import { stripHtml as stripHtmlText } from './text.js';
 
 function stripHtml(html) {
     return stripHtmlText(html, { preserveBlocks: true });
 }
 
-const ANSWER_ID_RE = /^\d+$/;
-const ANSWER_TYPED_RE = /^answer:(\d+):(\d+)$/;
-const ANSWER_PATH_RE = /^\/question\/(\d+)\/answer\/(\d+)\/?$/;
-const BARE_ANSWER_PATH_RE = /^\/answer\/(\d+)\/?$/;
 const QUESTION_PATH_RE = /^\/question\/(\d+)\/?$/;
 const QUESTION_API_PATH_RE = /^\/api\/v4\/questions\/(\d+)\/?$/;
-
-// Accepts: bare numeric id (`1937205528846655537`), the typed
-// target form used by the existing zhihu write adapters
-// (`answer:<qid>:<aid>`), or the full Zhihu URL pasted from a
-// browser (`https://www.zhihu.com/question/<qid>/answer/<aid>`).
-// Returns string-safe ids, or null when the input does not resolve to
-// any of those exact shapes.
-function parseAnswerTarget(input) {
-    const value = String(input ?? '').trim();
-    if (!value) return null;
-    if (ANSWER_ID_RE.test(value)) return { answerId: value, questionId: '' };
-    const typed = value.match(ANSWER_TYPED_RE);
-    if (typed) return { questionId: typed[1], answerId: typed[2] };
-    try {
-        const url = new URL(value);
-        if (
-            url.protocol !== 'https:' ||
-            url.username ||
-            url.password ||
-            url.port ||
-            (url.hostname !== 'www.zhihu.com' && url.hostname !== 'zhihu.com')
-        ) {
-            return null;
-        }
-        let m = url.pathname.match(ANSWER_PATH_RE);
-        if (m) return { questionId: m[1], answerId: m[2] };
-        m = url.pathname.match(BARE_ANSWER_PATH_RE);
-        if (m) return { answerId: m[1], questionId: '' };
-    } catch {
-        return null;
-    }
-    return null;
-}
-
-function extractAnswerId(input) {
-    return parseAnswerTarget(input)?.answerId ?? null;
-}
 
 function extractQuestionIdFromAnswerUrl(input) {
     const value = String(input ?? '').trim();
@@ -213,4 +173,4 @@ cli({
     },
 });
 
-export const __test__ = { stripHtml, extractAnswerId, parseAnswerTarget, extractQuestionIdFromAnswerUrl };
+export const __test__ = { stripHtml, extractQuestionIdFromAnswerUrl };

--- a/clis/zhihu/answer-detail.test.js
+++ b/clis/zhihu/answer-detail.test.js
@@ -316,23 +316,4 @@ describe('zhihu answer-detail helpers', () => {
         expect(helpers.stripHtml('a<br>b<br/>c')).toBe('a\nb\nc');
     });
 
-    it('parseAnswerTarget handles exact input shapes', () => {
-        expect(helpers.parseAnswerTarget('123')).toEqual({ answerId: '123', questionId: '' });
-        expect(helpers.parseAnswerTarget('answer:10:123')).toEqual({ answerId: '123', questionId: '10' });
-        expect(helpers.parseAnswerTarget('https://www.zhihu.com/question/10/answer/123')).toEqual({ answerId: '123', questionId: '10' });
-        expect(helpers.parseAnswerTarget('https://zhihu.com/answer/123?utm=1#x')).toEqual({ answerId: '123', questionId: '' });
-        expect(helpers.parseAnswerTarget('http://www.zhihu.com/question/10/answer/123')).toBeNull();
-        expect(helpers.parseAnswerTarget('https://www.zhihu.com/question/10/answer/123/extra')).toBeNull();
-    });
-
-    it('extractAnswerId keeps the legacy helper contract for tests', () => {
-        expect(helpers.extractAnswerId('123')).toBe('123');
-        expect(helpers.extractAnswerId('answer:10:123')).toBe('123');
-        expect(helpers.extractAnswerId('https://www.zhihu.com/question/10/answer/123')).toBe('123');
-        expect(helpers.extractAnswerId('https://www.zhihu.com/answer/123')).toBe('123');
-        expect(helpers.extractAnswerId('  123  ')).toBe('123');
-        expect(helpers.extractAnswerId('')).toBeNull();
-        expect(helpers.extractAnswerId('not-an-id')).toBeNull();
-        expect(helpers.extractAnswerId('https://example.com/answer/123')).toBeNull();
-    });
 });

--- a/clis/zhihu/answer-target.js
+++ b/clis/zhihu/answer-target.js
@@ -1,0 +1,37 @@
+const ANSWER_ID_RE = /^\d+$/;
+const ANSWER_TYPED_RE = /^answer:(\d+):(\d+)$/;
+export const ANSWER_PATH_RE = /^\/question\/(\d+)\/answer\/(\d+)\/?$/;
+const BARE_ANSWER_PATH_RE = /^\/answer\/(\d+)\/?$/;
+
+// Accepts: bare numeric id (`1937205528846655537`), the typed
+// target form used by the existing zhihu write adapters
+// (`answer:<qid>:<aid>`), or the full Zhihu URL pasted from a
+// browser (`https://www.zhihu.com/question/<qid>/answer/<aid>`).
+// Returns string-safe ids, or null when the input does not resolve to
+// any of those exact shapes.
+export function parseAnswerTarget(input) {
+    const value = String(input ?? '').trim();
+    if (!value) return null;
+    if (ANSWER_ID_RE.test(value)) return { answerId: value, questionId: '' };
+    const typed = value.match(ANSWER_TYPED_RE);
+    if (typed) return { questionId: typed[1], answerId: typed[2] };
+    try {
+        const url = new URL(value);
+        if (
+            url.protocol !== 'https:' ||
+            url.username ||
+            url.password ||
+            url.port ||
+            (url.hostname !== 'www.zhihu.com' && url.hostname !== 'zhihu.com')
+        ) {
+            return null;
+        }
+        let m = url.pathname.match(ANSWER_PATH_RE);
+        if (m) return { questionId: m[1], answerId: m[2] };
+        m = url.pathname.match(BARE_ANSWER_PATH_RE);
+        if (m) return { answerId: m[1], questionId: '' };
+    } catch {
+        return null;
+    }
+    return null;
+}

--- a/clis/zhihu/answer-target.test.js
+++ b/clis/zhihu/answer-target.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseAnswerTarget } from './answer-target.js';
+
+describe('zhihu answer target parser', () => {
+    it('accepts exact answer target shapes', () => {
+        expect(parseAnswerTarget('123')).toEqual({ answerId: '123', questionId: '' });
+        expect(parseAnswerTarget('  123  ')).toEqual({ answerId: '123', questionId: '' });
+        expect(parseAnswerTarget('answer:10:123')).toEqual({ answerId: '123', questionId: '10' });
+        expect(parseAnswerTarget('https://www.zhihu.com/question/10/answer/123')).toEqual({ answerId: '123', questionId: '10' });
+        expect(parseAnswerTarget('https://zhihu.com/question/10/answer/123?utm=1#x')).toEqual({ answerId: '123', questionId: '10' });
+        expect(parseAnswerTarget('https://www.zhihu.com/answer/123')).toEqual({ answerId: '123', questionId: '' });
+        expect(parseAnswerTarget('https://zhihu.com/answer/123?utm=1#x')).toEqual({ answerId: '123', questionId: '' });
+    });
+
+    it('rejects empty and malformed non-URL targets', () => {
+        expect(parseAnswerTarget(null)).toBeNull();
+        expect(parseAnswerTarget(undefined)).toBeNull();
+        expect(parseAnswerTarget('')).toBeNull();
+        expect(parseAnswerTarget('   ')).toBeNull();
+        expect(parseAnswerTarget('not-an-id')).toBeNull();
+        expect(parseAnswerTarget('-123')).toBeNull();
+        expect(parseAnswerTarget('answer:10')).toBeNull();
+        expect(parseAnswerTarget('answer:10:abc')).toBeNull();
+    });
+
+    it('requires exact HTTPS Zhihu hosts and answer paths', () => {
+        for (const target of [
+            'http://www.zhihu.com/question/10/answer/123',
+            'https://user@www.zhihu.com/question/10/answer/123',
+            'https://user:pass@www.zhihu.com/question/10/answer/123',
+            'https://www.zhihu.com:444/question/10/answer/123',
+            'https://www.zhihu.com.evil.com/question/10/answer/123',
+            'https://example.com/question/10/answer/123',
+            'https://zhuanlan.zhihu.com/question/10/answer/123',
+            'https://www.zhihu.com/question/10',
+            'https://www.zhihu.com/question/10/answer/123/extra',
+            'https://www.zhihu.com/answer/123/extra',
+        ]) {
+            expect(parseAnswerTarget(target)).toBeNull();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add a read-only Zhihu answer target helper and share parseAnswerTarget across answer-detail and answer-comments
- export the shared answer path regex for the two production question-id extractors while keeping write target.js untouched
- remove the answer-detail test-only extractAnswerId helper and move duplicate parser coverage into answer-target.test.js

## Boundaries
- no changes to clis/zhihu/target.js or write adapters
- command __test__ exports only lose imported/test-only parser entries; no re-export shim
- answer-detail and answer-comments extractQuestionIdFromAnswerUrl function bodies are unchanged against base
- command behavior tests are retained; parser contract coverage is centralized and strengthened

## Tests
- npx vitest run clis/zhihu/answer-detail.test.js clis/zhihu/answer-comments.test.js clis/zhihu/answer-target.test.js
- npx vitest run clis/zhihu
- npm run typecheck
- npm run build
- node dist/src/main.js validate zhihu
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check