### PR TITLE
fix(weixin): recover draft cover uploads

### DIFF
--- a/clis/weixin/create-draft.js
+++ b/clis/weixin/create-draft.js
@@ -1,32 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 const WEIXIN_DOMAIN = 'mp.weixin.qq.com';
 const WEIXIN_HOME = 'https://mp.weixin.qq.com/';
+const IMAGE_FILE_INPUT_SELECTOR = 'input[type="file"][name="file"]';
+const IMAGE_MIME_TYPES = new Map([
+    ['.jpg', 'image/jpeg'],
+    ['.jpeg', 'image/jpeg'],
+    ['.png', 'image/png'],
+    ['.gif', 'image/gif'],
+    ['.webp', 'image/webp'],
+]);
 
-async function getToken(page) {
-    return page.evaluate(`(window.location.href.match(/token=(\\d+)/)||[])[1]`);
+function unwrapEvaluateResult(payload) {
+    if (payload && typeof payload === 'object' && typeof payload.session === 'string' && Object.hasOwn(payload, 'data')) {
+        return payload.data;
+    }
+    return payload;
+}
+
+async function evaluate(page, script) {
+    return unwrapEvaluateResult(await page.evaluate(script));
+}
+
+function isRecoverableFileInputError(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return /unknown action|not supported|not[-\s]?allowed|notallowederror/i.test(message);
+}
+
+function resolveCoverImage(rawPath) {
+    const value = String(rawPath ?? '').trim();
+    if (!value) throw new ArgumentError('weixin create-draft cover-image cannot be empty');
+    const absPath = path.resolve(value);
+    let stat;
+    try {
+        stat = fs.statSync(absPath);
+    } catch {
+        throw new ArgumentError(`weixin create-draft cover-image does not exist: ${absPath}`);
+    }
+    if (!stat.isFile()) {
+        throw new ArgumentError(`weixin create-draft cover-image is not a file: ${absPath}`);
+    }
+    const extension = path.extname(absPath).toLowerCase();
+    const mimeType = IMAGE_MIME_TYPES.get(extension);
+    if (!mimeType) {
+        throw new ArgumentError('weixin create-draft cover-image must be JPEG, PNG, GIF, or WebP');
+    }
+    return { absPath, fileName: path.basename(absPath), mimeType };
 }
 
 async function navigateToEditor(page) {
     await page.goto(WEIXIN_HOME);
     await page.wait(3);
-    const token = await getToken(page);
+    const token = await evaluate(page, `(window.location.href.match(/token=(\\d+)/)||[])[1]`);
     if (!token) {
-        throw new CommandExecutionError('Could not extract session token. Please log in to mp.weixin.qq.com');
+        throw new AuthRequiredError(WEIXIN_DOMAIN, 'Please log in to the WeChat Official Account platform and retry.');
     }
     await page.goto(`https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2&action=edit&isNew=1&type=77&token=${token}&lang=zh_CN`);
     await page.wait(4);
-    const hasTitle = await page.evaluate('!!document.querySelector("textarea#title")');
-    if (!hasTitle) {
-        throw new CommandExecutionError('Article editor did not load. Session may have expired');
+    const hasTitle = await evaluate(page, '!!document.querySelector("textarea#title")');
+    if (hasTitle !== true) {
+        throw new CommandExecutionError('WeChat article editor did not load. The session may have expired.');
     }
 }
 
 async function fillField(page, selector, value) {
-    return page.evaluate(`(() => {
-        var el = document.querySelector('${selector}');
-        if (!el) return { ok: false, reason: 'not found: ${selector}' };
+    return evaluate(page, `(() => {
+        var el = document.querySelector(${JSON.stringify(selector)});
+        if (!el) return { ok: false, reason: 'field not found' };
         el.focus();
         var proto = el.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
         var setter = Object.getOwnPropertyDescriptor(proto, 'value');
@@ -40,7 +83,7 @@ async function fillField(page, selector, value) {
 }
 
 async function fillContent(page, text) {
-    return page.evaluate(`(() => {
+    return evaluate(page, `(() => {
         var editors = document.querySelectorAll('div[contenteditable="true"]');
         var editor = editors[editors.length - 1];
         if (!editor) return { ok: false, reason: 'content editor not found' };
@@ -53,121 +96,178 @@ async function fillContent(page, text) {
     })()`);
 }
 
-async function uploadContentImage(page, imagePath) {
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    const absPath = path.default.resolve(imagePath);
-    if (!fs.default.existsSync(absPath)) {
-        throw new CommandExecutionError(`Image not found: ${absPath}`);
-    }
-    if (!page.setFileInput) {
-        throw new CommandExecutionError('Image upload requires Browser Bridge with CDP support');
-    }
-
-    await page.evaluate(`(() => {
-        var li = document.querySelector('#js_editor_insertimage');
-        if (li) li.click();
-    })()`);
-    await page.wait(1);
-    await page.evaluate(`(() => {
-        var items = document.querySelectorAll('.js_img_dropdown_menu .tpl_dropdown_menu_item');
-        if (items[0]) items[0].click();
-    })()`);
-    await page.wait(1);
-
-    await page.setFileInput([absPath], 'input[type="file"][name="file"]');
-    await page.wait(8);
-
-    const cdnCount = await page.evaluate(`(() => {
+async function readCdnImageKeys(page) {
+    const keys = await evaluate(page, `(() => {
         var editor = document.querySelector('#ueditor_0');
-        return editor ? editor.querySelectorAll('img[src*="mmbiz"]').length : 0;
+        if (!editor) return [];
+        return Array.from(editor.querySelectorAll('img')).map(function(img) {
+            return img.getAttribute('data-src') || img.getAttribute('src') || '';
+        }).filter(function(src) { return /(?:mmbiz|qpic\\.cn)/i.test(src); });
     })()`);
-    if (cdnCount === 0) {
-        throw new CommandExecutionError('Image did not upload to WeChat CDN');
+    if (!Array.isArray(keys)) {
+        throw new CommandExecutionError('WeChat image upload returned a malformed editor image payload.');
     }
+    return keys.map(String);
+}
+
+async function injectImageFile(page, image) {
+    if (typeof page.setFileInput === 'function') {
+        try {
+            await page.setFileInput([image.absPath], IMAGE_FILE_INPUT_SELECTOR);
+            return;
+        } catch (error) {
+            if (!isRecoverableFileInputError(error)) {
+                const message = error instanceof Error ? error.message : String(error);
+                throw new CommandExecutionError(`WeChat image upload failed: ${message}`);
+            }
+        }
+    }
+
+    const base64 = fs.readFileSync(image.absPath).toString('base64');
+    const fallback = await evaluate(page, `(() => {
+        var input = document.querySelector(${JSON.stringify(IMAGE_FILE_INPUT_SELECTOR)});
+        if (!input) return { ok: false, reason: 'image file input not found' };
+        try {
+            var binary = atob(${JSON.stringify(base64)});
+            var bytes = new Uint8Array(binary.length);
+            for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            var transfer = new DataTransfer();
+            transfer.items.add(new File([bytes], ${JSON.stringify(image.fileName)}, { type: ${JSON.stringify(image.mimeType)} }));
+            var descriptor = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'files');
+            if (descriptor && descriptor.set) descriptor.set.call(input, transfer.files);
+            else input.files = transfer.files;
+            if (!input.files || input.files.length !== 1) return { ok: false, reason: 'file input rejected fallback file' };
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            return { ok: true };
+        } catch (error) {
+            return { ok: false, reason: String(error && error.message || error) };
+        }
+    })()`);
+    if (!fallback?.ok) {
+        throw new CommandExecutionError(`WeChat image upload fallback failed: ${fallback?.reason || 'unknown error'}`);
+    }
+}
+
+async function uploadContentImage(page, image) {
+    const previousKeys = await readCdnImageKeys(page);
+    const opened = await evaluate(page, `(() => {
+        var button = document.querySelector('#js_editor_insertimage');
+        if (!button) return { ok: false, reason: 'insert-image button not found' };
+        button.click();
+        return { ok: true };
+    })()`);
+    if (!opened?.ok) throw new CommandExecutionError(`Could not open WeChat image upload: ${opened?.reason || 'unknown error'}`);
+    await page.wait(1);
+
+    const selected = await evaluate(page, `(() => {
+        var item = document.querySelector('.js_img_dropdown_menu .tpl_dropdown_menu_item');
+        if (!item) return { ok: false, reason: 'upload menu item not found' };
+        item.click();
+        return { ok: true };
+    })()`);
+    if (!selected?.ok) throw new CommandExecutionError(`Could not select WeChat image upload: ${selected?.reason || 'unknown error'}`);
+    await page.wait(1);
+    await injectImageFile(page, image);
+
+    for (let attempt = 0; attempt < 15; attempt++) {
+        await page.wait(2);
+        const state = await evaluate(page, `(() => {
+            var previous = new Set(${JSON.stringify(previousKeys)});
+            var editor = document.querySelector('#ueditor_0');
+            var images = editor ? Array.from(editor.querySelectorAll('img')) : [];
+            var key = images.map(function(img) {
+                return img.getAttribute('data-src') || img.getAttribute('src') || '';
+            }).find(function(src) { return /(?:mmbiz|qpic\\.cn)/i.test(src) && !previous.has(src); });
+            var errorText = Array.from(document.querySelectorAll('.weui-desktop-tips, .weui-desktop-toast, .js_msgSenderTips'))
+                .filter(function(el) { return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length); })
+                .map(function(el) { return (el.innerText || el.textContent || '').trim(); })
+                .filter(Boolean).join('\\n');
+            return { ok: !!key, errorText: errorText };
+        })()`);
+        if (state?.ok) return;
+        if (state?.errorText && /(无法解析|上传失败|过大|频繁|不支持|错误)/.test(state.errorText)) {
+            throw new CommandExecutionError(`WeChat image upload failed: ${state.errorText}`);
+        }
+    }
+    throw new CommandExecutionError('WeChat image upload timed out before a new CDN image appeared in the editor.');
 }
 
 async function selectCoverFromContent(page) {
-    await page.evaluate('document.querySelector("#js_cover_description_area")?.scrollIntoView()');
+    await evaluate(page, 'document.querySelector("#js_cover_description_area")?.scrollIntoView()');
     await page.wait(1);
-
-    await page.evaluate('document.querySelector(".js_cover_btn_area")?.click()');
+    await evaluate(page, 'document.querySelector(".js_cover_btn_area")?.click()');
     await page.wait(1);
-
-    await page.evaluate(`(() => {
-        var links = document.querySelectorAll('a.pop-opr__button');
-        for (var i = 0; i < links.length; i++) {
-            if (links[i].textContent.trim() === '从正文选择') { links[i].click(); return; }
-        }
+    await evaluate(page, `(() => {
+        var link = Array.from(document.querySelectorAll('a.pop-opr__button')).find(function(el) {
+            return (el.textContent || '').trim() === '从正文选择';
+        });
+        if (link) link.click();
     })()`);
     await page.wait(2);
-
-    await page.evaluate(`(() => {
-        var img = document.querySelector('.weui-desktop-dialog_img-picker .appmsg_content_img');
-        if (img) img.click();
-    })()`);
+    await evaluate(page, `document.querySelector('.weui-desktop-dialog_img-picker .appmsg_content_img')?.click()`);
     await page.wait(1);
-
-    await page.evaluate(`(() => {
-        var btns = document.querySelectorAll('.weui-desktop-dialog_img-picker button');
-        for (var i = 0; i < btns.length; i++) {
-            if (btns[i].textContent.trim() === '下一步' && !btns[i].disabled) { btns[i].click(); return; }
-        }
+    await evaluate(page, `(() => {
+        var button = Array.from(document.querySelectorAll('.weui-desktop-dialog_img-picker button')).find(function(el) {
+            return (el.textContent || '').trim() === '下一步' && !el.disabled;
+        });
+        if (button) button.click();
     })()`);
 
-    // Crop dialog image rendering can be slow
     for (let attempt = 0; attempt < 8; attempt++) {
         await page.wait(2);
-        const ready = await page.evaluate(`(() => {
-            var btns = document.querySelectorAll('button');
-            for (var i = 0; i < btns.length; i++) {
-                if (btns[i].textContent.trim() === '确认' && btns[i].offsetHeight > 0 && !btns[i].disabled) return true;
-            }
-            return false;
+        const confirmed = await evaluate(page, `(() => {
+            var button = Array.from(document.querySelectorAll('button')).find(function(el) {
+                return (el.textContent || '').trim() === '确认' && !el.disabled && !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+            });
+            if (!button) return false;
+            button.click();
+            return true;
         })()`);
-        if (ready) break;
+        if (confirmed === true) break;
     }
 
-    await page.evaluate(`(() => {
-        var btns = document.querySelectorAll('button');
-        for (var i = 0; i < btns.length; i++) {
-            if (btns[i].textContent.trim() === '确认' && btns[i].offsetHeight > 0 && !btns[i].disabled) { btns[i].click(); return; }
-        }
-    })()`);
     await page.wait(2);
-    const hasCover = await page.evaluate(`(() => {
+    return evaluate(page, `(() => {
         var area = document.querySelector('#js_cover_area');
         if (!area) return false;
-        var found = false;
-        area.querySelectorAll('*').forEach(function(el) {
-            var bg = window.getComputedStyle(el).backgroundImage;
-            if (bg && bg.includes('mmbiz')) found = true;
+        if (area.querySelector('img[src*="mmbiz"], img[src*="qpic.cn"], img[data-src*="mmbiz"], img[data-src*="qpic.cn"]')) return true;
+        return Array.from(area.querySelectorAll('*')).some(function(el) {
+            return /(?:mmbiz|qpic\\.cn)/i.test(window.getComputedStyle(el).backgroundImage || '');
         });
-        return found;
     })()`);
-    return hasCover;
 }
 
-async function clickSaveDraft(page) {
-    const result = await page.evaluate(`(() => {
-        var btns = document.querySelectorAll('span, button, a');
-        for (var i = 0; i < btns.length; i++) {
-            if ((btns[i].textContent || '').trim() === '保存为草稿') { btns[i].click(); return { ok: true }; }
-        }
-        return { ok: false };
+async function readSaveState(page) {
+    return evaluate(page, `(() => {
+        var elements = Array.from(document.querySelectorAll('#js_save_success, .weui-desktop-toast, .weui-desktop-tips'));
+        var text = elements.filter(function(el) {
+            return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+        }).map(function(el) {
+            return (el.innerText || el.textContent || '').replace(/\\s+/g, ' ').trim();
+        }).find(function(value) { return /已保存|保存成功/.test(value); }) || '';
+        return { visible: !!text, text: text };
     })()`);
-    if (!result?.ok) throw new CommandExecutionError('Save draft button not found');
+}
 
-    for (let attempt = 0; attempt < 5; attempt++) {
-        await page.wait(2);
-        const saved = await page.evaluate(`(() => {
-            var el = document.querySelector('#js_save_success');
-            if (el && window.getComputedStyle(el).display !== 'none') return true;
-            return document.body.innerText.includes('已保存');
-        })()`);
-        if (saved) return true;
+async function saveDraft(page) {
+    const before = await readSaveState(page);
+    const result = await evaluate(page, `(() => {
+        var button = Array.from(document.querySelectorAll('span, button, a')).find(function(el) {
+            return (el.textContent || '').trim() === '保存为草稿' && !el.disabled;
+        });
+        if (!button) return { ok: false };
+        button.click();
+        return { ok: true };
+    })()`);
+    if (!result?.ok) throw new CommandExecutionError('WeChat save-draft button was not found.');
+
+    for (let attempt = 0; attempt < 8; attempt++) {
+        await page.wait(1);
+        const state = await readSaveState(page);
+        if (state?.visible && (!before?.visible || state.text !== before.text)) return;
     }
-    return false;
+    throw new CommandExecutionError('WeChat draft save was not confirmed by a fresh success status.');
 }
 
 export const createDraftCommand = cli({
@@ -190,37 +290,41 @@ export const createDraftCommand = cli({
     columns: ['status', 'detail'],
 
     func: async (page, kwargs) => {
-        await navigateToEditor(page);
+        try {
+            const coverImage = kwargs['cover-image'] ? resolveCoverImage(kwargs['cover-image']) : null;
+            await navigateToEditor(page);
 
-        const titleResult = await fillField(page, 'textarea#title', kwargs.title);
-        if (!titleResult?.ok) throw new CommandExecutionError('Failed to fill title');
-
-        if (kwargs.author) {
-            const authorResult = await fillField(page, 'input#author', kwargs.author);
-            if (!authorResult?.ok) throw new CommandExecutionError('Failed to fill author');
-        }
-
-        const contentResult = await fillContent(page, kwargs.content);
-        if (!contentResult?.ok) throw new CommandExecutionError('Failed to fill content');
-
-        if (kwargs['cover-image']) {
-            await uploadContentImage(page, kwargs['cover-image']);
-            const coverSet = await selectCoverFromContent(page);
-            if (!coverSet) {
-                // Non-fatal: draft can be saved without cover
+            const titleResult = await fillField(page, 'textarea#title', kwargs.title);
+            if (!titleResult?.ok) throw new CommandExecutionError('Failed to fill title');
+            if (kwargs.author) {
+                const authorResult = await fillField(page, 'input#author', kwargs.author);
+                if (!authorResult?.ok) throw new CommandExecutionError('Failed to fill author');
             }
+            const contentResult = await fillContent(page, kwargs.content);
+            if (!contentResult?.ok) throw new CommandExecutionError('Failed to fill content');
+
+            if (coverImage) {
+                await uploadContentImage(page, coverImage);
+                const coverSet = await selectCoverFromContent(page);
+                if (coverSet !== true) {
+                    throw new CommandExecutionError('WeChat uploaded the image but did not confirm it as the draft cover.');
+                }
+            }
+
+            if (kwargs.summary) {
+                const summaryResult = await fillField(page, 'textarea#js_description', kwargs.summary);
+                if (!summaryResult?.ok) throw new CommandExecutionError('Failed to fill summary');
+            }
+
+            await saveDraft(page);
+            return [{
+                status: 'draft saved',
+                detail: `"${kwargs.title}"${kwargs.author ? ` by ${kwargs.author}` : ''}${coverImage ? ' (with cover)' : ''}`,
+            }];
+        } catch (error) {
+            if (error instanceof CliError) throw error;
+            const message = error instanceof Error ? error.message : String(error);
+            throw new CommandExecutionError(`WeChat create-draft failed: ${message}`);
         }
-
-        if (kwargs.summary) {
-            await fillField(page, 'textarea#js_description', kwargs.summary);
-        }
-
-        await page.wait(1);
-        const success = await clickSaveDraft(page);
-
-        return [{
-            status: success ? 'draft saved' : 'save attempted, check browser to confirm',
-            detail: `"${kwargs.title}"${kwargs.author ? ` by ${kwargs.author}` : ''}${kwargs['cover-image'] ? ' (with cover)' : ''}`,
-        }];
     },
 });

--- a/clis/weixin/drafts.test.js
+++ b/clis/weixin/drafts.test.js
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
-import { AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { getRegistry } from '@jackwener/opencli/registry';
 import './create-draft.js';
 import './drafts.js';
@@ -10,9 +13,54 @@ function createPageMock(overrides = {}) {
         goto: vi.fn().mockResolvedValue(undefined),
         wait: vi.fn().mockResolvedValue(undefined),
         evaluate: overrides.evaluate ?? vi.fn().mockResolvedValue(undefined),
-        setFileInput: vi.fn().mockResolvedValue(undefined),
+        setFileInput: Object.hasOwn(overrides, 'setFileInput')
+            ? overrides.setFileInput
+            : vi.fn().mockResolvedValue(undefined),
     };
 }
+
+function envelope(data) {
+    return { session: 'site:weixin:test', data };
+}
+
+function createDraftEvaluate({ uploadReady = true, coverSelected = true, saveConfirmed = true, fallbackOk = true } = {}) {
+    let saveStateReads = 0;
+    return vi.fn().mockImplementation(async (script) => {
+        if (script.includes('window.location.href.match')) return envelope('123456');
+        if (script.includes('!!document.querySelector("textarea#title")')) return envelope(true);
+        if (script.includes("reason: 'field not found'")) return envelope({ ok: true });
+        if (script.includes("reason: 'content editor not found'")) return envelope({ ok: true });
+        if (script.includes("return Array.from(editor.querySelectorAll('img')).map")) return envelope([]);
+        if (script.includes("document.querySelector('#js_editor_insertimage')")) return envelope({ ok: true });
+        if (script.includes("document.querySelector('.js_img_dropdown_menu .tpl_dropdown_menu_item')")) return envelope({ ok: true });
+        if (script.includes('var transfer = new DataTransfer()')) return envelope(fallbackOk ? { ok: true } : { ok: false, reason: 'input rejected file' });
+        if (script.includes('var previous = new Set')) return envelope({ ok: uploadReady, errorText: '' });
+        if (script.includes("(el.textContent || '').trim() === '确认'")) return envelope(true);
+        if (script.includes("var area = document.querySelector('#js_cover_area')")) return envelope(coverSelected);
+        if (script.includes("find(function(value) { return /已保存|保存成功/.test(value); })")) {
+            saveStateReads += 1;
+            return envelope(saveStateReads === 1 || !saveConfirmed
+                ? { visible: false, text: '' }
+                : { visible: true, text: '保存成功' });
+        }
+        if (script.includes("=== '保存为草稿'")) return envelope({ ok: true });
+        return envelope(undefined);
+    });
+}
+
+const tempDirs = [];
+
+function createTempImage() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-weixin-'));
+    tempDirs.push(dir);
+    const imagePath = path.join(dir, 'cover.png');
+    fs.writeFileSync(imagePath, 'fake-png');
+    return imagePath;
+}
+
+afterEach(() => {
+    while (tempDirs.length) fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+});
 
 describe('weixin command registration', () => {
     it('registers create-draft and drafts commands', () => {
@@ -65,5 +113,101 @@ describe('weixin drafts command', () => {
         expect(result).toEqual([
             { Index: 1, Title: '第一篇草稿', Time: '2026-04-24 10:00' },
         ]);
+    });
+});
+
+describe('weixin create-draft cover upload', () => {
+    const command = getRegistry().get('weixin/create-draft');
+
+    it('rejects a missing cover file before browser navigation', async () => {
+        const page = createPageMock();
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': '/definitely/missing/cover.png',
+        })).rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('maps raw browser failures to CommandExecutionError', async () => {
+        const page = createPageMock({ evaluate: vi.fn().mockRejectedValue(new Error('bridge disconnected')) });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('uses setFileInput and only reports success after upload, cover, and save postconditions', async () => {
+        const imagePath = createTempImage();
+        const page = createPageMock({ evaluate: createDraftEvaluate() });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': imagePath,
+        })).resolves.toEqual([{ status: 'draft saved', detail: '"测试草稿" (with cover)' }]);
+        expect(page.setFileInput).toHaveBeenCalledWith([imagePath], 'input[type="file"][name="file"]');
+    });
+
+    it('falls back to DataTransfer for stale-extension upload errors and unwraps bridge envelopes', async () => {
+        const imagePath = createTempImage();
+        const evaluate = createDraftEvaluate();
+        const setFileInput = vi.fn().mockRejectedValue(new Error('Unknown action: set-file-input'));
+        const page = createPageMock({ evaluate, setFileInput });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': imagePath,
+        })).resolves.toEqual([{ status: 'draft saved', detail: '"测试草稿" (with cover)' }]);
+        expect(setFileInput).toHaveBeenCalledOnce();
+        expect(evaluate.mock.calls.some(([script]) => script.includes('var transfer = new DataTransfer()'))).toBe(true);
+    });
+
+    it('does not hide hard setFileInput failures behind the fallback', async () => {
+        const imagePath = createTempImage();
+        const evaluate = createDraftEvaluate();
+        const page = createPageMock({
+            evaluate,
+            setFileInput: vi.fn().mockRejectedValue(new Error('No element found matching selector')),
+        });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': imagePath,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+        expect(evaluate.mock.calls.some(([script]) => script.includes('var transfer = new DataTransfer()'))).toBe(false);
+    });
+
+    it.each([
+        ['new CDN image', { uploadReady: false }],
+        ['selected cover', { coverSelected: false }],
+        ['fresh save confirmation', { saveConfirmed: false }],
+    ])('fails closed when it cannot prove the %s postcondition', async (_label, scenario) => {
+        const imagePath = createTempImage();
+        const page = createPageMock({ evaluate: createDraftEvaluate(scenario) });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': imagePath,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps a rejected DataTransfer fallback to a typed failure', async () => {
+        const imagePath = createTempImage();
+        const page = createPageMock({
+            evaluate: createDraftEvaluate({ fallbackOk: false }),
+            setFileInput: vi.fn().mockRejectedValue(new Error('NotAllowedError: Not allowed')),
+        });
+
+        await expect(command.func(page, {
+            title: '测试草稿',
+            content: '测试正文',
+            'cover-image': imagePath,
+        })).rejects.toBeInstanceOf(CommandExecutionError);
     });
 });


### PR DESCRIPTION
## Problem

`weixin create-draft --cover-image` currently requires `page.setFileInput`. That method is optional on `IPage`, and stale Browser Bridge versions can reject it with `Unknown action` / `Not allowed`, so a valid local cover image cannot be attached even though the page can accept a `DataTransfer` file.

This is the clean replacement for #2105. The original PR identified the real Weixin failure, but its current diff also includes unrelated Medium, Pinterest, manifest, docs, and Weixin feature work on the contributor fork's default `main` branch. This PR preserves the useful fix without rewriting that default branch or carrying unrelated scope.

## Solution

- Keep `setFileInput` as the primary upload path.
- Fall back to a browser-side `DataTransfer` only when the file-input capability is missing or returns an explicit stale/unsupported error; hard selector/runtime failures do not silently fall through.
- Validate the cover path/type before navigation.
- Unwrap Browser Bridge `{ session, data }` results.
- Require a newly observed WeChat CDN image, a selected cover preview, and a fresh save-success signal before returning `draft saved`.
- Map login, input, bridge/network, upload, timeout, cover, and save failures to typed OpenCLI errors.

## Validation

- `npm run test:adapter -- --reporter=verbose clis/weixin` — 3 files / 45 tests passed
- `npm run typecheck`
- `npm run build` — manifest 1332
- `npm run docs:build`
- `npm run check:typed-error-lint` — new=0
- `npm run check:silent-column-drop` — new=0
- `npm run advise:listing-id-pairing` — advisory only
- `node --check clis/weixin/create-draft.js`
- `git diff --check`
