### PR TITLE
chore(linkedin): share messaging thread URL helpers

### DIFF
--- a/clis/linkedin/safe-send.js
+++ b/clis/linkedin/safe-send.js
@@ -1,42 +1,15 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { createHash } from 'node:crypto';
-import { unwrapEvaluateResult } from './shared.js';
+import { canonicalizeLinkedInThreadUrl, normalizeWhitespace, unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
-
-function normalizeWhitespace(value) {
-  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-}
 
 function normalizeName(value) {
   return normalizeWhitespace(value)
     .replace(/\s*[•·]\s*(?:1st|2nd|3rd\+?|degree connection).*$/i, '')
     .replace(/\s+LinkedIn.*$/i, '')
     .toLowerCase();
-}
-
-function isLinkedInHost(hostname) {
-  const host = String(hostname || '').toLowerCase();
-  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
-}
-
-function canonicalizeLinkedInThreadUrl(value) {
-  const raw = normalizeWhitespace(value);
-  if (!raw) return '';
-  try {
-    const url = new URL(raw);
-    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
-    const match = url.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i);
-    if (!match || !match[1]) return '';
-    url.hostname = 'www.linkedin.com';
-    url.hash = '';
-    url.search = '';
-    if (!url.pathname.endsWith('/')) url.pathname += '/';
-    return url.toString();
-  } catch {
-    return '';
-  }
 }
 
 function hashText(value) {
@@ -344,9 +317,7 @@ cli({
 });
 
 export const __test__ = {
-  normalizeWhitespace,
   normalizeName,
-  canonicalizeLinkedInThreadUrl,
   hashText,
   assessThreadSafety,
 };

--- a/clis/linkedin/safe-send.test.js
+++ b/clis/linkedin/safe-send.test.js
@@ -4,9 +4,7 @@ import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors'
 import './safe-send.js';
 
 const {
-  normalizeWhitespace,
   normalizeName,
-  canonicalizeLinkedInThreadUrl,
   hashText,
   assessThreadSafety,
 } = await import('./safe-send.js').then((m) => m.__test__);
@@ -34,16 +32,7 @@ function makeFakePage(probe) {
 
 describe('linkedin safe-send helpers', () => {
   it('normalizes whitespace and LinkedIn names for exact-ish comparisons', () => {
-    expect(normalizeWhitespace('  Lokesh\n\tRamesh  ')).toBe('Lokesh Ramesh');
     expect(normalizeName('Lokesh Ramesh • 1st')).toBe('lokesh ramesh');
-  });
-
-  it('canonicalizes thread URLs while dropping query and hash noise', () => {
-    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/?foo=1#bar'))
-      .toBe('https://www.linkedin.com/messaging/thread/abc/');
-    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/extra')).toBe('');
-    expect(canonicalizeLinkedInThreadUrl('https://evil-linkedin.com/messaging/thread/abc/')).toBe('');
-    expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/abc/')).toBe('');
   });
 
   it('fails closed when LinkedIn search produced no results even if a composer is visible', () => {

--- a/clis/linkedin/shared.js
+++ b/clis/linkedin/shared.js
@@ -11,6 +11,29 @@ export function normalizeWhitespace(value) {
   return String(value ?? '').replace(/[\u00a0\u202f]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+function isLinkedInHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
+}
+
+export function canonicalizeLinkedInThreadUrl(value) {
+  const raw = normalizeWhitespace(value);
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
+    const match = url.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i);
+    if (!match || !match[1]) return '';
+    url.hostname = 'www.linkedin.com';
+    url.hash = '';
+    url.search = '';
+    if (!url.pathname.endsWith('/')) url.pathname += '/';
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
 export function normalizeHttpUrl(value, base) {
   const raw = normalizeWhitespace(value);
   if (!raw) return '';

--- a/clis/linkedin/shared.test.js
+++ b/clis/linkedin/shared.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { decodeLinkedInSafetyUrl, unwrapEvaluateResult } from './shared.js';
+import {
+  canonicalizeLinkedInThreadUrl,
+  decodeLinkedInSafetyUrl,
+  normalizeWhitespace,
+  unwrapEvaluateResult,
+} from './shared.js';
 
 describe('linkedin shared helpers', () => {
   it('unwraps complete browser evaluate envelopes', () => {
@@ -36,5 +41,22 @@ describe('linkedin shared helpers', () => {
       .toBe('');
     expect(decodeLinkedInSafetyUrl('javascript:alert(1)')).toBe('');
     expect(decodeLinkedInSafetyUrl('https://user:pass@example.com/demo')).toBe('');
+  });
+
+  it('normalizes LinkedIn messaging whitespace', () => {
+    expect(normalizeWhitespace('  Lokesh\n\tRamesh  ')).toBe('Lokesh Ramesh');
+    expect(normalizeWhitespace('A\u00a0\u202fB')).toBe('A B');
+  });
+
+  it('canonicalizes LinkedIn messaging thread URLs', () => {
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/?foo=1#bar'))
+      .toBe('https://www.linkedin.com/messaging/thread/abc/');
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/?mini=true#x'))
+      .toBe('https://www.linkedin.com/messaging/thread/2-abc==/');
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/abc/extra')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('https://evil-linkedin.com/messaging/thread/abc/')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/abc/')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('https://user:pass@www.linkedin.com/messaging/thread/abc/')).toBe('');
+    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com:444/messaging/thread/abc/')).toBe('');
   });
 });

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -1,35 +1,8 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './shared.js';
+import { canonicalizeLinkedInThreadUrl, normalizeWhitespace, unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
-
-function normalizeWhitespace(value) {
-  return String(value ?? '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
-function isLinkedInHost(hostname) {
-  const host = String(hostname || '').toLowerCase();
-  return host === 'linkedin.com' || host.endsWith('.linkedin.com');
-}
-
-function canonicalizeLinkedInThreadUrl(value) {
-  const raw = normalizeWhitespace(value);
-  if (!raw) return '';
-  try {
-    const url = new URL(raw);
-    if (url.protocol !== 'https:' || url.username || url.password || url.port || !isLinkedInHost(url.hostname)) return '';
-    const match = url.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i);
-    if (!match || !match[1]) return '';
-    url.hostname = 'www.linkedin.com';
-    url.hash = '';
-    url.search = '';
-    if (!url.pathname.endsWith('/')) url.pathname += '/';
-    return url.toString();
-  } catch {
-    return '';
-  }
-}
 
 function requireStringArg(args, key, label = key) {
   const value = normalizeWhitespace(args[key]);
@@ -202,8 +175,6 @@ cli({
 });
 
 export const __test__ = {
-  normalizeWhitespace,
-  canonicalizeLinkedInThreadUrl,
   parseMaxScrolls,
   buildThreadSnapshotScript,
 };

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -3,7 +3,7 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { canonicalizeLinkedInThreadUrl, parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const { parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
 
 function makeFakePage(snapshot) {
   return {
@@ -14,14 +14,6 @@ function makeFakePage(snapshot) {
 }
 
 describe('linkedin thread-snapshot command', () => {
-  it('accepts only exact LinkedIn messaging thread URLs', () => {
-    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/?mini=true#x'))
-      .toBe('https://www.linkedin.com/messaging/thread/2-abc==/');
-    expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com/messaging/thread/2-abc==/extra')).toBe('');
-    expect(canonicalizeLinkedInThreadUrl('https://evil-linkedin.com/messaging/thread/2-abc==/')).toBe('');
-    expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/2-abc==/')).toBe('');
-  });
-
   it('validates max-scrolls without silent clamping', () => {
     expect(parseMaxScrolls(undefined)).toBe(30);
     expect(parseMaxScrolls(0)).toBe(0);


### PR DESCRIPTION
## Summary
- Move the duplicated LinkedIn messaging thread URL helpers from safe-send and thread-snapshot into existing clis/linkedin/shared.js.
- Reuse shared normalizeWhitespace and canonicalizeLinkedInThreadUrl from both messaging commands.
- Move the duplicate URL/whitespace direct coverage into shared.test.js while keeping command-specific tests focused on command behavior.

## Boundary
- Reuses existing shared.js; no new module/file boundary.
- isLinkedInHost stays private; canonicalizeLinkedInThreadUrl is exported.
- shared normalizeWhitespace body is unchanged.
- safe-send/thread-snapshot already import shared.js; this only adds normalizeWhitespace and canonicalizeLinkedInThreadUrl to existing imports.
- Command-local __test__ exports only lose imported helper keys; no re-export shim.
- Does not touch safe-send fail-closed send chain, thread-snapshot auth/malformed/thread mismatch logic, page-realm scripts/clean functions, connect/salesnav URL helpers, or LINKEDIN_DOMAIN constants.

## Validation
- npm run build
- npx vitest run clis/linkedin/safe-send.test.js clis/linkedin/thread-snapshot.test.js clis/linkedin/shared.test.js
- npx vitest run clis/linkedin
- npm run typecheck
- node dist/src/main.js validate linkedin
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check