### PR TITLE
chore(instagram): share current user helper

### DIFF
--- a/clis/instagram/_shared/runtime-info.js
+++ b/clis/instagram/_shared/runtime-info.js
@@ -79,3 +79,7 @@ export async function resolveInstagramRuntimeInfo(page) {
         instagramAjax: runtime?.instagramAjax || '',
     };
 }
+export async function resolveCurrentUserId(page) {
+    const cookies = await page.getCookies({ domain: 'instagram.com' });
+    return cookies.find((cookie) => cookie.name === 'ds_user_id')?.value || '';
+}

--- a/clis/instagram/_shared/runtime-info.test.js
+++ b/clis/instagram/_shared/runtime-info.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveCurrentUserId } from './runtime-info.js';
+
+describe('instagram runtime info helpers', () => {
+    it('reads the current user id from instagram cookies', async () => {
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([
+                { name: 'sessionid', value: 'session', domain: 'instagram.com' },
+                { name: 'ds_user_id', value: '123456789', domain: 'instagram.com' },
+                { name: 'csrftoken', value: 'csrf', domain: 'instagram.com' },
+            ]),
+        };
+
+        await expect(resolveCurrentUserId(page)).resolves.toBe('123456789');
+        expect(page.getCookies).toHaveBeenCalledTimes(1);
+        expect(page.getCookies).toHaveBeenNthCalledWith(1, { domain: 'instagram.com' });
+    });
+
+    it('returns an empty string when the current user id cookie is missing', async () => {
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([
+                { name: 'sessionid', value: 'session', domain: 'instagram.com' },
+                { name: 'csrftoken', value: 'csrf', domain: 'instagram.com' },
+            ]),
+        };
+
+        await expect(resolveCurrentUserId(page)).resolves.toBe('');
+        expect(page.getCookies).toHaveBeenCalledWith({ domain: 'instagram.com' });
+    });
+
+    it('returns an empty string when the current user id cookie value is empty', async () => {
+        const page = {
+            getCookies: vi.fn().mockResolvedValue([
+                { name: 'ds_user_id', value: '', domain: 'instagram.com' },
+            ]),
+        };
+
+        await expect(resolveCurrentUserId(page)).resolves.toBe('');
+        expect(page.getCookies).toHaveBeenCalledWith({ domain: 'instagram.com' });
+    });
+
+    it('propagates getCookies failures', async () => {
+        const error = new Error('cookies unavailable');
+        const page = {
+            getCookies: vi.fn().mockRejectedValue(error),
+        };
+
+        await expect(resolveCurrentUserId(page)).rejects.toBe(error);
+        expect(page.getCookies).toHaveBeenCalledWith({ domain: 'instagram.com' });
+    });
+});

--- a/clis/instagram/post.js
+++ b/clis/instagram/post.js
@@ -4,7 +4,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { installInstagramProtocolCapture, readInstagramProtocolCapture, } from './_shared/protocol-capture.js';
 import { publishMediaViaPrivateApi, publishImagesViaPrivateApi, resolveInstagramPrivatePublishConfig, } from './_shared/private-publish.js';
-import { resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
+import { resolveCurrentUserId, resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
 import { INSTAGRAM_HOME_URL, gotoInstagramHome } from './_shared/navigation.js';
 const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp']);
 const SUPPORTED_VIDEO_EXTENSIONS = new Set(['.mp4']);
@@ -1263,10 +1263,6 @@ async function waitForPublishSuccess(page) {
     }
     await page.screenshot({ path: '/tmp/instagram_post_share_debug.png' });
     throw new CommandExecutionError('Instagram post share confirmation did not appear', 'Inspect /tmp/instagram_post_share_debug.png for the final publish state');
-}
-async function resolveCurrentUserId(page) {
-    const cookies = await page.getCookies({ domain: 'instagram.com' });
-    return cookies.find((cookie) => cookie.name === 'ds_user_id')?.value || '';
 }
 async function resolveProfileUrl(page, currentUserId = '') {
     if (currentUserId) {

--- a/clis/instagram/reel.js
+++ b/clis/instagram/reel.js
@@ -5,7 +5,7 @@ import { Page as BrowserPage } from '@jackwener/opencli/browser/page';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { buildClickActionJs, buildEnsureComposerOpenJs, buildInspectUploadStageJs, } from './post.js';
-import { resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
+import { resolveCurrentUserId, resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
 import { INSTAGRAM_HOME_URL, gotoInstagramHome } from './_shared/navigation.js';
 const SUPPORTED_VIDEO_EXTENSIONS = new Set(['.mp4']);
 const INSTAGRAM_REEL_TIMEOUT_SECONDS = 600;
@@ -626,10 +626,6 @@ async function waitForPublishSuccess(page) {
             await page.wait({ time: 1 });
     }
     throw new CommandExecutionError('Instagram reel share confirmation did not appear');
-}
-async function resolveCurrentUserId(page) {
-    const cookies = await page.getCookies({ domain: 'instagram.com' });
-    return cookies.find((cookie) => cookie.name === 'ds_user_id')?.value || '';
 }
 async function resolveProfileUrl(page, currentUserId = '') {
     if (currentUserId) {

--- a/clis/instagram/story.js
+++ b/clis/instagram/story.js
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { publishStoryViaPrivateApi, resolveInstagramPrivatePublishConfig, } from './_shared/private-publish.js';
-import { resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
+import { resolveCurrentUserId, resolveInstagramRuntimeInfo } from './_shared/runtime-info.js';
 import { INSTAGRAM_HOME_URL } from './_shared/navigation.js';
 const SUPPORTED_STORY_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp']);
 const SUPPORTED_STORY_VIDEO_EXTENSIONS = new Set(['.mp4']);
@@ -38,10 +38,6 @@ function normalizeStoryMediaItem(kwargs) {
         return { type: 'video', filePath: resolved };
     }
     throw new ArgumentError(`Unsupported story media format: ${ext}`, 'Supported formats: images (.jpg, .jpeg, .png, .webp) and videos (.mp4)');
-}
-async function resolveCurrentUserId(page) {
-    const cookies = await page.getCookies({ domain: 'instagram.com' });
-    return cookies.find((cookie) => cookie.name === 'ds_user_id')?.value || '';
 }
 async function resolveCurrentUsername(page, currentUserId = '') {
     if (!currentUserId)


### PR DESCRIPTION
## Summary
- Move the identical Instagram current-user cookie lookup into clis/instagram/_shared/runtime-info.js
- Import resolveCurrentUserId from post/reel/story and remove the three local copies
- Add direct runtime-info tests for the cookie lookup contract

## Negative boundaries
- _shared/private-publish.js is zero diff; its explicit runtime-info re-export list is not widened
- _shared/navigation.js and navigation tests are zero diff
- Existing post/reel/story tests are zero diff
- post/reel/story command nodes and other runtime-info helpers are intended to remain unchanged apart from the imported helper binding

## Test rationale
- runtime-info.test.js covers the real cookie states separately: ds_user_id present, missing, and present with an empty string value
- getCookies rejection is propagated, guarding against future silent try/catch-to-empty behavior

## Local gates
- npx vitest run clis/instagram/post.test.js clis/instagram/reel.test.js clis/instagram/story.test.js clis/instagram/_shared/runtime-info.test.js
- npx vitest run clis/instagram
- npm run typecheck
- npm run build
- node dist/src/main.js validate instagram (PASS; existing post/reel positional arg-order warnings only)
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check