### PR TITLE
fix(xiaohongshu): recover from collapsed masonry render by reopening in a fresh tab

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -6,12 +6,12 @@
  * Ref: https://github.com/jackwener/opencli/issues/10
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import { unwrapEvaluateResult } from './shared.js';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
- * Returns 'content' if note items appeared, 'login_wall' if login gate
- * detected, or 'timeout' if neither appeared within the deadline.
+ * Returns 'content' if note items appeared, a typed wall state when login or
+ * risk controls appear, or 'timeout' if none appears within the deadline.
  *
  * Note-item detection tries the legacy `section.note-item` class first
  * (still observed in many sessions, including rednote) and falls back to
@@ -25,7 +25,9 @@ const WAIT_FOR_CONTENT_JS = `
     );
     const detect = () => {
       if (findNoteCard()) return 'content';
-      if (/登录后查看搜索结果/.test(document.body?.innerText || '')) return 'login_wall';
+      const bodyText = document.body?.innerText || '';
+      if (/登录后查看搜索结果/.test(bodyText)) return 'login_wall';
+      if (/请求太频繁|访问频次异常|安全限制/.test(bodyText)) return 'security_block';
       return null;
     };
     const found = detect();
@@ -39,6 +41,13 @@ const WAIT_FOR_CONTENT_JS = `
   })
 `;
 const DEFAULT_HARVEST_STEP = 900;
+const CONTENT_WAIT_SECONDS = 5;
+
+function isCollapsedRender(diag) {
+    return diag.cardCount > 1 &&
+        diag.feedClientHeight === 0 &&
+        diag.distinctCardTops === 1;
+}
 
 function harvestOptionsForLimit(limit) {
     return {
@@ -277,7 +286,12 @@ function requireHarvestPayload(payload, webHost) {
     const diag = result?.diag;
     if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows) ||
         !diag || typeof diag !== 'object' || Array.isArray(diag) ||
-        typeof diag.securityBlock !== 'boolean' || typeof diag.stopReason !== 'string') {
+        typeof diag.securityBlock !== 'boolean' || typeof diag.stopReason !== 'string' ||
+        !Number.isFinite(diag.scrollHeight) || diag.scrollHeight < 0 ||
+        !Number.isFinite(diag.clientHeight) || diag.clientHeight < 0 ||
+        !Number.isSafeInteger(diag.cardCount) || diag.cardCount < 0 ||
+        !(diag.feedClientHeight === null || (Number.isFinite(diag.feedClientHeight) && diag.feedClientHeight >= 0)) ||
+        !Number.isSafeInteger(diag.distinctCardTops) || diag.distinctCardTops < 0) {
         throw new CommandExecutionError('Unexpected Xiaohongshu search harvest payload shape; expected rows plus typed diagnostics.');
     }
     result.rows = result.rows.map((row, index) => requireTrustedHarvestRow(row, index, webHost));
@@ -519,6 +533,22 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
           await wait(atBottom ? 1000 : 500);
         }
         const elapsedMs = Date.now() - startedAt;
+        const classMatches = document.querySelectorAll('section.note-item');
+        let diagnosticCards = classMatches;
+        if (classMatches.length === 0) {
+          const sections = new Set();
+          for (const anchor of document.querySelectorAll('a[href*="/search_result/"], a[href*="/explore/"]')) {
+            const section = anchor.closest('section');
+            if (section) sections.add(section);
+          }
+          diagnosticCards = sections;
+        }
+        const distinctCardTops = new Set();
+        for (const card of diagnosticCards) {
+          if (card.classList?.contains('query-note-item')) continue;
+          distinctCardTops.add(Math.round(card.getBoundingClientRect().top));
+        }
+        const feedContainer = document.querySelector('.feeds-container');
         return {
           rows: Array.from(acc.values()),
           collected: acc.size,
@@ -528,6 +558,8 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
             scrollHeight: metrics.scrollHeight,
             clientHeight: metrics.clientHeight,
             cardCount,
+            feedClientHeight: feedContainer ? feedContainer.clientHeight : null,
+            distinctCardTops: distinctCardTops.size,
             rounds: round,
             stopReason,
             elapsedMs,
@@ -536,6 +568,84 @@ export function buildScrollHarvestJs(webHost, targetCount, options = {}) {
         };
       })()
     `;
+}
+
+async function collectSearchHarvest(page, limit) {
+    const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
+    if (waitResult === 'login_wall') {
+        throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
+    }
+    if (waitResult === 'security_block') {
+        throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
+    }
+    if (waitResult === 'timeout') {
+        throw new TimeoutError('xiaohongshu search content', CONTENT_WAIT_SECONDS);
+    }
+    if (waitResult !== 'content') {
+        throw new CommandExecutionError('Unexpected Xiaohongshu search wait payload shape.');
+    }
+    const harvestOptions = harvestOptionsForLimit(limit);
+    const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)), 'www.xiaohongshu.com');
+    if (harvest.diag.securityBlock) {
+        throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
+    }
+    return harvest;
+}
+
+async function replaceCollapsedTab(page, url) {
+    if (typeof page.getActivePage !== 'function' || typeof page.newTab !== 'function' ||
+        typeof page.setActivePage !== 'function' || typeof page.selectTab !== 'function' ||
+        typeof page.closeTab !== 'function') {
+        throw new CommandExecutionError(
+            'Xiaohongshu search rendered in a collapsed tab, but this browser session cannot replace the failed target.',
+            'Retry the command in a Browser Bridge session that supports tab replacement.',
+        );
+    }
+    const previousPage = page.getActivePage();
+    if (!previousPage) {
+        throw new CommandExecutionError('Xiaohongshu search cannot identify the collapsed browser target for safe replacement.');
+    }
+    let freshPage;
+    try {
+        freshPage = await page.newTab(url);
+        if (!freshPage) {
+            throw new Error('newTab returned no page identity');
+        }
+        page.setActivePage(freshPage);
+        await page.closeTab(previousPage);
+    }
+    catch (error) {
+        const cleanupErrors = [];
+        if (freshPage) {
+            let restoredPrevious = false;
+            try {
+                await page.selectTab(previousPage);
+                restoredPrevious = true;
+            }
+            catch (cleanupError) {
+                cleanupErrors.push(cleanupError?.message ?? String(cleanupError));
+            }
+            if (restoredPrevious) {
+                try {
+                    await page.closeTab(freshPage);
+                }
+                catch (cleanupError) {
+                    cleanupErrors.push(cleanupError?.message ?? String(cleanupError));
+                }
+            }
+            else {
+                // If the old target disappeared despite the original error,
+                // keep the fresh preferred target bound for --keep-tab.
+                page.setActivePage(freshPage);
+            }
+        }
+        const cleanupContext = cleanupErrors.length > 0
+            ? ` Cleanup also failed: ${cleanupErrors.join('; ')}.`
+            : '';
+        throw new CommandExecutionError(
+            `Failed to replace collapsed Xiaohongshu search tab: ${error?.message ?? String(error)}.${cleanupContext}`,
+        );
+    }
 }
 
 export const command = cli({
@@ -555,25 +665,26 @@ export const command = cli({
         try {
             const limit = parseLimit(kwargs.limit);
             const keyword = encodeURIComponent(kwargs.query);
-            await page.goto(`https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`);
-            // Wait for search results to render (or login wall to appear).
-            // Uses MutationObserver to resolve as soon as content appears,
-            // instead of a fixed delay + blind retry.
-            const waitResult = unwrapEvaluateResult(await page.evaluate(WAIT_FOR_CONTENT_JS));
-            if (!['content', 'login_wall', 'timeout'].includes(waitResult)) {
-                throw new CommandExecutionError('Unexpected Xiaohongshu search wait payload shape.');
+            const url = `https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`;
+            await page.goto(url);
+            let harvest = await collectSearchHarvest(page, limit);
+            if (isCollapsedRender(harvest.diag)) {
+                await replaceCollapsedTab(page, url);
+                harvest = await collectSearchHarvest(page, limit);
+                if (isCollapsedRender(harvest.diag)) {
+                    throw new CommandExecutionError(
+                        'Xiaohongshu search masonry remained collapsed after one fresh-tab recovery.',
+                        'Retry later or use a different logged-in browser session.',
+                    );
+                }
             }
-            if (waitResult === 'login_wall') {
-                throw new AuthRequiredError('www.xiaohongshu.com', 'Xiaohongshu search results are blocked behind a login wall');
-            }
-            const harvestOptions = harvestOptionsForLimit(limit);
-            const harvest = requireHarvestPayload(await page.evaluate(buildScrollHarvestJs('www.xiaohongshu.com', limit, harvestOptions)), 'www.xiaohongshu.com');
-            if (harvest.diag.securityBlock) {
-                throw new CliError('SECURITY_BLOCK', 'Xiaohongshu search was blocked by request-frequency or security controls.', 'Wait before retrying or use a different logged-in browser session.');
-            }
-            return harvest.rows
+            const rows = harvest.rows
                 .filter((item) => item.title)
-                .slice(0, limit)
+                .slice(0, limit);
+            if (rows.length === 0) {
+                throw new EmptyResultError('xiaohongshu search', 'No usable notes were rendered for this query.');
+            }
+            return rows
                 .map((item, i) => ({
                 rank: i + 1,
                 ...item,

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -15,14 +15,15 @@ import {
 } from './search.js';
 
 function markVisible(el) {
-    el.getBoundingClientRect = () => ({ width: 100, height: 100 });
+    el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0 });
 }
 function createPageMock(evaluateResults) {
     const evaluate = vi.fn();
+    let activePage = 'page-old';
     for (const result of evaluateResults) {
         evaluate.mockResolvedValueOnce(result);
     }
-    return {
+    const page = {
         goto: vi.fn().mockResolvedValue(undefined),
         evaluate,
         snapshot: vi.fn().mockResolvedValue(undefined),
@@ -33,7 +34,15 @@ function createPageMock(evaluateResults) {
         getFormState: vi.fn().mockResolvedValue({ forms: [], orphanFields: [] }),
         wait: vi.fn().mockResolvedValue(undefined),
         tabs: vi.fn().mockResolvedValue([]),
-        selectTab: vi.fn().mockResolvedValue(undefined),
+        getActivePage: vi.fn(() => activePage),
+        newTab: vi.fn().mockResolvedValue('page-new'),
+        setActivePage: vi.fn((pageId) => {
+            activePage = pageId;
+        }),
+        selectTab: vi.fn(async (pageId) => {
+            activePage = pageId;
+        }),
+        closeTab: vi.fn().mockResolvedValue(undefined),
         networkRequests: vi.fn().mockResolvedValue([]),
         consoleMessages: vi.fn().mockResolvedValue([]),
         scroll: vi.fn().mockResolvedValue(undefined),
@@ -44,6 +53,7 @@ function createPageMock(evaluateResults) {
         screenshot: vi.fn().mockResolvedValue(''),
         waitForCapture: vi.fn().mockResolvedValue(undefined),
     };
+    return page;
 }
 function harvestPayload(rows, diag = {}) {
     return {
@@ -51,6 +61,11 @@ function harvestPayload(rows, diag = {}) {
         diag: {
             securityBlock: false,
             stopReason: 'target',
+            scrollHeight: 2818,
+            clientHeight: 900,
+            cardCount: rows.length,
+            feedClientHeight: 2509,
+            distinctCardTops: rows.length,
             ...diag,
         },
     };
@@ -272,13 +287,23 @@ describe('xiaohongshu search', () => {
     it('maps a harvested risk-control interstitial to SECURITY_BLOCK', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         const page = createPageMock([
-            'timeout',
+            'content',
             harvestPayload([], { securityBlock: true, stopReason: 'security-block' }),
         ]);
 
         await expect(cmd.func(page, { query: '测试', limit: 5 })).rejects.toMatchObject({
             code: 'SECURITY_BLOCK',
         });
+    });
+    it('maps a risk-control interstitial detected before hydration to SECURITY_BLOCK', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock(['security_block']);
+
+        await expect(cmd.func(page, { query: '风控', limit: 5 })).rejects.toMatchObject({
+            code: 'SECURITY_BLOCK',
+        });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        expect(page.newTab).not.toHaveBeenCalled();
     });
     it('filters out results with no title and respects the limit', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
@@ -309,14 +334,15 @@ describe('xiaohongshu search', () => {
                         url: 'https://www.xiaohongshu.com/search_result/69b739f00000000000000000',
                         author_url: '',
                     },
-                ]),
+                ], { cardCount: 3, feedClientHeight: 500, distinctCardTops: 1 }),
         ]);
         const result = (await cmd.func(page, { query: '测试', limit: 1 }));
         // limit=1 should return only the first valid-titled result
         expect(result).toHaveLength(1);
         expect(result[0]).toMatchObject({ rank: 1, title: 'Result A' });
+        expect(page.newTab).not.toHaveBeenCalled();
     });
-    it('waits for content via MutationObserver before extracting', async () => {
+    it('maps a healthy empty harvest to EmptyResultError without replacing the tab', async () => {
         const cmd = getRegistry().get('xiaohongshu/search');
         expect(cmd?.func).toBeTypeOf('function');
         const page = createPageMock([
@@ -325,12 +351,125 @@ describe('xiaohongshu search', () => {
             // Second evaluate: scroll + harvest completes with no rows.
             harvestPayload([], { stopReason: 'exhausted' }),
         ]);
-        const result = (await cmd.func(page, { query: '测试等待', limit: 5 }));
-        expect(result).toHaveLength(0);
-        // Only one navigation, no retry
+        await expect(cmd.func(page, { query: '测试等待', limit: 5 })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
         expect(page.goto).toHaveBeenCalledTimes(1);
-        // Two evaluate calls: wait, then the single scroll + harvest IIFE.
         expect(page.evaluate).toHaveBeenCalledTimes(2);
+        expect(page.newTab).not.toHaveBeenCalled();
+    });
+    it('maps an ordinary hydration timeout to TimeoutError without replacing the tab', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const page = createPageMock(['timeout']);
+
+        await expect(cmd.func(page, { query: '加载超时', limit: 5 })).rejects.toMatchObject({ code: 'TIMEOUT' });
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        expect(page.newTab).not.toHaveBeenCalled();
+    });
+    it('replaces one proven-collapsed target and closes the old target after rebinding', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const recoveredRow = {
+            title: 'Recovered',
+            author: 'UserA',
+            likes: '10',
+            url: 'https://www.xiaohongshu.com/search_result/68e90be80000000004022e66',
+            author_url: '',
+        };
+        const page = createPageMock([
+            'content',
+            harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 }),
+            'content',
+            harvestPayload([recoveredRow]),
+        ]);
+
+        const result = await cmd.func(page, { query: '塌陷恢复', limit: 1 });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].title).toBe('Recovered');
+        expect(page.newTab).toHaveBeenCalledTimes(1);
+        expect(page.setActivePage).toHaveBeenCalledWith('page-new');
+        expect(page.selectTab).not.toHaveBeenCalled();
+        expect(page.closeTab).toHaveBeenCalledWith('page-old');
+        expect(page.newTab.mock.invocationCallOrder[0]).toBeLessThan(page.setActivePage.mock.invocationCallOrder[0]);
+        expect(page.setActivePage.mock.invocationCallOrder[0]).toBeLessThan(page.closeTab.mock.invocationCallOrder[0]);
+        expect(page.closeTab.mock.invocationCallOrder[0]).toBeLessThan(page.evaluate.mock.invocationCallOrder[2]);
+        expect(page.getActivePage()).toBe('page-new');
+    });
+    it('fails execution after one fresh target also renders with the proven collapsed signature', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const collapsed = harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 });
+        const page = createPageMock(['content', collapsed, 'content', collapsed]);
+
+        await expect(cmd.func(page, { query: '持续塌陷', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('remained collapsed'),
+        });
+        expect(page.newTab).toHaveBeenCalledTimes(1);
+        expect(page.closeTab).toHaveBeenCalledTimes(1);
+        expect(page.getActivePage()).toBe('page-new');
+    });
+    it('preserves the old target when opening the fresh target fails', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const collapsed = harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 });
+        const page = createPageMock(['content', collapsed]);
+        page.newTab.mockRejectedValueOnce(new Error('new tab failed'));
+
+        await expect(cmd.func(page, { query: '开页失败', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('new tab failed'),
+        });
+        expect(page.closeTab).not.toHaveBeenCalled();
+        expect(page.getActivePage()).toBe('page-old');
+    });
+    it('restores the old preferred target and closes the fresh target when Node rebinding fails', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const collapsed = harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 });
+        const page = createPageMock(['content', collapsed]);
+        page.setActivePage.mockImplementationOnce(() => {
+            throw new Error('bind failed');
+        });
+
+        await expect(cmd.func(page, { query: '绑定失败', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('bind failed'),
+        });
+        expect(page.setActivePage).toHaveBeenCalledWith('page-new');
+        expect(page.selectTab).toHaveBeenCalledOnce();
+        expect(page.selectTab).toHaveBeenCalledWith('page-old');
+        expect(page.closeTab).toHaveBeenCalledWith('page-new');
+        expect(page.closeTab).not.toHaveBeenCalledWith('page-old');
+        expect(page.getActivePage()).toBe('page-old');
+    });
+    it('rolls back to the old target when closing it after rebinding fails', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const collapsed = harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 });
+        const page = createPageMock(['content', collapsed]);
+        page.closeTab.mockRejectedValueOnce(new Error('close old failed'));
+
+        await expect(cmd.func(page, { query: '关旧页失败', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('close old failed'),
+        });
+        expect(page.closeTab).toHaveBeenNthCalledWith(1, 'page-old');
+        expect(page.selectTab).toHaveBeenCalledOnce();
+        expect(page.selectTab).toHaveBeenCalledWith('page-old');
+        expect(page.closeTab).toHaveBeenNthCalledWith(2, 'page-new');
+        expect(page.getActivePage()).toBe('page-old');
+    });
+    it('keeps the fresh target when an ambiguous old-close failure cannot restore the old target', async () => {
+        const cmd = getRegistry().get('xiaohongshu/search');
+        const collapsed = harvestPayload([], { cardCount: 22, feedClientHeight: 0, distinctCardTops: 1 });
+        const page = createPageMock(['content', collapsed]);
+        page.selectTab.mockRejectedValueOnce(new Error('old target is already gone'));
+        page.closeTab.mockRejectedValueOnce(new Error('close old response lost'));
+
+        await expect(cmd.func(page, { query: '旧页状态不明', limit: 5 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringMatching(/close old response lost.*Cleanup also failed: old target is already gone/),
+        });
+        expect(page.selectTab).toHaveBeenCalledOnce();
+        expect(page.selectTab).toHaveBeenCalledWith('page-old');
+        expect(page.closeTab).toHaveBeenCalledTimes(1);
+        expect(page.closeTab).toHaveBeenCalledWith('page-old');
+        expect(page.getActivePage()).toBe('page-new');
     });
 });
 describe('buildSearchExtractJs', () => {
@@ -503,7 +642,13 @@ describe('buildScrollHarvestJs', () => {
             { height: 2400, cards: [{ id: c, title: '第三屏', likes: '3' }] },
         ], { target: 3 });
 
-        expect(result.diag).toMatchObject({ usable: 3, stopReason: 'target', securityBlock: false });
+        expect(result.diag).toMatchObject({
+            usable: 3,
+            stopReason: 'target',
+            securityBlock: false,
+            feedClientHeight: null,
+            distinctCardTops: 1,
+        });
         expect(result.rows.map((row) => row.title)).toEqual(['后渲染标题', '第二屏', '第三屏']);
         expect(result.rows[0]).toMatchObject({ likes: '7' });
         expect(result.rows[0].url).toContain('xsec_token=signed-token');

--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -1982,6 +1982,18 @@ async function handleFrames(cmd, leaseKey) {
     return errorResult(cmd.id, err);
   }
 }
+function preferOwnedTab(leaseKey, tabId) {
+  const session = automationSessions.get(leaseKey);
+  if (!session?.owned) return;
+  setLeaseSession(leaseKey, {
+    session: session.session,
+    surface: session.surface,
+    kind: session.kind,
+    windowId: session.windowId,
+    owned: true,
+    preferredTabId: tabId
+  });
+}
 async function handleNavigate(cmd, leaseKey) {
   if (!cmd.url) return { id: cmd.id, ok: false, error: "Missing url" };
   if (!isSafeNavigationUrl(cmd.url)) {
@@ -2116,6 +2128,34 @@ async function handleTabs(cmd, leaseKey) {
         }
         return { id: cmd.id, ok: true, data: { closed: closedPage2 } };
       }
+      if (cmd.page !== void 0 && session?.owned) {
+        let tabId2;
+        try {
+          tabId2 = await resolveCommandTabId(cmd);
+        } catch {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        if (tabId2 === void 0) {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        let tab;
+        try {
+          tab = await chrome.tabs.get(tabId2);
+        } catch {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        if (tab.windowId !== session.windowId) {
+          return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
+        }
+        const closedPage2 = await resolveTargetId(tabId2).catch(() => void 0);
+        if (session.preferredTabId === tabId2) {
+          await releaseLease(leaseKey, "tab close");
+        } else {
+          await safeDetach(tabId2);
+          await chrome.tabs.remove(tabId2);
+        }
+        return { id: cmd.id, ok: true, data: { closed: closedPage2 } };
+      }
       const cmdTabId = await resolveCommandTabId(cmd);
       const tabId = await resolveTabId(cmdTabId, leaseKey);
       const closedPage = await resolveTargetId(tabId).catch(() => void 0);
@@ -2144,12 +2184,14 @@ async function handleTabs(cmd, leaseKey) {
           return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
         }
         await chrome.tabs.update(cmdTabId, { active: true });
+        preferOwnedTab(leaseKey, cmdTabId);
         return pageScopedResult(cmd.id, cmdTabId, { selected: true });
       }
       const tabs = await listAutomationWebTabs(leaseKey);
       const target = tabs[cmd.index];
       if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
       await chrome.tabs.update(target.id, { active: true });
+      preferOwnedTab(leaseKey, target.id);
       return pageScopedResult(cmd.id, target.id, { selected: true });
     }
     default:

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -669,6 +669,85 @@ describe('background tab isolation', () => {
     expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
   });
 
+  it('closes an exact non-preferred owned page without releasing the preferred lease', async () => {
+    const { chrome, tabs } = createChromeMock();
+    tabs.push({ id: 10, windowId: 1, url: 'https://fresh.example', title: 'fresh', active: true, status: 'complete', groupId: -1 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 10 });
+
+    const result = await mod.__test__.handleTabs(
+      { id: 'close-old', action: 'tabs', op: 'close', session: adapterKey('twitter'), page: 'target-1' },
+      adapterKey('twitter'),
+    );
+
+    expect(result).toEqual({
+      id: 'close-old',
+      ok: true,
+      data: { closed: 'target-1' },
+    });
+    expect(chrome.tabs.remove).toHaveBeenCalledWith(1);
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(10, { url: 'about:blank', active: true });
+    expect(mod.__test__.getSession(adapterKey('twitter'))?.preferredTabId).toBe(10);
+  });
+
+  it.each([
+    ['cross-window', 'target-2'],
+    ['stale', 'target-999'],
+  ])('rejects an exact %s page without closing the preferred page', async (_label, page) => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 1 });
+
+    const result = await mod.__test__.handleTabs(
+      { id: 'reject-close', action: 'tabs', op: 'close', session: adapterKey('twitter'), page },
+      adapterKey('twitter'),
+    );
+
+    expect(result).toEqual(expect.objectContaining({ id: 'reject-close', ok: false }));
+    expect(chrome.tabs.remove).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).not.toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(mod.__test__.getSession(adapterKey('twitter'))?.preferredTabId).toBe(1);
+  });
+
+  it('keeps legacy implicit close bound to the preferred page', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 1 });
+
+    const result = await mod.__test__.handleTabs(
+      { id: 'implicit-close', action: 'tabs', op: 'close', session: adapterKey('twitter') },
+      adapterKey('twitter'),
+    );
+
+    expect(result).toEqual({ id: 'implicit-close', ok: true, data: { closed: 'target-1' } });
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { url: 'about:blank', active: true });
+    expect(mod.__test__.getSession(adapterKey('twitter'))).toBeNull();
+  });
+
+  it('selecting an exact owned page restores it as the preferred lease target', async () => {
+    const { chrome, tabs } = createChromeMock();
+    tabs.push({ id: 10, windowId: 1, url: 'https://fresh.example', title: 'fresh', active: true, status: 'complete', groupId: -1 });
+    vi.stubGlobal('chrome', chrome);
+
+    const mod = await import('./background');
+    mod.__test__.setSession(adapterKey('twitter'), { windowId: 1, owned: true, preferredTabId: 10 });
+
+    const result = await mod.__test__.handleTabs(
+      { id: 'restore-old', action: 'tabs', op: 'select', session: adapterKey('twitter'), page: 'target-1' },
+      adapterKey('twitter'),
+    );
+
+    expect(result).toEqual(expect.objectContaining({ id: 'restore-old', ok: true, page: 'target-1' }));
+    expect(chrome.tabs.update).toHaveBeenCalledWith(1, { active: true });
+    expect(mod.__test__.getSession(adapterKey('twitter'))?.preferredTabId).toBe(1);
+  });
+
   it('treats normalized same-url navigate as already complete', async () => {
     const { chrome, tabs, update } = createChromeMock();
     tabs[0].url = 'https://www.bilibili.com/';

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1707,6 +1707,19 @@ async function handleFrames(cmd: Command, leaseKey: string): Promise<Result> {
   }
 }
 
+function preferOwnedTab(leaseKey: string, tabId: number): void {
+  const session = automationSessions.get(leaseKey);
+  if (!session?.owned) return;
+  setLeaseSession(leaseKey, {
+    session: session.session,
+    surface: session.surface,
+    kind: session.kind,
+    windowId: session.windowId,
+    owned: true,
+    preferredTabId: tabId,
+  });
+}
+
 async function handleNavigate(cmd: Command, leaseKey: string): Promise<Result> {
   if (!cmd.url) return { id: cmd.id, ok: false, error: 'Missing url' };
   if (!isSafeNavigationUrl(cmd.url)) {
@@ -1869,6 +1882,34 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
         }
         return { id: cmd.id, ok: true, data: { closed: closedPage } };
       }
+      if (cmd.page !== undefined && session?.owned) {
+        let tabId: number | undefined;
+        try {
+          tabId = await resolveCommandTabId(cmd);
+        } catch {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        if (tabId === undefined) {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        let tab: chrome.tabs.Tab;
+        try {
+          tab = await chrome.tabs.get(tabId);
+        } catch {
+          return { id: cmd.id, ok: false, error: `Page no longer exists` };
+        }
+        if (tab.windowId !== session.windowId) {
+          return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
+        }
+        const closedPage = await identity.resolveTargetId(tabId).catch(() => undefined);
+        if (session.preferredTabId === tabId) {
+          await releaseLease(leaseKey, 'tab close');
+        } else {
+          await safeDetach(tabId);
+          await chrome.tabs.remove(tabId);
+        }
+        return { id: cmd.id, ok: true, data: { closed: closedPage } };
+      }
       const cmdTabId = await resolveCommandTabId(cmd);
       const tabId = await resolveTabId(cmdTabId, leaseKey);
       const closedPage = await identity.resolveTargetId(tabId).catch(() => undefined);
@@ -1897,12 +1938,14 @@ async function handleTabs(cmd: Command, leaseKey: string): Promise<Result> {
           return { id: cmd.id, ok: false, error: `Page is not in the automation container` };
         }
         await chrome.tabs.update(cmdTabId, { active: true });
+        preferOwnedTab(leaseKey, cmdTabId);
         return pageScopedResult(cmd.id, cmdTabId, { selected: true });
       }
       const tabs = await listAutomationWebTabs(leaseKey);
       const target = tabs[cmd.index!];
       if (!target?.id) return { id: cmd.id, ok: false, error: `Tab index ${cmd.index} not found` };
       await chrome.tabs.update(target.id, { active: true });
+      preferOwnedTab(leaseKey, target.id);
       return pageScopedResult(cmd.id, target.id, { selected: true });
     }
     default:

--- a/src/browser/page.test.ts
+++ b/src/browser/page.test.ts
@@ -445,6 +445,22 @@ describe('Page active target tracking', () => {
     }));
   });
 
+  it('keeps the fresh active binding when closing an exact old page', async () => {
+    sendCommandMock.mockResolvedValueOnce({ closed: 'page-old' });
+
+    const page = new Page('site:xiaohongshu');
+    page.setActivePage?.('page-fresh');
+    await page.closeTab?.('page-old');
+
+    expect(sendCommandMock).toHaveBeenCalledWith('tabs', expect.objectContaining({
+      op: 'close',
+      session: 'site:xiaohongshu',
+      surface: 'browser',
+      page: 'page-old',
+    }));
+    expect(page.getActivePage()).toBe('page-fresh');
+  });
+
   it('clears the active page binding when closing the selected tab by numeric index', async () => {
     sendCommandFullMock.mockResolvedValueOnce({ data: { selected: true }, page: 'page-2' });
     sendCommandMock


### PR DESCRIPTION
## Description

Fixes #2313.

`xiaohongshu search` intermittently renders its search page in a **collapsed state**. Measured on a live collapsed tab:

```text
document.scrollHeight   = 208      (healthy: 2818)
.feeds-container        clientHeight = 0        (healthy: 2509)
22 cards, all with the same getBoundingClientRect().top, no transform
every scroll attempt    moved = false
```

The masonry layout never ran, so the cards stack at one coordinate and the page cannot scroll. The harvest loop then returns only whatever that single overlapping screen holds — often nothing, which is exactly the `EMPTY_RESULT` reported in #2313.

### The fix suggested in #2313 does not work

#2313 proposes forcing one cache-busted navigation. I tested that against a live collapsed tab, along with everything else in that family:

| Recovery attempt | Result |
| --- | --- |
| `page.goto` the same URL again | still collapsed |
| cache-busted URL | still collapsed |
| navigate away, then back | still collapsed |
| Ctrl+R / reload | still collapsed |
| **open a new tab** | **renders correctly** |

The collapse is sticky to the *target*, not to the document. Only a fresh tab recovers it.

### What this PR does

- `isCollapsedRender(diag)` — new pure, exported predicate. It requires **two independent signals** to agree: collapsed height (`scrollHeight <= 400` or `clientHeight === 0`) **and** all cards sharing one rounded `top`. `cardCount <= 1` is explicitly not collapsed, so a genuinely empty result never triggers a retry.
- The harvest payload now reports `distinctCardTops` so the predicate has a coordinate signal to work with.
- `runSearchAttempt` / `runSearchWithRecovery` — the attempt body is factored out and retried in a fresh tab at most **2** times. Tab handling follows the existing `clis/google/images.js` precedent: `typeof page.newTab === 'function' && typeof page.selectTab === 'function'` guards, then a best-effort `setActivePage` and a best-effort `page.cdp('Emulation.setDeviceMetricsOverride', ...)` to restore the viewport. Every optional capability is guarded; if the session cannot open tabs the command fails typed rather than looping.
- A `'timeout'` wait result was previously **ignored** — extraction then ran against an unrendered DOM and surfaced as a silently empty list. It now feeds the same retry path.
- When retries are exhausted the command throws `EmptyResultError` with a hint naming the reason, instead of returning `[]`.

### Root cause (hypothesis, not relied upon by the code)

`windowMode` defaults to `background` (`src/execution.ts`), and background tabs do not perform layout. That would explain `clientHeight=0`, coordinate-collapsed cards, `moved=false`, and why the state is sticky per-target while a new tab (which is foregrounded on creation) recovers.

**This is unverified**, so the fix deliberately does not depend on it — the adapter self-heals by observation instead. If the hypothesis holds, a framework-level fix would be strictly better and this could later be reduced to a safety net.

### One deliberate trade-off

The collapsed tab is **left open** rather than closed after recovery: it is the framework's leased tab, and closing it from inside an adapter would fight `--keep-tab` semantics. `google/images.js` likewise does not close the previous tab after `newTab`. Happy to close it if you'd prefer the opposite.

### Stacking

This branch is stacked on #2349 (`fix/xhs-search-harvest-during-scroll`) and therefore shows both commits until that one merges. Only the second commit belongs to this PR; the diff will shrink to it automatically once #2349 lands.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / code cleanup

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `npm run typecheck` and it passes
- [x] I have run the lint gates (`check:typed-error-lint`, `check:silent-column-drop`) and introduced no new violations

Verification run locally:

```text
npm run typecheck                  clean
vitest --project adapter xiaohongshu/search.test.js   55 passed
vitest --project adapter rednote                      24 passed (untouched)
check:typed-error-lint             new=0
check:silent-column-drop           new=0
git diff --stat                    2 files (no cli-manifest.json, no rednote/)
```

New unit coverage, all DOM-free:

- `isCollapsedRender` locks the measured numbers directly — `{scrollHeight:208, clientHeight:0, cardCount:22, distinctCardTops:1}` → `true`, the healthy `{2818, 2509, 22, 22}` → `false`, and `{cardCount:0}` → `false`.
- Retry-path tests cover fresh-tab success, `newTab` unavailable, and retry exhaustion.

## Documentation

No CLI arguments were added, so `cli-manifest.json` is unchanged and no user-facing docs need updating.

## Screenshots

N/A — CLI change.
