### PR TITLE
fix(browser): add direct CDP fallback

### DIFF
--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer } from 'node:http';
 
 const { MockWebSocket } = vi.hoisted(() => {
   class MockWebSocket {
@@ -95,5 +96,35 @@ describe('CDPBridge cookies', () => {
       ['Page.handleJavaScriptDialog', { accept: true, promptText: 'ok' }],
       ['Page.getLayoutMetrics', {}],
     ]);
+  });
+});
+
+describe('CDPBridge dedicated target', () => {
+  it('creates and closes an isolated tab for a website CLI', async () => {
+    const seen: string[] = [];
+    const server = createServer((req, res) => {
+      seen.push(`${req.method} ${req.url?.split('?')[0]}`);
+      if (req.method === 'PUT' && req.url?.startsWith('/json/new')) {
+        res.end(JSON.stringify({ id: 'T1', webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/page/T1' }));
+      } else if (req.method === 'GET' && req.url === '/json/close/T1') {
+        res.end('Target is closing');
+      } else {
+        res.writeHead(500).end('{}');
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const endpoint = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
+
+    try {
+      const bridge = new CDPBridge();
+      vi.spyOn(bridge, 'send').mockResolvedValue({});
+      await bridge.connect({ cdpEndpoint: endpoint, dedicatedTarget: true });
+      await bridge.close();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    expect(seen).toEqual(['PUT /json/new', 'GET /json/close/T1']);
   });
 });

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -21,6 +21,7 @@ import { getAllElectronApps } from '../electron-apps.js';
 import { CDPBasePage } from './base-page.js';
 
 export interface CDPTarget {
+  id?: string;
   type?: string;
   url?: string;
   title?: string;
@@ -52,8 +53,10 @@ export class CDPBridge implements IBrowserFactory {
   private _idCounter = 0;
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
+  private _httpBase: string | null = null;
+  private _createdTargetId: string | null = null;
 
-  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -61,12 +64,23 @@ export class CDPBridge implements IBrowserFactory {
 
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {
-      const targets = await fetchJsonDirect(`${endpoint.replace(/\/$/, '')}/json`) as CDPTarget[];
-      const target = selectCDPTarget(targets);
-      if (!target || !target.webSocketDebuggerUrl) {
-        throw new Error('No inspectable targets found at CDP endpoint');
+      const httpBase = endpoint.replace(/\/$/, '');
+      if (opts?.dedicatedTarget) {
+        const created = await fetchJsonDirect(`${httpBase}/json/new?url=about:blank`, 'PUT') as CDPTarget;
+        if (!created.id || !created.webSocketDebuggerUrl) {
+          throw new Error('CDP endpoint created an invalid target');
+        }
+        this._httpBase = httpBase;
+        this._createdTargetId = created.id;
+        wsUrl = created.webSocketDebuggerUrl;
+      } else {
+        const targets = await fetchJsonDirect(`${httpBase}/json`) as CDPTarget[];
+        const target = selectCDPTarget(targets);
+        if (!target || !target.webSocketDebuggerUrl) {
+          throw new Error('No inspectable targets found at CDP endpoint');
+        }
+        wsUrl = target.webSocketDebuggerUrl;
       }
-      wsUrl = target.webSocketDebuggerUrl;
     }
 
     return new Promise((resolve, reject) => {
@@ -137,6 +151,11 @@ export class CDPBridge implements IBrowserFactory {
     }
     this._pending.clear();
     this._eventListeners.clear();
+    if (this._httpBase && this._createdTargetId) {
+      await fetchJsonDirect(`${this._httpBase}/json/close/${this._createdTargetId}`, 'GET', false).catch(() => {});
+      this._httpBase = null;
+      this._createdTargetId = null;
+    }
   }
 
   async send(method: string, params: Record<string, unknown> = {}, timeoutMs: number = CDP_SEND_TIMEOUT): Promise<unknown> {
@@ -549,10 +568,10 @@ export const __test__ = {
   scoreCDPTarget,
 };
 
-function fetchJsonDirect(url: string): Promise<unknown> {
+function fetchJsonDirect(url: string, method: 'GET' | 'PUT' = 'GET', parseJson = true): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const parsed = new URL(url);
-    const request = (parsed.protocol === 'https:' ? httpsRequest : httpRequest)(parsed, (res) => {
+    const request = (parsed.protocol === 'https:' ? httpsRequest : httpRequest)(parsed, { method }, (res) => {
       const statusCode = res.statusCode ?? 0;
       if (statusCode < 200 || statusCode >= 300) {
         res.resume();
@@ -563,8 +582,13 @@ function fetchJsonDirect(url: string): Promise<unknown> {
       const chunks: Buffer[] = [];
       res.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
       res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        if (!parseJson) {
+          resolve(body);
+          return;
+        }
         try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          resolve(JSON.parse(body));
         } catch (error) {
           reject(error instanceof Error ? error : new Error(String(error)));
         }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -14,6 +14,8 @@ import { classifyAdapter } from './help.js';
 const {
   mockBrowserConnect,
   mockBrowserClose,
+  mockCdpConnect,
+  mockCdpClose,
   mockBindTab,
   mockSendCommand,
   mockExecFileSync,
@@ -21,6 +23,8 @@ const {
 } = vi.hoisted(() => ({
   mockBrowserConnect: vi.fn(),
   mockBrowserClose: vi.fn(),
+  mockCdpConnect: vi.fn(),
+  mockCdpClose: vi.fn(),
   mockBindTab: vi.fn(),
   mockSendCommand: vi.fn(),
   mockExecFileSync: vi.fn(),
@@ -33,6 +37,10 @@ vi.mock('./browser/index.js', () => {
     BrowserBridge: class {
       connect = mockBrowserConnect;
       close = mockBrowserClose;
+    },
+    CDPBridge: class {
+      connect = mockCdpConnect;
+      close = mockCdpClose;
     },
   };
 });
@@ -613,7 +621,7 @@ describe('createProgram root help descriptions', () => {
       });
       // session is now a hidden internal option (consumed from the <session> positional).
       // namespace_options should only list user-facing options.
-      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['window']);
+      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['window', 'cdpEndpoint']);
       expect(data.structured_help).toMatchObject({
         usage: 'opencli browser <session> tab --help -f yaml',
       });
@@ -644,8 +652,8 @@ describe('createProgram root help descriptions', () => {
         },
       });
       expect(data.command_options.map((option: any) => option.name)).toEqual(['role', 'name', 'label', 'text', 'testid', 'nth', 'tab']);
-      // session is hidden; only `window` surfaces as a namespace option.
-      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['window']);
+      // session is hidden; user-facing browser routing options remain visible.
+      expect(data.namespace_options.map((option: any) => option.name)).toEqual(['window', 'cdpEndpoint']);
       expect(data.global_options.map((option: any) => option.name)).toContain('profile');
     } finally {
       process.argv = argv;
@@ -1171,6 +1179,9 @@ describe('browser tab targeting commands', () => {
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
     mockBrowserClose.mockReset().mockResolvedValue(undefined);
+    mockCdpConnect.mockReset().mockImplementation(async () => browserState.page as IPage);
+    mockCdpClose.mockReset().mockResolvedValue(undefined);
+    delete process.env.OPENCLI_CDP_ENDPOINT;
     delete process.env.OPENCLI_WINDOW;
     mockBindTab.mockReset().mockResolvedValue({
       session: 'test',
@@ -1256,6 +1267,29 @@ describe('browser tab targeting commands', () => {
 
     expect(mockBrowserConnect).toHaveBeenCalledWith({ timeout: 45, session: 'test', surface: 'browser', windowMode: 'foreground' });
     expect(browserState.page?.snapshot).toHaveBeenCalled();
+  });
+
+  it('routes browser commands through CDP when an endpoint is provided', async () => {
+    const program = createProgram('', '');
+
+    await program.parseAsync([
+      'node',
+      'opencli',
+      'browser',
+      '--session',
+      'test',
+      '--cdp-endpoint',
+      'http://127.0.0.1:9222',
+      'state',
+    ]);
+
+    expect(mockBrowserConnect).not.toHaveBeenCalled();
+    expect(mockCdpConnect).toHaveBeenCalledWith({
+      timeout: 45,
+      cdpEndpoint: 'http://127.0.0.1:9222',
+    });
+    expect(browserState.page?.snapshot).toHaveBeenCalled();
+    expect(mockCdpClose).toHaveBeenCalledTimes(1);
   });
 
   it('passes browser --window through Commander options without relying on env pre-processing', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,11 +41,16 @@ import { aliasForContextId, loadProfileConfig, profileRouteParams, renameProfile
 import { formatDaemonVersion, isDaemonStale } from './browser/daemon-version.js';
 import { DEFAULT_BROWSER_CONNECT_TIMEOUT } from './browser/config.js';
 import type { BrowserDownloadWaitResult, IPage, ScreenshotOptions } from './types.js';
-import type { BrowserWindowMode } from './runtime.js';
+import { getBrowserFactory, type BrowserWindowMode } from './runtime.js';
 
 const CLI_FILE = fileURLToPath(import.meta.url);
 const BROWSER_TAB_OPTION_DESCRIPTION = 'Target tab/page identity returned by "browser open", "browser tab new", or "browser tab list"';
 const FOLLOW_POLL_MS = 1_000;
+const BROWSER_PAGE_CLEANUP = Symbol('opencli.browserPageCleanup');
+
+type BrowserPageWithCleanup = IPage & {
+  [BROWSER_PAGE_CLEANUP]?: () => Promise<void>;
+};
 
 type BrowserNetworkItem = {
   url: string;
@@ -594,10 +599,25 @@ async function getBrowserPage(
   session: string,
   targetPage?: string,
   profileSelection?: ProfileSelection,
-  opts: { windowMode?: BrowserWindowMode } = {},
+  opts: { windowMode?: BrowserWindowMode; cdpEndpoint?: string } = {},
 ): Promise<import('./types.js').IPage> {
-  const { BrowserBridge } = await import('./browser/index.js');
-  const bridge = new BrowserBridge();
+  const cdpEndpoint = opts.cdpEndpoint?.trim();
+  const BrowserFactory = getBrowserFactory(undefined, cdpEndpoint);
+  const bridge = new BrowserFactory();
+  if (cdpEndpoint) {
+    if (targetPage) {
+      throw new Error('Direct CDP mode does not support --tab. Start Chrome with a dedicated profile instead.');
+    }
+    const page = await bridge.connect({
+      timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
+      cdpEndpoint,
+    }) as BrowserPageWithCleanup;
+    Object.defineProperties(page, {
+      session: { value: session, configurable: true },
+      [BROWSER_PAGE_CLEANUP]: { value: () => bridge.close(), configurable: true },
+    });
+    return page;
+  }
   // Internal GC timeout for browser sessions. Not the per-command runtime timeout.
   const envTimeout = process.env.OPENCLI_BROWSER_IDLE_TIMEOUT;
   const idleTimeout = envTimeout ? parseInt(envTimeout, 10) : undefined;
@@ -656,6 +676,13 @@ function getCommandOption(command: Command | undefined, option: string): unknown
   return undefined;
 }
 
+function getBrowserCdpEndpoint(command?: Command): string | undefined {
+  const raw = getCommandOption(command, 'cdpEndpoint');
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  const env = process.env.OPENCLI_CDP_ENDPOINT;
+  return typeof env === 'string' && env.trim() ? env.trim() : undefined;
+}
+
 function getBrowserSession(command?: Command): string {
   // The CLI surface is `opencli browser <session> <subcommand>`. main.ts rewrites
   // argv to insert `--session <name>` before commander parses it; this helper
@@ -686,6 +713,10 @@ function getPageScope(page: import('./types.js').IPage): string {
     ? contextId.trim()
     : (typeof preferredContextId === 'string' && preferredContextId.trim() ? preferredContextId.trim() : undefined);
   return getBrowserScope(getPageSession(page), selected);
+}
+
+async function closeBrowserPageTransport(page: IPage): Promise<void> {
+  await (page as BrowserPageWithCleanup)[BROWSER_PAGE_CLEANUP]?.().catch(() => {});
 }
 
 type SnapshotSource = 'dom' | 'ax';
@@ -979,6 +1010,7 @@ export function createProgram(BUILTIN_CLIS: string, USER_CLIS: string): Command 
     // positional; main.ts argv preprocessor rewrites positional -> --session.
     .addOption(new Option('--session <name>', 'Internal — set automatically from the <session> positional').hideHelp())
     .option('--window <mode>', 'Browser window mode: foreground or background')
+    .option('--cdp-endpoint <url>', 'Chrome DevTools Protocol endpoint for direct browser automation')
     .description('Browser control — navigate, click, type, extract, wait (no LLM needed)')
     .usage('<session> <command> [options]')
     .addHelpText('after', `
@@ -1088,7 +1120,10 @@ Examples:
         const session = getBrowserSession(command);
         const profileSelection = getBrowserProfileSelection(command);
         const windowMode = getBrowserWindowMode(command, 'foreground');
-        page = await getBrowserPage(session, targetPage, profileSelection, { windowMode });
+        page = await getBrowserPage(session, targetPage, profileSelection, {
+          windowMode,
+          cdpEndpoint: getBrowserCdpEndpoint(command),
+        });
         await fn(page, ...args);
       } catch (err) {
         if (err instanceof BrowserConnectError) {
@@ -1118,6 +1153,8 @@ Examples:
           }
         }
         process.exitCode = EXIT_CODES.GENERIC_ERROR;
+      } finally {
+        if (page) await closeBrowserPageTransport(page);
       }
     };
   }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -238,11 +238,12 @@ export async function executeCommand(
   try {
     if (shouldUseBrowserSession(cmd)) {
       const electron = isElectronApp(cmd.site);
+      const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
       let cdpEndpoint: string | undefined;
+      let dedicatedTarget = false;
 
       if (electron) {
         // Electron apps: respect manual endpoint override, then try auto-detect
-        const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
         if (manualEndpoint) {
           const port = Number(new URL(manualEndpoint).port);
           if (!await probeCDP(port)) {
@@ -255,6 +256,9 @@ export async function executeCommand(
         } else {
           cdpEndpoint = await resolveElectronEndpoint(cmd.site);
         }
+      } else if (manualEndpoint) {
+        cdpEndpoint = manualEndpoint;
+        dedicatedTarget = true;
       }
 
       const BrowserFactory = getBrowserFactory(cmd.site);
@@ -414,7 +418,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, dedicatedTarget, ...profileRouting, windowMode, surface: 'adapter', siteSession });
       } catch (err) {
         browserRunError = err;
         throw err;

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,12 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CDPBridge } from './browser/cdp.js';
+import { getBrowserFactory } from './runtime.js';
+
+describe('getBrowserFactory', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('routes website CLIs over CDP when OPENCLI_CDP_ENDPOINT is set', () => {
+    vi.stubEnv('OPENCLI_CDP_ENDPOINT', 'http://127.0.0.1:9222');
+    expect(getBrowserFactory('twitter')).toBe(CDPBridge);
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,8 +10,9 @@ export { DEFAULT_BROWSER_COMMAND_TIMEOUT, DEFAULT_BROWSER_CONNECT_TIMEOUT };
  * Returns the appropriate browser factory based on site type.
  * Uses CDPBridge for registered Electron apps, otherwise BrowserBridge.
  */
-export function getBrowserFactory(site?: string): new () => IBrowserFactory {
+export function getBrowserFactory(site?: string, cdpEndpoint = process.env.OPENCLI_CDP_ENDPOINT): new () => IBrowserFactory {
   if (site && isElectronApp(site)) return CDPBridge;
+  if (cdpEndpoint?.trim()) return CDPBridge;
   return BrowserBridge;
 }
 
@@ -54,14 +55,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
+  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent'; dedicatedTarget?: boolean } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -69,6 +70,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       session: opts.session,
       cdpEndpoint: opts.cdpEndpoint,
+      dedicatedTarget: opts.dedicatedTarget,
       contextId: opts.contextId,
       preferredContextId: opts.preferredContextId,
       idleTimeout: opts.idleTimeout,


### PR DESCRIPTION
## Summary
- route browser-backed website adapters through direct CDP when `OPENCLI_CDP_ENDPOINT` is set
- add `opencli browser --cdp-endpoint` routing and close the direct-CDP transport after each command
- create and remove an isolated CDP tab for adapter runs so existing tabs are not hijacked

## Root cause
Browser Bridge can resolve an invalid/stale target and fail `chrome.debugger.attach` with `Cannot access a chrome-extension:// URL of different extension`, including in a clean Chrome profile. Direct CDP provides a deterministic fallback without disabling unrelated extensions.

## Validation
- `npm run typecheck`
- `npm test` — 609 files passed, 6964 tests passed, 1 skipped
- `npm run build`
- real Chrome CDP: browser-backed Bilibili adapter returned data
- real Chrome CDP: `open -> get title (Example Domain) -> close` all exited 0

Related: #1341, #2286, #1325