### PR TITLE
chore: shrink convention-audit baselines to current findings

### DIFF
--- a/scripts/silent-column-drop-baseline.json
+++ b/scripts/silent-column-drop-baseline.json
@@ -502,14 +502,6 @@
     ]
   },
   {
-    "command": "jike/notifications",
-    "file": "clis/jike/notifications.js",
-    "missing": [
-      "actionType",
-      "fromUser"
-    ]
-  },
-  {
     "command": "jike/topic",
     "file": "clis/jike/topic.js",
     "missing": [
@@ -603,15 +595,6 @@
     "file": "clis/twitter/bookmarks.js",
     "missing": [
       "name"
-    ]
-  },
-  {
-    "command": "twitter/list-remove",
-    "file": "clis/twitter/list-remove.js",
-    "missing": [
-      "method",
-      "ts",
-      "url"
     ]
   },
   {
@@ -759,14 +742,6 @@
       "seller_score",
       "seller_url",
       "status"
-    ]
-  },
-  {
-    "command": "xianyu/search",
-    "file": "clis/xianyu/search.js",
-    "missing": [
-      "extra",
-      "original_price"
     ]
   },
   {

--- a/scripts/typed-error-lint-baseline.json
+++ b/scripts/typed-error-lint-baseline.json
@@ -131,7 +131,7 @@
     "rule": "silent-clamp",
     "command": "douyin/user-videos",
     "file": "clis/douyin/user-videos.js",
-    "line": 17,
+    "line": 35,
     "text": "return Math.min(DEFAULT_COMMENT_LIMIT, Math.max(1, Math.round(numeric)));",
     "occurrence": 0
   },
@@ -139,7 +139,7 @@
     "rule": "silent-clamp",
     "command": "douyin/user-videos",
     "file": "clis/douyin/user-videos.js",
-    "line": 11,
+    "line": 29,
     "text": "return Math.min(MAX_USER_VIDEOS_LIMIT, Math.max(1, Math.round(numeric)));",
     "occurrence": 0
   },
@@ -148,14 +148,6 @@
     "command": "eastmoney/announcement",
     "file": "clis/eastmoney/announcement.js",
     "line": 24,
-    "text": "const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "eastmoney/convertible",
-    "file": "clis/eastmoney/convertible.js",
-    "line": 36,
     "text": "const limit = Math.max(1, Math.min(Number(args.limit) || 20, 100));",
     "occurrence": 0
   },
@@ -617,26 +609,10 @@
   },
   {
     "rule": "silent-clamp",
-    "command": "twitter/bookmarks",
-    "file": "clis/twitter/bookmarks.js",
-    "line": 157,
-    "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
     "command": "twitter/following",
     "file": "clis/twitter/following.js",
-    "line": 232,
+    "line": 214,
     "text": "const fetchCount = Math.min(50, limit - allUsers.length + 10);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "twitter/likes",
-    "file": "clis/twitter/likes.js",
-    "line": 208,
-    "text": "const fetchCount = Math.min(100, limit - allTweets.length + 10);",
     "occurrence": 0
   },
   {
@@ -659,7 +635,7 @@
     "rule": "silent-clamp",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 316,
+    "line": 134,
     "text": "const fetchCount = Math.min(USER_TWEETS_PAGE_SIZE, limit - all.length + 10);",
     "occurrence": 0
   },
@@ -753,34 +729,10 @@
   },
   {
     "rule": "silent-clamp",
-    "command": "youtube/history",
-    "file": "clis/youtube/history.js",
-    "line": 22,
-    "text": "await page.autoScroll({ times: Math.min(Math.max(Math.ceil(limit / 20), 1), 8), delayMs: 1200 });",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "youtube/history",
-    "file": "clis/youtube/history.js",
-    "line": 19,
-    "text": "const limit = Math.min(kwargs.limit || 30, 200);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
     "command": "youtube/playlist",
     "file": "clis/youtube/playlist.js",
     "line": 37,
     "text": "const limit = Math.min(kwargs.limit || 50, 200);",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-clamp",
-    "command": "youtube/search",
-    "file": "clis/youtube/search.js",
-    "line": 21,
-    "text": "const limit = Math.min(kwargs.limit || 20, 50);",
     "occurrence": 0
   },
   {
@@ -905,17 +857,9 @@
   },
   {
     "rule": "silent-sentinel",
-    "command": "twitter/article",
-    "file": "clis/twitter/article.js",
-    "line": 109,
-    "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
-    "occurrence": 0
-  },
-  {
-    "rule": "silent-sentinel",
     "command": "twitter/bookmarks",
     "file": "clis/twitter/bookmarks.js",
-    "line": 55,
+    "line": 57,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -923,7 +867,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/likes",
     "file": "clis/twitter/likes.js",
-    "line": 91,
+    "line": 73,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },
@@ -963,7 +907,7 @@
     "rule": "silent-sentinel",
     "command": "twitter/tweets",
     "file": "clis/twitter/tweets.js",
-    "line": 163,
+    "line": 28,
     "text": "const screenName = user?.legacy?.screen_name || user?.core?.screen_name || 'unknown';",
     "occurrence": 0
   },


### PR DESCRIPTION
## Summary

Regenerate the two convention-audit baselines from authoritative `main@50902ffe6b06d63e6c2de00aef01cbc4256ffc42` after the recent adapter, output, and browser-network fixes:

- typed-error lint: 137 → 130 entries
- silent-column-drop: 97 → 94 entries

No production source, docs, manifest, or test changes are included.

## Resolved findings removed

Typed-error baseline:

- `eastmoney/convertible` silent clamp
- `twitter/bookmarks` and `twitter/likes` old fetch-count signatures
- `twitter/article` silent sentinel
- `youtube/history` two silent clamps
- `youtube/search` silent clamp

Silent-column baseline:

- `jike/notifications`
- `twitter/list-remove`
- `xianyu/search`

The seven inserted JSON lines are only current line-number refreshes for surviving Douyin/Twitter findings. Normalized signatures excluding line numbers show no added waiver.

## Verification

- clean-base audits before regeneration: typed current=130/baseline=137/new=0/resolved=7; silent current=94/baseline=97/new=0/resolved=3
- regenerated each file twice with its checker's `--update-baseline`; SHA-256 hashes were stable
- normalized comparison: typed added=0/removed=7; silent added=0/removed=3
- final exact-head gates: typed 130/130 and silent 94/94, both new=0/resolved=0
- full unit/extension/adapter suite with isolated OpenCLI config: 627 files, 7,265 passed + 1 skipped
- typecheck and build (manifest 1,356)
- docs build and coverage 178/178
- production audit: 0 vulnerabilities
- listing-id advisory: 14 existing
- `git diff --check` and merge-tree clean
- #2406 browser-network fix, #2375 output fix, #2393 Ctrip, #2394 Jike, #2395 LinkedIn, #2398 recon docs, #2396 Gmail, Trip, and Nowcoder remain byte-identical to the base
