### PR TITLE
feat(extension): allow window-restore CDP methods for browser adapters

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -2213,6 +2213,11 @@ const CDP_ALLOWLIST = /* @__PURE__ */ new Set([
   "Page.captureScreenshot",
   "Page.getFrameTree",
   "Page.handleJavaScriptDialog",
+  // Window visibility (used by browser adapters to restore a minimized window
+  // before native key input; these only affect the user's own browser window)
+  "Browser.getWindowForTarget",
+  "Browser.setWindowBounds",
+  "Page.bringToFront",
   // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
   "Runtime.enable",
   // Emulation (used by screenshot full-page)

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1970,6 +1970,11 @@ const CDP_ALLOWLIST = new Set([
   'Page.captureScreenshot',
   'Page.getFrameTree',
   'Page.handleJavaScriptDialog',
+  // Window visibility (used by browser adapters to restore a minimized window
+  // before native key input; these only affect the user's own browser window)
+  'Browser.getWindowForTarget',
+  'Browser.setWindowBounds',
+  'Page.bringToFront',
   // Runtime.enable needed for CDP attach setup (Runtime.evaluate goes through 'exec' action)
   'Runtime.enable',
   // Emulation (used by screenshot full-page)


### PR DESCRIPTION
## Description

Adds three window-visibility methods to the extension CDP allowlist so browser adapters can restore a minimized or fully-occluded window before sending native key input:

- `Browser.getWindowForTarget`
- `Browser.setWindowBounds`
- `Page.bringToFront`

These only affect the user's own browser window and are scoped to the existing allowlist model.

## Why

Adapters that drive logged-in pages (e.g. the AI Studio adapter in #2288) need a visible tab twice:

1. Chrome drops trusted CDP key events in minimized windows, so native-key submit requires a restored window.
2. Chrome throttles hidden tabs, and AI Studio delays rendering the completed model turn until the tab is visible again — without a restore path the response wait times out even though generation succeeded server-side.

Today such adapters fall back to OS-specific restore helpers. The built-in fallback is Windows-only (PowerShell/user32), which leaves **macOS and Linux with no restore path at all**. CDP-based restore works cross-platform, and on Windows it also avoids the PowerShell window flash / topmost workaround.

## Verification

- `vitest run --project extension`: 97/97 passing
- dist rebuilt via `vite build`; diff is exactly the 5 added allowlist lines
