### PR TITLE
fix(twitter): read current following follower counts

### DIFF
--- a/clis/twitter/following.js
+++ b/clis/twitter/following.js
@@ -77,7 +77,10 @@ function extractUser(result) {
         screen_name: screenName,
         name: core.name || legacy.name || '',
         bio: legacy.description || result.profile_bio?.description || '',
-        followers: legacy.followers_count || legacy.normal_followers_count || 0,
+        followers: result.relationship_counts?.followers
+            ?? legacy.followers_count
+            ?? legacy.normal_followers_count
+            ?? 0,
     };
 }
 

--- a/clis/twitter/following.test.js
+++ b/clis/twitter/following.test.js
@@ -39,6 +39,24 @@ describe('twitter following helpers', () => {
         });
     });
 
+    it('reads the current relationship_counts follower field before legacy fallbacks', () => {
+        const user = __test__.extractUser({
+            __typename: 'User',
+            core: { screen_name: 'alice', name: 'Alice' },
+            relationship_counts: { followers: 123 },
+            legacy: { followers_count: 100 },
+        });
+        expect(user?.followers).toBe(123);
+
+        const zero = __test__.extractUser({
+            __typename: 'User',
+            core: { screen_name: 'new_account', name: 'New Account' },
+            relationship_counts: { followers: 0 },
+            legacy: { followers_count: 100 },
+        });
+        expect(zero?.followers).toBe(0);
+    });
+
     it('returns null for non-User typename', () => {
         expect(__test__.extractUser({ __typename: 'Tweet' })).toBeNull();
         expect(__test__.extractUser(null)).toBeNull();
@@ -200,6 +218,7 @@ function followingPayload(users, cursor) {
                                                     result: {
                                                         __typename: 'User',
                                                         core: { screen_name: name, name: name.toUpperCase() },
+                                                        relationship_counts: { followers: 42 },
                                                         legacy: { description: `${name} bio`, followers_count: 10 },
                                                     },
                                                 },
@@ -263,6 +282,7 @@ describe('twitter following command', () => {
         const rows = await command.func(page, { user: '@elonmusk', limit: 3 });
 
         expect(rows.map((row) => row.screen_name)).toEqual(['alice', 'bob', 'carol']);
+        expect(rows.map((row) => row.followers)).toEqual([42, 42, 42]);
         expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://x.com' });
         const callText = (call) => call.map((part) => typeof part === 'function' ? part.toString() : String(part)).join('\n');
         const userLookupScript = callText(page.evaluate.mock.calls.find((call) => callText(call).includes('/UserByScreenName')) || []);


### PR DESCRIPTION
## Summary

- read follower counts from the current GraphQL `relationship_counts.followers` field
- preserve legacy `followers_count` / `normal_followers_count` fallbacks
- use nullish precedence so a real modern count of zero is not replaced by stale legacy data

## Live evidence

Before this patch, `twitter following elonmusk --limit 3` returned follower counts `[0, 0, 0]`. The captured current `Following` payload contains non-zero counts only under `relationship_counts.followers`.

After the patch, the same three accounts returned `[6180586, 16207011, 3489262]`.

Traces:
- before: `20260824105435-21b9d7a4`
- after: `20260824105712-130e348f`

## Verification

- focused following/followers: 42/42
- all Twitter tests: 45 files / 554 tests
- typecheck
- build: 1,334 manifest entries
- `validate twitter`: 46 commands, 0 errors, 0 warnings
- typed-error lint: new=0
- silent-column-drop: new=0
