### PR TITLE
fix(jike): reject anonymous read sessions

### DIFF
--- a/clis/jike/auth-read.test.js
+++ b/clis/jike/auth-read.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { requireJikeIdentity } from './utils.js';
+import './auth.js';
+import './feed.js';
+import './notifications.js';
+import './search.js';
+
+function makePage(...evaluateResults) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    autoScroll: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockImplementation(async () => evaluateResults.shift()),
+  };
+}
+
+const identity = {
+  ok: true,
+  user_id: 'user-1',
+  screen_name: 'Alice',
+  username: 'alice',
+};
+
+describe('Jike identity guard', () => {
+  it('preserves the whoami identity contract', async () => {
+    const page = makePage(identity);
+
+    await expect(getRegistry().get('jike/whoami').func(page, {})).resolves.toEqual({
+      logged_in: true,
+      site: 'jike',
+      user_id: 'user-1',
+      screen_name: 'Alice',
+      username: 'alice',
+    });
+    expect(page.goto).toHaveBeenCalledWith('https://web.okjike.com/');
+  });
+
+  it('classifies missing or rejected credentials as AuthRequiredError', async () => {
+    await expect(requireJikeIdentity(makePage({
+      kind: 'auth',
+      detail: 'Jike JK_ACCESS_TOKEN missing from localStorage (anonymous)',
+    }))).rejects.toBeInstanceOf(AuthRequiredError);
+  });
+
+  it.each([
+    [{ kind: 'http', httpStatus: 503 }],
+    [{ kind: 'exception', detail: 'network failed' }],
+    [{ unexpected: true }],
+  ])('classifies non-auth probe failure as CommandExecutionError', async (probe) => {
+    await expect(requireJikeIdentity(makePage(probe))).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it.each([
+    ['jike/feed', {}, 'https://web.okjike.com'],
+    ['jike/search', { query: 'OpenCLI' }, 'https://web.okjike.com/search?q=OpenCLI'],
+    ['jike/notifications', {}, 'https://web.okjike.com/notification'],
+  ])('prevents %s from silently returning an empty anonymous result', async (commandName, args, expectedUrl) => {
+    const page = makePage({
+      kind: 'auth',
+      detail: 'Jike JK_ACCESS_TOKEN missing from localStorage (anonymous)',
+    });
+
+    await expect(getRegistry().get(commandName).func(page, args)).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(page.goto).toHaveBeenCalledWith(expectedUrl);
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [
+      'jike/feed',
+      { limit: 1 },
+      [{ id: 'post-1', author: 'Alice', content: 'hello', likes: 2, comments: 1, time: 'now', url: 'https://web.okjike.com/originalPost/post-1' }],
+    ],
+    [
+      'jike/search',
+      { query: 'OpenCLI', limit: 1 },
+      [{ id: 'post-2', author: 'Bob', content: 'result', likes: 3, comments: 4, time: 'later', url: 'https://web.okjike.com/originalPost/post-2' }],
+    ],
+  ])('continues %s extraction after a successful identity probe', async (commandName, args, rows) => {
+    const page = makePage(identity, rows);
+
+    await expect(getRegistry().get(commandName).func(page, args)).resolves.toEqual(rows);
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues notification extraction after a successful identity probe', async () => {
+    const page = makePage(identity, [{
+      actionType: 'LIKE_ORIGINAL_POST',
+      fromUser: 'Bob',
+      content: 'hello\nworld',
+      time: 'now',
+    }]);
+
+    await expect(getRegistry().get('jike/notifications').func(page, { limit: 1 })).resolves.toEqual([{
+      type: '赞了你',
+      user: 'Bob',
+      content: 'hello world',
+      time: 'now',
+    }]);
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clis/jike/auth-read.test.js
+++ b/clis/jike/auth-read.test.js
@@ -37,6 +37,26 @@ describe('Jike identity guard', () => {
     expect(page.goto).toHaveBeenCalledWith('https://web.okjike.com/');
   });
 
+  it('keeps login polling after a transient non-auth probe failure', async () => {
+    const page = makePage(
+      { kind: 'auth', detail: 'anonymous' },
+      { kind: 'http', httpStatus: 503 },
+      identity,
+    );
+
+    await expect(getRegistry().get('jike/login').func(page, { timeout: 5 })).resolves.toEqual({
+      status: 'login_complete',
+      logged_in: true,
+      site: 'jike',
+      user_id: 'user-1',
+      screen_name: 'Alice',
+      username: 'alice',
+    });
+    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://web.okjike.com/');
+    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://web.okjike.com/login');
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+  });
+
   it('classifies missing or rejected credentials as AuthRequiredError', async () => {
     await expect(requireJikeIdentity(makePage({
       kind: 'auth',

--- a/clis/jike/auth.js
+++ b/clis/jike/auth.js
@@ -22,10 +22,11 @@ registerSiteAuthCommands({
     try {
       return await requireJikeIdentity(page);
     } catch (error) {
-      if (error instanceof AuthRequiredError) {
-        throw new AuthRequiredError('web.okjike.com', 'Waiting for Jike login');
-      }
-      throw error;
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new AuthRequiredError(
+        'web.okjike.com',
+        detail ? `Waiting for Jike login: ${detail}` : 'Waiting for Jike login',
+      );
     }
   },
 });

--- a/clis/jike/auth.js
+++ b/clis/jike/auth.js
@@ -1,37 +1,15 @@
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+import { requireJikeIdentity } from './utils.js';
 
 // Jike web (web.okjike.com) is an SPA shell that stores a JWT in localStorage
 // under JK_ACCESS_TOKEN and forwards it as the x-jike-access-token header to the
 // api.ruguoapp.com gateway. The JWT payload is encrypted, so identity is read
 // from the /1.0/users/profile endpoint rather than from the token or a cookie.
-const WHOAMI_PROBE = `(async () => {
-  try {
-    const token = localStorage.getItem('JK_ACCESS_TOKEN') || '';
-    if (!token) return { kind: 'auth', detail: 'Jike JK_ACCESS_TOKEN missing from localStorage (anonymous)' };
-    const r = await fetch('https://api.ruguoapp.com/1.0/users/profile', {
-      headers: { 'x-jike-access-token': token, Accept: 'application/json' },
-    });
-    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Jike users/profile HTTP ' + r.status };
-    if (!r.ok) return { kind: 'http', httpStatus: r.status };
-    const d = await r.json();
-    const u = d && d.user;
-    if (!u || !u.id) return { kind: 'auth', detail: 'Jike users/profile returned no user (anonymous)' };
-    return { ok: true, user_id: String(u.id), screen_name: String(u.screenName || ''), username: String(u.username || '') };
-  } catch (e) {
-    return { kind: 'exception', detail: String(e && e.message || e) };
-  }
-})()`;
-
 async function verifyJikeIdentity(page) {
   await page.goto('https://web.okjike.com/');
   await page.wait(2);
-  const probe = await page.evaluate(WHOAMI_PROBE);
-  if (probe?.kind === 'auth') throw new AuthRequiredError('web.okjike.com', probe.detail);
-  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Jike users/profile`);
-  if (probe?.kind === 'exception') throw new CommandExecutionError(`Jike whoami failed: ${probe.detail}`);
-  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jike probe: ${JSON.stringify(probe)}`);
-  return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+  return requireJikeIdentity(page);
 }
 
 registerSiteAuthCommands({
@@ -41,8 +19,13 @@ registerSiteAuthCommands({
   columns: ['user_id', 'screen_name', 'username'],
   verify: verifyJikeIdentity,
   poll: async (page) => {
-    const probe = await page.evaluate(WHOAMI_PROBE);
-    if (!probe?.ok) throw new AuthRequiredError('web.okjike.com', 'Waiting for Jike login');
-    return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+    try {
+      return await requireJikeIdentity(page);
+    } catch (error) {
+      if (error instanceof AuthRequiredError) {
+        throw new AuthRequiredError('web.okjike.com', 'Waiting for Jike login');
+      }
+      throw error;
+    }
   },
 });

--- a/clis/jike/feed.js
+++ b/clis/jike/feed.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getPostDataJs } from './utils.js';
+import { getPostDataJs, requireJikeIdentity } from './utils.js';
 /**
  * 即刻首页动态流适配器
  *
@@ -22,6 +22,7 @@ cli({
         const limit = kwargs.limit || 20;
         // 1. 导航到即刻首页，等待 SPA 重定向到 /following
         await page.goto('https://web.okjike.com');
+        await requireJikeIdentity(page);
         // 2. 通过 React fiber 提取帖子数据
         const extract = async () => {
             return (await page.evaluate(`(() => {

--- a/clis/jike/notifications.js
+++ b/clis/jike/notifications.js
@@ -1,4 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { requireJikeIdentity } from './utils.js';
 // 将通知类型代码映射为中文标签
 function resolveActionLabel(type) {
     if (!type)
@@ -34,6 +35,7 @@ cli({
         const limit = kwargs.limit || 20;
         // 1. 直接导航到通知页
         await page.goto('https://web.okjike.com/notification');
+        await requireJikeIdentity(page);
         // 3. 优先用 React fiber 提取通知数据
         //    通知 fiber 数据结构与帖子不同，需查找含 type + user 字段的 props
         const fiberResults = (await page.evaluate(`(() => {

--- a/clis/jike/search.js
+++ b/clis/jike/search.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getPostDataJs } from './utils.js';
+import { getPostDataJs, requireJikeIdentity } from './utils.js';
 /**
  * 即刻搜索适配器
  *
@@ -25,6 +25,7 @@ cli({
         // 1. 直接导航到搜索页
         const encodedKeyword = encodeURIComponent(keyword);
         await page.goto(`https://web.okjike.com/search?q=${encodedKeyword}`);
+        await requireJikeIdentity(page);
         // 2. 通过 React fiber 提取帖子数据
         const extract = async () => {
             return (await page.evaluate(`(() => {

--- a/clis/jike/utils.js
+++ b/clis/jike/utils.js
@@ -1,9 +1,39 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+
 /**
  * 即刻适配器公共定义
  *
  * JikePost 接口和 getPostData 函数在 feed.ts / search.ts 中复用，
  * 统一维护于此文件避免重复。
  */
+
+const JIKE_IDENTITY_PROBE = `(async () => {
+  try {
+    const token = localStorage.getItem('JK_ACCESS_TOKEN') || '';
+    if (!token) return { kind: 'auth', detail: 'Jike JK_ACCESS_TOKEN missing from localStorage (anonymous)' };
+    const r = await fetch('https://api.ruguoapp.com/1.0/users/profile', {
+      headers: { 'x-jike-access-token': token, Accept: 'application/json' },
+    });
+    if (r.status === 401 || r.status === 403) return { kind: 'auth', detail: 'Jike users/profile HTTP ' + r.status };
+    if (!r.ok) return { kind: 'http', httpStatus: r.status };
+    const d = await r.json();
+    const u = d && d.user;
+    if (!u || !u.id) return { kind: 'auth', detail: 'Jike users/profile returned no user (anonymous)' };
+    return { ok: true, user_id: String(u.id), screen_name: String(u.screenName || ''), username: String(u.username || '') };
+  } catch (e) {
+    return { kind: 'exception', detail: String(e && e.message || e) };
+  }
+})()`;
+
+export async function requireJikeIdentity(page) {
+  const probe = await page.evaluate(JIKE_IDENTITY_PROBE);
+  if (probe?.kind === 'auth') throw new AuthRequiredError('web.okjike.com', probe.detail);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Jike users/profile`);
+  if (probe?.kind === 'exception') throw new CommandExecutionError(`Jike identity probe failed: ${probe.detail}`);
+  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jike identity probe: ${JSON.stringify(probe)}`);
+  return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+}
+
 /**
  * 注入浏览器 evaluate 的 JS 函数字符串。
  * 从 React fiber 树中向上最多走 10 层，找到含 id 字段的 props.data。


### PR DESCRIPTION
## Summary

- share the existing Jike `users/profile` identity probe between auth and read commands
- make `feed`, `search`, and `notifications` fail with `AUTH_REQUIRED` before Fiber/DOM extraction when the page session is anonymous or expired
- preserve the existing `whoami` identity contract and the login command's retry-on-transient-probe-failure semantics
- preserve all read-command columns/extraction behavior

## Evidence

On the current connected Chrome profile, `jike whoami` returned `AUTH_REQUIRED`, while the three read commands each returned successful `[]`. A same-origin read-only replay of `POST https://api.ruguoapp.com/1.0/personalUpdate/followingUpdates` had no `JK_ACCESS_TOKEN`/`JK_DEVICE_ID` and returned HTTP 401 with upstream message `未登录`.

This PR intentionally does not migrate feed/search/notifications to their internal APIs: the current profile cannot provide the required signed-in non-empty response, pagination termination, and field-parity evidence. It only fixes the independently proven silent-auth failure.

## Verification

- `npx vitest run clis/jike/*.test.js` — 17/17 pass
- command-level login regression: anonymous → transient profile HTTP 503 → successful identity continues polling and completes
- `npm run typecheck` — pass
- `npm run build` — pass, manifest 1,335 entries
- `node dist/src/main.js validate jike` — 12 commands, 0 errors/warnings
- `npm run check:typed-error-lint` — new=0
- `npm run check:silent-column-drop` — new=0
- live built commands: feed/search/notifications each exit 77 with `AUTH_REQUIRED`
- `git diff --check` — pass
