### PR TITLE
chore(linux-do): share formatting helpers

### DIFF
--- a/clis/linux-do/feed.js
+++ b/clis/linux-do/feed.js
@@ -14,6 +14,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { toLocalTime } from './format.js';
 const LINUX_DO_HOME = 'https://linux.do';
 const LINUX_DO_METADATA_TTL_MS = 24 * 60 * 60 * 1000;
 let liveTagsPromise = null;
@@ -219,14 +220,6 @@ async function fetchLiveCategories(page) {
         });
     }
     return liveCategoriesPromise;
-}
-function toLocalTime(utcStr) {
-    if (!utcStr)
-        return '';
-    const d = new Date(utcStr);
-    if (isNaN(d.getTime()))
-        return utcStr;
-    return d.toLocaleString();
 }
 function normalizeReplyCount(postsCount) {
     const count = typeof postsCount === 'number' ? postsCount : 1;

--- a/clis/linux-do/format.js
+++ b/clis/linux-do/format.js
@@ -1,0 +1,28 @@
+export function toLocalTime(utcStr) {
+    if (!utcStr)
+        return '';
+    const date = new Date(utcStr);
+    return Number.isNaN(date.getTime()) ? utcStr : date.toLocaleString();
+}
+
+export function stripHtml(html) {
+    return (html || '')
+        .replace(/<br\s*\/?>/gi, ' ')
+        .replace(/<\/(p|div|li|blockquote|h[1-6])>/gi, ' ')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#(?:(\d+)|x([0-9a-fA-F]+));/g, (_, dec, hex) => {
+        try {
+            return String.fromCodePoint(dec !== undefined ? Number(dec) : parseInt(hex, 16));
+        }
+        catch {
+            return '';
+        }
+    })
+        .replace(/\s+/g, ' ')
+        .trim();
+}

--- a/clis/linux-do/format.test.js
+++ b/clis/linux-do/format.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { stripHtml, toLocalTime } from './format.js';
+
+describe('linux-do format helpers', () => {
+    it('normalizes empty, invalid, and valid timestamps', () => {
+        const validInput = '2025-04-05T10:00:00.000Z';
+        expect(toLocalTime('')).toBe('');
+        expect(toLocalTime(null)).toBe('');
+        expect(toLocalTime(undefined)).toBe('');
+        expect(toLocalTime('not-a-date')).toBe('not-a-date');
+        expect(toLocalTime(validInput)).not.toBe(validInput);
+        expect(toLocalTime(validInput)).toBe(new Date(validInput).toLocaleString());
+    });
+
+    it('strips HTML blocks and collapses whitespace', () => {
+        expect(stripHtml('<p>Hello</p><div>world</div><br/>again')).toBe('Hello world again');
+        expect(stripHtml('  one   <br>   two\nthree  ')).toBe('one two three');
+    });
+
+    it('decodes named and numeric entities', () => {
+        expect(stripHtml('&nbsp;&amp;&lt;&gt;&quot;')).toBe('&<>"');
+        expect(stripHtml('&#65; &#x42;')).toBe('A B');
+    });
+
+    it('drops invalid numeric code points instead of throwing', () => {
+        expect(stripHtml('a &#9999999999; b')).toBe('a b');
+    });
+
+    it('coerces falsy input to an empty string', () => {
+        expect(stripHtml('')).toBe('');
+        expect(stripHtml(null)).toBe('');
+        expect(stripHtml(undefined)).toBe('');
+    });
+});

--- a/clis/linux-do/topic-content.js
+++ b/clis/linux-do/topic-content.js
@@ -1,14 +1,9 @@
 import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { htmlToMarkdown, isRecord } from '@jackwener/opencli/utils';
+import { toLocalTime } from './format.js';
 const LINUX_DO_DOMAIN = 'linux.do';
 const LINUX_DO_HOME = 'https://linux.do';
-function toLocalTime(utcStr) {
-    if (!utcStr)
-        return '';
-    const date = new Date(utcStr);
-    return Number.isNaN(date.getTime()) ? utcStr : date.toLocaleString();
-}
 function normalizeTopicPayload(payload) {
     if (!isRecord(payload))
         return null;
@@ -151,5 +146,4 @@ export const __test__ = {
     buildTopicMarkdownDocument,
     extractTopicContent,
     normalizeTopicPayload,
-    toLocalTime,
 };

--- a/clis/linux-do/topic.js
+++ b/clis/linux-do/topic.js
@@ -1,32 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { fetchLinuxDoJson } from './feed.js';
-function toLocalTime(utcStr) {
-    if (!utcStr)
-        return '';
-    const date = new Date(utcStr);
-    return Number.isNaN(date.getTime()) ? utcStr : date.toLocaleString();
-}
-function strip(html) {
-    return (html || '')
-        .replace(/<br\s*\/?>/gi, ' ')
-        .replace(/<\/(p|div|li|blockquote|h[1-6])>/gi, ' ')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#(?:(\d+)|x([0-9a-fA-F]+));/g, (_, dec, hex) => {
-        try {
-            return String.fromCodePoint(dec !== undefined ? Number(dec) : parseInt(hex, 16));
-        }
-        catch {
-            return '';
-        }
-    })
-        .replace(/\s+/g, ' ')
-        .trim();
-}
+import { stripHtml as strip, toLocalTime } from './format.js';
 cli({
     site: 'linux-do',
     name: 'topic',

--- a/clis/linux-do/user-posts.js
+++ b/clis/linux-do/user-posts.js
@@ -1,32 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { fetchLinuxDoJson } from './feed.js';
-function toLocalTime(utcStr) {
-    if (!utcStr)
-        return '';
-    const date = new Date(utcStr);
-    return Number.isNaN(date.getTime()) ? utcStr : date.toLocaleString();
-}
-function strip(html) {
-    return (html || '')
-        .replace(/<br\s*\/?>/gi, ' ')
-        .replace(/<\/(p|div|li|blockquote|h[1-6])>/gi, ' ')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#(?:(\d+)|x([0-9a-fA-F]+));/g, (_, dec, hex) => {
-        try {
-            return String.fromCodePoint(dec !== undefined ? Number(dec) : parseInt(hex, 16));
-        }
-        catch {
-            return '';
-        }
-    })
-        .replace(/\s+/g, ' ')
-        .trim();
-}
+import { stripHtml as strip, toLocalTime } from './format.js';
 cli({
     site: 'linux-do',
     name: 'user-posts',

--- a/clis/linux-do/user-topics.js
+++ b/clis/linux-do/user-topics.js
@@ -1,11 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { fetchLinuxDoJson } from './feed.js';
-function toLocalTime(utcStr) {
-    if (!utcStr)
-        return '';
-    const date = new Date(utcStr);
-    return Number.isNaN(date.getTime()) ? utcStr : date.toLocaleString();
-}
+import { toLocalTime } from './format.js';
 cli({
     site: 'linux-do',
     name: 'user-topics',


### PR DESCRIPTION
## Summary
- add a site-local Linux.do format helper module for time and HTML formatting
- import the shared toLocalTime helper across feed/topic/topic-content/user-topics/user-posts
- import stripHtml as strip for topic and user-posts while preserving existing call-site names
- add direct helper contract coverage without changing existing Linux.do test files

## Boundaries
- 7-file Linux.do-only diff
- no changes to existing feed.test.js or topic-content.test.js
- topic-content __test__ only loses imported toLocalTime; retained keys stay local
- all five complete cli({...}) nodes are unchanged
- retained feed metadata/cache/request helpers are unchanged
- valid timestamp test compares to the current environment's toLocaleString result and does not pin a locale/TZ string

## Tests
- npx vitest run clis/linux-do
- npm run typecheck
- npm run build
- node dist/src/main.js validate linux-do
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check