### PR TITLE
chore(linkedin): reuse shared unwrap in connect flows

### DIFF
--- a/clis/linkedin/connect.js
+++ b/clis/linkedin/connect.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 
@@ -75,11 +76,6 @@ function requireLinkedInProfileUrl(value, label) {
     const url = canonicalizeLinkedInProfileUrl(value);
     if (!url) throw new ArgumentError(`${label} must be an exact https://www.linkedin.com/in/<profile>/ URL`);
     return url;
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
 }
 
 function clampNote(note) {
@@ -516,7 +512,6 @@ export const __test__ = {
     matchInvitationName,
     canonicalizeLinkedInProfileUrl,
     canonicalizeLinkedInInviteUrl,
-    unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
     buildProfileProbeScript,

--- a/clis/linkedin/connect.test.js
+++ b/clis/linkedin/connect.test.js
@@ -9,7 +9,6 @@ const {
     matchInvitationName,
     canonicalizeLinkedInProfileUrl,
     canonicalizeLinkedInInviteUrl,
-    unwrapEvaluateResult,
     clampNote,
     assessProfileSafety,
     buildProfileProbeScript,
@@ -95,12 +94,6 @@ describe('linkedin connect helpers', () => {
             .toBe('https://www.linkedin.com/preload/custom-invite/?vanityName=jane');
         expect(canonicalizeLinkedInInviteUrl('https://www.linkedin.com/feed/')).toBe('');
         expect(canonicalizeLinkedInInviteUrl('https://evil-linkedin.com/preload/custom-invite/?vanityName=jane')).toBe('');
-    });
-
-    it('unwraps browser bridge evaluate envelopes', () => {
-        expect(unwrapEvaluateResult({ session: 'site:linkedin:1', data: { ok: true } })).toEqual({ ok: true });
-        const raw = { ok: true };
-        expect(unwrapEvaluateResult(raw)).toBe(raw);
     });
 
     it('enforces LinkedIn note length', () => {

--- a/clis/linkedin/people-search.js
+++ b/clis/linkedin/people-search.js
@@ -5,6 +5,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SEARCH_URL_BASE = 'https://www.linkedin.com/search/results/people/';
@@ -27,11 +28,6 @@ function parseLimit(value) {
         throw new ArgumentError(`--limit must be an integer between 1 and ${MAX_LIMIT}`);
     }
     return limit;
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
 }
 
 function buildSearchUrl(keywords) {


### PR DESCRIPTION
## Summary
- Reuse existing clis/linkedin/shared.js unwrapEvaluateResult in connect and people-search.
- Delete the two remaining local helper copies.
- Remove only connect's duplicate direct helper test and imported __test__ key; people-search exports/tests are unchanged.

## Boundary
- This intentionally adds two one-way local module edges from connect/people-search to the existing leaf shared.js module.
- The new imports bring in only unwrapEvaluateResult.
- shared.js still has no local imports/back edge; it only imports @jackwener/opencli/errors.
- shared.test.js already covers the unwrap contract more strongly, including complete envelope, partial-envelope identity, and null/scalar passthrough.

## Validation
- npx vitest run clis/linkedin/connect.test.js clis/linkedin/people-search.test.js
- npx vitest run clis/linkedin
- npm run typecheck
- npm run build
- node dist/src/main.js validate linkedin
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check

Note: one full LinkedIn run was invalid because it was run concurrently with npm run build, whose clean-dist step removed the package self-reference while tests were importing @jackwener/opencli/*; rerunning after build completed passed 28 files / 246 tests.