### PR TITLE
chore(douyin): reuse shared evaluate unwrap in search

### DIFF
--- a/clis/douyin/search.js
+++ b/clis/douyin/search.js
@@ -42,6 +42,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './_shared/evaluate-result.js';
 
 export const MAX_SEARCH_LIMIT = 30;
 // Time budget for the SPA's initial DOM commit. Empirically the
@@ -242,13 +243,6 @@ const WAIT_AND_EXTRACT_JS = (timeoutMs) => `
     }, ${timeoutMs});
   })
 `;
-
-function unwrapEvaluateResult(payload) {
-    if (payload && !Array.isArray(payload) && typeof payload === 'object' && 'session' in payload && 'data' in payload) {
-        return payload.data;
-    }
-    return payload;
-}
 
 cli({
     site: 'douyin',


### PR DESCRIPTION
## Summary
`clis/douyin/search.js` carried a byte-identical copy of `unwrapEvaluateResult`; the site's own `clis/douyin/_shared/evaluate-result.js` already exports the same function and `browser-fetch.js`/`vod-upload.js` already import it. This binds `search.js` to the existing export and deletes the copy — 1-file diff.

## Equivalence & edges
Byte-identical bodies (same Array guard, same condition order). New edge `search.js → _shared/evaluate-result.js` is site-local and acyclic (`evaluate-result.js` imports only package errors, no top-level `cli()`).

## Test net account
Zero test changes; no test referenced the private copy; no cross-site importer.

## Gates (local)
vitest clis/douyin 25 files / 201 tests PASS; build PASS (manifest unchanged); typecheck PASS.