### PR TITLE
feat(twitter): intercept complete followers timeline

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -39648,7 +39648,7 @@
     "description": "Get accounts following a Twitter/X user (defaults to the logged-in user when no user is given)",
     "access": "read",
     "domain": "x.com",
-    "strategy": "ui",
+    "strategy": "intercept",
     "browser": true,
     "args": [
       {

--- a/clis/twitter/followers.js
+++ b/clis/twitter/followers.js
@@ -1,75 +1,67 @@
-import { ArgumentError, AuthRequiredError, selectorError, EmptyResultError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, EmptyResultError, CommandExecutionError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { normalizeTwitterScreenName, unwrapBrowserResult } from './shared.js';
+import { looksLikePrivateTwitterTimeline, normalizeTwitterGraphqlPayload, normalizeTwitterScreenName, unwrapBrowserResult } from './shared.js';
 
-/**
- * Extract follower rows from Twitter/X follower-list SPA cells.
- *
- * Verified DOM shape on x.com followers list (confirmed live 2026-05-05):
- *   - `[data-testid="UserCell"]` per follower
- *     - `[data-testid="UserAvatar-Container-<handle>"]` — stable handle source
- *     - `[data-testid="<userId>-follow"]` — follow button (i18n-independent)
- *     - `[data-testid="userFollowIndicator"]` — "Follows you" badge when present
- *     - the bio (when present) is rendered into `cell.innerText` but has NO
- *       dedicated testid in the list view (`UserDescription` only appears on
- *       the standalone profile page, NOT inside follower-list cells).
- *
- * Strategy: subtract the i18n-variable button / badge texts from the lines of
- * `cell.innerText`, treat the first remaining `@…` line as the handle, the
- * first non-handle line as display name, and the rest as bio. We avoid
- * locale-coupled string matching (`"Follow"` / `"关注"` / `"Folgen"`).
- *
- * Note: Twitter does NOT render follower COUNTS in the list view, so the
- * `followers` column is omitted from the output schema. Use
- * `opencli twitter profile <user>` to read a per-user follower count.
- */
-async function extractFollowersFromDOM(page) {
-    const script = `() => {
-        const cells = document.querySelectorAll('[data-testid="UserCell"]');
-        const out = [];
-        for (const cell of cells) {
-            // Collect i18n-variable UI strings to strip from the cell text.
-            const stripTexts = new Set();
-            const buttons = cell.querySelectorAll(
-                '[data-testid$="-follow"],[data-testid$="-unfollow"],[data-testid="userFollowIndicator"]'
-            );
-            for (const el of buttons) {
-                const t = (el.innerText || '').trim();
-                if (t) stripTexts.add(t);
+const MAX_PAGINATION_PAGES = 100;
+const CAPTURE_TIMEOUT_SECONDS = 10;
+
+function extractFollower(result) {
+    if (!result || result.__typename !== 'User')
+        return null;
+    const core = result.core || {};
+    const legacy = result.legacy || {};
+    const screenName = core.screen_name || legacy.screen_name || '';
+    if (!screenName) {
+        throw new CommandExecutionError('Malformed Twitter follower: missing screen_name');
+    }
+    return {
+        screen_name: screenName,
+        name: core.name || legacy.name || '',
+        bio: result.profile_bio?.description || legacy.description || '',
+    };
+}
+
+function parseFollowers(value) {
+    const data = normalizeTwitterGraphqlPayload(value);
+    const users = [];
+    let nextCursor = null;
+    let bottomTerminated = false;
+    const instructions = data?.data?.user?.result?.timeline_v2?.timeline?.instructions
+        || data?.data?.user?.result?.timeline?.timeline?.instructions
+        || [];
+    for (const instruction of instructions) {
+        if (instruction?.type === 'TimelineTerminateTimeline' && instruction.direction === 'Bottom') {
+            bottomTerminated = true;
+        }
+        for (const entry of instruction.entries || []) {
+            const content = entry.content;
+            if (content?.entryType === 'TimelineTimelineCursor' || content?.__typename === 'TimelineTimelineCursor') {
+                if (content.cursorType === 'Bottom' || content.cursorType === 'ShowMore')
+                    nextCursor = content.value;
+                continue;
             }
-            const lines = (cell.innerText || '')
-                .split('\\n')
-                .map(s => s.trim())
-                .filter(Boolean)
-                .filter(l => !stripTexts.has(l));
-            // Pull the @handle line; fall back to UserAvatar-Container-<handle>.
-            let screen_name = '';
-            const remaining = [];
-            for (const l of lines) {
-                if (!screen_name && l.startsWith('@')) {
-                    screen_name = l.slice(1).split(/\\s/)[0];
-                } else {
-                    remaining.push(l);
-                }
+            if (entry.entryId?.startsWith('cursor-bottom-') || entry.entryId?.startsWith('cursor-showMore-')) {
+                nextCursor = content?.value || content?.itemContent?.value || nextCursor;
+                continue;
             }
-            if (!screen_name) {
-                const av = cell.querySelector('[data-testid^="UserAvatar-Container-"]');
-                const tid = av ? av.getAttribute('data-testid') || '' : '';
-                if (tid.startsWith('UserAvatar-Container-')) {
-                    screen_name = tid.slice('UserAvatar-Container-'.length);
-                }
-            }
-            // First non-handle line is display name (may equal handle when the user hasn't set one).
-            const name = remaining[0] || screen_name;
-            // Lines past the display name form the bio.
-            const bio = remaining.slice(1).join(' ').replace(/\\s+/g, ' ').trim();
-            if (screen_name) {
-                out.push({ screen_name, name, bio });
+            if (entry.entryId?.startsWith('user-')) {
+                const user = extractFollower(content?.itemContent?.user_results?.result);
+                if (user)
+                    users.push(user);
             }
         }
-        return out;
-    }`;
-    return page.evaluate(script);
+    }
+    return { data, users, nextCursor: bottomTerminated ? null : nextCursor, bottomTerminated };
+}
+
+function twitterGraphqlError(payload) {
+    const errors = payload?.errors;
+    if (!Array.isArray(errors) || errors.length === 0)
+        return null;
+    const first = errors[0] || {};
+    const code = first.code === undefined ? '' : ` ${first.code}`;
+    const message = typeof first.message === 'string' ? `: ${first.message}` : '';
+    return `Twitter Followers GraphQL error${code}${message}`;
 }
 
 function normalizeScreenName(value) {
@@ -82,7 +74,7 @@ cli({
     access: 'read',
     description: 'Get accounts following a Twitter/X user (defaults to the logged-in user when no user is given)',
     domain: 'x.com',
-    strategy: Strategy.UI,
+    strategy: Strategy.INTERCEPT,
     browser: true,
     args: [
         {
@@ -94,8 +86,9 @@ cli({
         },
         { name: 'limit', type: 'int', default: 50, help: 'Maximum number of follower rows to return (default 50). Must be a positive integer.' },
     ],
-    // `followers` (count) is NOT exposed: the SPA followers-list view does not
-    // render it. Use `twitter profile <user>` for per-user follower counts.
+    // Preserve the historical three-column contract even though the GraphQL
+    // payload also contains per-user relationship counts. Use `twitter profile`
+    // when a dedicated follower count is needed.
     columns: ['screen_name', 'name', 'bio'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit;
@@ -108,9 +101,15 @@ cli({
         if (rawUser && !targetUser) {
             throw new ArgumentError('twitter followers user must be a valid Twitter/X handle', 'Example: opencli twitter followers @elonmusk --limit 100');
         }
+        await page.goto('https://x.com/home');
+        await page.wait({ selector: '[data-testid="primaryColumn"]' });
+        const cookies = await page.getCookies({ url: 'https://x.com' });
+        const ct0 = cookies.find((cookie) => cookie.name === 'ct0')?.value || null;
+        if (!ct0) {
+            throw new AuthRequiredError('x.com', 'Not logged into x.com (no ct0 cookie)');
+        }
+
         if (!targetUser) {
-            await page.goto('https://x.com/home');
-            await page.wait({ selector: '[data-testid="primaryColumn"]' });
             // Bridge wraps primitive page.evaluate returns as { session, data:<value> };
             // unwrap so the href string is usable downstream.
             const href = unwrapBrowserResult(await page.evaluate(`() => {
@@ -129,58 +128,75 @@ cli({
             throw new ArgumentError('twitter followers user cannot be empty', 'Example: opencli twitter followers @elonmusk --limit 100');
         }
 
-        // 1. Navigate to profile page
-        await page.goto(`https://x.com/${targetUser}`);
-        await page.wait(3);
-
-        // 2. Click the followers tab via SPA navigation (preserves session/state).
-        //    Twitter sometimes only renders /verified_followers on profiles with
-        //    badge filtering enabled; try the canonical link first, fall back.
-        const safeUser = JSON.stringify(targetUser);
-        const clicked = await page.evaluate(`() => {
-            const target = ${safeUser};
-            const selectors = [
-                'a[href="/' + target + '/followers"]',
-                'a[href="/' + target + '/verified_followers"]',
-            ];
-            for (const sel of selectors) {
-                const link = document.querySelector(sel);
-                if (link) { link.click(); return true; }
-            }
-            return false;
+        await page.installInterceptor('/Followers?');
+        const targetPath = `/${targetUser}/followers`;
+        await page.evaluate(`() => {
+            const targetPath = ${JSON.stringify(targetPath)};
+            window.history.pushState({}, '', targetPath);
+            window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
         }`);
-        if (!clicked) {
-            throw selectorError('Twitter followers link', 'Twitter may have changed the layout.');
+        try {
+            await page.waitForCapture(CAPTURE_TIMEOUT_SECONDS);
+        }
+        catch {
+            throw new TimeoutError('twitter followers API capture', CAPTURE_TIMEOUT_SECONDS, 'No Followers response was observed after opening the followers list.');
+        }
+        const currentPath = unwrapBrowserResult(await page.evaluate('() => window.location.pathname'));
+        if (typeof currentPath !== 'string' || !currentPath.toLowerCase().endsWith('/followers')) {
+            throw new CommandExecutionError('SPA navigation to Twitter followers failed');
         }
 
-        // 3. Wait for follower cells to appear
-        await page.wait({ selector: '[data-testid="UserCell"]', timeout: 10000 });
-
-        // 4. Extract from DOM, scroll to load more, dedupe by screen_name
         const allFollowers = [];
         const seen = new Set();
-        let sameCount = 0;
-        while (allFollowers.length < limit && sameCount < 3) {
-            const rawFollowers = await extractFollowersFromDOM(page);
-            if (!Array.isArray(rawFollowers)) {
-                throw new CommandExecutionError('Twitter followers extraction returned malformed rows');
+        let cursor = null;
+        let lastRawResponse = null;
+        let pages = 0;
+
+        const consumeCaptured = async () => {
+            const requests = await page.getInterceptedRequests();
+            if (!Array.isArray(requests)) {
+                throw new CommandExecutionError('Twitter followers interceptor returned malformed responses');
             }
-            const followers = rawFollowers;
-            const newFollowers = followers.filter(f => !seen.has(f.screen_name));
-            for (const f of newFollowers) {
-                seen.add(f.screen_name);
-                allFollowers.push(f);
+            for (const request of requests) {
+                const { data, users, nextCursor } = parseFollowers(request);
+                const graphqlError = twitterGraphqlError(data);
+                if (graphqlError)
+                    throw new CommandExecutionError(graphqlError);
+                lastRawResponse = data;
+                for (const user of users) {
+                    if (!seen.has(user.screen_name)) {
+                        seen.add(user.screen_name);
+                        allFollowers.push(user);
+                    }
+                }
+                cursor = nextCursor;
             }
-            if (newFollowers.length === 0) {
-                sameCount++;
-            } else {
-                sameCount = 0;
-            }
-            if (allFollowers.length >= limit) break;
+        };
+
+        await consumeCaptured();
+        while (allFollowers.length < limit && cursor && pages < MAX_PAGINATION_PAGES) {
+            const beforeCount = allFollowers.length;
+            const beforeCursor = cursor;
             await page.autoScroll({ times: 1, delayMs: 500 });
-            await page.wait(2);
+            try {
+                await page.waitForCapture(CAPTURE_TIMEOUT_SECONDS);
+            }
+            catch {
+                throw new TimeoutError('twitter followers pagination', CAPTURE_TIMEOUT_SECONDS, `Twitter returned a continuation cursor after ${allFollowers.length} rows, but the next Followers response was not observed.`);
+            }
+            await consumeCaptured();
+            pages++;
+            if (allFollowers.length === beforeCount && cursor === beforeCursor) {
+                throw new CommandExecutionError('Twitter followers pagination repeated a cursor without returning new users');
+            }
+        }
+        if (allFollowers.length < limit && cursor && pages >= MAX_PAGINATION_PAGES) {
+            throw new CommandExecutionError(`Twitter followers pagination exceeded ${MAX_PAGINATION_PAGES} pages before cursor exhaustion`);
         }
         if (allFollowers.length === 0) {
+            if (looksLikePrivateTwitterTimeline(lastRawResponse)) {
+                throw new EmptyResultError('twitter followers', `No follower data returned for @${targetUser} (the target account may have set their followers list to private)`);
+            }
             throw new EmptyResultError('twitter followers', `No followers found for @${targetUser}`);
         }
         return allFollowers.slice(0, limit);
@@ -188,6 +204,8 @@ cli({
 });
 
 export const __test__ = {
-    extractFollowersFromDOM,
+    extractFollower,
     normalizeScreenName,
+    parseFollowers,
+    twitterGraphqlError,
 };

--- a/clis/twitter/followers.test.js
+++ b/clis/twitter/followers.test.js
@@ -1,9 +1,81 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import { __test__ } from './followers.js';
 
-describe('twitter followers command', () => {
+function followerResult(screenName, overrides = {}) {
+    return {
+        __typename: 'User',
+        core: { screen_name: screenName, name: screenName.toUpperCase() },
+        profile_bio: { description: `${screenName} bio` },
+        relationship_counts: { followers: 10, following: 5 },
+        ...overrides,
+    };
+}
+
+function followersPayload(users, cursor, { terminateBottom = false } = {}) {
+    return {
+        data: {
+            user: {
+                result: {
+                    __typename: 'User',
+                    timeline: {
+                        timeline: {
+                            instructions: [
+                                ...(terminateBottom ? [{ type: 'TimelineTerminateTimeline', direction: 'Bottom' }] : []),
+                                {
+                                    entries: [
+                                        ...users.map((name) => ({
+                                            entryId: `user-${name}`,
+                                            content: {
+                                                itemContent: {
+                                                    user_results: { result: followerResult(name) },
+                                                },
+                                            },
+                                        })),
+                                        ...(cursor ? [{
+                                            entryId: `cursor-bottom-${cursor}`,
+                                            content: {
+                                                entryType: 'TimelineTimelineCursor',
+                                                cursorType: 'Bottom',
+                                                value: cursor,
+                                            },
+                                        }] : []),
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function createFollowersPage(captureBatches, {
+    ct0 = 'token',
+    profileHref = '/viewer',
+    currentPath = '/elonmusk/followers',
+} = {}) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn(async () => (ct0 ? [{ name: 'ct0', value: ct0 }] : [])),
+        installInterceptor: vi.fn().mockResolvedValue(undefined),
+        waitForCapture: vi.fn().mockResolvedValue(undefined),
+        autoScroll: vi.fn().mockResolvedValue(undefined),
+        getInterceptedRequests: vi.fn(async () => captureBatches.shift() || []),
+        evaluate: vi.fn(async (script) => {
+            const text = String(script);
+            if (text.includes('AppTabBar_Profile_Link')) return profileHref;
+            if (text.includes('window.location.pathname')) return currentPath;
+            if (text.includes('history.pushState')) return undefined;
+            throw new Error(`Unexpected evaluate: ${text.slice(0, 100)}`);
+        }),
+    };
+}
+
+describe('twitter followers helpers', () => {
     it('normalizes exact profile handles and rejects route-like hrefs', () => {
         expect(__test__.normalizeScreenName('@viewer')).toBe('viewer');
         expect(__test__.normalizeScreenName('/viewer')).toBe('viewer');
@@ -12,51 +84,155 @@ describe('twitter followers command', () => {
         expect(__test__.normalizeScreenName('/viewer/extra')).toBe('');
     });
 
+    it('extracts modern GraphQL user fields and preserves the three-column contract', () => {
+        expect(__test__.extractFollower(followerResult('alice'))).toEqual({
+            screen_name: 'alice',
+            name: 'ALICE',
+            bio: 'alice bio',
+        });
+    });
+
+    it('falls back to legacy user fields', () => {
+        expect(__test__.extractFollower({
+            __typename: 'User',
+            legacy: { screen_name: 'legacy', name: 'Legacy', description: 'old bio' },
+        })).toEqual({ screen_name: 'legacy', name: 'Legacy', bio: 'old bio' });
+    });
+
+    it('typed-fails when a GraphQL user loses its identity field', () => {
+        expect(() => __test__.extractFollower({ __typename: 'User', core: { name: 'Missing' } }))
+            .toThrow(CommandExecutionError);
+    });
+
+    it('parses timeline users and the bottom cursor', () => {
+        const parsed = __test__.parseFollowers(followersPayload(['alice', 'bob'], 'cursor-1'));
+        expect(parsed.users.map((user) => user.screen_name)).toEqual(['alice', 'bob']);
+        expect(parsed.nextCursor).toBe('cursor-1');
+    });
+
+    it('treats a bottom termination instruction as authoritative over a decorative cursor', () => {
+        const parsed = __test__.parseFollowers(followersPayload(['alice'], 'decorative-cursor', { terminateBottom: true }));
+        expect(parsed.users.map((user) => user.screen_name)).toEqual(['alice']);
+        expect(parsed.bottomTerminated).toBe(true);
+        expect(parsed.nextCursor).toBeNull();
+    });
+
+    it('unwraps Browser Bridge envelopes before parsing', () => {
+        const parsed = __test__.parseFollowers({ session: 'site:twitter', data: followersPayload(['alice'], null) });
+        expect(parsed.users.map((user) => user.screen_name)).toEqual(['alice']);
+    });
+
+    it('formats GraphQL error payloads without treating them as empty success', () => {
+        expect(__test__.twitterGraphqlError({ errors: [{ code: 88, message: 'Rate limit exceeded' }] }))
+            .toBe('Twitter Followers GraphQL error 88: Rate limit exceeded');
+        expect(__test__.twitterGraphqlError({ data: {} })).toBeNull();
+    });
+});
+
+describe('twitter followers command', () => {
     it('rejects invalid explicit users before navigation', async () => {
         const command = getRegistry().get('twitter/followers');
-        const page = {
-            goto: vi.fn(),
-            wait: vi.fn(),
-            evaluate: vi.fn(),
-        };
+        const page = createFollowersPage([]);
 
         await expect(command.func(page, { user: 'viewer/extra', limit: 10 })).rejects.toBeInstanceOf(ArgumentError);
         expect(page.goto).not.toHaveBeenCalled();
-        expect(page.wait).not.toHaveBeenCalled();
-        expect(page.evaluate).not.toHaveBeenCalled();
+        expect(page.getCookies).not.toHaveBeenCalled();
     });
 
-    it('rejects non-profile AppTabBar hrefs instead of navigating to route followers', async () => {
+    it('requires an authenticated x.com session before interception', async () => {
         const command = getRegistry().get('twitter/followers');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            wait: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn(async (script) => {
-                if (String(script).includes('AppTabBar_Profile_Link')) return '/home';
-                throw new Error(`Unexpected evaluate: ${String(script).slice(0, 80)}`);
-            }),
-        };
+        const page = createFollowersPage([], { ct0: null });
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 })).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.installInterceptor).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-profile AppTabBar hrefs instead of navigating to a route-like handle', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([], { profileHref: '/home' });
 
         await expect(command.func(page, { limit: 10 })).rejects.toBeInstanceOf(AuthRequiredError);
         expect(page.goto).toHaveBeenCalledWith('https://x.com/home');
-        expect(page.goto).not.toHaveBeenCalledWith('https://x.com/home/followers');
+        expect(page.installInterceptor).not.toHaveBeenCalled();
     });
 
-    it('typed-fails instead of throwing "filter is not a function" when extractFollowersFromDOM returns a non-array', async () => {
+    it('intercepts the canonical Followers operation, paginates, deduplicates, and respects limit', async () => {
         const command = getRegistry().get('twitter/followers');
-        const page = {
-            goto: vi.fn().mockResolvedValue(undefined),
-            wait: vi.fn().mockResolvedValue(undefined),
-            autoScroll: vi.fn().mockResolvedValue(undefined),
-            evaluate: vi.fn(async (script) => {
-                const text = String(script);
-                if (text.includes('AppTabBar_Profile_Link')) return '/viewer';
-                if (text.includes('/followers') && text.includes('click')) return true;
-                if (text.includes('UserCell')) return undefined;
-                return undefined;
-            }),
-        };
+        const page = createFollowersPage([
+            [followersPayload(['alice', 'bob'], 'cursor-1')],
+            [followersPayload(['bob', 'carol', 'dave'], null)],
+        ]);
 
-        await expect(command.func(page, { user: 'someone', limit: 5 })).rejects.toBeInstanceOf(CommandExecutionError);
+        const rows = await command.func(page, { user: '@elonmusk', limit: 3 });
+
+        expect(rows.map((row) => row.screen_name)).toEqual(['alice', 'bob', 'carol']);
+        expect(page.installInterceptor).toHaveBeenCalledWith('/Followers?');
+        expect(page.autoScroll).toHaveBeenCalledTimes(1);
+        expect(page.waitForCapture).toHaveBeenCalledTimes(2);
+        const navigation = page.evaluate.mock.calls.find(([script]) => String(script).includes('history.pushState'));
+        expect(String(navigation?.[0])).toContain('/elonmusk/followers');
+        expect(String(navigation?.[0])).not.toContain('verified_followers');
+    });
+
+    it('typed-fails when the initial Followers capture times out', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([]);
+        page.waitForCapture.mockRejectedValueOnce(new Error('No network capture'));
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 }))
+            .rejects.toBeInstanceOf(TimeoutError);
+        expect(page.getInterceptedRequests).not.toHaveBeenCalled();
+    });
+
+    it('does not silently return partial rows when a later GraphQL page fails', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([
+            [followersPayload(['alice'], 'cursor-1')],
+            [{ errors: [{ code: 88, message: 'Rate limit exceeded' }] }],
+        ]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('returns the upstream-complete first page without scrolling when Twitter terminates the bottom timeline', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([[
+            followersPayload(['alice', 'bob'], 'decorative-cursor', { terminateBottom: true }),
+        ]]);
+
+        const rows = await command.func(page, { user: 'elonmusk', limit: 100 });
+
+        expect(rows.map((row) => row.screen_name)).toEqual(['alice', 'bob']);
+        expect(page.autoScroll).not.toHaveBeenCalled();
+    });
+
+    it('does not silently return partial rows when a continuation capture times out', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([[followersPayload(['alice'], 'cursor-1')]]);
+        page.waitForCapture
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error('No network capture'));
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 }))
+            .rejects.toBeInstanceOf(TimeoutError);
+    });
+
+    it('surfaces a private-followers hint for an empty timeline object', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([[
+            { data: { user: { result: { __typename: 'User', timeline: {} } } } },
+        ]]);
+
+        await expect(command.func(page, { user: 'private_user', limit: 10 }))
+            .rejects.toMatchObject({ hint: expect.stringContaining('followers list to private') });
+    });
+
+    it('fails fast when the interceptor returns no follower rows', async () => {
+        const command = getRegistry().get('twitter/followers');
+        const page = createFollowersPage([[followersPayload([], null)]]);
+
+        await expect(command.func(page, { user: 'elonmusk', limit: 10 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
     });
 });


### PR DESCRIPTION
## Summary

- replace virtualized DOM scraping with the browser's natural `Followers` GraphQL response
- always open the full `/<user>/followers` route; remove the verified-only fallback
- preserve `screen_name,name,bio` while adding typed auth, GraphQL, timeout, private-list, malformed, repeated-cursor, and pagination-guard failures

## Why INTERCEPT

The signed-in site request includes an opaque `x-client-transaction-id`. The natural page request returned HTTP 200 and 70 users; an otherwise equivalent same-origin replay without that site-generated header returned HTTP 404. Interception reuses the browser's exact request without copying or reverse-engineering transaction signing.

The old DOM implementation returned only 23 rows for `elonmusk --limit 100` and silently navigated to `/verified_followers`. The new implementation returned the upstream-complete 70 full followers in 6.6 seconds. A default-limit live run returned exactly 50 rows in 5.4 seconds.

`TimelineTerminateTimeline` with `direction: Bottom` is treated as authoritative even when the same response contains a decorative bottom cursor.

## Verification

- focused followers/following tests: 41/41
- all Twitter tests: 45 files / 553 tests
- typecheck
- build: 1,334 manifest entries
- `validate twitter`: 46 commands, 0 errors, 0 warnings
- typed-error lint: new=0
- silent-column-drop: new=0
- live traces: `20260824101157-994dbe20`, `20260824101610-f94dd8b6`
