### PR TITLE
chore(linkedin): reuse shared unwrap in salesnav

### DIFF
--- a/clis/linkedin/salesnav-inbox.js
+++ b/clis/linkedin/salesnav-inbox.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SALES_INBOX_URL = 'https://www.linkedin.com/sales/inbox/';
@@ -20,11 +21,6 @@ export function parseLimit(value, defaultValue = DEFAULT_LIMIT) {
     throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
   }
   return limit;
-}
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
 }
 
 export function encodeRestliDecoration(value) {

--- a/clis/linkedin/salesnav-message.js
+++ b/clis/linkedin/salesnav-message.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SALES_HOME = 'https://www.linkedin.com/sales/';
@@ -15,11 +16,6 @@ function requireStringArg(args, key, label = key) {
   const value = normalizeWhitespace(args[key]);
   if (!value) throw new ArgumentError(`${label} is required`);
   return value;
-}
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
 }
 
 function isLinkedInHost(hostname) {

--- a/clis/linkedin/salesnav-search.js
+++ b/clis/linkedin/salesnav-search.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SALES_HOME = 'https://www.linkedin.com/sales/';
@@ -27,11 +28,6 @@ function parseLimit(value) {
     throw new ArgumentError('--limit must be an integer between 1 and 500');
   }
   return limit;
-}
-
-function unwrapEvaluateResult(payload) {
-  if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-  return payload;
 }
 
 // Sales Navigator keeps the structural ( ) , : of the query literal and only


### PR DESCRIPTION
## Summary
- Reuse existing clis/linkedin/shared.js unwrapEvaluateResult in the three Sales Navigator commands.
- Delete the three local helper copies from salesnav-inbox, salesnav-search, and salesnav-message.
- Keep tests, shared.js/shared.test.js, connect/people-search, Sales Navigator URL/parse/auth helpers, and command behavior untouched.

## Boundary
- This intentionally adds new one-way local module edges from salesnav-* to the existing leaf shared.js module.
- The new imports bring in only unwrapEvaluateResult.
- shared.js still has no local imports/back edge; it only imports @jackwener/opencli/errors.

## Validation
- npx vitest run clis/linkedin/salesnav-inbox.test.js clis/linkedin/salesnav-search.test.js clis/linkedin/salesnav-message.test.js
- npx vitest run clis/linkedin
- npm run typecheck
- npm run build
- node dist/src/main.js validate linkedin
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check