### PR TITLE
chore(xueqiu): share html stripping helper

### DIFF
--- a/clis/xueqiu/feed.js
+++ b/clis/xueqiu/feed.js
@@ -1,14 +1,5 @@
 import { cli } from '@jackwener/opencli/registry';
-import { fetchXueqiuJson } from './utils.js';
-function strip(html) {
-    return (html || '')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .trim();
-}
+import { fetchXueqiuJson, stripHtml as strip } from './utils.js';
 cli({
     site: 'xueqiu',
     name: 'feed',

--- a/clis/xueqiu/hot.js
+++ b/clis/xueqiu/hot.js
@@ -1,14 +1,5 @@
 import { cli } from '@jackwener/opencli/registry';
-import { fetchXueqiuJson } from './utils.js';
-function strip(html) {
-    return (html || '')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .trim();
-}
+import { fetchXueqiuJson, stripHtml as strip } from './utils.js';
 cli({
     site: 'xueqiu',
     name: 'hot',

--- a/clis/xueqiu/utils.js
+++ b/clis/xueqiu/utils.js
@@ -18,6 +18,16 @@ export function formatChinaDate(ts) {
     return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
+export function stripHtml(html) {
+    return (html || '')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .trim();
+}
+
 /**
  * Fetch a xueqiu JSON API from inside the browser context (credentials included).
  * Page must already be navigated to xueqiu.com before calling this function.

--- a/clis/xueqiu/utils.test.js
+++ b/clis/xueqiu/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatChinaDate } from './utils.js';
+import { formatChinaDate, stripHtml } from './utils.js';
 
 describe('formatChinaDate', () => {
     it('returns the Asia/Shanghai date for a UTC ms at China midnight', () => {
@@ -22,5 +22,28 @@ describe('formatChinaDate', () => {
     it('returns null for nullish input', () => {
         expect(formatChinaDate(null)).toBeNull();
         expect(formatChinaDate(undefined)).toBeNull();
+    });
+});
+
+describe('stripHtml', () => {
+    it('removes HTML tags', () => {
+        expect(stripHtml('<p>Hello <strong>Xueqiu</strong></p>')).toBe('Hello Xueqiu');
+    });
+    it('decodes current named entities before trimming', () => {
+        expect(stripHtml(' &nbsp;A&amp;B&lt;C&gt; &nbsp; ')).toBe('A&B<C>');
+    });
+    it('returns empty strings for nullish and empty input', () => {
+        expect(stripHtml(null)).toBe('');
+        expect(stripHtml(undefined)).toBe('');
+        expect(stripHtml('')).toBe('');
+    });
+    it('does not insert spaces between adjacent block tags', () => {
+        expect(stripHtml('<p>first</p><p>second</p>')).toBe('firstsecond');
+    });
+    it('does not decode numeric entities', () => {
+        expect(stripHtml('&#65; &#x42;')).toBe('&#65; &#x42;');
+    });
+    it('does not collapse whitespace', () => {
+        expect(stripHtml('a   b')).toBe('a   b');
     });
 });


### PR DESCRIPTION
## Summary
- move the duplicated Xueqiu HTML stripping helper into existing clis/xueqiu/utils.js as stripHtml
- import it in feed/hot as strip to keep existing call sites unchanged
- add direct utils tests for current tag/entity/trim/nullish behavior plus Xueqiu-specific no separator, no numeric entity decode, and no whitespace collapse contracts

## Scope
- 4 files only: clis/xueqiu/utils.js, feed.js, hot.js, utils.test.js
- no changes to fetchXueqiuJson, formatChinaDate, command text, URLs, fields, substring(0, 200), or cross-site stripHtml implementations

## Tests
- npx vitest run clis/xueqiu
- npm run typecheck
- npm run build
- node dist/src/main.js validate xueqiu
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check