### PR TITLE
refactor(sinafinance): use rolling news API

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -32949,9 +32949,9 @@
     "name": "rolling-news",
     "description": "新浪财经滚动新闻",
     "access": "read",
-    "domain": "finance.sina.com.cn/roll",
-    "strategy": "cookie",
-    "browser": true,
+    "domain": "feed.mix.sina.com.cn",
+    "strategy": "public",
+    "browser": false,
     "args": [],
     "columns": [
       "column",
@@ -32961,8 +32961,7 @@
     ],
     "type": "js",
     "modulePath": "sinafinance/rolling-news.js",
-    "sourceFile": "sinafinance/rolling-news.js",
-    "navigateBefore": "https://finance.sina.com.cn/roll"
+    "sourceFile": "sinafinance/rolling-news.js"
   },
   {
     "site": "sinafinance",

--- a/clis/sinafinance/rolling-news.js
+++ b/clis/sinafinance/rolling-news.js
@@ -1,41 +1,90 @@
 /**
- * Sinafinance rolling news feed
+ * Sina Finance rolling news feed.
+ *
+ * The roll page itself loads this public JSON endpoint and renders the rows.
+ * Calling it directly avoids a browser launch and preserves the visible page
+ * contract (财经 column, title, China-local timestamp, article URL).
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+const ROLL_API = 'https://feed.mix.sina.com.cn/api/roll/get';
+
+function pad2(value) {
+    return String(value).padStart(2, '0');
+}
+
+function formatRollTimestamp(value) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds <= 0)
+        return '';
+    // Sina's roll page presents finance news in China Standard Time.
+    const date = new Date(seconds * 1000 + 8 * 60 * 60 * 1000);
+    return `${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())} ${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`;
+}
+
+function normalizeRollRows(payload) {
+    if (payload?.result?.status?.code !== 0) {
+        throw new CommandExecutionError(`Sina Finance rolling news API failed: ${payload?.result?.status?.msg || 'unknown status'}`);
+    }
+    const items = payload?.result?.data;
+    if (!Array.isArray(items)) {
+        throw new CommandExecutionError('Sina Finance rolling news API returned malformed data');
+    }
+    if (items.length === 0) {
+        throw new EmptyResultError('sinafinance rolling-news');
+    }
+    return items.map((item, index) => {
+        const title = typeof item?.title === 'string' ? item.title.trim() : '';
+        const url = typeof item?.url === 'string' ? item.url.trim() : '';
+        const date = formatRollTimestamp(item?.ctime);
+        if (!title || !url || !date) {
+            throw new CommandExecutionError(`Sina Finance rolling news API returned malformed row ${index + 1}`);
+        }
+        return {
+            column: '财经',
+            title,
+            date,
+            url,
+        };
+    });
+}
+
 cli({
     site: 'sinafinance',
     name: 'rolling-news',
     access: 'read',
     description: '新浪财经滚动新闻',
-    domain: 'finance.sina.com.cn/roll',
-    strategy: Strategy.COOKIE,
+    domain: 'feed.mix.sina.com.cn',
+    strategy: Strategy.PUBLIC,
+    browser: false,
     args: [],
     columns: ['column', 'title', 'date', 'url'],
-    func: async (page, _args) => {
-        await page.goto(`https://finance.sina.com.cn/roll/#pageid=384&lid=2519`);
-        await page.wait({ selector: '.d_list_txt li', timeout: 10000 });
-        const payload = await page.evaluate(`
-      (() => {
-        const cleanText = (value) => (value || '').replace(/\\s+/g, ' ').trim();
-        const results = [];
-        document.querySelectorAll('.d_list_txt li').forEach(el => {
-          const titleEl = el.querySelector('.c_tit a');
-          const columnEl = el.querySelector('.c_chl');
-          const dateEl = el.querySelector('.c_time');
-          const url = titleEl?.getAttribute('href') || '';
-          if (!url) return;
-          results.push({
-            title: cleanText(titleEl?.textContent || ''),
-            column: cleanText(columnEl?.textContent || ''),
-            date: cleanText(dateEl?.textContent || ''),
-            url: url,
-          });
+    func: async () => {
+        const params = new URLSearchParams({
+            pageid: '384',
+            lid: '2519',
+            k: '',
+            num: '50',
+            page: '1',
         });
-        return results;
-      })()
-    `);
-        if (!Array.isArray(payload))
-            return [];
-        return payload;
+        let response;
+        try {
+            response = await fetch(`${ROLL_API}?${params}`);
+        }
+        catch (error) {
+            throw new CommandExecutionError(`Sina Finance rolling news request failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        if (!response.ok) {
+            throw new CommandExecutionError(`Sina Finance rolling news API returned HTTP ${response.status}`);
+        }
+        let payload;
+        try {
+            payload = await response.json();
+        }
+        catch (error) {
+            throw new CommandExecutionError(`Sina Finance rolling news API returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        return normalizeRollRows(payload);
     },
 });

--- a/clis/sinafinance/rolling-news.test.js
+++ b/clis/sinafinance/rolling-news.test.js
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './rolling-news.js';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('sinafinance rolling-news', () => {
+    it('reads the public roll API and preserves the visible row contract', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                result: {
+                    status: { code: 0, msg: 'succ' },
+                    data: [{
+                        title: '金价企稳',
+                        ctime: '1787531937',
+                        url: 'https://finance.sina.com.cn/example.shtml',
+                    }],
+                },
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const command = getRegistry().get('sinafinance/rolling-news');
+        await expect(command.func({})).resolves.toEqual([{
+            column: '财经',
+            title: '金价企稳',
+            date: '08-24 08:38',
+            url: 'https://finance.sina.com.cn/example.shtml',
+        }]);
+
+        const requested = new URL(fetchMock.mock.calls[0][0]);
+        expect(requested.origin + requested.pathname).toBe('https://feed.mix.sina.com.cn/api/roll/get');
+        expect(Object.fromEntries(requested.searchParams)).toEqual({
+            pageid: '384',
+            lid: '2519',
+            k: '',
+            num: '50',
+            page: '1',
+        });
+    });
+
+    it.each([
+        ['status failure', { result: { status: { code: 1, msg: 'busy' } } }, CommandExecutionError],
+        ['empty data', { result: { status: { code: 0 }, data: [] } }, EmptyResultError],
+        ['malformed row', { result: { status: { code: 0 }, data: [{ title: '', ctime: '1', url: '' }] } }, CommandExecutionError],
+    ])('rejects %s', async (_label, payload, errorType) => {
+        const command = getRegistry().get('sinafinance/rolling-news');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => payload,
+        }));
+        await expect(command.func({})).rejects.toBeInstanceOf(errorType);
+    });
+
+    it('turns transport, HTTP, and JSON failures into typed errors', async () => {
+        const command = getRegistry().get('sinafinance/rolling-news');
+
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+        await expect(command.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+        await expect(command.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => { throw new SyntaxError('bad json'); },
+        }));
+        await expect(command.func({})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});


### PR DESCRIPTION
## Summary

- replace the browser/DOM implementation of `sinafinance rolling-news` with the public JSON endpoint used by Sina's roll page
- preserve the existing `column,title,date,url` output contract and China-local timestamp formatting
- add typed failures for transport, HTTP, JSON, upstream status, empty data, and malformed rows
- add focused production-path tests and regenerate the manifest (`COOKIE` → `PUBLIC`, browser no longer required)

## Evidence

The current roll page requests:

`https://feed.mix.sina.com.cn/api/roll/get?pageid=384&lid=2519&k=&num=50&page=1`

A direct replay returns HTTP 200 JSON with `result.status.code === 0` and 50 non-empty rows containing the rendered `title`, `ctime`, and `url` fields. A live run of the rebuilt command returned the expected finance news rows without launching a browser.

## Verification

- `npx vitest run clis/sinafinance/rolling-news.test.js clis/sinafinance/stock.test.js` (7/7)
- `npm run typecheck`
- `npm run build` (manifest 1332)
- `node dist/src/main.js validate sinafinance` (4 commands, 0 warnings/errors)
- `git diff --check`
