### PR TITLE
chore(linkedin): share people search auth helpers

### DIFF
--- a/clis/linkedin/people-search.js
+++ b/clis/linkedin/people-search.js
@@ -5,15 +5,11 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './shared.js';
+import { looksLinkedInAuthWall, normalizeWhitespace, unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 const SEARCH_URL_BASE = 'https://www.linkedin.com/search/results/people/';
 const MAX_LIMIT = 10;
-
-function normalizeWhitespace(value) {
-    return String(value ?? '').replace(/[  ]/g, ' ').replace(/\s+/g, ' ').trim();
-}
 
 function requireStringArg(args, key, label = key) {
     const value = normalizeWhitespace(args[key]);
@@ -32,14 +28,6 @@ function parseLimit(value) {
 
 function buildSearchUrl(keywords) {
     return SEARCH_URL_BASE + '?keywords=' + encodeURIComponent(keywords);
-}
-
-function looksLinkedInAuthWall(value) {
-    const text = normalizeWhitespace(value).toLowerCase();
-    if (!text) return false;
-    return /linkedin\.com\/(?:login|checkpoint|authwall|uas)/i.test(text)
-        || /\b(sign in|log in|join linkedin|captcha|verification required)\b/i.test(text)
-        || /(请登录|登录领英|安全验证)/.test(text);
 }
 
 function normalizeProfileUrl(value) {
@@ -257,10 +245,8 @@ cli({
 });
 
 export const __test__ = {
-    normalizeWhitespace,
     parseLimit,
     buildSearchUrl,
-    looksLinkedInAuthWall,
     normalizeProfileUrl,
     normalizePeopleRows,
     parseNonNegativeCount,

--- a/clis/linkedin/people-search.test.js
+++ b/clis/linkedin/people-search.test.js
@@ -7,7 +7,6 @@ import './people-search.js';
 const {
     parseLimit,
     buildSearchUrl,
-    looksLinkedInAuthWall,
     normalizeProfileUrl,
     normalizePeopleRows,
     parseNonNegativeCount,
@@ -86,12 +85,6 @@ describe('linkedin people-search command', () => {
         expect(normalizeProfileUrl('https://evil-linkedin.com/in/bob-builder')).toBe('');
         expect(normalizeProfileUrl('http://www.linkedin.com/in/bob-builder')).toBe('');
         expect(normalizeProfileUrl('https://www.linkedin.com/company/opencli')).toBe('');
-    });
-
-    it('detects LinkedIn auth-wall URLs separately from CUL redirects', () => {
-        expect(looksLinkedInAuthWall('https://www.linkedin.com/authwall Sign in to continue')).toBe(true);
-        expect(looksLinkedInAuthWall('https://www.linkedin.com/checkpoint/challenge security verification required')).toBe(true);
-        expect(looksLinkedInAuthWall('https://www.linkedin.com/feed/')).toBe(false);
     });
 
     it('rejects malformed extraction rows instead of fabricating success rows', () => {

--- a/clis/linkedin/shared.test.js
+++ b/clis/linkedin/shared.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   canonicalizeLinkedInThreadUrl,
   decodeLinkedInSafetyUrl,
+  looksLinkedInAuthWall,
   normalizeWhitespace,
   unwrapEvaluateResult,
 } from './shared.js';
@@ -58,5 +59,14 @@ describe('linkedin shared helpers', () => {
     expect(canonicalizeLinkedInThreadUrl('http://www.linkedin.com/messaging/thread/abc/')).toBe('');
     expect(canonicalizeLinkedInThreadUrl('https://user:pass@www.linkedin.com/messaging/thread/abc/')).toBe('');
     expect(canonicalizeLinkedInThreadUrl('https://www.linkedin.com:444/messaging/thread/abc/')).toBe('');
+  });
+
+  it('detects LinkedIn auth-wall URLs and text branches', () => {
+    expect(looksLinkedInAuthWall('https://www.linkedin.com/authwall Sign in to continue')).toBe(true);
+    expect(looksLinkedInAuthWall('https://www.linkedin.com/checkpoint/challenge security verification required')).toBe(true);
+    expect(looksLinkedInAuthWall('https://www.linkedin.com/feed/')).toBe(false);
+    expect(looksLinkedInAuthWall('https://www.linkedin.com/login')).toBe(true);
+    expect(looksLinkedInAuthWall('Please sign in to continue')).toBe(true);
+    expect(looksLinkedInAuthWall('请登录后继续')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- bind linkedin people-search to existing shared normalizeWhitespace and looksLinkedInAuthWall helpers
- remove the local people-search helper copies and avoid any __test__ re-export shim
- move the auth-wall direct assertions to shared.test.js and add URL-only, English-only, and Chinese-only branch isolation coverage

## Boundaries
- shared.js is zero diff; existing shared helper implementations are unchanged
- search.js and search tests are zero diff; search's page-probe auth helper is intentionally untouched
- people-search command node remains unchanged (hash 17c98bab814e), with retained top-level functions and SSR extraction script unchanged

## Tests
- npm run build
- npx vitest run clis/linkedin/people-search.test.js clis/linkedin/shared.test.js
- npx vitest run clis/linkedin
- npm run typecheck
- node dist/src/main.js validate linkedin
- npm run check:typed-error-lint
- npm run check:silent-column-drop
- git diff --check