### PR TITLE
chore(upwork): reuse shared browser unwrap

### DIFF
--- a/clis/upwork/utils.js
+++ b/clis/upwork/utils.js
@@ -18,6 +18,7 @@ import {
     ArgumentError,
     CommandExecutionError,
 } from '@jackwener/opencli/errors';
+export { unwrapBrowserResult } from '../_shared/search-adapter.js';
 
 export const UPWORK_ORIGIN = 'https://www.upwork.com';
 
@@ -29,13 +30,6 @@ const FEED_TABS = {
 };
 
 const SORT_VALUES = new Set(['recency', 'relevance', 'client_total_charge', 'client_total_reviews']);
-
-export function unwrapBrowserResult(value) {
-    if (value && typeof value === 'object' && !Array.isArray(value) && 'session' in value && 'data' in value) {
-        return value.data;
-    }
-    return value;
-}
 
 export function isPlainObject(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);


### PR DESCRIPTION
## Summary
`clis/upwork/utils.js` carried a byte-identical copy of `unwrapBrowserResult` that `clis/_shared/search-adapter.js` already exports (same conditions, same order). This deletes the copy and re-exports the shared one from `utils.js`, so the three import sites (`feed.js`/`detail.js`/`search.js`) stay untouched — 1-file diff.

## Equivalence & edges
Byte-identical bodies; no behavior surface. New edge `upwork/utils.js → _shared/search-adapter.js` follows the existing cross-boundary precedent (five sites already import from `_shared/search-adapter.js`); `search-adapter.js` imports only package errors — acyclic, no top-level `cli()` side effects.

## Test net account
Zero test changes; upwork tests exercise the re-exported binding through the same import path.

## Gates (local)
vitest clis/upwork 49 tests PASS; build PASS (manifest unchanged); typecheck PASS.