### PR TITLE
chore(codex): reuse actions evaluate unwrap in model

### DIFF
--- a/clis/codex/model.js
+++ b/clis/codex/model.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, selectorError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_actions.js';
 
 // Codex Desktop App exposes the active model + reasoning level on a button
 // in the composer bottom toolbar. As of 2026-05-31 the button has no
@@ -15,13 +16,6 @@ import { ArgumentError, CommandExecutionError, selectorError } from '@jackwener/
 
 const MODEL_BTN_TEXT_RE = /5\.\d|[Ee]xtra [Hh]igh|^High$|^Medium$|^Low$|^Auto$|^Fast$|^Speed$|^Pro$|GPT-/;
 const MODEL_BTN_PATTERN = MODEL_BTN_TEXT_RE.source;
-
-function unwrapEvaluateResult(result) {
-    if (result && typeof result === 'object' && 'data' in result && 'session' in result) {
-        return result.data;
-    }
-    return result;
-}
 
 function normalizeModelText(value) {
     return String(value ?? '')


### PR DESCRIPTION
## Summary
`clis/codex/model.js` carried a byte-identical private copy of `unwrapEvaluateResult`; `clis/codex/_actions.js` already exports the same function and `extract-diff.js`/`rename.js`/`send.js` already import it. This binds `model.js` to the existing export and deletes the copy.

## Equivalence & edges
Deleted copy and the export are byte-identical. New edge `model.js → _actions.js` is acyclic: `_actions.js` imports only `./sidebar.js`, which imports only package errors; neither reaches back to `model.js`. `_actions.js` has no top-level `cli()` side effects.

## Test net account
Zero test changes; no test referenced the private copy; no cross-site importer.

## Gates (local)
vitest clis/codex 34 tests PASS; build PASS (manifest unchanged); typecheck PASS.