### PR TITLE
chore(slock): share task identity postcondition

### DIFF
--- a/clis/slock/task-claim.js
+++ b/clis/slock/task-claim.js
@@ -8,11 +8,12 @@
 // (re)claimed. The server rejects done/closed.
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { authHeadersFragment } from './in-page.js';
 import { dispatchEvaluateResult } from './errors.js';
 import { SLOCK_SITE, SLOCK_DOMAIN, SLOCK_HOME_URL, SLOCK_API_BASE } from './shared.js';
 import { assertMessageIdShape } from './resolve.js';
+import { assertTaskIdentity } from './task-identity.js';
 
 cli({
   site: SLOCK_SITE,
@@ -59,14 +60,3 @@ cli({
     }));
   },
 });
-
-function assertTaskIdentity(t, expectedId, commandName) {
-  const taskId = t?.id;
-  if (!taskId) {
-    throw new CommandExecutionError(`Slock ${commandName} succeeded without returning task id ${expectedId}; refusing to report a task row.`);
-  }
-  if (taskId !== expectedId) {
-    throw new CommandExecutionError(`Slock ${commandName} returned task id ${taskId}, expected ${expectedId}.`);
-  }
-  return taskId;
-}

--- a/clis/slock/task-claim.test.js
+++ b/clis/slock/task-claim.test.js
@@ -69,8 +69,11 @@ describe('slock task-claim', () => {
 
   it('[postcondition] rejects a 2xx claim response with the wrong task identity', async () => {
     const page = makePage({ kind: 'ok', rows: [{ id: '550e8400-e29b-41d4-a716-446655440001', taskStatus: 'in_progress' }] });
-    await expect(command.func(page, { taskId: ID }))
+    const result = command.func(page, { taskId: ID });
+    await expect(result)
       .rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(result)
+      .rejects.toThrow(`Slock task-claim returned task id 550e8400-e29b-41d4-a716-446655440001, expected ${ID}.`);
   });
 
   it('passes --server override into authHeadersFragment', async () => {

--- a/clis/slock/task-identity.js
+++ b/clis/slock/task-identity.js
@@ -1,0 +1,12 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+export function assertTaskIdentity(t, expectedId, commandName) {
+  const taskId = t?.id;
+  if (!taskId) {
+    throw new CommandExecutionError(`Slock ${commandName} succeeded without returning task id ${expectedId}; refusing to report a task row.`);
+  }
+  if (taskId !== expectedId) {
+    throw new CommandExecutionError(`Slock ${commandName} returned task id ${taskId}, expected ${expectedId}.`);
+  }
+  return taskId;
+}

--- a/clis/slock/task-unclaim.js
+++ b/clis/slock/task-unclaim.js
@@ -5,11 +5,12 @@
 // (done / closed) task.
 
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError } from '@jackwener/opencli/errors';
 import { authHeadersFragment } from './in-page.js';
 import { dispatchEvaluateResult } from './errors.js';
 import { SLOCK_SITE, SLOCK_DOMAIN, SLOCK_HOME_URL, SLOCK_API_BASE } from './shared.js';
 import { assertMessageIdShape } from './resolve.js';
+import { assertTaskIdentity } from './task-identity.js';
 
 cli({
   site: SLOCK_SITE,
@@ -53,14 +54,3 @@ cli({
     }));
   },
 });
-
-function assertTaskIdentity(t, expectedId, commandName) {
-  const taskId = t?.id;
-  if (!taskId) {
-    throw new CommandExecutionError(`Slock ${commandName} succeeded without returning task id ${expectedId}; refusing to report a task row.`);
-  }
-  if (taskId !== expectedId) {
-    throw new CommandExecutionError(`Slock ${commandName} returned task id ${taskId}, expected ${expectedId}.`);
-  }
-  return taskId;
-}

--- a/clis/slock/task-unclaim.test.js
+++ b/clis/slock/task-unclaim.test.js
@@ -43,7 +43,10 @@ describe('slock task-unclaim', () => {
 
   it('[postcondition] rejects a 2xx unclaim response without task identity', async () => {
     const page = makePage({ kind: 'ok', rows: [{ taskStatus: 'todo' }] });
-    await expect(command.func(page, { taskId: ID }))
+    const result = command.func(page, { taskId: ID });
+    await expect(result)
       .rejects.toBeInstanceOf(CommandExecutionError);
+    await expect(result)
+      .rejects.toThrow(`Slock task-unclaim succeeded without returning task id ${ID}; refusing to report a task row.`);
   });
 });


### PR DESCRIPTION
## Summary
- add a leaf task-identity helper for claim/unclaim postcondition checks
- import it from task-claim and task-unclaim while narrowing each errors import to ArgumentError
- strengthen existing postcondition tests with exact action-specific messages without re-running write commands

## Boundaries
- 5-file scope only
- no changes to clis/slock/shared.js or task-status.js
- no direct helper test and no __test__ shim
- both complete cli({...}) nodes are unchanged
- claim/unclaim endpoints, snippets, write errors, assignee/status/receipt mapping, and call-sites are unchanged

## Tests
- npx vitest run clis/slock/task-claim.test.js clis/slock/task-unclaim.test.js
- npx vitest run clis/slock
- npm run typecheck
- npm run build
- node dist/src/main.js validate slock
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check