### PR TITLE
chore(release): bump version to 1.8.7

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.21",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.21",
+      "version": "1.0.23",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- bump root @jackwener/opencli from 1.8.6 to 1.8.7
- bump Chrome extension from 1.0.22 to 1.0.23 because extension source/dist changed since v1.8.6
- fix extension/package-lock.json top-level version metadata while bumping

## Release notes
- This follows the existing main v* release flow: one v1.8.7 tag publishes npm and attaches the extension zip to the same GitHub Release.
- No separate ext-v* tag is planned.

## Checks
- npm run build
- npm run typecheck
- cd extension && npm ci
- cd extension && npm run build
- cd extension && npm run package:release -- --out /tmp/opencli-extension-package-1.0.23-check
- git diff --check

## Note
- A local extension-only tsc --noEmit run currently reports pre-existing strict test typing errors; the release workflow does not run that command. The release-critical extension build and package path passed.