### PR TITLE
chore(linkedin): reuse shared evaluate unwrap

### DIFF
--- a/clis/linkedin/inbox.js
+++ b/clis/linkedin/inbox.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'linkedin.com';
 const MESSAGING_URL = 'https://www.linkedin.com/messaging/';
@@ -16,11 +17,6 @@ const DEFAULT_LIMIT = 40;
 // call. We then re-issue that same request (URL lifted from the Performance API,
 // so the rotating queryId is always current) and parse LinkedIn's normalized
 // JSON. Same session, same origin, same request the page already makes.
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
-}
 
 function threadUrl(threadId) {
   return threadId ? `https://www.linkedin.com/messaging/thread/${threadId}/` : '';

--- a/clis/linkedin/safe-send.js
+++ b/clis/linkedin/safe-send.js
@@ -1,16 +1,12 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 
 function normalizeWhitespace(value) {
   return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
 }
 
 function normalizeName(value) {
@@ -349,7 +345,6 @@ cli({
 
 export const __test__ = {
   normalizeWhitespace,
-  unwrapEvaluateResult,
   normalizeName,
   canonicalizeLinkedInThreadUrl,
   hashText,

--- a/clis/linkedin/sent-invitations.js
+++ b/clis/linkedin/sent-invitations.js
@@ -1,13 +1,9 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SENT_URL = 'https://www.linkedin.com/mynetwork/invitation-manager/sent/';
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
-}
 
 function buildSentInvitationsScript() {
   return String.raw`(() => {
@@ -88,5 +84,4 @@ cli({
 
 export const __test__ = {
   buildSentInvitationsScript,
-  unwrapEvaluateResult,
 };

--- a/clis/linkedin/shared.test.js
+++ b/clis/linkedin/shared.test.js
@@ -1,7 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { decodeLinkedInSafetyUrl } from './shared.js';
+import { decodeLinkedInSafetyUrl, unwrapEvaluateResult } from './shared.js';
 
 describe('linkedin shared helpers', () => {
+  it('unwraps complete browser evaluate envelopes', () => {
+    const data = { ok: true, rows: [1, 2] };
+    expect(unwrapEvaluateResult({ session: 'site:linkedin:1', data })).toBe(data);
+  });
+
+  it('preserves non-envelope payload identity', () => {
+    const raw = { data: { ok: true } };
+    const sessionOnly = { session: 'site:linkedin:1' };
+    expect(unwrapEvaluateResult(raw)).toBe(raw);
+    expect(unwrapEvaluateResult(sessionOnly)).toBe(sessionOnly);
+  });
+
+  it('returns null and scalar evaluate payloads unchanged', () => {
+    expect(unwrapEvaluateResult(null)).toBe(null);
+    expect(unwrapEvaluateResult('text')).toBe('text');
+    expect(unwrapEvaluateResult(42)).toBe(42);
+  });
+
   it('normalizes empty and direct HTTP URLs', () => {
     expect(decodeLinkedInSafetyUrl('')).toBe('');
     expect(decodeLinkedInSafetyUrl(null)).toBe('');

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -1,15 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 
 function normalizeWhitespace(value) {
   return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
 }
 
 function isLinkedInHost(hostname) {
@@ -209,6 +205,5 @@ export const __test__ = {
   normalizeWhitespace,
   canonicalizeLinkedInThreadUrl,
   parseMaxScrolls,
-  unwrapEvaluateResult,
   buildThreadSnapshotScript,
 };


### PR DESCRIPTION
## Summary
- reuse existing shared.unwrapEvaluateResult in linkedin inbox, safe-send, sent-invitations, and thread-snapshot
- remove the four duplicate local unwrap helpers and the definition-only command __test__ keys
- extend shared.test.js with direct envelope/partial/null/scalar unwrap contract tests

## Scope / negative boundary
- exactly five files: four general messaging command files plus shared.test.js
- shared.js is zero diff; the shared helper body is unchanged
- connect, people-search, and salesnav unwrap helpers stay zero diff for separate subsystem batches
- four complete command nodes and retained helper/build script nodes were raw-text checked unchanged against origin/main
- no thread URL, arg parsing, or messaging behavior helpers were merged

## Validation
- npx vitest run clis/linkedin/inbox.test.js clis/linkedin/safe-send.test.js clis/linkedin/sent-invitations.test.js clis/linkedin/thread-snapshot.test.js clis/linkedin/shared.test.js (5 files / 34 tests)
- npx vitest run clis/linkedin (28 files / 247 tests)
- npm run typecheck
- npm run build (manifest 1332)
- node dist/src/main.js validate linkedin (25/0/0)
- npm run check:typed-error-lint (new=0)
- npm run check:silent-column-drop (new=0)
- git diff --check