### PR TITLE
fix(output): keep markdown rows intact for multi-line cells

### DIFF
--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -32,9 +32,9 @@ describe('output TTY detection', () => {
 
   it('respects explicit -f json even in non-TTY', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true });
-    render([{ name: 'alice' }], { fmt: 'json' });
+    render([{ name: 'alice', note: 'line 1\nline 2' }], { fmt: 'json' });
     const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(JSON.parse(out)).toEqual([{ name: 'alice' }]);
+    expect(JSON.parse(out)).toEqual([{ name: 'alice', note: 'line 1\nline 2' }]);
   });
 
   it('shows elapsed time when elapsed is 0', () => {
@@ -58,6 +58,24 @@ describe('output TTY detection', () => {
     const out = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
     expect(out).toBe('# Title\n\nBody');
     expect(out).not.toContain('| markdown |');
+  });
+
+  it('keeps markdown records on one physical row across embedded line breaks', () => {
+    render([
+      { id: 'mixed', cell: 'left|right\r\nmiddle\n\nlast\rtail' },
+      { id: 'null', cell: null },
+      { id: 'undefined', cell: undefined },
+    ], { fmt: 'md', columns: ['id', 'cell'] });
+
+    const lines = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(lines).toEqual([
+      '| id | cell |',
+      '| --- | --- |',
+      '| mixed | left\\|right<br>middle<br><br>last<br>tail |',
+      '| null |  |',
+      '| undefined |  |',
+    ]);
+    expect(lines.every((line: string) => !/[\r\n]/.test(line))).toBe(true);
   });
 
   it('escapes pipe characters in markdown table cells', () => {

--- a/src/output.ts
+++ b/src/output.ts
@@ -124,7 +124,10 @@ function renderMarkdown(data: unknown, opts: RenderOptions): void {
   console.log('| ' + columns.join(' | ') + ' |');
   console.log('| ' + columns.map(() => '---').join(' | ') + ' |');
   for (const row of rows) {
-    console.log('| ' + columns.map(c => String((row as Record<string, unknown>)[c] ?? '').replace(/\|/g, '\\|')).join(' | ') + ' |');
+    console.log('| ' + columns.map(c => String((row as Record<string, unknown>)[c] ?? '')
+      .replace(/\|/g, '\\|')
+      // Any embedded line break would split the physical table row.
+      .replace(/\r\n?|\n/g, '<br>')).join(' | ') + ' |');
   }
 }
 


### PR DESCRIPTION
## Summary

Markdown table cells currently escape `|` but pass embedded line breaks through unchanged, so a single logical record can become several physical rows and invalidate the table. This keeps each record on one physical row by rendering line-break sequences inside Markdown cells as `<br>`.

## Contract

The change is intentionally local to `renderMarkdown`:

- `LF`, `CRLF`, and bare `CR` each become one `<br>`;
- repeated line breaks preserve their count (`\n\n` → `<br><br>`);
- pipe escaping composes with line-break conversion in the same cell;
- `null` and `undefined` remain empty Markdown cells;
- Markdown headers, separators, column order, and record count are unchanged;
- JSON and every other non-Markdown renderer stay on their existing code paths and do not receive `<br>` conversion;
- no generic normalization helper or broader HTML escaping is introduced.

Bare `CR` is handled explicitly because leaving a carriage-return control in a cell can overwrite or visually corrupt the physical output line even when it does not create a Unix newline.

## Reproduction and regression

On current main, a cell containing `left|right\r\nmiddle\n\nlast\rtail` is printed across multiple physical lines. The refreshed head emits one data row:

```md
| mixed | left\|right<br>middle<br><br>last<br>tail |
```

The renderer-level test asserts the exact header, separator, and three data records; verifies `<br>` placement for all three newline forms and repeated breaks; covers pipe+break, `null`, and `undefined`; and asserts every `console.log` record is free of `CR`/`LF`. Reverse validation confirmed that removing the conversion makes the regression fail. The existing explicit-JSON test now includes a multiline value and proves its content is preserved unchanged.

## Verification

Exact head: `b371760ad4e38cd4d167209007fb70a57271abec`  
Base/live main at validation: `6b3dffd398b907c0a1437c8ad017068819fb401f`

- output unit test: `1 file / 8 tests` passed
- typecheck passed
- build/manifest passed: `1356` entries, manifest unchanged
- docs build passed (existing chunk-size warning only)
- source/test/built-main syntax checks passed
- typed-error lint: `new=0`, `resolved=7`
- silent-column-drop: `new=0`, `resolved=3`
- listing-id advisory unchanged at `14`
- production audit: `0 vulnerabilities`
- diff check and merge-tree clean

The final diff is only `src/output.ts` and `src/output.test.ts`; therefore the exact base preserves #2393 Ctrip, #2394 Jike, #2395 LinkedIn, #2398 recon docs, #2396 Gmail, plus Trip and Nowcoder. Earlier heads/checks are stale.
