### PR TITLE
chore(linkedin): share safety URL decoder

### DIFF
--- a/clis/linkedin/profile-experience.js
+++ b/clis/linkedin/profile-experience.js
@@ -3,6 +3,7 @@ import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/erro
 import {
   assertLinkedInAuthenticated,
   assertSafeLinkedinUrl,
+  decodeLinkedInSafetyUrl,
   normalizeHttpUrl,
   normalizeWhitespace,
   unwrapEvaluateResult,
@@ -27,18 +28,6 @@ function profileExperienceUrl(profileUrl) {
     throw new CommandExecutionError('LinkedIn profile-experience requires a resolved /in/<handle>/ profile URL');
   }
   return new URL(`${parsed.pathname.replace(/\/?$/, '/') }details/experience/`, 'https://www.linkedin.com').toString();
-}
-
-function decodeLinkedInSafetyUrl(value) {
-  const url = normalizeWhitespace(value);
-  if (!url) return '';
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname.endsWith('linkedin.com') && parsed.pathname === '/safety/go/') {
-      return normalizeHttpUrl(parsed.searchParams.get('url') || '');
-    }
-  } catch {}
-  return normalizeHttpUrl(url);
 }
 
 function isChromeLine(line) {
@@ -659,7 +648,6 @@ cli({
 export const __test__ = {
   normalizeProfileUrl,
   profileExperienceUrl,
-  decodeLinkedInSafetyUrl,
   parseDateRangeParts,
   parseCompanyLine,
   parseLocationLine,

--- a/clis/linkedin/profile-experience.test.js
+++ b/clis/linkedin/profile-experience.test.js
@@ -6,7 +6,6 @@ import './profile-experience.js';
 const {
   normalizeProfileUrl,
   profileExperienceUrl,
-  decodeLinkedInSafetyUrl,
   parseDateRangeParts,
   parseCompanyLine,
   parseLocationLine,
@@ -135,14 +134,6 @@ Who your viewers also viewed`, 'https://www.linkedin.com/in/gauravsaxena1997/');
     expect(() => normalizeExperience({ title: '' })).toThrow(CommandExecutionError);
     expect(normalizeExperience({ rank: '2', total_count: '4', title: ' AI Engineer ', company: ' Self Employed ', skill_url: ' https://example.com/skills ' }))
       .toMatchObject({ rank: 2, total_count: 4, title: 'AI Engineer', company: 'Self Employed', skill_url: 'https://example.com/skills' });
-  });
-
-  it('decodes LinkedIn safety redirect URLs', () => {
-    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=https%3A%2F%2Fexample.com%2Fdemo&urlhash=x'))
-      .toBe('https://example.com/demo');
-    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=javascript%3Aalert(1)&urlhash=x'))
-      .toBe('');
-    expect(decodeLinkedInSafetyUrl('javascript:alert(1)')).toBe('');
   });
 
   it('builds browser extraction scripts that parse as JavaScript', () => {

--- a/clis/linkedin/profile-projects.js
+++ b/clis/linkedin/profile-projects.js
@@ -3,6 +3,7 @@ import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/erro
 import {
   assertLinkedInAuthenticated,
   assertSafeLinkedinUrl,
+  decodeLinkedInSafetyUrl,
   normalizeHttpUrl,
   normalizeWhitespace,
   unwrapEvaluateResult,
@@ -53,18 +54,6 @@ function parseProjectText(rawText, profileUrl, index) {
     profile_url: profileUrl,
     raw_text: lines.join(' | '),
   };
-}
-
-function decodeLinkedInSafetyUrl(value) {
-  const url = normalizeWhitespace(value);
-  if (!url) return '';
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname.endsWith('linkedin.com') && parsed.pathname === '/safety/go/') {
-      return normalizeHttpUrl(parsed.searchParams.get('url') || '');
-    }
-  } catch {}
-  return normalizeHttpUrl(url);
 }
 
 function parseProjectsSectionText(rawText, profileUrl) {
@@ -306,6 +295,5 @@ export const __test__ = {
   profileProjectsUrl,
   parseProjectText,
   parseProjectsSectionText,
-  decodeLinkedInSafetyUrl,
   normalizeProject,
 };

--- a/clis/linkedin/profile-projects.test.js
+++ b/clis/linkedin/profile-projects.test.js
@@ -3,7 +3,7 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
 import './profile-projects.js';
 
-const { normalizeProfileUrl, profileProjectsUrl, parseProjectText, parseProjectsSectionText, decodeLinkedInSafetyUrl, normalizeProject } = await import('./profile-projects.js').then((m) => m.__test__);
+const { normalizeProfileUrl, profileProjectsUrl, parseProjectText, parseProjectsSectionText, normalizeProject } = await import('./profile-projects.js').then((m) => m.__test__);
 
 describe('linkedin profile-projects adapter', () => {
   const command = getRegistry().get('linkedin/profile-projects');
@@ -102,10 +102,4 @@ Who your viewers also viewed`, 'https://www.linkedin.com/in/gauravsaxena1997/');
       .toMatchObject({ urls: 'https://example.com/demo' });
   });
 
-  it('decodes LinkedIn safety redirect URLs', () => {
-    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=https%3A%2F%2Fgithub.com%2Fjackwener%2FOpenCLI&urlhash=x'))
-      .toBe('https://github.com/jackwener/OpenCLI');
-    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=javascript%3Aalert(1)&urlhash=x'))
-      .toBe('');
-  });
 });

--- a/clis/linkedin/shared.js
+++ b/clis/linkedin/shared.js
@@ -24,6 +24,18 @@ export function normalizeHttpUrl(value, base) {
   }
 }
 
+export function decodeLinkedInSafetyUrl(value) {
+  const url = normalizeWhitespace(value);
+  if (!url) return '';
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.endsWith('linkedin.com') && parsed.pathname === '/safety/go/') {
+      return normalizeHttpUrl(parsed.searchParams.get('url') || '');
+    }
+  } catch {}
+  return normalizeHttpUrl(url);
+}
+
 export function compactRepeatedText(value) {
   const text = normalizeWhitespace(value);
   if (!text) return '';

--- a/clis/linkedin/shared.test.js
+++ b/clis/linkedin/shared.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { decodeLinkedInSafetyUrl } from './shared.js';
+
+describe('linkedin shared helpers', () => {
+  it('normalizes empty and direct HTTP URLs', () => {
+    expect(decodeLinkedInSafetyUrl('')).toBe('');
+    expect(decodeLinkedInSafetyUrl(null)).toBe('');
+    expect(decodeLinkedInSafetyUrl(' https://example.com/demo ')).toBe('https://example.com/demo');
+  });
+
+  it('decodes LinkedIn safety redirect URLs', () => {
+    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=https%3A%2F%2Fgithub.com%2Fjackwener%2FOpenCLI&urlhash=x'))
+      .toBe('https://github.com/jackwener/OpenCLI');
+  });
+
+  it('rejects unsafe safety redirect targets', () => {
+    expect(decodeLinkedInSafetyUrl('https://www.linkedin.com/safety/go/?url=javascript%3Aalert(1)&urlhash=x'))
+      .toBe('');
+    expect(decodeLinkedInSafetyUrl('javascript:alert(1)')).toBe('');
+    expect(decodeLinkedInSafetyUrl('https://user:pass@example.com/demo')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- move the identical Node-side LinkedIn safety URL decoder from profile-experience/profile-projects into clis/linkedin/shared.js
- keep the three browser-evaluate string-local decoder copies unchanged because they run in the page realm and have a distinct relative-URL contract
- move duplicate command-level decoder tests into shared.test.js, including direct URL, safety redirect, javascript rejection, and credentials rejection coverage

## Scope / negative boundary
- exactly six files: profile-experience/profile-projects source + tests, shared.js, shared.test.js
- no re-export shim from command __test__; each command __test__ only loses the imported helper key
- complete command nodes, extraction builders, dialog builder, and existing shared helpers were raw-text checked unchanged against origin/main
- existing browser-realm credential handling mismatch is intentionally out of scope for this pure consolidation batch

## Validation
- npx vitest run clis/linkedin/profile-experience.test.js clis/linkedin/profile-projects.test.js clis/linkedin/shared.test.js (3 files / 17 tests)
- npx vitest run clis/linkedin (28 files / 244 tests)
- npm run typecheck
- npm run build (manifest 1332)
- node dist/src/main.js validate linkedin (25/0/0)
- npm run check:typed-error-lint (new=0)
- npm run check:silent-column-drop (new=0)
- git diff --check