### PR TITLE
chore(xiaohongshu): share evaluate unwrap helper

### DIFF
--- a/clis/rednote/search.js
+++ b/clis/rednote/search.js
@@ -7,7 +7,8 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate, unwrapEvaluateResult } from '../xiaohongshu/search.js';
+import { buildScrollUntilJs, buildSearchExtractJs, noteIdToDate } from '../xiaohongshu/search.js';
+import { unwrapEvaluateResult } from '../xiaohongshu/shared.js';
 
 function parseLimit(raw) {
     const parsed = Number(raw);

--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -8,6 +8,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 const XHS_WEB_HOST = 'www.xiaohongshu.com';
 const ASK_COLUMNS = [
@@ -21,13 +22,6 @@ const ASK_COLUMNS = [
     'message_id',
     'conversation_id',
 ];
-
-export function unwrapEvaluateResult(payload) {
-    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
-}
 
 function parseBoundedInteger(raw, defaultValue, min, max, label) {
     const value = raw ?? defaultValue;

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -8,7 +8,6 @@ import {
     normalizeAskSource,
     parseAskLimit,
     parseAskTimeout,
-    unwrapEvaluateResult,
 } from './ask.js';
 import './ask.js';
 
@@ -174,9 +173,6 @@ describe('xiaohongshu ask', () => {
         });
     });
 
-    it('unwraps Browser Bridge envelopes', () => {
-        expect(unwrapEvaluateResult({ session: 'site:xiaohongshu', data: { ok: true } })).toEqual({ ok: true });
-    });
 
     it('runs the page evaluate path and normalizes returned sources', async () => {
         const cmd = getRegistry().get('xiaohongshu/ask');

--- a/clis/xiaohongshu/creator-notes.js
+++ b/clis/xiaohongshu/creator-notes.js
@@ -9,6 +9,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 const DATE_LINE_RE = /^发布于 (\d{4}年\d{2}月\d{2}日 \d{2}:\d{2})$/;
 const METRIC_LINE_RE = /^\d+$/;
 const VISIBILITY_LINE_RE = /可见$/;
@@ -107,12 +108,6 @@ function mapAnalyzeItems(items) {
         comments: item.comment_count ?? 0,
         url: buildNoteDetailUrl(item.id),
     }));
-}
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
 }
 // Capture the dashboard's signed /api/galaxy/* responses on window.__xhsCapture
 // since a direct fetch() from page.evaluate bypasses the x-s signing and gets 406.
@@ -475,5 +470,4 @@ export const __test__ = {
     harvestAnalyzeListCaptures,
     isAnalyzeCaptureComplete,
     parseCaptureMapPayload,
-    unwrapEvaluateResult,
 };

--- a/clis/xiaohongshu/delete-note.js
+++ b/clis/xiaohongshu/delete-note.js
@@ -14,18 +14,13 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 const NOTE_MANAGER_URL = 'https://creator.xiaohongshu.com/new/note-manager';
 const ROW_SETTLE_MS = 3000;
 const MODAL_SETTLE_MS = 2000;
 const VERIFY_TIMEOUT_MS = 10_000;
 const VERIFY_POLL_MS = 1000;
 const NOTE_ID_RE = /^[0-9a-f]{24}$/i;
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
-}
 function requireEvaluateString(payload, context) {
     if (typeof payload !== 'string') {
         throw new CommandExecutionError(`xiaohongshu/delete-note: malformed ${context} payload`);

--- a/clis/xiaohongshu/feed.js
+++ b/clis/xiaohongshu/feed.js
@@ -14,6 +14,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 
 function parseLimit(raw) {
     const parsed = Number(raw ?? 20);
@@ -67,13 +68,6 @@ const FEEDS_READ_JS = `
 
 function toCleanString(value) {
     return typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
 }
 
 /**

--- a/clis/xiaohongshu/follow.js
+++ b/clis/xiaohongshu/follow.js
@@ -18,6 +18,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { normalizeXhsUserId } from './user-helpers.js';
+import { unwrapEvaluateResult } from './shared.js';
 
 const PROFILE_SETTLE_MS = 2500;
 const STATE_FLIP_TIMEOUT_MS = 5000;
@@ -26,13 +27,6 @@ const USER_ID_RE = /^[a-zA-Z0-9]{8,32}$/;
 function isXiaohongshuHost(hostname) {
     const host = String(hostname || '').toLowerCase();
     return host === 'xiaohongshu.com' || host.endsWith('.xiaohongshu.com');
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
 }
 
 function requireActionResult(payload, context) {

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -7,6 +7,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, 'login_wall' if login gate
@@ -241,19 +242,6 @@ function extractSearchRows(webHost) {
     return results;
 }
 
-/**
- * `page.evaluate` may return either the raw IIFE value or a
- * `{ session, data }` envelope depending on the browser-bridge version.
- * Adapter code that called `Array.isArray(payload)` directly on the
- * envelope silently received [] for every search. This helper normalizes
- * both shapes so callers can keep their Array.isArray checks unchanged.
- */
-export function unwrapEvaluateResult(payload) {
-    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
-}
 function isTrustedAuthorUrl(url, webHost) {
     if (url === '')
         return true;

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -11,7 +11,6 @@ import {
     noteKeyFromUrl,
     noteUrlInfo,
     shouldStopScrolling,
-    unwrapEvaluateResult,
     usableRowCount,
 } from './search.js';
 
@@ -615,31 +614,5 @@ describe('noteIdToDate (ObjectID timestamp parsing)', () => {
     it('returns empty string when timestamp is out of range', () => {
         // All zeros → ts = 0
         expect(noteIdToDate('https://www.xiaohongshu.com/search_result/000000000000000000000000')).toBe('');
-    });
-});
-describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
-    it('returns the raw array unchanged when payload is already an array', () => {
-        const arr = [{ title: 'a' }, { title: 'b' }];
-        expect(unwrapEvaluateResult(arr)).toBe(arr);
-    });
-    it('unwraps { session, data: [...] } envelope to the inner array', () => {
-        const arr = [{ title: 'a' }];
-        const env = { session: 'site:xiaohongshu:abc', data: arr };
-        expect(unwrapEvaluateResult(env)).toBe(arr);
-    });
-    it('unwraps primitive data from Browser Bridge envelopes', () => {
-        expect(unwrapEvaluateResult({ session: 'site:xiaohongshu:abc', data: 'login_wall' })).toBe('login_wall');
-    });
-    it('passes non-envelope objects through unchanged', () => {
-        const obj = { results: [], loginWall: true };
-        expect(unwrapEvaluateResult(obj)).toBe(obj);
-    });
-    it('handles null and undefined safely', () => {
-        expect(unwrapEvaluateResult(null)).toBe(null);
-        expect(unwrapEvaluateResult(undefined)).toBe(undefined);
-    });
-    it('unwraps non-array envelope data so callers can validate the payload shape', () => {
-        const env = { session: 'x', data: { not: 'an array' } };
-        expect(unwrapEvaluateResult(env)).toEqual({ not: 'an array' });
     });
 });

--- a/clis/xiaohongshu/shared.js
+++ b/clis/xiaohongshu/shared.js
@@ -1,0 +1,10 @@
+/**
+ * Unwrap a Browser Bridge `{ session, data }` envelope while preserving raw
+ * payload identity. Named array properties do not survive Bridge/CDP JSON.
+ */
+export function unwrapEvaluateResult(payload) {
+    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
+        return payload.data;
+    }
+    return payload;
+}

--- a/clis/xiaohongshu/shared.test.js
+++ b/clis/xiaohongshu/shared.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { unwrapEvaluateResult } from './shared.js';
+
+describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
+    it('returns non-envelope arrays by identity', () => {
+        const arr = [{ id: '1' }];
+        expect(unwrapEvaluateResult(arr)).toBe(arr);
+    });
+    it('unwraps the { session, data } envelope by identity', () => {
+        const data = { ok: true };
+        const env = { session: 'site:xiaohongshu', data };
+        expect(unwrapEvaluateResult(env)).toBe(data);
+    });
+    it('unwraps scalar data payloads', () => {
+        expect(unwrapEvaluateResult({ session: 'site:xiaohongshu:abc', data: 'login_wall' })).toBe('login_wall');
+    });
+    it('passes through plain objects without both envelope keys', () => {
+        const obj = { session: 'only-session' };
+        expect(unwrapEvaluateResult(obj)).toBe(obj);
+        const dataOnly = { data: [1] };
+        expect(unwrapEvaluateResult(dataOnly)).toBe(dataOnly);
+    });
+    it('passes through raw JSON primitives', () => {
+        expect(unwrapEvaluateResult(null)).toBe(null);
+        expect(unwrapEvaluateResult(42)).toBe(42);
+    });
+});

--- a/clis/xiaohongshu/unfollow.js
+++ b/clis/xiaohongshu/unfollow.js
@@ -13,6 +13,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { normalizeXhsUserId } from './user-helpers.js';
+import { unwrapEvaluateResult } from './shared.js';
 
 const PROFILE_SETTLE_MS = 2500;
 const MODAL_SETTLE_MS = 1500;
@@ -22,13 +23,6 @@ const USER_ID_RE = /^[a-zA-Z0-9]{8,32}$/;
 function isXiaohongshuHost(hostname) {
     const host = String(hostname || '').toLowerCase();
     return host === 'xiaohongshu.com' || host.endsWith('.xiaohongshu.com');
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
 }
 
 function requireActionResult(payload, context) {


### PR DESCRIPTION
## Summary

Collapse the seven local `unwrapEvaluateResult` copies in `clis/xiaohongshu/` (ask, feed, search, creator-notes, delete-note, follow, unfollow) into one adapter-local `clis/xiaohongshu/shared.js` export, and point the cross-site consumer `clis/rednote/search.js` at it.

## Equivalence

The seven copies span three textual variants differing only in an `Array.isArray` guard and condition order. For Browser Bridge JSON-reachable values, arrays cannot retain custom named `session` / `data` properties across serialization, so all variants have the same behavior. The canonical shared copy keeps the explicit array guard.

Ownership stays at the narrow leaf module `clis/xiaohongshu/shared.js`; Rednote imports that leaf directly. The new import graph is one-way and acyclic, and the build validates the cross-site path.

## Test net account

- Shared contract coverage keeps only reachable behavior: raw array identity, `{ session, data }` envelope identity, scalar data unwrapping, partial-envelope object passthrough, and raw JSON primitive passthrough.
- Redundant per-consumer helper exports and tests are removed, including the orphaned search source comment.
- Net diff: 46 additions / 86 deletions across 12 files.

## Gates (exact head `313bd2b3`, base `c003a1b1`)

- XHS + Rednote adapter tests: 23 files / 336 tests passed
- typecheck passed
- build / manifest passed (1332 entries)
- docs build passed
- touched-file and dist syntax checks passed
- typed-error lint: new=0, resolved=4
- silent-column-drop: new=0, resolved=2
- listing-id advisory: 14 (non-gating)
- production high audit: 0 vulnerabilities
- diff-check and merge-tree clean
