### PR TITLE
chore(zhihu): reuse paginate evaluate unwrap in search

### DIFF
--- a/clis/zhihu/search.js
+++ b/clis/zhihu/search.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { stripHtml } from './text.js';
+import { unwrapEvaluateResult } from './paginate.js';
 
 function itemKey(item) {
     const obj = item.object || {};
@@ -65,11 +66,6 @@ function requireType(value) {
         throw new ArgumentError(`zhihu search --type must be one of: ${TYPES.join(', ')}`, 'Example: opencli zhihu search codex --type answer');
     }
     return type;
-}
-
-function unwrapEvaluateResult(payload) {
-    if (payload && typeof payload === 'object' && 'data' in payload && 'session' in payload) return payload.data;
-    return payload;
 }
 
 function requireSearchPayload(data, url) {


### PR DESCRIPTION
## Summary
`clis/zhihu/search.js` carried a byte-identical private copy of `unwrapEvaluateResult`; `clis/zhihu/paginate.js` already exports the same function and `user.js` already imports it. This binds `search.js` to the existing export and deletes the copy. Site-local edge onto an already-consumed export; no cycle (`paginate.js` imports only package errors).

## Equivalence
Deleted copy and the export are byte-identical (same condition order, no Array guard on either side) — no behavior surface at all.

## Test net account
Zero test changes; no test referenced the private copy; no cross-site importer (verified by grep and by the manifest build's import gate).

## Gates (local)
vitest clis/zhihu 24 files / 180 tests PASS; build PASS (manifest unchanged); typecheck PASS.