### PR TITLE
fix(xiaohongshu): harvest search rows during scroll instead of first/last screen union

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -6,7 +6,7 @@
  * Ref: https://github.com/jackwener/opencli/issues/10
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
@@ -37,6 +37,76 @@ const WAIT_FOR_CONTENT_JS = `
     setTimeout(() => { observer.disconnect(); resolve('timeout'); }, 5000);
   })
 `;
+const DEFAULT_HARVEST_STEP = 900;
+
+function harvestOptionsForLimit(limit) {
+    return {
+        maxRounds: 12 + Math.ceil((limit - 1) * 48 / 99),
+        budgetMs: 15_000 + Math.ceil((limit - 1) * 45_000 / 99),
+        step: DEFAULT_HARVEST_STEP,
+    };
+}
+
+export function noteKeyFromUrl(url) {
+    if (typeof url !== 'string')
+        return '';
+    const match = url.match(/\/(?:search_result|explore|note)\/([0-9a-f]{24})(?=[?#/]|$)/i);
+    return match ? match[1].toLowerCase() : '';
+}
+
+export function mergeHarvestedRow(acc, row) {
+    const url = typeof row?.url === 'string' ? row.url : '';
+    const key = noteKeyFromUrl(url) || url;
+    if (!key)
+        return acc;
+    const prev = acc.get(key);
+    if (!prev) {
+        acc.set(key, { ...row });
+        return acc;
+    }
+    for (const field of ['title', 'author', 'author_url']) {
+        if (!prev[field] && row?.[field])
+            prev[field] = row[field];
+    }
+    if ((!prev.likes || prev.likes === '0') && row?.likes && row.likes !== '0') {
+        prev.likes = row.likes;
+    }
+    if (url.includes('xsec_token=') && !String(prev.url || '').includes('xsec_token=')) {
+        prev.url = url;
+    }
+    return acc;
+}
+
+/**
+ * Counts rows that would survive the title filter applied after harvesting.
+ * Masonry cards expose their link before their title, so a freshly discovered
+ * card is not yet a usable result.
+ */
+export function usableRowCount(acc) {
+    let count = 0;
+    for (const row of acc.values()) {
+        if (row?.title)
+            count++;
+    }
+    return count;
+}
+
+export function shouldStopScrolling(state) {
+    if (state.collected >= state.target)
+        return { stop: true, reason: 'target' };
+    if (state.elapsedMs >= state.budgetMs)
+        return { stop: true, reason: 'budget' };
+    if (state.round >= state.maxRounds)
+        return { stop: true, reason: 'max-rounds' };
+    if (state.atBottom && state.stalledRounds >= 3)
+        return { stop: true, reason: 'exhausted' };
+    if (!state.moved && state.stalledRounds >= 3)
+        return { stop: true, reason: 'wedged' };
+    // No-new-row plateaus alone are not terminal: XHS has stalled at
+    // scrollTop=4500 / scrollHeight=6960 and then resumed loading.
+    return { stop: false, reason: '' };
+}
+
 /**
  * Extract approximate publish date from a Xiaohongshu note URL.
  * XHS note IDs follow MongoDB ObjectID format where the first 8 hex
@@ -60,6 +130,89 @@ export function stripXhsAuthorDateSuffix(value) {
     const stripped = text.replace(/\s*(?:\d{1,2}天前|\d+小时前|\d+分钟前|\d+秒前|刚刚|昨天|前天|\d+周前|\d+个月前|\d{1,2}-\d{1,2}|\d{4}-\d{1,2}-\d{1,2})$/u, '').trim();
     return stripped || text;
 }
+
+function extractSearchRows(webHost) {
+    const normalizeUrl = (href) => {
+        if (!href)
+            return '';
+        if (href.startsWith('http://') || href.startsWith('https://'))
+            return href;
+        if (href.startsWith('/'))
+            return `https://${webHost}${href}`;
+        return '';
+    };
+    const cleanText = (value) => (value || '').replace(/\s+/g, ' ').trim();
+    const isVisibleNote = (el) => {
+        const rect = el.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0)
+            return false;
+        const style = getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+    };
+    const results = [];
+    const seen = new Set();
+    // Note containers: legacy `section.note-item` first, fallback to any
+    // `<section>` wrapping a search-result/explore link (#1506 reports the
+    // class being dropped on some xhs renders).
+    const collectNoteCards = () => {
+        const classMatches = document.querySelectorAll('section.note-item');
+        if (classMatches.length > 0)
+            return classMatches;
+        const sections = new Set();
+        for (const a of document.querySelectorAll('a[href*="/search_result/"], a[href*="/explore/"]')) {
+            const section = a.closest('section');
+            if (section)
+                sections.add(section);
+        }
+        return sections;
+    };
+    for (const el of collectNoteCards()) {
+        // Skip "related searches" sections
+        if (el.classList?.contains('query-note-item'))
+            continue;
+        if (!isVisibleNote(el))
+            continue;
+        const titleEl = el.querySelector('.title, .note-title, a.title, .footer .title span');
+        const nameEl = el.querySelector('a.author .name, .author-name, .nick-name, .name');
+        const authorWrapEl = el.querySelector('a.author');
+        let author = cleanText(nameEl?.textContent || '');
+        if (!author && authorWrapEl) {
+            const nameChild = authorWrapEl.querySelector('.name');
+            author = nameChild ? cleanText(nameChild.textContent || '') : stripXhsAuthorDateSuffix(authorWrapEl.textContent || '');
+        }
+        const likesEl = el.querySelector('.count, .like-count, .like-wrapper .count');
+        // Prefer search_result link (preserves xsec_token) over generic /explore/ link
+        const detailLinkEl = el.querySelector('a.cover.mask') ||
+            el.querySelector('a[href*="/search_result/"]') ||
+            el.querySelector('a[href*="/explore/"]') ||
+            el.querySelector('a[href*="/note/"]');
+        const authorLinkEl = el.querySelector('a.author, a[href*="/user/profile/"]');
+        const url = normalizeUrl(detailLinkEl?.getAttribute('href') || '');
+        if (!url)
+            continue;
+        const key = url;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        // Fallback title: the new bare-section render keeps the note caption
+        // inside the search_result anchor's first span, not in a class-named
+        // .title element. Pull from there when the class-based pick is empty.
+        let title = cleanText(titleEl?.textContent || '');
+        if (!title) {
+            const captionSpan = detailLinkEl?.querySelector('span');
+            title = cleanText(captionSpan?.textContent || '');
+        }
+        results.push({
+            title,
+            author,
+            likes: cleanText(likesEl?.textContent || '0'),
+            url,
+            author_url: normalizeUrl(authorLinkEl?.getAttribute('href') || ''),
+        });
+    }
+    return results;
+}
+
 /**
  * `page.evaluate` may return either the raw IIFE value or a
  * `{ session, data }` envelope depending on the browser-bridge version.
@@ -73,12 +226,12 @@ export function unwrapEvaluateResult(payload) {
     }
     return payload;
 }
-function requireSearchRows(payload, phase) {
-    const rows = unwrapEvaluateResult(payload);
-    if (!Array.isArray(rows)) {
-        throw new CommandExecutionError(`Unexpected Xiaohongshu search ${phase} payload shape; expected an array of rows.`);
+function requireHarvestPayload(payload) {
+    const result = unwrapEvaluateResult(payload);
+    if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows)) {
+        throw new CommandExecutionError('Unexpected Xiaohongshu search harvest payload shape; expected an object with a rows array.');
     }
-    return rows;
+    return result;
 }
 export function parseLimit(raw) {
     const parsed = Number(raw ?? 20);
@@ -183,90 +336,184 @@ export function buildScrollUntilJs(targetCount, maxScrolls = 15) {
 export function buildSearchExtractJs(webHost) {
     return `
       (() => {
-        const normalizeUrl = (href) => {
-          if (!href) return '';
-          if (href.startsWith('http://') || href.startsWith('https://')) return href;
-          if (href.startsWith('/')) return 'https://${webHost}' + href;
-          return '';
-        };
-
-        const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
         const stripXhsAuthorDateSuffix = ${stripXhsAuthorDateSuffix.toString()};
-        const isVisibleNote = (el) => {
-          const rect = el.getBoundingClientRect();
-          if (rect.width <= 0 || rect.height <= 0) return false;
-          const style = getComputedStyle(el);
-          return style.display !== 'none' && style.visibility !== 'hidden';
-        };
-
-        const results = [];
-        const seen = new Set();
-
-        // Note containers: legacy \`section.note-item\` first, fallback to any
-        // \`<section>\` wrapping a search-result/explore link (#1506 reports the
-        // class being dropped on some xhs renders).
-        const collectNoteCards = () => {
-          const classMatches = document.querySelectorAll('section.note-item');
-          if (classMatches.length > 0) return classMatches;
-          const sections = new Set();
-          for (const a of document.querySelectorAll('a[href*="/search_result/"], a[href*="/explore/"]')) {
-            const section = a.closest('section');
-            if (section) sections.add(section);
-          }
-          return sections;
-        };
-
-        for (const el of collectNoteCards()) {
-          // Skip "related searches" sections
-          if (el.classList?.contains('query-note-item')) continue;
-          if (!isVisibleNote(el)) continue;
-
-          const titleEl = el.querySelector('.title, .note-title, a.title, .footer .title span');
-          const nameEl = el.querySelector('a.author .name, .author-name, .nick-name, .name');
-          const authorWrapEl = el.querySelector('a.author');
-          let author = cleanText(nameEl?.textContent || '');
-          if (!author && authorWrapEl) {
-            const nameChild = authorWrapEl.querySelector('.name');
-            author = nameChild ? cleanText(nameChild.textContent || '') : stripXhsAuthorDateSuffix(authorWrapEl.textContent || '');
-          }
-          const likesEl = el.querySelector('.count, .like-count, .like-wrapper .count');
-          // Prefer search_result link (preserves xsec_token) over generic /explore/ link
-          const detailLinkEl =
-            el.querySelector('a.cover.mask') ||
-            el.querySelector('a[href*="/search_result/"]') ||
-            el.querySelector('a[href*="/explore/"]') ||
-            el.querySelector('a[href*="/note/"]');
-          const authorLinkEl = el.querySelector('a.author, a[href*="/user/profile/"]');
-
-          const url = normalizeUrl(detailLinkEl?.getAttribute('href') || '');
-          if (!url) continue;
-
-          const key = url;
-          if (seen.has(key)) continue;
-          seen.add(key);
-
-          // Fallback title: the new bare-section render keeps the note caption
-          // inside the search_result anchor's first span, not in a class-named
-          // .title element. Pull from there when the class-based pick is empty.
-          let title = cleanText(titleEl?.textContent || '');
-          if (!title) {
-            const captionSpan = detailLinkEl?.querySelector('span');
-            title = cleanText(captionSpan?.textContent || '');
-          }
-
-          results.push({
-            title,
-            author,
-            likes: cleanText(likesEl?.textContent || '0'),
-            url,
-            author_url: normalizeUrl(authorLinkEl?.getAttribute('href') || ''),
-          });
-        }
-
-        return results;
+        const extractSearchRows = ${extractSearchRows.toString()};
+        return extractSearchRows(${JSON.stringify(webHost)});
       })()
     `;
 }
+
+export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
+    const maxRounds = options.maxRounds ?? 30;
+    const budgetMs = options.budgetMs ?? 30_000;
+    const step = options.step ?? DEFAULT_HARVEST_STEP;
+    if (!Number.isSafeInteger(targetCount) || targetCount < 1) {
+        throw new ArgumentError(`targetCount must be a positive integer, got ${JSON.stringify(targetCount)}`);
+    }
+    if (!Number.isSafeInteger(maxRounds) || maxRounds < 1) {
+        throw new ArgumentError(`maxRounds must be a positive integer, got ${JSON.stringify(maxRounds)}`);
+    }
+    if (!Number.isFinite(budgetMs) || budgetMs <= 0) {
+        throw new ArgumentError(`budgetMs must be a positive number, got ${JSON.stringify(budgetMs)}`);
+    }
+    if (!Number.isFinite(step) || step < 0) {
+        throw new ArgumentError(`step must be a non-negative number, got ${JSON.stringify(step)}`);
+    }
+    return `
+      (async () => {
+        const targetCount = ${targetCount};
+        const maxRounds = ${maxRounds};
+        const budgetMs = ${budgetMs};
+        const configuredStep = ${step};
+        const webHost = ${JSON.stringify(webHost)};
+        const noteKeyFromUrl = ${noteKeyFromUrl.toString()};
+        const mergeHarvestedRow = ${mergeHarvestedRow.toString()};
+        const stripXhsAuthorDateSuffix = ${stripXhsAuthorDateSuffix.toString()};
+        const extractSearchRows = ${extractSearchRows.toString()};
+        const usableRowCount = ${usableRowCount.toString()};
+        const shouldStopScrolling = ${shouldStopScrolling.toString()};
+        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        const rootScroller = document.scrollingElement || document.documentElement || document.body;
+        const isRootScroller = (el) =>
+          !el || el === rootScroller || el === document.documentElement || el === document.body;
+        const rootScrollHeight = () => Math.max(
+          rootScroller?.scrollHeight || 0,
+          document.documentElement?.scrollHeight || 0,
+          document.body?.scrollHeight || 0
+        );
+        const rootClientHeight = () => Math.max(
+          window.innerHeight || 0,
+          rootScroller?.clientHeight || 0,
+          document.documentElement?.clientHeight || 0
+        );
+        const findScrollContainer = () => {
+          let best = rootScroller;
+          let bestRange = Math.max(0, rootScrollHeight() - rootClientHeight());
+          const candidates = document.querySelectorAll(
+            '.feeds-container, .search-container, .container, main, [class*="scroll"], [class*="feed"]'
+          );
+          for (const el of candidates) {
+            if (isRootScroller(el)) continue;
+            const style = getComputedStyle(el);
+            if (!/(?:auto|scroll|overlay)/.test(style.overflowY || '')) continue;
+            const range = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
+            if (range > bestRange) {
+              best = el;
+              bestRange = range;
+            }
+          }
+          return best;
+        };
+        const scrollContainer = findScrollContainer();
+        const readScrollMetrics = () => {
+          const rootTop = Math.max(
+            window.scrollY || window.pageYOffset || 0,
+            rootScroller?.scrollTop || 0,
+            document.documentElement?.scrollTop || 0,
+            document.body?.scrollTop || 0
+          );
+          if (!isRootScroller(scrollContainer)) {
+            return {
+              rootTop,
+              containerTop: scrollContainer.scrollTop || 0,
+              scrollTop: scrollContainer.scrollTop || 0,
+              scrollHeight: scrollContainer.scrollHeight || 0,
+              clientHeight: scrollContainer.clientHeight || 0,
+            };
+          }
+          return {
+            rootTop,
+            containerTop: rootTop,
+            scrollTop: rootTop,
+            scrollHeight: rootScrollHeight(),
+            clientHeight: rootClientHeight(),
+          };
+        };
+        const scrollStep = Math.max(400, window.innerHeight || 0, configuredStep);
+        const driveScroll = () => {
+          if (typeof window.scrollBy === 'function') window.scrollBy(0, scrollStep);
+          if (!isRootScroller(scrollContainer)) {
+            scrollContainer.scrollTop += scrollStep;
+          } else if (typeof window.scrollBy !== 'function' && rootScroller) {
+            rootScroller.scrollTop += scrollStep;
+          }
+        };
+        const acc = new Map();
+        const startedAt = Date.now();
+        let previousCollected = null;
+        let previousUsable = null;
+        let previousMetrics = null;
+        let stalledRounds = 0;
+        let cardCount = 0;
+        let round = 0;
+        let stopReason = '';
+        let metrics = readScrollMetrics();
+        let securityBlock = false;
+        while (true) {
+          round++;
+          const currentRows = extractSearchRows(webHost);
+          cardCount = currentRows.length;
+          for (const row of currentRows) mergeHarvestedRow(acc, row);
+          securityBlock = securityBlock ||
+            /请求太频繁|访问频次异常|安全限制/.test(document.body?.innerText || '');
+          metrics = readScrollMetrics();
+          const moved = previousMetrics === null ||
+            metrics.rootTop !== previousMetrics.rootTop ||
+            metrics.containerTop !== previousMetrics.containerTop;
+          const usable = usableRowCount(acc);
+          // Backfilling a title on an already-known card is progress even when
+          // no new card showed up, so both counters gate the stall detector.
+          if (previousCollected !== null && acc.size === previousCollected && usable === previousUsable) {
+            stalledRounds++;
+          } else {
+            stalledRounds = 0;
+          }
+          const atBottom = metrics.scrollHeight <= metrics.clientHeight + 2 ||
+            metrics.scrollTop + metrics.clientHeight >= metrics.scrollHeight - 8;
+          const elapsedMs = Date.now() - startedAt;
+          const decision = shouldStopScrolling({
+            // Untitled cards are dropped after the loop, so counting them
+            // toward the target would silently shrink the result set.
+            collected: usable,
+            target: targetCount,
+            round,
+            maxRounds,
+            elapsedMs,
+            budgetMs,
+            atBottom,
+            stalledRounds,
+            moved,
+          });
+          if (decision.stop) {
+            stopReason = decision.reason;
+            break;
+          }
+          previousCollected = acc.size;
+          previousUsable = usable;
+          previousMetrics = metrics;
+          driveScroll();
+          await wait(400 + Math.random() * 400);
+        }
+        const elapsedMs = Date.now() - startedAt;
+        return {
+          rows: Array.from(acc.values()),
+          collected: acc.size,
+          diag: {
+            usable: usableRowCount(acc),
+            scrollTop: metrics.scrollTop,
+            scrollHeight: metrics.scrollHeight,
+            clientHeight: metrics.clientHeight,
+            cardCount,
+            rounds: round,
+            stopReason,
+            elapsedMs,
+            securityBlock,
+          },
+        };
+      })()
+    `;
+}
+
 export const command = cli({
     site: 'xiaohongshu',
     name: 'search',
@@ -291,30 +538,12 @@ export const command = cli({
         if (waitResult === 'login_wall') {
             throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
         }
-        // Extract before scrolling. Xiaohongshu uses a virtualized masonry
-        // layout, so scrolling to the bottom can evict the initially visible
-        // note cards from the DOM and make extraction return [] even though the
-        // browser rendered results correctly.
-        const initialPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'initial extraction');
-        const payload = [...initialPayload];
-        if (payload.length < limit) {
-            // Scroll until enough rows are rendered or the lazy-load plateaus.
-            // Replaces the previous fixed `autoScroll({ times: 2 })` which capped
-            // extraction at ~13 notes regardless of `--limit` (#1471).
-            await page.evaluate(buildScrollUntilJs(limit));
-            const scrolledPayload = requireSearchRows(await page.evaluate(buildSearchExtractJs('www.xiaohongshu.com')), 'post-scroll extraction');
-            const seen = new Set(payload.map((item) => item.url).filter(Boolean));
-            for (const item of scrolledPayload) {
-                if (item?.url && seen.has(item.url))
-                    continue;
-                if (item?.url)
-                    seen.add(item.url);
-                payload.push(item);
-                if (payload.length >= limit)
-                    break;
-            }
+        const harvestOptions = harvestOptionsForLimit(limit);
+        const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)));
+        if (harvest.diag?.securityBlock) {
+            throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
         }
-        const data = payload;
+        const data = harvest.rows;
         return data
             .filter((item) => item.title)
             .slice(0, limit)

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -42,39 +42,64 @@ const DEFAULT_HARVEST_STEP = 900;
 function harvestOptionsForLimit(limit) {
     return {
         maxRounds: 12 + Math.ceil((limit - 1) * 48 / 99),
-        budgetMs: 15_000 + Math.ceil((limit - 1) * 45_000 / 99),
+        // Browser Bridge/CDP evaluates time out at 60s. Keep enough headroom
+        // for serialization and transport even at --limit 100.
+        budgetMs: 10_000 + Math.ceil((limit - 1) * 35_000 / 99),
         step: DEFAULT_HARVEST_STEP,
     };
 }
 
-export function noteKeyFromUrl(url) {
-    if (typeof url !== 'string')
-        return '';
-    const match = url.match(/\/(?:search_result|explore|note)\/([0-9a-f]{24})(?=[?#/]|$)/i);
-    return match ? match[1].toLowerCase() : '';
+export function noteUrlInfo(url, webHost = '') {
+    if (typeof url !== 'string' || !url)
+        return { key: '', signed: false };
+    try {
+        const parsed = new URL(url);
+        const expectedHost = String(webHost || '').toLowerCase();
+        if (parsed.protocol !== 'https:' || (expectedHost && parsed.hostname.toLowerCase() !== expectedHost)) {
+            return { key: '', signed: false };
+        }
+        const match = parsed.pathname.match(/^\/(?:search_result|explore|note)\/([0-9a-f]{24})\/?$/i);
+        return {
+            key: match ? match[1].toLowerCase() : '',
+            signed: Boolean(parsed.searchParams.get('xsec_token')?.trim()),
+        };
+    }
+    catch {
+        return { key: '', signed: false };
+    }
 }
 
-export function mergeHarvestedRow(acc, row) {
+export function noteKeyFromUrl(url, webHost = '') {
+    return noteUrlInfo(url, webHost).key;
+}
+
+export function mergeHarvestedRow(acc, row, webHost = '') {
     const url = typeof row?.url === 'string' ? row.url : '';
-    const key = noteKeyFromUrl(url) || url;
+    const info = noteUrlInfo(url, webHost);
+    const key = info.key;
     if (!key)
-        return acc;
+        return false;
     const prev = acc.get(key);
     if (!prev) {
         acc.set(key, { ...row });
-        return acc;
+        return true;
     }
+    let changed = false;
     for (const field of ['title', 'author', 'author_url']) {
-        if (!prev[field] && row?.[field])
+        if (!prev[field] && row?.[field]) {
             prev[field] = row[field];
+            changed = true;
+        }
     }
     if ((!prev.likes || prev.likes === '0') && row?.likes && row.likes !== '0') {
         prev.likes = row.likes;
+        changed = true;
     }
-    if (url.includes('xsec_token=') && !String(prev.url || '').includes('xsec_token=')) {
+    if (info.signed && !noteUrlInfo(prev.url, webHost).signed) {
         prev.url = url;
+        changed = true;
     }
-    return acc;
+    return changed;
 }
 
 /**
@@ -98,12 +123,11 @@ export function shouldStopScrolling(state) {
         return { stop: true, reason: 'budget' };
     if (state.round >= state.maxRounds)
         return { stop: true, reason: 'max-rounds' };
-    if (state.atBottom && state.stalledRounds >= 3)
-        return { stop: true, reason: 'exhausted' };
-    if (!state.moved && state.stalledRounds >= 3)
-        return { stop: true, reason: 'wedged' };
-    // No-new-row plateaus alone are not terminal: XHS has stalled at
-    // scrollTop=4500 / scrollHeight=6960 and then resumed loading.
+    if (state.idleRounds >= 3)
+        return { stop: true, reason: state.atBottom ? 'exhausted' : 'wedged' };
+    // No-new-row plateaus alone are not terminal. An idle round requires
+    // both unchanged harvested data and unchanged scroll geometry, so a
+    // slow height expansion or a still-moving viewport remains progress.
     return { stop: false, reason: '' };
 }
 
@@ -135,11 +159,15 @@ function extractSearchRows(webHost) {
     const normalizeUrl = (href) => {
         if (!href)
             return '';
-        if (href.startsWith('http://') || href.startsWith('https://'))
-            return href;
-        if (href.startsWith('/'))
-            return `https://${webHost}${href}`;
-        return '';
+        try {
+            const parsed = new URL(href, `https://${webHost}/`);
+            if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== webHost.toLowerCase())
+                return '';
+            return parsed.href;
+        }
+        catch {
+            return '';
+        }
     };
     const cleanText = (value) => (value || '').replace(/\s+/g, ' ').trim();
     const isVisibleNote = (el) => {
@@ -228,8 +256,11 @@ export function unwrapEvaluateResult(payload) {
 }
 function requireHarvestPayload(payload) {
     const result = unwrapEvaluateResult(payload);
-    if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows)) {
-        throw new CommandExecutionError('Unexpected Xiaohongshu search harvest payload shape; expected an object with a rows array.');
+    const diag = result?.diag;
+    if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows) ||
+        !diag || typeof diag !== 'object' || Array.isArray(diag) ||
+        typeof diag.securityBlock !== 'boolean' || typeof diag.stopReason !== 'string') {
+        throw new CommandExecutionError('Unexpected Xiaohongshu search harvest payload shape; expected rows plus typed diagnostics.');
     }
     return result;
 }
@@ -366,7 +397,7 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
         const budgetMs = ${budgetMs};
         const configuredStep = ${step};
         const webHost = ${JSON.stringify(webHost)};
-        const noteKeyFromUrl = ${noteKeyFromUrl.toString()};
+        const noteUrlInfo = ${noteUrlInfo.toString()};
         const mergeHarvestedRow = ${mergeHarvestedRow.toString()};
         const stripXhsAuthorDateSuffix = ${stripXhsAuthorDateSuffix.toString()};
         const extractSearchRows = ${extractSearchRows.toString()};
@@ -374,8 +405,6 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
         const shouldStopScrolling = ${shouldStopScrolling.toString()};
         const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
         const rootScroller = document.scrollingElement || document.documentElement || document.body;
-        const isRootScroller = (el) =>
-          !el || el === rootScroller || el === document.documentElement || el === document.body;
         const rootScrollHeight = () => Math.max(
           rootScroller?.scrollHeight || 0,
           document.documentElement?.scrollHeight || 0,
@@ -386,25 +415,6 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
           rootScroller?.clientHeight || 0,
           document.documentElement?.clientHeight || 0
         );
-        const findScrollContainer = () => {
-          let best = rootScroller;
-          let bestRange = Math.max(0, rootScrollHeight() - rootClientHeight());
-          const candidates = document.querySelectorAll(
-            '.feeds-container, .search-container, .container, main, [class*="scroll"], [class*="feed"]'
-          );
-          for (const el of candidates) {
-            if (isRootScroller(el)) continue;
-            const style = getComputedStyle(el);
-            if (!/(?:auto|scroll|overlay)/.test(style.overflowY || '')) continue;
-            const range = Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0));
-            if (range > bestRange) {
-              best = el;
-              bestRange = range;
-            }
-          }
-          return best;
-        };
-        const scrollContainer = findScrollContainer();
         const readScrollMetrics = () => {
           const rootTop = Math.max(
             window.scrollY || window.pageYOffset || 0,
@@ -412,38 +422,28 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
             document.documentElement?.scrollTop || 0,
             document.body?.scrollTop || 0
           );
-          if (!isRootScroller(scrollContainer)) {
-            return {
-              rootTop,
-              containerTop: scrollContainer.scrollTop || 0,
-              scrollTop: scrollContainer.scrollTop || 0,
-              scrollHeight: scrollContainer.scrollHeight || 0,
-              clientHeight: scrollContainer.clientHeight || 0,
-            };
-          }
           return {
             rootTop,
-            containerTop: rootTop,
             scrollTop: rootTop,
             scrollHeight: rootScrollHeight(),
             clientHeight: rootClientHeight(),
           };
         };
-        const scrollStep = Math.max(400, window.innerHeight || 0, configuredStep);
-        const driveScroll = () => {
-          if (typeof window.scrollBy === 'function') window.scrollBy(0, scrollStep);
-          if (!isRootScroller(scrollContainer)) {
-            scrollContainer.scrollTop += scrollStep;
-          } else if (typeof window.scrollBy !== 'function' && rootScroller) {
+        const driveScroll = (metrics) => {
+          // Never advance farther than one viewport. A larger step can skip a
+          // complete virtualized frame before it is harvested.
+          const viewport = metrics.clientHeight || configuredStep;
+          const scrollStep = Math.max(1, Math.min(configuredStep, viewport));
+          if (typeof window.scrollBy === 'function') {
+            window.scrollBy(0, scrollStep);
+          } else if (rootScroller) {
             rootScroller.scrollTop += scrollStep;
           }
         };
         const acc = new Map();
         const startedAt = Date.now();
-        let previousCollected = null;
-        let previousUsable = null;
         let previousMetrics = null;
-        let stalledRounds = 0;
+        let idleRounds = 0;
         let cardCount = 0;
         let round = 0;
         let stopReason = '';
@@ -451,22 +451,28 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
         let securityBlock = false;
         while (true) {
           round++;
+          securityBlock = /请求太频繁|访问频次异常|安全限制/.test(document.body?.innerText || '');
+          if (securityBlock) {
+            stopReason = 'security-block';
+            metrics = readScrollMetrics();
+            break;
+          }
           const currentRows = extractSearchRows(webHost);
           cardCount = currentRows.length;
-          for (const row of currentRows) mergeHarvestedRow(acc, row);
-          securityBlock = securityBlock ||
-            /请求太频繁|访问频次异常|安全限制/.test(document.body?.innerText || '');
+          let dataChanged = false;
+          for (const row of currentRows) {
+            if (mergeHarvestedRow(acc, row, webHost)) dataChanged = true;
+          }
           metrics = readScrollMetrics();
-          const moved = previousMetrics === null ||
-            metrics.rootTop !== previousMetrics.rootTop ||
-            metrics.containerTop !== previousMetrics.containerTop;
+          const geometryChanged = previousMetrics === null ||
+            metrics.scrollTop !== previousMetrics.scrollTop ||
+            metrics.scrollHeight !== previousMetrics.scrollHeight ||
+            metrics.clientHeight !== previousMetrics.clientHeight;
           const usable = usableRowCount(acc);
-          // Backfilling a title on an already-known card is progress even when
-          // no new card showed up, so both counters gate the stall detector.
-          if (previousCollected !== null && acc.size === previousCollected && usable === previousUsable) {
-            stalledRounds++;
+          if (previousMetrics !== null && !dataChanged && !geometryChanged) {
+            idleRounds++;
           } else {
-            stalledRounds = 0;
+            idleRounds = 0;
           }
           const atBottom = metrics.scrollHeight <= metrics.clientHeight + 2 ||
             metrics.scrollTop + metrics.clientHeight >= metrics.scrollHeight - 8;
@@ -481,18 +487,17 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
             elapsedMs,
             budgetMs,
             atBottom,
-            stalledRounds,
-            moved,
+            idleRounds,
           });
           if (decision.stop) {
             stopReason = decision.reason;
             break;
           }
-          previousCollected = acc.size;
-          previousUsable = usable;
           previousMetrics = metrics;
-          driveScroll();
-          await wait(400 + Math.random() * 400);
+          driveScroll(metrics);
+          // At the bottom, give lazy loading a full second before counting an
+          // idle round. Mid-page frames need only a short render settle.
+          await wait(atBottom ? 1000 : 500);
         }
         const elapsedMs = Date.now() - startedAt;
         return {
@@ -528,32 +533,42 @@ export const command = cli({
     ],
     columns: ['rank', 'title', 'author', 'likes', 'published_at', 'url'],
     func: async (page, kwargs) => {
-        const limit = parseLimit(kwargs.limit);
-        const keyword = encodeURIComponent(kwargs.query);
-        await page.goto(`https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
-        // Wait for search results to render (or login wall to appear).
-        // Uses MutationObserver to resolve as soon as content appears,
-        // instead of a fixed delay + blind retry.
-        const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
-        if (waitResult === 'login_wall') {
-            throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
+        try {
+            const limit = parseLimit(kwargs.limit);
+            const keyword = encodeURIComponent(kwargs.query);
+            await page.goto(`https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
+            // Wait for search results to render (or login wall to appear).
+            // Uses MutationObserver to resolve as soon as content appears,
+            // instead of a fixed delay + blind retry.
+            const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
+            if (!['content', 'login_wall', 'timeout'].includes(waitResult)) {
+                throw new CommandExecutionError('Unexpected Xiaohongshu search wait payload shape.');
+            }
+            if (waitResult === 'login_wall') {
+                throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
+            }
+            const harvestOptions = harvestOptionsForLimit(limit);
+            const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)));
+            if (harvest.diag.securityBlock) {
+                throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
+            }
+            return harvest.rows
+                .filter((item) => item.title)
+                .slice(0, limit)
+                .map((item, i) => ({
+                rank: i + 1,
+                ...item,
+                published_at: noteIdToDate(item.url),
+            }));
         }
-        const harvestOptions = harvestOptionsForLimit(limit);
-        const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)));
-        if (harvest.diag?.securityBlock) {
-            throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
+        catch (err) {
+            if (err instanceof CliError)
+                throw err;
+            throw new CommandExecutionError(`Xiaohongshu search failed: ${err?.message ?? String(err)}`);
         }
-        const data = harvest.rows;
-        return data
-            .filter((item) => item.title)
-            .slice(0, limit)
-            .map((item, i) => ({
-            rank: i + 1,
-            ...item,
-            published_at: noteIdToDate(item.url),
-        }));
     },
 });
 export const __test__ = {
+    harvestOptionsForLimit,
     stripXhsAuthorDateSuffix,
 };

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -254,7 +254,37 @@ export function unwrapEvaluateResult(payload) {
     }
     return payload;
 }
-function requireHarvestPayload(payload) {
+function isTrustedAuthorUrl(url, webHost) {
+    if (url === '')
+        return true;
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'https:' &&
+            parsed.hostname.toLowerCase() === webHost.toLowerCase() &&
+            /^\/user\/profile\/[^/]+\/?$/i.test(parsed.pathname);
+    }
+    catch {
+        return false;
+    }
+}
+function requireTrustedHarvestRow(row, index, webHost) {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+        throw new CommandExecutionError(`Unexpected Xiaohongshu search harvest row ${index + 1} shape; expected an object.`);
+    }
+    for (const field of ['title', 'author', 'likes', 'url', 'author_url']) {
+        if (typeof row[field] !== 'string') {
+            throw new CommandExecutionError(`Unexpected Xiaohongshu search harvest row ${index + 1} shape; expected string ${field}.`);
+        }
+    }
+    if (!noteUrlInfo(row.url, webHost).key) {
+        throw new CommandExecutionError(`Unexpected Xiaohongshu search harvest row ${index + 1} URL; expected a trusted note URL.`);
+    }
+    if (!isTrustedAuthorUrl(row.author_url, webHost)) {
+        throw new CommandExecutionError(`Unexpected Xiaohongshu search harvest row ${index + 1} author URL; expected a trusted profile URL.`);
+    }
+    return row;
+}
+function requireHarvestPayload(payload, webHost) {
     const result = unwrapEvaluateResult(payload);
     const diag = result?.diag;
     if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows) ||
@@ -262,6 +292,7 @@ function requireHarvestPayload(payload) {
         typeof diag.securityBlock !== 'boolean' || typeof diag.stopReason !== 'string') {
         throw new CommandExecutionError('Unexpected Xiaohongshu search harvest payload shape; expected rows plus typed diagnostics.');
     }
+    result.rows = result.rows.map((row, index) => requireTrustedHarvestRow(row, index, webHost));
     return result;
 }
 export function parseLimit(raw) {
@@ -548,7 +579,7 @@ export const command = cli({
                 throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
             }
             const harvestOptions = harvestOptionsForLimit(limit);
-            const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)));
+            const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)), 'www.xiaohongshu.com');
             if (harvest.diag.securityBlock) {
                 throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
             }

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { JSDOM } from 'jsdom';
-import { __test__, buildScrollUntilJs, noteIdToDate, unwrapEvaluateResult } from './search.js';
+import {
+    __test__,
+    buildScrollHarvestJs,
+    buildSearchExtractJs,
+    buildScrollUntilJs,
+    mergeHarvestedRow,
+    noteIdToDate,
+    noteKeyFromUrl,
+    shouldStopScrolling,
+    unwrapEvaluateResult,
+    usableRowCount,
+} from './search.js';
 
 function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100 });
@@ -86,8 +97,8 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: initial DOM extraction (already enough results) through Browser Bridge envelope.
-            { session: 'site:xiaohongshu', data: rows },
+            // Second evaluate: scroll + harvest through Browser Bridge envelope.
+            { session: 'site:xiaohongshu', data: { rows, collected: 1, diag: {} } },
         ]);
         const result = await cmd.func(page, { query: '特斯拉', limit: 1 });
         // Should only do one goto (the search page itself), no per-note detail navigation
@@ -108,7 +119,7 @@ describe('xiaohongshu search', () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         const page = createPageMock([
             'content',
-            { session: 'site:xiaohongshu', data: { rows: [] } },
+            { session: 'site:xiaohongshu', data: { rows: 'nope' } },
         ]);
 
         await expect(cmd.func(page, { query: '测试', limit: 1 })).rejects.toMatchObject({
@@ -122,30 +133,34 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: initial DOM extraction (already enough valid rows)
-            [
-                {
-                    title: 'Result A',
-                    author: 'UserA',
-                    likes: '10',
-                    url: 'https://www.xiaohongshu.com/search_result/aaa',
-                    author_url: '',
-                },
-                {
-                    title: '',
-                    author: 'UserB',
-                    likes: '5',
-                    url: 'https://www.xiaohongshu.com/search_result/bbb',
-                    author_url: '',
-                },
-                {
-                    title: 'Result C',
-                    author: 'UserC',
-                    likes: '3',
-                    url: 'https://www.xiaohongshu.com/search_result/ccc',
-                    author_url: '',
-                },
-            ],
+            // Second evaluate: scroll + harvest result.
+            {
+                rows: [
+                    {
+                        title: 'Result A',
+                        author: 'UserA',
+                        likes: '10',
+                        url: 'https://www.xiaohongshu.com/search_result/aaa',
+                        author_url: '',
+                    },
+                    {
+                        title: '',
+                        author: 'UserB',
+                        likes: '5',
+                        url: 'https://www.xiaohongshu.com/search_result/bbb',
+                        author_url: '',
+                    },
+                    {
+                        title: 'Result C',
+                        author: 'UserC',
+                        likes: '3',
+                        url: 'https://www.xiaohongshu.com/search_result/ccc',
+                        author_url: '',
+                    },
+                ],
+                collected: 3,
+                diag: {},
+            },
         ]);
         const result = (await cmd.func(page, { query: '测试', limit: 1 }));
         // limit=1 should return only the first valid-titled result
@@ -158,44 +173,40 @@ describe('xiaohongshu search', () => {
         const page = createPageMock([
             // First evaluate: MutationObserver wait (content appeared)
             'content',
-            // Second evaluate: initial extraction (no rows rendered)
-            [],
-            // Third evaluate: scroll-until row count
-            0,
-            // Fourth evaluate: post-scroll extraction (still no rows)
-            [],
+            // Second evaluate: scroll + harvest completes with no rows.
+            { rows: [], collected: 0, diag: {} },
         ]);
         const result = (await cmd.func(page, { query: '测试等待', limit: 5 }));
         expect(result).toHaveLength(0);
         // Only one navigation, no retry
         expect(page.goto).toHaveBeenCalledTimes(1);
-        // Four evaluate calls: wait, initial extraction, scroll-until, post-scroll extraction.
-        expect(page.evaluate).toHaveBeenCalledTimes(4);
+        // Two evaluate calls: wait, then the single scroll + harvest IIFE.
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
     });
-    it('scrolls only when the initial extraction has fewer rows than requested', async () => {
+    it('harvests rows while scrolling in a single evaluate call', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
             'content',
-            [
-                { title: 'Result A', author: 'UserA', likes: '10', url: 'https://www.xiaohongshu.com/search_result/aaa', author_url: '' },
-            ],
-            3,
-            [
-                { title: 'Result A', author: 'UserA', likes: '10', url: 'https://www.xiaohongshu.com/search_result/aaa', author_url: '' },
-                { title: 'Result B', author: 'UserB', likes: '5', url: 'https://www.xiaohongshu.com/search_result/bbb', author_url: '' },
-            ],
+            {
+                rows: [
+                    { title: 'Result A', author: 'UserA', likes: '10', url: 'https://www.xiaohongshu.com/search_result/aaa', author_url: '' },
+                    { title: 'Result B', author: 'UserB', likes: '5', url: 'https://www.xiaohongshu.com/search_result/bbb', author_url: '' },
+                ],
+                collected: 2,
+                diag: {},
+            },
         ]);
 
         const result = (await cmd.func(page, { query: '测试等待', limit: 2 }));
 
         expect(result).toHaveLength(2);
         expect(result.map((item) => item.title)).toEqual(['Result A', 'Result B']);
-        expect(page.evaluate).toHaveBeenCalledTimes(4);
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
     });
-    it('separates fallback author text from appended relative date', async () => {
-        const cmd = getRegistry().get('xiaohongshu/search');
-        expect(cmd?.func).toBeTypeOf('function');
+});
+describe('buildSearchExtractJs', () => {
+    it('separates fallback author text from appended relative date', () => {
         const dom = new JSDOM(`
           <section class="note-item">
             <a class="cover mask" href="/search_result/68e90be80000000004022e66?xsec_token=test-token"></a>
@@ -207,11 +218,8 @@ describe('xiaohongshu search', () => {
           </section>
         `, { url: 'https://www.xiaohongshu.com/search_result?keyword=test' });
         markVisible(dom.window.document.querySelector('section.note-item'));
-        const page = createPageMock([]);
-        page.evaluate.mockImplementationOnce(async () => 'content');
-        page.evaluate.mockImplementationOnce(async (script) => Function('document', 'getComputedStyle', `return (${script})`)(dom.window.document, dom.window.getComputedStyle.bind(dom.window)));
-
-        const result = await cmd.func(page, { query: '测试', limit: 1 });
+        const script = buildSearchExtractJs('www.xiaohongshu.com');
+        const result = Function('document', 'getComputedStyle', `return (${script})`)(dom.window.document, dom.window.getComputedStyle.bind(dom.window));
 
         expect(result[0]).toMatchObject({
             title: '数字作者测试',
@@ -219,6 +227,129 @@ describe('xiaohongshu search', () => {
             likes: '8',
             author_url: 'https://www.xiaohongshu.com/user/profile/author123',
         });
+    });
+});
+describe('noteKeyFromUrl', () => {
+    it('extracts a 24-character note id from supported paths', () => {
+        expect(noteKeyFromUrl('https://www.xiaohongshu.com/search_result/68e90be80000000004022e66?xsec_token=a')).toBe('68e90be80000000004022e66');
+        expect(noteKeyFromUrl('https://www.xiaohongshu.com/explore/68E90BE80000000004022E66')).toBe('68e90be80000000004022e66');
+        expect(noteKeyFromUrl('https://www.xiaohongshu.com/note/68e90be80000000004022e66/')).toBe('68e90be80000000004022e66');
+    });
+    it('returns an empty key when no supported note id is present', () => {
+        expect(noteKeyFromUrl('https://www.xiaohongshu.com/user/profile/635a9c720000000018028b40')).toBe('');
+        expect(noteKeyFromUrl('')).toBe('');
+    });
+});
+describe('mergeHarvestedRow', () => {
+    const noteId = '68e90be80000000004022e66';
+    const unsignedUrl = `https://www.xiaohongshu.com/explore/${noteId}`;
+    const signedUrl = `https://www.xiaohongshu.com/search_result/${noteId}?xsec_token=signed`;
+
+    it('backfills an empty title from a later render', () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '', author: '', likes: '0', url: unsignedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '后渲染标题', author: '作者', likes: '7', url: signedUrl, author_url: '/user/profile/a' });
+        expect(acc.get(noteId)).toMatchObject({
+            title: '后渲染标题',
+            author: '作者',
+            author_url: '/user/profile/a',
+        });
+    });
+    it('does not overwrite a non-empty title', () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '原始标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '后续标题', author: '', likes: '2', url: signedUrl, author_url: '' });
+        expect(acc.get(noteId).title).toBe('原始标题');
+    });
+    it("backfills likes when the placeholder value is '0'", () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '0', url: unsignedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '42', url: signedUrl, author_url: '' });
+        expect(acc.get(noteId).likes).toBe('42');
+    });
+    it('upgrades an unsigned URL to a signed xsec_token URL', () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' });
+        expect(acc.get(noteId).url).toBe(signedUrl);
+    });
+    it('does not downgrade a signed URL to an unsigned URL', () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
+        expect(acc.get(noteId).url).toBe(signedUrl);
+    });
+    it('deduplicates different token URLs for the same note id', () => {
+        const acc = new Map();
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-a`, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-b`, author_url: '' });
+        expect(acc.size).toBe(1);
+    });
+});
+describe('usableRowCount', () => {
+    it('counts only rows that survive the post-harvest title filter', () => {
+        // Regression lock: a --limit 100 run stopped at collected=100 but emitted
+        // 84 rows, because 16 cards had not rendered their title yet when the
+        // target check fired.
+        const acc = new Map();
+        acc.set('a', { title: '有标题', url: 'https://www.xiaohongshu.com/explore/a' });
+        acc.set('b', { title: '', url: 'https://www.xiaohongshu.com/explore/b' });
+        acc.set('c', { url: 'https://www.xiaohongshu.com/explore/c' });
+        expect(usableRowCount(acc)).toBe(1);
+    });
+    it('returns zero for an empty accumulator', () => {
+        expect(usableRowCount(new Map())).toBe(0);
+    });
+});
+describe('shouldStopScrolling', () => {
+    const baseState = {
+        collected: 5,
+        target: 100,
+        round: 3,
+        maxRounds: 30,
+        elapsedMs: 5_000,
+        budgetMs: 60_000,
+        atBottom: false,
+        stalledRounds: 0,
+        moved: true,
+    };
+
+    it('does not stop for a mid-page plateau while scrolling can still move', () => {
+        // Regression lock: the old plateau rule exited at scrollTop=4500 / scrollHeight=6960.
+        expect(shouldStopScrolling({ ...baseState, stalledRounds: 6 })).toEqual({ stop: false, reason: '' });
+    });
+    it('stops when the target count is collected', () => {
+        expect(shouldStopScrolling({ ...baseState, collected: 100 })).toEqual({ stop: true, reason: 'target' });
+    });
+    it('stops when the time budget is exhausted', () => {
+        expect(shouldStopScrolling({ ...baseState, elapsedMs: 60_000 })).toEqual({ stop: true, reason: 'budget' });
+    });
+    it('stops when the maximum round count is reached', () => {
+        expect(shouldStopScrolling({ ...baseState, round: 30 })).toEqual({ stop: true, reason: 'max-rounds' });
+    });
+    it('stops after repeated stalls at the real bottom', () => {
+        expect(shouldStopScrolling({ ...baseState, atBottom: true, stalledRounds: 3 })).toEqual({ stop: true, reason: 'exhausted' });
+    });
+    it('stops after repeated stalls when scrolling is wedged', () => {
+        expect(shouldStopScrolling({ ...baseState, stalledRounds: 3, moved: false })).toEqual({ stop: true, reason: 'wedged' });
+    });
+});
+describe('buildScrollHarvestJs', () => {
+    it('builds a bounded async harvest loop without jumping to the document bottom', () => {
+        const js = buildScrollHarvestJs('www.xiaohongshu.com', 37, { maxRounds: 20, budgetMs: 30_000, step: 900 });
+        expect(js).toContain('(async () =>');
+        expect(js).toContain('const targetCount = 37');
+        expect(js).not.toContain('scrollTo(0, document.body.scrollHeight)');
+        expect(js).toContain('Array.from(acc.values())');
+    });
+    it('gates the target check on usable rows rather than raw discoveries', () => {
+        const js = buildScrollHarvestJs('www.xiaohongshu.com', 37, { maxRounds: 20, budgetMs: 30_000, step: 900 });
+        expect(js).toContain('const usable = usableRowCount(acc)');
+        expect(js).toContain('collected: usable');
+    });
+    it('rejects invalid targetCount and maxRounds arguments', () => {
+        expect(() => buildScrollHarvestJs('www.xiaohongshu.com', 0)).toThrow(/targetCount/);
+        expect(() => buildScrollHarvestJs('www.xiaohongshu.com', 10, { maxRounds: 0 })).toThrow(/maxRounds/);
     });
 });
 describe('buildScrollUntilJs', () => {

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -223,6 +223,38 @@ describe('xiaohongshu search', () => {
             message: expect.stringContaining('payload shape'),
         });
     });
+    it('fails typed instead of silently dropping malformed harvest rows', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            'content',
+            harvestPayload([null]),
+        ]);
+
+        await expect(cmd.func(page, { query: '测试', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('harvest row 1 shape'),
+        });
+    });
+    it('fails typed instead of emitting untrusted harvest row URLs', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            'content',
+            harvestPayload([
+                {
+                    title: '外站结果',
+                    author: 'UserA',
+                    likes: '10',
+                    url: 'https://evil.example/explore/68e90be80000000004022e66',
+                    author_url: '',
+                },
+            ]),
+        ]);
+
+        await expect(cmd.func(page, { query: '测试', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('trusted note URL'),
+        });
+    });
     it('fails typed for malformed wait envelopes and raw bridge failures', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         const malformedPage = createPageMock([{ session: 'site:xiaohongshu', data: { state: 'content' } }]);
@@ -261,21 +293,21 @@ describe('xiaohongshu search', () => {
                         title: 'Result A',
                         author: 'UserA',
                         likes: '10',
-                        url: 'https://www.xiaohongshu.com/search_result/aaa',
+                        url: 'https://www.xiaohongshu.com/search_result/68e90be80000000004022e66',
                         author_url: '',
                     },
                     {
                         title: '',
                         author: 'UserB',
                         likes: '5',
-                        url: 'https://www.xiaohongshu.com/search_result/bbb',
+                        url: 'https://www.xiaohongshu.com/search_result/697f6c74000000002103de17',
                         author_url: '',
                     },
                     {
                         title: 'Result C',
                         author: 'UserC',
                         likes: '3',
-                        url: 'https://www.xiaohongshu.com/search_result/ccc',
+                        url: 'https://www.xiaohongshu.com/search_result/69b739f00000000000000000',
                         author_url: '',
                     },
                 ]),

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -9,6 +9,7 @@ import {
     mergeHarvestedRow,
     noteIdToDate,
     noteKeyFromUrl,
+    noteUrlInfo,
     shouldStopScrolling,
     unwrapEvaluateResult,
     usableRowCount,
@@ -44,6 +45,101 @@ function createPageMock(evaluateResults) {
         screenshot: vi.fn().mockResolvedValue(''),
         waitForCapture: vi.fn().mockResolvedValue(undefined),
     };
+}
+function harvestPayload(rows, diag = {}) {
+    return {
+        rows,
+        diag: {
+            securityBlock: false,
+            stopReason: 'target',
+            ...diag,
+        },
+    };
+}
+function noteCard({ id, title = '', likes = '0', signed = false, host = 'www.xiaohongshu.com' }) {
+    const token = signed ? '?xsec_token=signed-token' : '';
+    return `
+      <section class="note-item">
+        <a class="cover mask" href="https://${host}/explore/${id}${token}"><span>${title}</span></a>
+        <div class="title">${title}</div>
+        <a class="author" href="/user/profile/author123"><span class="name">作者</span></a>
+        <span class="count">${likes}</span>
+      </section>
+    `;
+}
+async function runHarvestFrames(frames, { target = frames.length, stallsBeforeAdvance = 0 } = {}) {
+    const dom = new JSDOM('<body></body>', {
+        url: 'https://www.xiaohongshu.com/search_result?keyword=test',
+    });
+    const { document } = dom.window;
+    const root = document.documentElement;
+    const viewport = 600;
+    let frameIndex = 0;
+    let scrollTop = 0;
+    let scrollCalls = 0;
+    const scrollDeltas = [];
+
+    const currentFrame = () => frames[frameIndex];
+    const render = () => {
+        const frame = currentFrame();
+        document.body.innerHTML = frame.securityBlock
+            ? '<main>请求太频繁，请稍后再试</main>'
+            : frame.cards.map(noteCard).join('');
+        for (const el of document.querySelectorAll('section.note-item')) markVisible(el);
+    };
+    render();
+
+    Object.defineProperty(document.body, 'innerText', {
+        configurable: true,
+        get: () => document.body.textContent || '',
+    });
+    for (const el of [root, document.body]) {
+        Object.defineProperty(el, 'scrollHeight', {
+            configurable: true,
+            get: () => currentFrame().height,
+        });
+        Object.defineProperty(el, 'scrollTop', {
+            configurable: true,
+            get: () => scrollTop,
+            set: (value) => { scrollTop = Number(value) || 0; },
+        });
+    }
+    Object.defineProperty(root, 'clientHeight', { configurable: true, value: viewport });
+    Object.defineProperty(dom.window, 'innerHeight', { configurable: true, value: viewport });
+    Object.defineProperty(dom.window, 'scrollY', { configurable: true, get: () => scrollTop });
+    Object.defineProperty(dom.window, 'pageYOffset', { configurable: true, get: () => scrollTop });
+    dom.window.scrollBy = (_x, delta) => {
+        scrollCalls++;
+        scrollDeltas.push(delta);
+        if (scrollCalls > stallsBeforeAdvance && frameIndex < frames.length - 1) {
+            frameIndex++;
+            scrollTop = Math.min(scrollTop + delta, Math.max(0, currentFrame().height - viewport));
+            render();
+        }
+    };
+
+    const immediateTimeout = (resolve) => {
+        resolve();
+        return 1;
+    };
+    const script = buildScrollHarvestJs('www.xiaohongshu.com', target, {
+        maxRounds: 12,
+        budgetMs: 30_000,
+        step: 900,
+    });
+    const result = await Function(
+        'document',
+        'window',
+        'getComputedStyle',
+        'setTimeout',
+        `return (${script})`,
+    )(
+        document,
+        dom.window,
+        dom.window.getComputedStyle.bind(dom.window),
+        immediateTimeout,
+    );
+    return { result, scrollDeltas };
 }
 describe('xiaohongshu search', () => {
     it('rejects invalid limit before browser navigation', async () => {
@@ -98,7 +194,7 @@ describe('xiaohongshu search', () => {
             // First evaluate: MutationObserver wait (content appeared)
             'content',
             // Second evaluate: scroll + harvest through Browser Bridge envelope.
-            { session: 'site:xiaohongshu', data: { rows, collected: 1, diag: {} } },
+            { session: 'site:xiaohongshu', data: harvestPayload(rows) },
         ]);
         const result = await cmd.func(page, { query: '特斯拉', limit: 1 });
         // Should only do one goto (the search page itself), no per-note detail navigation
@@ -127,6 +223,32 @@ describe('xiaohongshu search', () => {
             message: expect.stringContaining('payload shape'),
         });
     });
+    it('fails typed for malformed wait envelopes and raw bridge failures', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const malformedPage = createPageMock([{ session: 'site:xiaohongshu', data: { state: 'content' } }]);
+        await expect(cmd.func(malformedPage, { query: '测试', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('wait payload'),
+        });
+
+        const failedPage = createPageMock([]);
+        failedPage.evaluate.mockRejectedValueOnce(new Error('bridge disconnected'));
+        await expect(cmd.func(failedPage, { query: '测试', limit: 1 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('bridge disconnected'),
+        });
+    });
+    it('maps a harvested risk-control interstitial to SECURITY_BLOCK', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock([
+            'timeout',
+            harvestPayload([], { securityBlock: true, stopReason: 'security-block' }),
+        ]);
+
+        await expect(cmd.func(page, { query: '测试', limit: 5 })).rejects.toMatchObject({
+            code: 'SECURITY_BLOCK',
+        });
+    });
     it('filters out results with no title and respects the limit', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');
@@ -134,8 +256,7 @@ describe('xiaohongshu search', () => {
             // First evaluate: MutationObserver wait (content appeared)
             'content',
             // Second evaluate: scroll + harvest result.
-            {
-                rows: [
+            harvestPayload([
                     {
                         title: 'Result A',
                         author: 'UserA',
@@ -157,10 +278,7 @@ describe('xiaohongshu search', () => {
                         url: 'https://www.xiaohongshu.com/search_result/ccc',
                         author_url: '',
                     },
-                ],
-                collected: 3,
-                diag: {},
-            },
+                ]),
         ]);
         const result = (await cmd.func(page, { query: '测试', limit: 1 }));
         // limit=1 should return only the first valid-titled result
@@ -174,34 +292,13 @@ describe('xiaohongshu search', () => {
             // First evaluate: MutationObserver wait (content appeared)
             'content',
             // Second evaluate: scroll + harvest completes with no rows.
-            { rows: [], collected: 0, diag: {} },
+            harvestPayload([], { stopReason: 'exhausted' }),
         ]);
         const result = (await cmd.func(page, { query: '测试等待', limit: 5 }));
         expect(result).toHaveLength(0);
         // Only one navigation, no retry
         expect(page.goto).toHaveBeenCalledTimes(1);
         // Two evaluate calls: wait, then the single scroll + harvest IIFE.
-        expect(page.evaluate).toHaveBeenCalledTimes(2);
-    });
-    it('harvests rows while scrolling in a single evaluate call', async () => {
-        const cmd = getRegistry().get('xiaohongshu/search');
-        expect(cmd?.func).toBeTypeOf('function');
-        const page = createPageMock([
-            'content',
-            {
-                rows: [
-                    { title: 'Result A', author: 'UserA', likes: '10', url: 'https://www.xiaohongshu.com/search_result/aaa', author_url: '' },
-                    { title: 'Result B', author: 'UserB', likes: '5', url: 'https://www.xiaohongshu.com/search_result/bbb', author_url: '' },
-                ],
-                collected: 2,
-                diag: {},
-            },
-        ]);
-
-        const result = (await cmd.func(page, { query: '测试等待', limit: 2 }));
-
-        expect(result).toHaveLength(2);
-        expect(result.map((item) => item.title)).toEqual(['Result A', 'Result B']);
         expect(page.evaluate).toHaveBeenCalledTimes(2);
     });
 });
@@ -239,16 +336,27 @@ describe('noteKeyFromUrl', () => {
         expect(noteKeyFromUrl('https://www.xiaohongshu.com/user/profile/635a9c720000000018028b40')).toBe('');
         expect(noteKeyFromUrl('')).toBe('');
     });
+    it('binds note identity and signed-token provenance to the expected host', () => {
+        const id = '68e90be80000000004022e66';
+        expect(noteKeyFromUrl(`https://evil.example/explore/${id}`, 'www.xiaohongshu.com')).toBe('');
+        expect(noteUrlInfo(`http://www.xiaohongshu.com/explore/${id}?xsec_token=token`, 'www.xiaohongshu.com'))
+            .toEqual({ key: '', signed: false });
+        expect(noteUrlInfo(`https://www.xiaohongshu.com/explore/${id}?xsec_token=`, 'www.xiaohongshu.com'))
+            .toEqual({ key: id, signed: false });
+        expect(noteUrlInfo(`https://www.xiaohongshu.com/explore/${id}?xsec_token=token`, 'www.xiaohongshu.com'))
+            .toEqual({ key: id, signed: true });
+    });
 });
 describe('mergeHarvestedRow', () => {
     const noteId = '68e90be80000000004022e66';
     const unsignedUrl = `https://www.xiaohongshu.com/explore/${noteId}`;
     const signedUrl = `https://www.xiaohongshu.com/search_result/${noteId}?xsec_token=signed`;
+    const webHost = 'www.xiaohongshu.com';
 
     it('backfills an empty title from a later render', () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '', author: '', likes: '0', url: unsignedUrl, author_url: '' });
-        mergeHarvestedRow(acc, { title: '后渲染标题', author: '作者', likes: '7', url: signedUrl, author_url: '/user/profile/a' });
+        mergeHarvestedRow(acc, { title: '', author: '', likes: '0', url: unsignedUrl, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '后渲染标题', author: '作者', likes: '7', url: signedUrl, author_url: '/user/profile/a' }, webHost);
         expect(acc.get(noteId)).toMatchObject({
             title: '后渲染标题',
             author: '作者',
@@ -257,33 +365,44 @@ describe('mergeHarvestedRow', () => {
     });
     it('does not overwrite a non-empty title', () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '原始标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
-        mergeHarvestedRow(acc, { title: '后续标题', author: '', likes: '2', url: signedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '原始标题', author: '', likes: '1', url: unsignedUrl, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '后续标题', author: '', likes: '2', url: signedUrl, author_url: '' }, webHost);
         expect(acc.get(noteId).title).toBe('原始标题');
     });
     it("backfills likes when the placeholder value is '0'", () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '0', url: unsignedUrl, author_url: '' });
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '42', url: signedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '0', url: unsignedUrl, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '42', url: signedUrl, author_url: '' }, webHost);
         expect(acc.get(noteId).likes).toBe('42');
     });
     it('upgrades an unsigned URL to a signed xsec_token URL', () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' }, webHost);
         expect(acc.get(noteId).url).toBe(signedUrl);
     });
     it('does not downgrade a signed URL to an unsigned URL', () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' });
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: signedUrl, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: unsignedUrl, author_url: '' }, webHost);
         expect(acc.get(noteId).url).toBe(signedUrl);
     });
     it('deduplicates different token URLs for the same note id', () => {
         const acc = new Map();
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-a`, author_url: '' });
-        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-b`, author_url: '' });
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-a`, author_url: '' }, webHost);
+        mergeHarvestedRow(acc, { title: '标题', author: '', likes: '1', url: `${signedUrl}-b`, author_url: '' }, webHost);
         expect(acc.size).toBe(1);
+    });
+    it('rejects an untrusted-host row instead of letting it collide by note id', () => {
+        const acc = new Map();
+        expect(mergeHarvestedRow(acc, {
+            title: '外站',
+            author: '',
+            likes: '1',
+            url: `https://evil.example/explore/${noteId}`,
+            author_url: '',
+        }, webHost)).toBe(false);
+        expect(acc.size).toBe(0);
     });
 });
 describe('usableRowCount', () => {
@@ -310,13 +429,12 @@ describe('shouldStopScrolling', () => {
         elapsedMs: 5_000,
         budgetMs: 60_000,
         atBottom: false,
-        stalledRounds: 0,
-        moved: true,
+        idleRounds: 0,
     };
 
-    it('does not stop for a mid-page plateau while scrolling can still move', () => {
+    it('does not stop for a row plateau while scroll geometry still changes', () => {
         // Regression lock: the old plateau rule exited at scrollTop=4500 / scrollHeight=6960.
-        expect(shouldStopScrolling({ ...baseState, stalledRounds: 6 })).toEqual({ stop: false, reason: '' });
+        expect(shouldStopScrolling({ ...baseState, idleRounds: 0 })).toEqual({ stop: false, reason: '' });
     });
     it('stops when the target count is collected', () => {
         expect(shouldStopScrolling({ ...baseState, collected: 100 })).toEqual({ stop: true, reason: 'target' });
@@ -328,24 +446,63 @@ describe('shouldStopScrolling', () => {
         expect(shouldStopScrolling({ ...baseState, round: 30 })).toEqual({ stop: true, reason: 'max-rounds' });
     });
     it('stops after repeated stalls at the real bottom', () => {
-        expect(shouldStopScrolling({ ...baseState, atBottom: true, stalledRounds: 3 })).toEqual({ stop: true, reason: 'exhausted' });
+        expect(shouldStopScrolling({ ...baseState, atBottom: true, idleRounds: 3 })).toEqual({ stop: true, reason: 'exhausted' });
     });
     it('stops after repeated stalls when scrolling is wedged', () => {
-        expect(shouldStopScrolling({ ...baseState, stalledRounds: 3, moved: false })).toEqual({ stop: true, reason: 'wedged' });
+        expect(shouldStopScrolling({ ...baseState, idleRounds: 3 })).toEqual({ stop: true, reason: 'wedged' });
     });
 });
 describe('buildScrollHarvestJs', () => {
-    it('builds a bounded async harvest loop without jumping to the document bottom', () => {
-        const js = buildScrollHarvestJs('www.xiaohongshu.com', 37, { maxRounds: 20, budgetMs: 30_000, step: 900 });
-        expect(js).toContain('(async () =>');
-        expect(js).toContain('const targetCount = 37');
-        expect(js).not.toContain('scrollTo(0, document.body.scrollHeight)');
-        expect(js).toContain('Array.from(acc.values())');
+    it('keeps the largest harvest budget below the 60s Browser Bridge evaluate deadline', () => {
+        expect(__test__.harvestOptionsForLimit(100).budgetMs).toBe(45_000);
     });
-    it('gates the target check on usable rows rather than raw discoveries', () => {
-        const js = buildScrollHarvestJs('www.xiaohongshu.com', 37, { maxRounds: 20, budgetMs: 30_000, step: 900 });
-        expect(js).toContain('const usable = usableRowCount(acc)');
-        expect(js).toContain('collected: usable');
+    it('harvests virtualized frames, backfills staged fields, and never skips beyond one viewport', async () => {
+        const a = '68e90be80000000004022e66';
+        const b = '697f6c74000000002103de17';
+        const c = '69b739f00000000000000000';
+        const { result, scrollDeltas } = await runHarvestFrames([
+            { height: 1200, cards: [{ id: a, title: '', likes: '0' }] },
+            {
+                height: 1800,
+                cards: [
+                    { id: a, title: '后渲染标题', likes: '7', signed: true },
+                    { id: b, title: '第二屏', likes: '0' },
+                ],
+            },
+            { height: 2400, cards: [{ id: c, title: '第三屏', likes: '3' }] },
+        ], { target: 3 });
+
+        expect(result.diag).toMatchObject({ usable: 3, stopReason: 'target', securityBlock: false });
+        expect(result.rows.map((row) => row.title)).toEqual(['后渲染标题', '第二屏', '第三屏']);
+        expect(result.rows[0]).toMatchObject({ likes: '7' });
+        expect(result.rows[0].url).toContain('xsec_token=signed-token');
+        expect(scrollDeltas.length).toBeGreaterThan(0);
+        expect(Math.max(...scrollDeltas)).toBeLessThanOrEqual(600);
+    });
+    it('survives two slow no-movement rounds when later height/data progress arrives', async () => {
+        const { result } = await runHarvestFrames([
+            { height: 600, cards: [{ id: '68e90be80000000004022e66', title: '第一屏' }] },
+            { height: 1200, cards: [{ id: '697f6c74000000002103de17', title: '慢加载第二屏' }] },
+        ], { target: 2, stallsBeforeAdvance: 2 });
+
+        expect(result.rows.map((row) => row.title)).toEqual(['第一屏', '慢加载第二屏']);
+        expect(result.diag).toMatchObject({ usable: 2, stopReason: 'target' });
+    });
+    it('stops only after stable idle rounds at the real bottom', async () => {
+        const { result } = await runHarvestFrames([
+            { height: 600, cards: [{ id: '68e90be80000000004022e66', title: '唯一结果' }] },
+        ], { target: 5 });
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.diag).toMatchObject({ usable: 1, stopReason: 'exhausted', rounds: 4 });
+    });
+    it('detects a security block before spending the scroll budget', async () => {
+        const { result } = await runHarvestFrames([
+            { height: 600, cards: [], securityBlock: true },
+        ], { target: 5 });
+
+        expect(result.rows).toEqual([]);
+        expect(result.diag).toMatchObject({ securityBlock: true, stopReason: 'security-block', rounds: 1 });
     });
     it('rejects invalid targetCount and maxRounds arguments', () => {
         expect(() => buildScrollHarvestJs('www.xiaohongshu.com', 0)).toThrow(/targetCount/);


### PR DESCRIPTION
## Description

`xiaohongshu search` returns roughly 20 rows no matter what `--limit` is set to.

The search results page is a **virtualized masonry list** — cards scrolled past are evicted from the DOM. The current flow is extract → scroll to bottom → extract again, so the second extraction can no longer see the first screen. The result set is the union of the first and last screens, and everything in between is silently lost.

This is the same symptom class as #1471 (`--limit > 13` capped), which #1487 addressed by adding `buildScrollUntilJs`. That fix made the page load more content but kept extracting only at the ends, so it did not survive virtualization.

**Fix:** harvest inside the scroll loop. A single `page.evaluate` now drives the scroll and accumulates rows into a page-land `Map` keyed by note id, so a card that gets recycled is already banked. The accumulator stays in page-land so every virtualized frame is harvested in one bounded evaluation; host-side per-round accumulation would also preserve rows, but would widen the contract to dozens of Browser Bridge round trips.

Three related defects, all found while validating the above, ride along:

**Rows are merged, not deduplicated on first sight.** Masonry cards render in stages: the `<a>` lands before the title text. A row first seen with an empty title used to be cached empty and never revisited, then dropped by the trailing `.filter(item => item.title)`. Measured on a deep-harvest run: 317 rows collected, 274 emitted, 43 lost this way. Now empty fields are backfilled on a later encounter, non-empty fields are never overwritten, and an unsigned `/explore/` URL can be upgraded to an `xsec_token`-signed one but never downgraded. The likes check treats `'0'` as a placeholder, because the extractor writes `'0'` for a count that has not rendered yet.

For the same reason the **target check counts only rows that already have a title**. Counting raw discoveries let the loop stop the instant 100 cards were known — before the last screen had rendered its titles — and the filter then cut the output back to 84. This one is easy to miss because the emitted rows all look fine; the loss is invisible unless you compare against the internal counter.

**"No new rows this round" is no longer, on its own, a reason to stop.** The old plateau rule was observed firing at `scrollTop=4500` of `scrollHeight=6960` — squarely mid-page, where Xiaohongshu had merely paused lazy-loading and then resumed. Stopping now requires the plateau to coincide with either a real bottom or wedged scrolling, alongside the target / round / wall-clock bounds.

**Risk-control interstitials raise `SECURITY_BLOCK`** (matching `note.js`, `comments.js`, `download.js`) instead of surfacing as a short result set that is indistinguishable from the truncation bug above.

### Notes on scope

- Scrolling advances by a **viewport-sized step**, never `scrollTo(0, document.body.scrollHeight)` — jumping to the bottom skips whole screens of cards, which is precisely what has to be avoided here. There is a test asserting the generated source does not contain that call.
- **No new CLI arguments**, so no `cli-manifest.json` change. Round and wall-clock budgets are derived from the already-validated `--limit`. This also keeps the diff clear of #2276, which adds args to the same command entry.
- `buildScrollUntilJs` is **byte-for-byte untouched** and `buildSearchExtractJs` keeps its signature and semantics (its IIFE body was lifted to a plain function and is re-injected via `toString()`). `clis/rednote/search.js` imports both and is unaffected — its 24 tests still pass unchanged.
- **Small `--limit` values now finish sooner** than before: reaching the target ends the loop, whereas previously `buildScrollUntilJs` ran regardless.
- `clis/rednote/search.js` has the same defect in a worse form — it is scroll-then-extract with no initial extraction, so it only ever sees the last screen. Deliberately left alone here: I have no way to test rednote against the live site, and an unverified change would weaken the evidence for this one. Happy to follow up separately.

Related issue: #1471 (earlier form of the same cap)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Used positional args for the command's primary subject unless a named flag is clearly better *(unchanged)*
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Same query, `--limit 100`, three consecutive runs before and after.

**Before** (values observed across repeated runs of the same query):

```
34 / 34 / 34 / 100 / 104 / 0 rows
```

**After:**

```
run 1  exit=0  elapsed=16s  rows=100  emptyTitle=0  uniq=100  signed=100
run 2  exit=0  elapsed=15s  rows=100  emptyTitle=0  uniq=100  signed=100
run 3  exit=0  elapsed=14s  rows=100  emptyTitle=0  uniq=100  signed=100
```

`uniq` counts distinct note ids, `signed` counts URLs that retained their `xsec_token`.

Internal harvest diagnostics from those runs:

```
{"cardCount":52,"clientHeight":675,"elapsedMs":5656,"rounds":8,"scrollHeight":10128,"scrollTop":6300,"stopReason":"target","usable":103}
{"cardCount":50,"clientHeight":675,"elapsedMs":5343,"rounds":8,"scrollHeight":10174,"scrollTop":6300,"stopReason":"target","usable":104}
{"cardCount":42,"clientHeight":675,"elapsedMs":6290,"rounds":9,"scrollHeight":10272,"scrollTop":7200,"stopReason":"target","usable":103}
```

Note `cardCount` (cards present in the DOM at the final round) is 42–52 while `usable` is 103–104 — that gap is the virtualization this PR works around.

### Checks

```
npm run typecheck                                              clean
npx vitest run --project adapter clis/xiaohongshu/search.js    54 passed
npx vitest run --project adapter clis/rednote/                 24 passed
npm run check:typed-error-lint                                 new=0 (resolved=4)
npm run check:silent-column-drop                               new=0 (resolved=2)
```

### Guardrail validation

The new tests are decomposed into pure functions so they need no DOM and no fixture — JSDOM has no layout, so an HTML fixture cannot reproduce virtualization and would only give false confidence.

To confirm the guardrails are not vacuous, I re-injected each original defect and checked the suite fails:

| Injected defect | Tests failing |
| --- | --- |
| Cache-on-first-sight (`if (acc.has(key)) return acc`) | 3 |
| Fixed plateau threshold (`stalledRounds >= 3` alone stops) | 3 |
| Jump to `document.body.scrollHeight` | 1 |

Two of the new assertions are pinned directly to observed values:

- `shouldStopScrolling({ ..., atBottom: false, stalledRounds: 6, moved: true })` must not stop — locks the `scrollTop=4500 / scrollHeight=6960` early exit.
- `usableRowCount` counts only titled rows — locks the `collected=100 → 84 emitted` regression.


