### PR TITLE
fix: declare the Node >=20.18.1 floor that undici 7.x already requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ open the app once and use the System page to install or repair the `opencli`
 command.
 
 **Option B — npm global install (CLI-only / CI / servers):**
-OpenCLI requires **Node.js >= 20** when installed through npm.
+OpenCLI requires **Node.js >= 20.18.1** when installed through npm.
 
 ```bash
 node --version
@@ -290,7 +290,7 @@ See **[TESTING.md](./TESTING.md)** for how to run and write tests.
 - **"Extension not connected"** — Ensure the Browser Bridge extension is installed from the [Chrome Web Store](https://chromewebstore.google.com/detail/opencli/ildkmabpimmkaediidaifkhjpohdnifk) and **enabled** in `chrome://extensions`.
 - **"attach failed: Cannot access a chrome-extension:// URL"** — Another extension may be interfering. Try disabling other extensions temporarily.
 - **Empty data or 'Unauthorized' error** — Your Chrome/Chromium login session may have expired. Navigate to the target site and log in again.
-- **Node API errors / missing `fetch` / startup crash on old Node** — OpenCLI requires **Node.js >= 20**. Run `node --version`, upgrade Node if needed, then retry.
+- **Node API errors / missing `fetch` / startup crash on old Node** — OpenCLI requires **Node.js >= 20.18.1**. Run `node --version`, upgrade Node if needed, then retry.
 - **Daemon issues** — Check status: `curl localhost:19825/status` · View logs: `curl localhost:19825/logs`
 
 ## Star History

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ UI 来做环境诊断、更新、浏览器登录态保活和网页转 Markdown�
 System 页面安装或修复 `opencli` 命令。
 
 **方式 B — npm 全局安装（纯 CLI / CI / 服务器）：**
-通过 npm 安装时，OpenCLI 要求 **Node.js >= 20**。
+通过 npm 安装时，OpenCLI 要求 **Node.js >= 20.18.1**。
 
 ```bash
 node --version
@@ -328,7 +328,7 @@ opencli plugin uninstall my-tool                            # 卸载
 - **返回空数据，或者报错 "Unauthorized"**
   - Chrome/Chromium 里的登录态可能已经过期。请打开当前页面，在新标签页重新手工登录或刷新该页面。
 - **Node API 错误 / 缺少 `fetch` / 旧 Node 启动即崩**
-  - OpenCLI 要求 **Node.js >= 20**。先执行 `node --version`，如果版本过低先升级，再重试命令。
+  - OpenCLI 要求 **Node.js >= 20.18.1**。先执行 `node --version`，如果版本过低先升级，再重试命令。
 - **Daemon 问题**
   - 检查 daemon 状态：`curl localhost:19825/status`
   - 查看扩展日志：`curl localhost:19825/logs`

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Make any website or Electron App your CLI. AI-powered.",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.1"
   },
   "type": "module",
   "main": "dist/src/main.js",


### PR DESCRIPTION
## Summary
`undici@7.29.0` (pinned by #2326) requires Node `>=20.18.1`; `package.json#engines` still promised `>=20.0.0`. This updates the declaration to match reality: engines, the lock's root mirror, and both README (en/zh) Node claims.

## Why declare-up rather than downgrade undici (first principles, per @WAWQAQ)
The earlier alternative (#2379, closed) proposed undici `^6.28.0` to preserve the `>=20.0.0` promise. Re-derivation showed that promise protects nobody: **Node 20 reached EOL in April 2026**, so a 20.0–20.17 user is on an unpatched EOL runtime regardless of what we declare. Security-forward posture favors the maintained undici 7.x line — future advisories land there first, while 6.x backports can stop any time. Current state: production `npm audit` is 0 either way; this PR just makes the floor honest.

## Not changed
`src/main.ts`'s fast-path Node gate stays major-level (`>=20`) — it is a friendly startup helper, not the contract; npm's EBADENGINE handles the precise floor.

## Gates (local)
`npm ci --dry-run --ignore-scripts` valid; typecheck PASS; build PASS (manifest unchanged).