### PR TITLE
fix: move undici to ^6.28.0 to restore the Node >=20.0.0 contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "js-yaml": "^4.3.1",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
-        "undici": "7.29.0",
+        "undici": "^6.28.0",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -3012,6 +3012,16 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -4039,12 +4049,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "js-yaml": "^4.3.1",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
-    "undici": "7.29.0",
+    "undici": "^6.28.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
#2326 bumped undici 6.27.0 → 7.29.0 citing CVE-2026-13697. Per the GitHub advisory, that CVE's vulnerable ranges are **>=7.0.0 <7.29.0** and 8.x — **6.x was never affected**. The 7.x line, however, requires Node **>=20.18.1**, while `package.json#engines` promises **>=20.0.0** — a silent public-contract break for Node 20.0–20.17 users (npm EBADENGINE warnings, and the runtime floor genuinely rises).

## Fix (decision: WAWQAQ-approved option A)
`undici: ^6.28.0`. What 6.27.0 actually needed was **6.28.0**, which patches the three current advisories that do cover 6.x (CVE-2026-15157 / 16729 / 16728). Advisory matrix verified via the GitHub advisory API:

| Advisory | 6.x range | fixed in |
|---|---|---|
| CVE-2026-13697 | not affected | — |
| CVE-2026-15157 / 16729 / 16728 | <6.28.0 | 6.28.0 |

undici 6.28.0 engines: `node >=18.17` — comfortably within our `>=20.0.0` promise.

## Verification
- `npm audit --omit=dev`: **0 vulnerabilities** after the change.
- `npm ci --dry-run --ignore-scripts`: lock valid.
- `src/node-network.test.ts` (the undici consumer): 8/8 PASS; typecheck PASS; build PASS.
- Full unit project: 1319+ pass; the failing browser-state tests in `cli.test.ts` are the known pre-existing local-env leakage (identical on clean main; hosted CI runs them green).