### PR TITLE
chore(browser): share CDP page capabilities

### DIFF
--- a/src/browser/base-page.test.ts
+++ b/src/browser/base-page.test.ts
@@ -58,6 +58,18 @@ class ActionPage extends BasePage {
 
 const resolveOk = { ok: true, matches_n: 1, match_level: 'exact' };
 
+describe('BasePage capability boundary', () => {
+  it('does not expose CDP-only capabilities on transport-neutral pages', () => {
+    const page = new TestPage() as unknown as Record<string, unknown>;
+
+    expect('cdp' in page).toBe(false);
+    expect('handleJavaScriptDialog' in page).toBe(false);
+    expect('nativeClick' in page).toBe(false);
+    expect('nativeType' in page).toBe(false);
+    expect('nativeKeyPress' in page).toBe(false);
+  });
+});
+
 describe('BasePage.fetchJson', () => {
   it('passes a narrow browser-context JSON request and parses the response in Node', async () => {
     const page = new TestPage();

--- a/src/browser/base-page.ts
+++ b/src/browser/base-page.ts
@@ -1234,6 +1234,64 @@ export abstract class BasePage implements IPage {
   }
 }
 
+export abstract class CDPBasePage extends BasePage {
+  abstract cdp(method: string, params?: Record<string, unknown>): Promise<unknown>;
+
+  async handleJavaScriptDialog(accept: boolean, promptText?: string): Promise<void> {
+    await this.cdp('Page.handleJavaScriptDialog', {
+      accept,
+      ...(promptText !== undefined && { promptText }),
+    });
+  }
+
+  async nativeClick(x: number, y: number): Promise<void> {
+    await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x,
+      y,
+    });
+    await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      x,
+      y,
+      button: 'left',
+      clickCount: 1,
+    });
+    await this.cdp('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      x,
+      y,
+      button: 'left',
+      clickCount: 1,
+    });
+  }
+
+  async nativeType(text: string): Promise<void> {
+    // Use Input.insertText for reliable Unicode/CJK text insertion
+    await this.cdp('Input.insertText', { text });
+  }
+
+  async nativeKeyPress(key: string, modifiers: string[] = []): Promise<void> {
+    let modifierFlags = 0;
+    for (const mod of modifiers) {
+      if (mod === 'Alt') modifierFlags |= 1;
+      if (mod === 'Ctrl' || mod === 'Control') modifierFlags |= 2;
+      if (mod === 'Meta') modifierFlags |= 4;
+      if (mod === 'Shift') modifierFlags |= 8;
+    }
+    await this.cdp('Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key,
+      modifiers: modifierFlags,
+    });
+    await this.cdp('Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key,
+      modifiers: modifierFlags,
+    });
+  }
+}
+
 function axTreeParams(frame: BrowserRef['frame'] | undefined): Record<string, unknown> {
   return frame?.frameId
     ? {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -18,7 +18,7 @@ import { generateStealthJs } from './stealth.js';
 import { waitForDomStableJs } from './dom-helpers.js';
 import { isRecord, saveBase64ToFile } from '../utils.js';
 import { getAllElectronApps } from '../electron-apps.js';
-import { BasePage } from './base-page.js';
+import { CDPBasePage } from './base-page.js';
 
 export interface CDPTarget {
   type?: string;
@@ -183,7 +183,7 @@ export class CDPBridge implements IBrowserFactory {
   }
 }
 
-class CDPPage extends BasePage {
+class CDPPage extends CDPBasePage {
   private _pageEnabled = false;
 
   // Network capture state (mirrors extension/src/cdp.ts NetworkCaptureEntry shape)
@@ -414,61 +414,8 @@ class CDPPage extends BasePage {
     return this.bridge.send(method, params);
   }
 
-  async handleJavaScriptDialog(accept: boolean, promptText?: string): Promise<void> {
-    await this.cdp('Page.handleJavaScriptDialog', {
-      accept,
-      ...(promptText !== undefined && { promptText }),
-    });
-  }
-
-  async nativeClick(x: number, y: number): Promise<void> {
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mouseMoved',
-      x,
-      y,
-    });
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mousePressed',
-      x,
-      y,
-      button: 'left',
-      clickCount: 1,
-    });
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mouseReleased',
-      x,
-      y,
-      button: 'left',
-      clickCount: 1,
-    });
-  }
-
-  async nativeType(text: string): Promise<void> {
-    await this.cdp('Input.insertText', { text });
-  }
-
   async insertText(text: string): Promise<void> {
     await this.nativeType(text);
-  }
-
-  async nativeKeyPress(key: string, modifiers: string[] = []): Promise<void> {
-    let modifierFlags = 0;
-    for (const mod of modifiers) {
-      if (mod === 'Alt') modifierFlags |= 1;
-      if (mod === 'Ctrl' || mod === 'Control') modifierFlags |= 2;
-      if (mod === 'Meta') modifierFlags |= 4;
-      if (mod === 'Shift') modifierFlags |= 8;
-    }
-    await this.cdp('Input.dispatchKeyEvent', {
-      type: 'keyDown',
-      key,
-      modifiers: modifierFlags,
-    });
-    await this.cdp('Input.dispatchKeyEvent', {
-      type: 'keyUp',
-      key,
-      modifiers: modifierFlags,
-    });
   }
 }
 

--- a/src/browser/page.ts
+++ b/src/browser/page.ts
@@ -15,7 +15,7 @@ import { buildEvaluateExpression } from './utils.js';
 import { saveBase64ToFile } from '../utils.js';
 import { generateStealthJs } from './stealth.js';
 import { waitForDomStableJs } from './dom-helpers.js';
-import { BasePage } from './base-page.js';
+import { CDPBasePage } from './base-page.js';
 import { classifyBrowserError } from './errors.js';
 import { log } from '../logger.js';
 
@@ -39,7 +39,7 @@ function isStalePageIdentityError(err: unknown): boolean {
 /**
  * Page — implements IPage by talking to the daemon via HTTP.
  */
-export class Page extends BasePage {
+export class Page extends CDPBasePage {
   private readonly _idleTimeout: number | undefined;
 
   constructor(
@@ -345,23 +345,6 @@ export class Page extends BasePage {
     });
   }
 
-  async handleJavaScriptDialog(accept: boolean, promptText?: string): Promise<void> {
-    await this.cdp('Page.handleJavaScriptDialog', {
-      accept,
-      ...(promptText !== undefined && { promptText }),
-    });
-  }
-
-  /** CDP native click fallback — called when JS el.click() fails */
-  protected override async tryNativeClick(x: number, y: number): Promise<boolean> {
-    try {
-      await this.nativeClick(x, y);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   /** Precise click using DOM.getContentQuads/getBoxModel for inline elements */
   async clickWithQuads(ref: string): Promise<void> {
     const safeRef = JSON.stringify(ref);
@@ -424,48 +407,4 @@ export class Page extends BasePage {
     `);
   }
 
-  async nativeClick(x: number, y: number): Promise<void> {
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mouseMoved',
-      x,
-      y,
-    });
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mousePressed',
-      x, y,
-      button: 'left',
-      clickCount: 1,
-    });
-    await this.cdp('Input.dispatchMouseEvent', {
-      type: 'mouseReleased',
-      x, y,
-      button: 'left',
-      clickCount: 1,
-    });
-  }
-
-  async nativeType(text: string): Promise<void> {
-    // Use Input.insertText for reliable Unicode/CJK text insertion
-    await this.cdp('Input.insertText', { text });
-  }
-
-  async nativeKeyPress(key: string, modifiers: string[] = []): Promise<void> {
-    let modifierFlags = 0;
-    for (const mod of modifiers) {
-      if (mod === 'Alt') modifierFlags |= 1;
-      if (mod === 'Ctrl' || mod === 'Control') modifierFlags |= 2;
-      if (mod === 'Meta') modifierFlags |= 4;
-      if (mod === 'Shift') modifierFlags |= 8;
-    }
-    await this.cdp('Input.dispatchKeyEvent', {
-      type: 'keyDown',
-      key,
-      modifiers: modifierFlags,
-    });
-    await this.cdp('Input.dispatchKeyEvent', {
-      type: 'keyUp',
-      key,
-      modifiers: modifierFlags,
-    });
-  }
 }


### PR DESCRIPTION
## Summary
- add an internal CDPBasePage subclass for CDP-only dialog/native input helpers
- move Page and CDPPage to CDPBasePage and remove their duplicate CDP helper methods
- remove Page's redundant tryNativeClick override so BasePage's existing fallback path handles it
- add a capability-boundary test proving transport-neutral TestPage still lacks cdp/dialog/native methods

## Negative boundaries
- BasePage transport-neutral methods and IPage optional capability contract are not widened
- src/types.ts and package exports are unchanged
- page.test.ts and cdp.test.ts are unchanged
- Page/CDPPage retained members stay scoped outside the deleted duplicate helper methods; CDPPage.insertText and both cdp methods remain local

## Verification
- npx vitest run src/browser/base-page.test.ts src/browser/page.test.ts src/browser/cdp.test.ts (72/72)
- npx vitest run src/browser (28 files / 432 tests)
- npm run typecheck
- npm run build (manifest 1332)
- node dist/src/main.js validate (1332 commands, 0 errors, 8 pre-existing warnings)
- npm run check:typed-error-lint (new=0)
- npm run check:silent-column-drop (new=0)
- git diff --check

## Mutation proof
- temporarily added nativeClick to BasePage; the new capability-boundary test failed on nativeClick presence, then the temporary edit was reverted and focused tests passed again.
