### PR TITLE
chore(youtube): share browser unwrap helper

### DIFF
--- a/clis/youtube/shared.js
+++ b/clis/youtube/shared.js
@@ -1,0 +1,11 @@
+/**
+ * Shared helpers for youtube adapters.
+ */
+
+/** Unwrap the browser-bridge evaluate envelope ({ session, data }). */
+export function unwrapBrowserResult(value) {
+    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
+        return value.data;
+    }
+    return value;
+}

--- a/clis/youtube/transcript.js
+++ b/clis/youtube/transcript.js
@@ -13,13 +13,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
 import { groupTranscriptSegments, formatGroupedTranscript, } from './transcript-group.js';
 import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-
-function unwrapBrowserResult(value) {
-    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
-        return value.data;
-    }
-    return value;
-}
+import { unwrapBrowserResult } from './shared.js';
 
 function normalizeSegmentsPayload(value, source, { allowNull = false } = {}) {
     const payload = unwrapBrowserResult(value);

--- a/clis/youtube/video.js
+++ b/clis/youtube/video.js
@@ -4,13 +4,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { extractJsonAssignmentFromHtml, parseVideoId, prepareYoutubeApiPage } from './utils.js';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-
-function unwrapBrowserResult(value) {
-    if (value && typeof value === 'object' && 'session' in value && 'data' in value) {
-        return value.data;
-    }
-    return value;
-}
+import { unwrapBrowserResult } from './shared.js';
 
 function requireVideoPayload(value) {
     const payload = unwrapBrowserResult(value);


### PR DESCRIPTION
## Summary
`clis/youtube/video.js` and `clis/youtube/transcript.js` carried byte-identical private copies of `unwrapBrowserResult`. This moves the exact body (byte-preserving — no Array-guard variant change, so no equivalence argument is even needed) to a new site-local `clis/youtube/shared.js` and binds both files.

## Edges
Two one-way site-local edges onto leaf `shared.js` (zero imports); each import binds only `unwrapBrowserResult`.

## Test net account
Zero test changes; the existing envelope test in `video.test.js` drives through `command.func` and keeps covering the behavior.

## Gates (local)
vitest clis/youtube 6 files / 51 tests PASS; build PASS (manifest unchanged); typecheck PASS.