### PR TITLE
chore(zhihu): share answer normalization helpers

### DIFF
--- a/clis/zhihu/answer-comments.js
+++ b/clis/zhihu/answer-comments.js
@@ -1,12 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeCount, normalizeUnixSeconds, stripHtml } from './answer-normalize.js';
 import { ANSWER_PATH_RE, parseAnswerTarget } from './answer-target.js';
-import { stripHtml as stripHtmlText } from './text.js';
-
-function stripHtml(html) {
-    return stripHtmlText(html, { preserveBlocks: true });
-}
-
 
 function extractQuestionIdFromAnswerUrl(input) {
     const value = String(input ?? '').trim();
@@ -18,16 +13,6 @@ function extractQuestionIdFromAnswerUrl(input) {
     } catch {
         return '';
     }
-}
-
-function normalizeCount(value) {
-    return Number.isInteger(value) && value >= 0 ? value : 0;
-}
-
-function normalizeUnixSeconds(value) {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0
-        ? new Date(value * 1000).toISOString()
-        : '';
 }
 
 function memberName(author) {
@@ -247,4 +232,4 @@ cli({
     },
 });
 
-export const __test__ = { stripHtml, normalizeCommentsApiUrl, buildRows };
+export const __test__ = { normalizeCommentsApiUrl, buildRows };

--- a/clis/zhihu/answer-detail.js
+++ b/clis/zhihu/answer-detail.js
@@ -1,11 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { normalizeCount, normalizeUnixSeconds, stripHtml } from './answer-normalize.js';
 import { ANSWER_PATH_RE, parseAnswerTarget } from './answer-target.js';
-import { stripHtml as stripHtmlText } from './text.js';
-
-function stripHtml(html) {
-    return stripHtmlText(html, { preserveBlocks: true });
-}
 
 const QUESTION_PATH_RE = /^\/question\/(\d+)\/?$/;
 const QUESTION_API_PATH_RE = /^\/api\/v4\/questions\/(\d+)\/?$/;
@@ -25,16 +21,6 @@ function extractQuestionIdFromAnswerUrl(input) {
     } catch {
         return '';
     }
-}
-
-function normalizeCount(value) {
-    return Number.isInteger(value) && value >= 0 ? value : 0;
-}
-
-function normalizeUnixSeconds(value) {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0
-        ? new Date(value * 1000).toISOString()
-        : '';
 }
 
 cli({
@@ -173,4 +159,4 @@ cli({
     },
 });
 
-export const __test__ = { stripHtml, extractQuestionIdFromAnswerUrl };
+export const __test__ = { extractQuestionIdFromAnswerUrl };

--- a/clis/zhihu/answer-detail.test.js
+++ b/clis/zhihu/answer-detail.test.js
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import './answer-detail.js';
-import { __test__ as helpers } from './answer-detail.js';
 
 describe('zhihu answer-detail', () => {
     it('registers as a cookie read command', () => {
@@ -296,24 +295,4 @@ describe('zhihu answer-detail', () => {
         }
         expect(page.goto).not.toHaveBeenCalled();
     });
-});
-
-describe('zhihu answer-detail helpers', () => {
-    it('stripHtml drops tags and decodes common entities', () => {
-        const out = helpers.stripHtml('<p>hi&nbsp;there &amp; you</p><p>second</p>');
-        expect(out).toBe('hi there & you\n\nsecond');
-    });
-
-    it('stripHtml decodes numeric entities', () => {
-        expect(helpers.stripHtml('&#34;中文&#34; &#x26; &#39;test&#39;')).toBe('"中文" & \'test\'');
-    });
-
-    it('stripHtml keeps invalid numeric entities unchanged', () => {
-        expect(helpers.stripHtml('bad &#9999999999; entity')).toBe('bad &#9999999999; entity');
-    });
-
-    it('stripHtml maps <br> to single newline', () => {
-        expect(helpers.stripHtml('a<br>b<br/>c')).toBe('a\nb\nc');
-    });
-
 });

--- a/clis/zhihu/answer-normalize.js
+++ b/clis/zhihu/answer-normalize.js
@@ -1,0 +1,15 @@
+import { stripHtml as stripHtmlText } from './text.js';
+
+export function stripHtml(html) {
+    return stripHtmlText(html, { preserveBlocks: true });
+}
+
+export function normalizeCount(value) {
+    return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+export function normalizeUnixSeconds(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? new Date(value * 1000).toISOString()
+        : '';
+}

--- a/clis/zhihu/answer-normalize.test.js
+++ b/clis/zhihu/answer-normalize.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCount, normalizeUnixSeconds, stripHtml } from './answer-normalize.js';
+
+describe('zhihu answer normalize helpers', () => {
+    it('strips answer HTML through block-preserving text normalization', () => {
+        expect(stripHtml('<p>hi&nbsp;there &amp; you</p><p>second</p>')).toBe('hi there & you\n\nsecond');
+        expect(stripHtml('a<br>b<br/>c')).toBe('a\nb\nc');
+        expect(stripHtml('&#34;中文&#34; &#x26; &#39;test&#39;')).toBe('"中文" & \'test\'');
+    });
+
+    it('keeps invalid numeric entities unchanged', () => {
+        expect(stripHtml('bad &#9999999999; entity')).toBe('bad &#9999999999; entity');
+    });
+
+    it('normalizes counts to non-negative integers', () => {
+        expect(normalizeCount(0)).toBe(0);
+        expect(normalizeCount(12)).toBe(12);
+        for (const value of [-1, 1.5, Number.NaN, Infinity, '3', null, undefined, {}, []]) {
+            expect(normalizeCount(value)).toBe(0);
+        }
+    });
+
+    it('normalizes positive finite unix seconds to ISO timestamps', () => {
+        expect(normalizeUnixSeconds(1700000000)).toBe('2023-11-14T22:13:20.000Z');
+        for (const value of [0, -1, Number.NaN, Infinity, -Infinity, '1700000000', null, undefined]) {
+            expect(normalizeUnixSeconds(value)).toBe('');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add a site-local answer-normalize helper module for answer HTML/count/timestamp normalization
- update answer-detail and answer-comments to import the shared helpers without changing command bodies
- move wrapper-direct stripHtml tests to answer-normalize.test.js and keep command __test__ exports local-only

## Boundaries
- no changes to answer-target.js, target.js, text.js, text.test.js, collection.js, question.js, or search.js
- answer-detail/answer-comments complete cli({...}) nodes are unchanged
- answer-detail/answer-comments extractQuestionIdFromAnswerUrl helpers are unchanged
- flat callers still import text.js directly; answer-normalize is only used by the two answer commands

## Tests
- npx vitest run clis/zhihu/answer-detail.test.js clis/zhihu/answer-comments.test.js clis/zhihu/answer-normalize.test.js clis/zhihu/text.test.js
- npx vitest run clis/zhihu
- npm run typecheck
- npm run build
- node dist/src/main.js validate zhihu
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check