### PR TITLE
fix: sync package-lock with undici 7.29.0 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "^4.3.1",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
-        "undici": "^6.27.0",
+        "undici": "7.29.0",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -3012,16 +3012,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -4049,12 +4039,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## Summary
#2326 pinned `undici` `7.29.0` in package.json but did not regenerate `package-lock.json` (root deps still `^6.27.0`). `npm ci` therefore fails with `EUSAGE` on main and on every PR merge ref — all hosted checks currently die at install in seconds (e.g. the #2360 runs).

## Change
`npm install --package-lock-only` against main. Lock-only diff: root dep mirror updated to `7.29.0`, `node_modules/undici` entry 6.27.0 → 7.29.0, and the now-dedupable `jsdom/node_modules/undici` override removed.

## Verification
`npm ci --dry-run --ignore-scripts` passes locally (previously EUSAGE). Full validation = the hosted checks on this PR.