### PR TITLE
fix(codex): detect virtualized assistant responses in ask

### DIFF
--- a/clis/codex/ask.js
+++ b/clis/codex/ask.js
@@ -22,11 +22,21 @@ export const askCommand = cli({
             throw new ArgumentError('--timeout must be a positive integer (seconds)');
         }
         const selected = await openCodexConversation(page, kwargs);
-        // Snapshot the current content length before sending
-        const beforeLen = await page.evaluate(`
+        // Snapshot the latest assistant identity. Codex virtualizes older turns,
+        // so turn/message counts can stay constant after a new response appears.
+        const beforeState = await page.evaluate(`
       (function() {
-        const turns = document.querySelectorAll('[data-content-search-turn-key]');
-        return turns.length;
+        const messages = Array.from(document.querySelectorAll('[data-markdown-text-style="assistant-message"]'));
+        const lastMessage = messages[messages.length - 1] || null;
+        const unit = lastMessage?.closest('[data-content-search-unit-key]');
+        const annotation = lastMessage?.closest('[data-response-annotation-target]');
+        return {
+          assistantKey: unit?.getAttribute('data-content-search-unit-key')
+            || annotation?.getAttribute('data-response-annotation-target')
+            || '',
+          assistantCount: messages.length,
+          turnCount: document.querySelectorAll('[data-content-search-turn-key]').length,
+        };
       })()
     `);
         // Inject and send
@@ -49,15 +59,36 @@ export const askCommand = cli({
         const maxPolls = Math.ceil(timeout / pollInterval);
         let response = '';
         for (let i = 0; i < maxPolls; i++) {
-            await page.wait(pollInterval);
+            await page.sleep(pollInterval);
             const result = await page.evaluate(`
-        (function(prevLen) {
-          const turns = document.querySelectorAll('[data-content-search-turn-key]');
-          if (turns.length <= prevLen) return null;
-          const lastTurn = turns[turns.length - 1];
-          const text = lastTurn.innerText || lastTurn.textContent;
-          return text ? text.trim() : null;
-        })(${beforeLen})
+        (function(prevState) {
+          const assistantMessages = Array.from(document.querySelectorAll('[data-markdown-text-style="assistant-message"]'));
+          const lastMessage = assistantMessages[assistantMessages.length - 1] || null;
+          if (lastMessage) {
+            const unit = lastMessage.closest('[data-content-search-unit-key]');
+            const annotation = lastMessage.closest('[data-response-annotation-target]');
+            const assistantKey = unit?.getAttribute('data-content-search-unit-key')
+              || annotation?.getAttribute('data-response-annotation-target')
+              || '';
+            if ((assistantKey && assistantKey !== prevState.assistantKey)
+              || (!assistantKey && assistantMessages.length > prevState.assistantCount)) {
+              const text = lastMessage.innerText || lastMessage.textContent;
+              return text ? text.trim() : null;
+            }
+          }
+
+          // Older Codex builds did not expose assistant-message markers.
+          if (prevState.assistantCount === 0 && assistantMessages.length === 0) {
+            const turns = document.querySelectorAll('[data-content-search-turn-key]');
+            if (turns.length > prevState.turnCount) {
+              const lastTurn = turns[turns.length - 1];
+              const text = lastTurn.innerText || lastTurn.textContent;
+              return text ? text.trim() : null;
+            }
+          }
+
+          return null;
+        })(${JSON.stringify(beforeState)})
       `);
             if (result) {
                 response = result;

--- a/clis/codex/ask.test.js
+++ b/clis/codex/ask.test.js
@@ -1,0 +1,97 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { askCommand } from './ask.js';
+
+function assistantTurn(turnKey, messageKey, text) {
+  return `
+    <section data-content-search-turn-key="${turnKey}">
+      <div data-content-search-unit-key="${turnKey}:${messageKey}" data-response-annotation-target="${messageKey}">
+        <div data-markdown-text-style="assistant-message">${text}</div>
+      </div>
+    </section>
+  `;
+}
+
+function makePage(initialHtml, onPoll) {
+  const dom = new JSDOM(`<body>${initialHtml}</body>`, { runScripts: 'outside-only' });
+  let poll = 0;
+  const page = {
+    evaluate: vi.fn(async (script) => {
+      if (script.includes("document.execCommand('insertText'")) return true;
+      return dom.window.eval(script);
+    }),
+    wait: vi.fn(async (seconds) => {
+      expect(seconds).toBe(0.5);
+    }),
+    sleep: vi.fn(async (seconds) => {
+      expect(seconds).toBe(3);
+      poll += 1;
+      onPoll(dom.window.document, poll);
+    }),
+    pressKey: vi.fn().mockResolvedValue(undefined),
+  };
+  return page;
+}
+
+describe('codex ask', () => {
+  it('detects a new assistant identity when virtualized counts stay unchanged', async () => {
+    const page = makePage(
+      assistantTurn('turn-old', 'msg-old', 'OLD'),
+      (document) => {
+        document.body.innerHTML = assistantTurn('turn-new', 'msg-new', 'VIRTUAL_OK');
+      },
+    );
+
+    const result = await askCommand.func(page, { text: 'reply VIRTUAL_OK', timeout: 3 });
+
+    expect(result).toEqual([
+      { Role: 'User', Project: '', Conversation: '', Text: 'reply VIRTUAL_OK' },
+      { Role: 'Assistant', Project: '', Conversation: '', Text: 'VIRTUAL_OK' },
+    ]);
+    expect(page.evaluate.mock.calls[0][0]).toContain('data-content-search-unit-key');
+    expect(page.evaluate.mock.calls[2][0]).toContain('data-response-annotation-target');
+  });
+
+  it('does not return a new turn before its assistant message exists', async () => {
+    const page = makePage(
+      assistantTurn('turn-old', 'msg-old', 'OLD'),
+      (document, poll) => {
+        document.body.innerHTML = poll === 1
+          ? `${assistantTurn('turn-old', 'msg-old', 'OLD')}<section data-content-search-turn-key="turn-new">USER\nTHINKING</section>`
+          : `${assistantTurn('turn-old', 'msg-old', 'OLD')}${assistantTurn('turn-new', 'msg-new', 'FINISHED_OK')}`;
+      },
+    );
+
+    const result = await askCommand.func(page, { text: 'reply FINISHED_OK', timeout: 6 });
+
+    expect(result[1]).toEqual({
+      Role: 'Assistant',
+      Project: '',
+      Conversation: '',
+      Text: 'FINISHED_OK',
+    });
+    expect(page.sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to turn count for Codex builds without assistant markers', async () => {
+    const page = makePage(
+      '<section data-content-search-turn-key="turn-old">OLD</section>',
+      (document) => {
+        document.body.innerHTML = `
+          <section data-content-search-turn-key="turn-old">OLD</section>
+          <section data-content-search-turn-key="turn-new">LEGACY_OK</section>
+        `;
+      },
+    );
+
+    const result = await askCommand.func(page, { text: 'reply LEGACY_OK', timeout: 3 });
+
+    expect(result[1]).toEqual({
+      Role: 'Assistant',
+      Project: '',
+      Conversation: '',
+      Text: 'LEGACY_OK',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Track the latest Codex assistant message identity in `codex ask` instead of relying only on the number of rendered turns.

This is the response-virtualization portion previously discussed in #2281, split from the CDP target-selection issue fixed by #2244.

## Reproduction on current `main`

Tested on Windows with:

- OpenCLI base: `c003a1b1c2a7f3435ef832412a9cdbf745a803ac`
- Codex Desktop: `26.818.5229.0`
- Chromium/CDP: `151.0.7922.170` / Protocol `1.3`

Once the visible conversation reached 10 turns, submitting another prompt kept both the rendered turn count and assistant-message count at 10. Codex dropped the oldest visible turn and rendered the new response with new message identities:

- before: `data-content-search-unit-key=01a0318a-63d3-79e1-8afd-9f90ad5c04e0:msg_0ed9e6d2b319116f016a8ba894596c87d089f40022c8154da2`
- after: `data-content-search-unit-key=01a0318a-c62e-7521-b1b0-54a08895788f:msg_0ed9e6d2b319116f016a8ba8ac8b9087d09ba851bf16569d5c`

`data-response-annotation-target` changed with the same assistant response. The unpatched command timed out after 18 seconds even though the DOM contained the exact requested response, because the rendered turn count never increased.

At a lower turn count, the old polling could also return too early: the new user/thinking turn increased the turn count before an assistant marker existed, so `codex ask` returned the in-progress turn text instead of waiting for the assistant response.

## Fix

- Snapshot the latest assistant message identity before sending.
- Prefer `data-content-search-unit-key`, with `data-response-annotation-target` as a fallback.
- Return only when a new latest assistant identity is present, then extract only that assistant message.
- Retain a turn-count fallback for older Codex DOMs where neither assistant marker exists.
- Use `page.sleep()` for the polling interval so the configured timeout is not shortened by `BasePage.wait()`'s DOM-stability semantics.

The change is local to the Codex adapter.

## Tests

Added regression coverage for:

- stable rendered counts with a changed assistant identity;
- a new user/thinking turn that must not be returned before the assistant appears;
- the legacy no-marker turn-count fallback.

Validated with:

```text
npm run build
npx vitest run clis/codex/ask.test.js clis/codex/sidebar.test.js src/browser.test.ts
node dist/src/main.js validate codex
```

Results:

- build passed;
- 3 test files / 63 tests passed;
- Codex validation passed: 16 commands, 0 errors, 0 warnings.

## Real Windows E2E

After the fix:

```text
opencli codex ask "Reply with exactly FIXED_E2E_OK and nothing else." --timeout 60
```

returned the actual new assistant response:

```text
FIXED_E2E_OK
```

The CDP target was the main `app://-/index.html` renderer rather than `avatar-overlay`.