### PR TITLE
fix(trip): repair flight extraction — dropped font-black class emptied every row

### DIFF
--- a/clis/trip/flight-round.js
+++ b/clis/trip/flight-round.js
@@ -66,7 +66,11 @@ cli({
         }
         const raw = await page.evaluate(buildFlightExtractJs());
         if (!Array.isArray(raw)) {
-            throw new CommandExecutionError('Trip.com flight DOM extraction returned malformed rows');
+            const reason = raw && typeof raw === 'object' && typeof raw.error === 'string'
+                && /^malformed flight card \d+: [a-z /]+$/.test(raw.error)
+                ? `: ${raw.error}`
+                : '';
+            throw new CommandExecutionError(`Trip.com flight DOM extraction returned malformed rows${reason}`);
         }
         if (raw.length === 0) {
             throw new EmptyResultError('trip flight-round', `No round-trip flights for ${fromCode} to ${toCode} on ${depart} .. ${ret}`);

--- a/clis/trip/flight.js
+++ b/clis/trip/flight.js
@@ -61,7 +61,11 @@ cli({
         }
         const raw = await page.evaluate(buildFlightExtractJs());
         if (!Array.isArray(raw)) {
-            throw new CommandExecutionError('Trip.com flight DOM extraction returned malformed rows');
+            const reason = raw && typeof raw === 'object' && typeof raw.error === 'string'
+                && /^malformed flight card \d+: [a-z /]+$/.test(raw.error)
+                ? `: ${raw.error}`
+                : '';
+            throw new CommandExecutionError(`Trip.com flight DOM extraction returned malformed rows${reason}`);
         }
         if (raw.length === 0) {
             throw new EmptyResultError('trip flight', `No flights for ${fromCode} to ${toCode} on ${date}`);

--- a/clis/trip/trip.test.js
+++ b/clis/trip/trip.test.js
@@ -160,8 +160,8 @@ describe('trip flight command (registry-level)', () => {
     it('throws CommandExecutionError on render timeout and on malformed extraction', async () => {
         await expect(cmd.func(createPageMock(['timeout']), { from: 'LON', to: 'NYC', date: '2026-08-15', limit: 5 }))
             .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not render flight cards') });
-        await expect(cmd.func(createPageMock(['content', { rows: [] }]), { from: 'LON', to: 'NYC', date: '2026-08-15', limit: 5 }))
-            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed rows') });
+        await expect(cmd.func(createPageMock(['content', { error: 'malformed flight card 0: endpoint time/airport' }]), { from: 'LON', to: 'NYC', date: '2026-08-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('endpoint time/airport') });
     });
 
     it('throws EmptyResultError when extraction returns no flights', async () => {
@@ -202,12 +202,20 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
     const CARD = `
       <div class="result-item">
         <div data-testid="flights-name">Norse Atlantic Airways</div>
-        <div data-testid="flight-time-2026-09-07 13:05:00"><span>1:05</span><span>PM</span></div>
-        <div>LGW</div><div>N</div>
-        <div data-testid="flightInfoDuration"><span>7h 50m</span></div>
-        <div data-testid="stopInfoText">Nonstop</div>
-        <div data-testid="flight-time-2026-09-07 15:55:00"><span>3:55</span><span>PM</span></div>
-        <div>JFK</div><div>T4</div>
+        <div data-testid="flt-info-stop__wrapper">
+          <div role="textbox" aria-label="London Gatwick Airport N">
+            <div><span data-testid="flight-time-2026-09-07 13:05:00"><span>1:05</span><span>PM</span></span></div>
+            <span><span>LGW</span><span>N</span></span>
+          </div>
+          <div>
+            <div data-testid="flightInfoDuration"><span>7h 50m</span></div>
+            <div data-testid="stopInfoText">Nonstop</div>
+          </div>
+          <div role="textbox" aria-label="John F. Kennedy International Airport T4">
+            <div><span data-testid="flight-time-2026-09-07 15:55:00"><span>3:55</span><span>PM</span></span></div>
+            <span><span>JFK</span><span>T4</span></span>
+          </div>
+        </div>
         <div data-testid="flight_price_1-0">$662</div>
       </div>`;
 
@@ -216,13 +224,68 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
     const OVERNIGHT_CARD = `
       <div class="result-item">
         <div data-testid="flights-name">China Southern Airlines</div>
-        <div data-testid="flight-time-2026-09-07 19:50:00"><span>7:50</span><span>PM</span></div>
-        <div>SHA</div><div>T2</div>
-        <div data-testid="flightInfoDuration"><span>17h 40m</span></div>
-        <div data-testid="stopInfoText">2h 40m in Guangzhou</div>
-        <div data-testid="flight-time-2026-09-08 06:30:00"><span>6:30</span><span>AM</span></div>
-        <div>LGW</div><div>S</div><div>+1</div>
+        <div data-testid="flt-info-stop__wrapper">
+          <div role="textbox" aria-label="Shanghai Hongqiao International Airport T2">
+            <div><span data-testid="flight-time-2026-09-07 19:50:00"><span>7:50</span><span>PM</span></span></div>
+            <span><span>SHA</span><span>T2</span></span>
+          </div>
+          <div>
+            <div data-testid="flightInfoDuration"><span>17h 40m</span></div>
+            <div data-testid="stopInfoText">2h 40m in Guangzhou</div>
+          </div>
+          <div role="textbox" aria-label="London Gatwick Airport S">
+            <div><span data-testid="flight-time-2026-09-08 06:30:00"><span>6:30</span><span>AM</span></span></div>
+            <span><span>LGW</span><span>S</span></span><span>+1</span>
+          </div>
+        </div>
         <div data-testid="flight_price_1-0">$557</div>
+      </div>`;
+
+    // A real three-letter airline name and a currency badge are both valid card
+    // leaves but neither belongs to the route. The old card-wide leaf scan would
+    // incorrectly emit ANA -> LHR; the neighboring card also guards row ordering.
+    const DISTRACTOR_CARD = `
+      <div class="result-item">
+        <div data-testid="flights-name">ANA</div>
+        <div data-testid="flt-info-stop__wrapper">
+          <div role="textbox" aria-label="Heathrow Airport T2">
+            <div><span data-testid="flight-time-2026-09-07 09:00:00"><span>9:00</span><span>AM</span></span></div>
+            <span><span>LHR</span><span>T2</span></span>
+          </div>
+          <div>
+            <div data-testid="flightInfoDuration"><span>13h 45m</span></div>
+            <div data-testid="stopInfoText">Nonstop</div>
+          </div>
+          <div role="textbox" aria-label="Haneda Airport T3">
+            <div><span data-testid="flight-time-2026-09-08 06:45:00"><span>6:45</span><span>AM</span></span></div>
+            <span><span>HND</span><span>T3</span></span>
+          </div>
+        </div>
+        <span>USD</span>
+        <div data-testid="flight_price_1-0">$910</div>
+      </div>`;
+
+    // Current Trip.com evidence for CXI -> HNL across the International Date
+    // Line: the visible card renders `-1` and the local-ISO arrival is Sep 1
+    // even though the local departure is Sep 2.
+    const DATE_LINE_CARD = `
+      <div class="result-item">
+        <div data-testid="flights-name">Fiji Airways</div>
+        <div data-testid="flt-info-stop__wrapper">
+          <div role="textbox" aria-label="Cassidy International Airport">
+            <div><span data-testid="flight-time-2026-09-02 16:25:00"><span>4:25</span><span>PM</span></span></div>
+            <span><span>CXI</span></span>
+          </div>
+          <div>
+            <div data-testid="flightInfoDuration"><span>3h 25m</span></div>
+            <div data-testid="stopInfoText">Nonstop</div>
+          </div>
+          <div role="textbox" aria-label="Honolulu International Airport T1">
+            <div><span data-testid="flight-time-2026-09-01 08:50:00"><span>8:50</span><span>AM</span></span></div>
+            <span><span>HNL</span><span>T1</span></span><span>-1</span>
+          </div>
+        </div>
+        <div data-testid="flight_price_1-0">$745</div>
       </div>`;
 
     it('extracts a flight card via data-testid + time/code anchors', () => {
@@ -257,15 +320,83 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
         expect(runExtract(CARD)[0].arrivalTime).toBe('3:55 PM');
     });
 
+    it('keeps airport provenance and order card-local despite realistic 3-letter distractors', () => {
+        const rows = runExtract(CARD + DISTRACTOR_CARD);
+        expect(rows).toHaveLength(2);
+        expect(rows.map((row) => [row.airline, row.departureAirport, row.arrivalAirport, row.arrivalTime])).toEqual([
+            ['Norse Atlantic Airways', 'LGW', 'JFK', '3:55 PM'],
+            ['ANA', 'LHR', 'HND', '6:45 AM+1'],
+        ]);
+    });
+
+    it('ignores hidden route, endpoint, time, and airport duplicates', () => {
+        const hiddenRoute = `<div hidden data-testid="flt-info-stop__wrapper">
+          <div role="textbox"><span data-testid="flight-time-2026-09-07 00:00:00">12:00 AM</span><span>AAA</span></div>
+          <div role="textbox"><span data-testid="flight-time-2026-09-07 01:00:00">1:00 AM</span><span>BBB</span></div>
+        </div>`;
+        const hiddenEndpoint = `<div role="textbox" style="visibility: hidden">
+          <span data-testid="flight-time-2026-09-07 02:00:00">2:00 AM</span><span>CCC</span>
+        </div>`;
+        const hiddenDuplicates = CARD
+            .replace('<div data-testid="flt-info-stop__wrapper">', `${hiddenRoute}<div data-testid="flt-info-stop__wrapper">${hiddenEndpoint}`)
+            .replace(
+                '<div><span data-testid="flight-time-2026-09-07 13:05:00">',
+                `<span hidden data-testid="flight-time-2026-09-07 09:00:00"><span>9:00</span><span>AM</span></span>
+                 <span aria-hidden="true"><span>LHR</span></span>
+                 <span style="display: none"><span>SFO</span></span>
+                 <span style="visibility: hidden"><span>CDG</span></span>
+                 <div><span data-testid="flight-time-2026-09-07 13:05:00">`,
+            );
+        expect(runExtract(hiddenDuplicates)).toEqual(runExtract(CARD));
+    });
+
+    it('fails closed when duplicate time or airport evidence is visible', () => {
+        const duplicateTime = CARD.replace(
+            '<div><span data-testid="flight-time-2026-09-07 13:05:00">',
+            `<span data-testid="flight-time-2026-09-07 09:00:00"><span>9:00</span><span>AM</span></span>
+             <div><span data-testid="flight-time-2026-09-07 13:05:00">`,
+        );
+        expect(runExtract(duplicateTime)).toMatchObject({ error: expect.stringContaining('endpoint time/airport') });
+
+        const duplicateAirport = CARD.replace('<span><span>LGW</span><span>N</span></span>', '<span><span>LGW</span><span>LHR</span></span>');
+        expect(runExtract(duplicateAirport)).toMatchObject({ error: expect.stringContaining('endpoint time/airport') });
+    });
+
+    it('uses strict calendar dates for year rollover without local-time parsing', () => {
+        const yearRollover = OVERNIGHT_CARD
+            .replace('2026-09-07 19:50:00', '2026-12-31 19:50:00')
+            .replace('2026-09-08 06:30:00', '2027-01-01 06:30:00');
+        expect(runExtract(yearRollover)[0].arrivalTime).toBe('6:30 AM+1');
+    });
+
+    it('preserves Trip.com\'s negative day suffix for a date-line crossing', () => {
+        expect(runExtract(DATE_LINE_CARD)).toEqual([{
+            airline: 'Fiji Airways',
+            departureTime: '4:25 PM',
+            departureAirport: 'CXI',
+            arrivalTime: '8:50 AM-1',
+            arrivalAirport: 'HNL',
+            duration: '3h 25m',
+            stops: 'Nonstop',
+            price: 745,
+            currency: 'USD',
+        }]);
+    });
+
+    it('fails closed on malformed local-ISO anchors', () => {
+        const malformedDate = CARD.replace('2026-09-07 15:55:00', '2026-02-30 15:55:00');
+        expect(runExtract(malformedDate)).toMatchObject({ error: expect.stringContaining('endpoint time/airport') });
+    });
+
     it('keeps price null when the price node is missing/non-numeric', () => {
         const noPrice = CARD.replace('<div data-testid="flight_price_1-0">$662</div>', '<div data-testid="flight_price_1-0">--</div>');
         expect(runExtract(noPrice)[0].price).toBeNull();
     });
 
-    it('drops cards missing airline or an airport (no sentinel rows)', () => {
+    it('fails closed on cards missing airline or route endpoints', () => {
         const noAirline = CARD.replace('<div data-testid="flights-name">Norse Atlantic Airways</div>', '');
-        expect(runExtract(noAirline)).toEqual([]);
-        expect(runExtract('<div class="result-item"></div>')).toEqual([]);
+        expect(runExtract(noAirline)).toMatchObject({ error: expect.stringContaining('airline') });
+        expect(runExtract('<div class="result-item"></div>')).toMatchObject({ error: expect.stringContaining('airline') });
     });
 });
 
@@ -599,6 +730,8 @@ describe('trip flight-round command (registry-level)', () => {
             .rejects.toThrow('Trip.com is asking for a verification');
         await expect(cmd.func(createPageMock(['timeout']), { from: 'LON', to: 'NYC', depart: '2026-08-15', return: '2026-08-22', limit: 5 }))
             .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not render flight cards') });
+        await expect(cmd.func(createPageMock(['content', { error: 'malformed flight card 1: route endpoints' }]), { from: 'LON', to: 'NYC', depart: '2026-08-15', return: '2026-08-22', limit: 5 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('route endpoints') });
         await expect(cmd.func(createPageMock(['content', []]), { from: 'LON', to: 'NYC', depart: '2026-08-15', return: '2026-08-22', limit: 5 }))
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
     });

--- a/clis/trip/trip.test.js
+++ b/clis/trip/trip.test.js
@@ -211,6 +211,20 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
         <div data-testid="flight_price_1-0">$662</div>
       </div>`;
 
+    // Overnight leg: Trip.com renders a literal `+1` next to the arrival airport and
+    // the `flight-time-` anchors land on the following calendar day.
+    const OVERNIGHT_CARD = `
+      <div class="result-item">
+        <div data-testid="flights-name">China Southern Airlines</div>
+        <div data-testid="flight-time-2026-09-07 19:50:00"><span>7:50</span><span>PM</span></div>
+        <div>SHA</div><div>T2</div>
+        <div data-testid="flightInfoDuration"><span>17h 40m</span></div>
+        <div data-testid="stopInfoText">2h 40m in Guangzhou</div>
+        <div data-testid="flight-time-2026-09-08 06:30:00"><span>6:30</span><span>AM</span></div>
+        <div>LGW</div><div>S</div><div>+1</div>
+        <div data-testid="flight_price_1-0">$557</div>
+      </div>`;
+
     it('extracts a flight card via data-testid + time/code anchors', () => {
         expect(runExtract(CARD)).toEqual([{
             airline: 'Norse Atlantic Airways',
@@ -223,6 +237,24 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
             price: 662,
             currency: 'USD',
         }]);
+    });
+
+    it('flags a later-day arrival with a +N suffix', () => {
+        expect(runExtract(OVERNIGHT_CARD)).toEqual([{
+            airline: 'China Southern Airlines',
+            departureTime: '7:50 PM',
+            departureAirport: 'SHA',
+            arrivalTime: '6:30 AM+1',
+            arrivalAirport: 'LGW',
+            duration: '17h 40m',
+            stops: '2h 40m in Guangzhou',
+            price: 557,
+            currency: 'USD',
+        }]);
+    });
+
+    it('leaves same-day arrivals unsuffixed', () => {
+        expect(runExtract(CARD)[0].arrivalTime).toBe('3:55 PM');
     });
 
     it('keeps price null when the price node is missing/non-numeric', () => {

--- a/clis/trip/trip.test.js
+++ b/clis/trip/trip.test.js
@@ -196,15 +196,18 @@ describe('trip buildFlightExtractJs (JSDOM)', () => {
         return Function('document', `return (${js})`)(dom.window.document);
     }
 
+    // Mirrors Trip.com's live card markup (captured 2026-08). Airport codes sit in
+    // plain leaf nodes — the `font-black` class this fixture used to assert on is
+    // gone from the site, which is exactly what let the old selector rot unnoticed.
     const CARD = `
       <div class="result-item">
         <div data-testid="flights-name">Norse Atlantic Airways</div>
-        <div class="font-black_x">LGW</div>
-        <div class="font-black_x">JFK</div>
-        <span>1:05</span><span>PM</span>
-        <span>3:55</span><span>PM</span>
-        <span>7h 50m</span>
+        <div data-testid="flight-time-2026-09-07 13:05:00"><span>1:05</span><span>PM</span></div>
+        <div>LGW</div><div>N</div>
+        <div data-testid="flightInfoDuration"><span>7h 50m</span></div>
         <div data-testid="stopInfoText">Nonstop</div>
+        <div data-testid="flight-time-2026-09-07 15:55:00"><span>3:55</span><span>PM</span></div>
+        <div>JFK</div><div>T4</div>
         <div data-testid="flight_price_1-0">$662</div>
       </div>`;
 

--- a/clis/trip/utils.js
+++ b/clis/trip/utils.js
@@ -94,8 +94,10 @@ export function buildFlightRoundSearchUrl(fromCode, toCode, depart, ret) {
  * `.result-item` cards. Fields are read from stable `data-testid` anchors plus
  * the `HH:MM` / `AM-PM` / `IATA` leaf-node pattern. Airport codes come from the
  * same leaf scan as the times — Trip.com no longer emits the `font-black` class
- * the previous selector keyed on. Cards missing the airline, both airports, or
- * both times are dropped rather than surfaced with blanks.
+ * the previous selector keyed on. Arrival times carry a `+N` suffix when the
+ * `flight-time-<ISO>` anchors show the leg landing on a later calendar day.
+ * Cards missing the airline, both airports, or both times are dropped rather
+ * than surfaced with blanks.
  */
 export function buildFlightExtractJs() {
     return `
@@ -112,6 +114,11 @@ export function buildFlightExtractJs() {
           const duration = leaves.find((t) => /^\\d+h(\\s\\d+m)?$/.test(t)) || null;
           if (!airline || codes.length < 2 || times.length < 2) return;
           const withMeridiem = (i) => times[i] + (meridiems[i] ? ' ' + meridiems[i] : '');
+          const stamps = Array.from(card.querySelectorAll('[data-testid^="flight-time-"]'))
+            .map((el) => (el.getAttribute('data-testid') || '').slice('flight-time-'.length));
+          const dayOffset = stamps.length > 1
+            ? Math.round((Date.parse(stamps[1].slice(0, 10)) - Date.parse(stamps[0].slice(0, 10))) / 86400000)
+            : 0;
           const priceEl = card.querySelector('[data-testid^="flight_price"]');
           const priceText = clean(priceEl);
           const priceNum = priceText.replace(/[^0-9.]/g, '');
@@ -119,7 +126,7 @@ export function buildFlightExtractJs() {
             airline,
             departureTime: withMeridiem(0),
             departureAirport: codes[0],
-            arrivalTime: withMeridiem(1),
+            arrivalTime: withMeridiem(1) + (dayOffset > 0 ? '+' + dayOffset : ''),
             arrivalAirport: codes[1],
             duration,
             stops: clean(card.querySelector('[data-testid="stopInfoText"]')) || null,

--- a/clis/trip/utils.js
+++ b/clis/trip/utils.js
@@ -92,8 +92,10 @@ export function buildFlightRoundSearchUrl(fromCode, toCode, depart, ret) {
 /**
  * Browser-context IIFE that extracts flight rows from Trip.com's rendered
  * `.result-item` cards. Fields are read from stable `data-testid` anchors plus
- * the `HH:MM` / `AM-PM` / `IATA` leaf-node pattern. Cards missing the airline,
- * both airports, or both times are dropped rather than surfaced with blanks.
+ * the `HH:MM` / `AM-PM` / `IATA` leaf-node pattern. Airport codes come from the
+ * same leaf scan as the times — Trip.com no longer emits the `font-black` class
+ * the previous selector keyed on. Cards missing the airline, both airports, or
+ * both times are dropped rather than surfaced with blanks.
  */
 export function buildFlightExtractJs() {
     return `
@@ -102,10 +104,9 @@ export function buildFlightExtractJs() {
         const rows = [];
         document.querySelectorAll('.result-item').forEach((card) => {
           const airline = clean(card.querySelector('[data-testid="flights-name"]'));
-          const codes = Array.from(card.querySelectorAll('[class*="font-black"]'))
-            .map((el) => clean(el)).filter((t) => /^[A-Z]{3}$/.test(t));
           const leaves = Array.from(card.querySelectorAll('*'))
             .filter((el) => !el.children.length).map((el) => clean(el));
+          const codes = leaves.filter((t) => /^[A-Z]{3}$/.test(t));
           const times = leaves.filter((t) => /^\\d{1,2}:\\d{2}$/.test(t));
           const meridiems = leaves.filter((t) => /^(AM|PM)$/.test(t));
           const duration = leaves.find((t) => /^\\d+h(\\s\\d+m)?$/.test(t)) || null;

--- a/clis/trip/utils.js
+++ b/clis/trip/utils.js
@@ -92,48 +92,129 @@ export function buildFlightRoundSearchUrl(fromCode, toCode, depart, ret) {
 /**
  * Browser-context IIFE that extracts flight rows from Trip.com's rendered
  * `.result-item` cards. Fields are read from stable `data-testid` anchors plus
- * the `HH:MM` / `AM-PM` / `IATA` leaf-node pattern. Airport codes come from the
- * same leaf scan as the times — Trip.com no longer emits the `font-black` class
- * the previous selector keyed on. Arrival times carry a `+N` suffix when the
- * `flight-time-<ISO>` anchors show the leg landing on a later calendar day.
- * Cards missing the airline, both airports, or both times are dropped rather
- * than surfaced with blanks.
+ * the endpoint wrappers that bind one local-ISO time anchor to one airport.
+ * Trip.com no longer emits the `font-black` class the previous selector keyed
+ * on, but scanning every leaf in a card is too broad: an airline or price badge
+ * can itself be three uppercase letters. Arrival times carry the signed day
+ * suffix Trip.com renders (`+N` or `-N`) when the two local calendar dates
+ * differ. Any ambiguous or malformed card makes the whole extraction non-array
+ * so the host command fails typed instead of silently returning a wrong route
+ * or a partial result set.
  */
 export function buildFlightExtractJs() {
     return `
       (() => {
         const clean = (el) => el ? (el.textContent || '').replace(/\\s+/g, ' ').trim() : '';
+        const invalid = (cardIndex, field) => ({ error: 'malformed flight card ' + cardIndex + ': ' + field });
+        const isVisible = (el, boundary) => {
+          for (let node = el; node; node = node.parentElement) {
+            if (node.hidden || (node.getAttribute('aria-hidden') || '').toLowerCase() === 'true') return false;
+            const view = node.ownerDocument && node.ownerDocument.defaultView;
+            const style = view && typeof view.getComputedStyle === 'function' ? view.getComputedStyle(node) : null;
+            if (style && (style.display === 'none' || style.visibility === 'hidden')) return false;
+            if (node === boundary) break;
+          }
+          return true;
+        };
+        const visibleText = (root, boundary = root) => {
+          if (!isVisible(root, boundary)) return '';
+          const parts = [];
+          const visit = (node) => {
+            if (node.nodeType === 3) {
+              const value = (node.textContent || '').replace(/\\s+/g, ' ').trim();
+              if (value) parts.push(value);
+              return;
+            }
+            if (node.nodeType !== 1 || !isVisible(node, boundary)) return;
+            Array.from(node.childNodes).forEach(visit);
+          };
+          visit(root);
+          return parts.join(' ');
+        };
+        const visibleLeafTexts = (root, boundary = root) => {
+          const elements = root.children.length ? Array.from(root.querySelectorAll('*')) : [root];
+          return elements
+            .filter((el) => !el.children.length && isVisible(el, boundary))
+            .map((el) => clean(el))
+            .filter(Boolean);
+        };
+        const parseStamp = (anchor) => {
+          const raw = anchor && anchor.getAttribute('data-testid');
+          const match = /^flight-time-(\\d{4})-(\\d{2})-(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2})$/.exec(raw || '');
+          if (!match) return null;
+          const year = Number(match[1]);
+          const month = Number(match[2]);
+          const day = Number(match[3]);
+          const hour = Number(match[4]);
+          const minute = Number(match[5]);
+          const second = Number(match[6]);
+          if (hour > 23 || minute > 59 || second > 59) return null;
+          const utc = Date.UTC(year, month - 1, day);
+          const check = new Date(utc);
+          if (check.getUTCFullYear() !== year || check.getUTCMonth() !== month - 1 || check.getUTCDate() !== day) return null;
+          return { dayNumber: Math.floor(utc / 86400000), hour, minute };
+        };
+        const parseEndpoint = (endpoint) => {
+          const anchors = Array.from(endpoint.querySelectorAll('[data-testid^="flight-time-"]'))
+            .filter((anchor) => isVisible(anchor, endpoint));
+          if (anchors.length !== 1) return null;
+          const stamp = parseStamp(anchors[0]);
+          if (!stamp) return null;
+          const display = visibleText(anchors[0], endpoint);
+          const timeMatch = /^(\\d{1,2}):(\\d{2})(?:\\s*(AM|PM))?$/.exec(display);
+          if (!timeMatch) return null;
+          let displayHour = Number(timeMatch[1]);
+          const displayMinute = Number(timeMatch[2]);
+          const meridiem = timeMatch[3] || null;
+          if (displayMinute > 59) return null;
+          if (meridiem) {
+            if (displayHour < 1 || displayHour > 12) return null;
+            displayHour = displayHour % 12 + (meridiem === 'PM' ? 12 : 0);
+          } else if (displayHour > 23) {
+            return null;
+          }
+          if (displayHour !== stamp.hour || displayMinute !== stamp.minute) return null;
+          const codes = visibleLeafTexts(endpoint)
+            .filter((text) => /^[A-Z]{3}$/.test(text));
+          if (codes.length !== 1) return null;
+          const normalizedTime = timeMatch[1] + ':' + timeMatch[2] + (meridiem ? ' ' + meridiem : '');
+          return { time: normalizedTime, airport: codes[0], dayNumber: stamp.dayNumber };
+        };
         const rows = [];
-        document.querySelectorAll('.result-item').forEach((card) => {
+        const cards = Array.from(document.querySelectorAll('.result-item'));
+        for (let cardIndex = 0; cardIndex < cards.length; cardIndex += 1) {
+          const card = cards[cardIndex];
           const airline = clean(card.querySelector('[data-testid="flights-name"]'));
-          const leaves = Array.from(card.querySelectorAll('*'))
-            .filter((el) => !el.children.length).map((el) => clean(el));
-          const codes = leaves.filter((t) => /^[A-Z]{3}$/.test(t));
-          const times = leaves.filter((t) => /^\\d{1,2}:\\d{2}$/.test(t));
-          const meridiems = leaves.filter((t) => /^(AM|PM)$/.test(t));
-          const duration = leaves.find((t) => /^\\d+h(\\s\\d+m)?$/.test(t)) || null;
-          if (!airline || codes.length < 2 || times.length < 2) return;
-          const withMeridiem = (i) => times[i] + (meridiems[i] ? ' ' + meridiems[i] : '');
-          const stamps = Array.from(card.querySelectorAll('[data-testid^="flight-time-"]'))
-            .map((el) => (el.getAttribute('data-testid') || '').slice('flight-time-'.length));
-          const dayOffset = stamps.length > 1
-            ? Math.round((Date.parse(stamps[1].slice(0, 10)) - Date.parse(stamps[0].slice(0, 10))) / 86400000)
-            : 0;
+          if (!airline) return invalid(cardIndex, 'airline');
+          const routeWrappers = Array.from(card.querySelectorAll('[data-testid="flt-info-stop__wrapper"]'))
+            .filter((el) => isVisible(el, card));
+          if (routeWrappers.length !== 1) return invalid(cardIndex, 'route wrapper');
+          const endpointWrappers = Array.from(routeWrappers[0].querySelectorAll('[role="textbox"]'))
+            .filter((el) => isVisible(el, routeWrappers[0]))
+            .filter((el) => Array.from(el.querySelectorAll('[data-testid^="flight-time-"]'))
+              .some((anchor) => isVisible(anchor, el)));
+          if (endpointWrappers.length !== 2) return invalid(cardIndex, 'route endpoints');
+          const departure = parseEndpoint(endpointWrappers[0]);
+          const arrival = parseEndpoint(endpointWrappers[1]);
+          if (!departure || !arrival) return invalid(cardIndex, 'endpoint time/airport');
+          const dayOffset = arrival.dayNumber - departure.dayNumber;
+          const daySuffix = dayOffset > 0 ? '+' + dayOffset : (dayOffset < 0 ? String(dayOffset) : '');
+          const duration = clean(card.querySelector('[data-testid="flightInfoDuration"]')) || null;
           const priceEl = card.querySelector('[data-testid^="flight_price"]');
           const priceText = clean(priceEl);
           const priceNum = priceText.replace(/[^0-9.]/g, '');
           rows.push({
             airline,
-            departureTime: withMeridiem(0),
-            departureAirport: codes[0],
-            arrivalTime: withMeridiem(1) + (dayOffset > 0 ? '+' + dayOffset : ''),
-            arrivalAirport: codes[1],
+            departureTime: departure.time,
+            departureAirport: departure.airport,
+            arrivalTime: arrival.time + daySuffix,
+            arrivalAirport: arrival.airport,
             duration,
             stops: clean(card.querySelector('[data-testid="stopInfoText"]')) || null,
             price: priceNum ? Number(priceNum) : null,
             currency: priceText.startsWith('$') ? 'USD' : (priceText.replace(/[0-9.,\\s]/g, '') || null),
           });
-        });
+        }
         return rows;
       })()
     `;


### PR DESCRIPTION
## Summary

`trip flight` and `trip flight-round` returned no rows after Trip.com removed the `font-black` class from airport-code leaves. This fixes the shared extractor without falling back to a card-wide three-letter scan, which is ambiguous in real cards (`ANA` airline names and `USD` badges are valid distractors).

## Strategy

- **Strategy:** `UI_SELECTOR`
- **Contract:** `visible-ui`
- **Evidence:** current one-way and round-trip cards expose one visible `[data-testid="flt-info-stop__wrapper"]`; inside it, two visible `[role="textbox"]` endpoints each bind one local-ISO `flight-time-*` anchor to one endpoint-local IATA leaf.
- **Auth/session:** registry `Strategy.COOKIE` is only the Browser Bridge session carrier; the extraction contract is the rendered visible UI.

## Extraction contract

For every `.result-item`, the extractor now requires:

1. exactly one visible route wrapper;
2. exactly two visible time-bearing endpoint wrappers in card order;
3. exactly one visible strict local-ISO anchor per endpoint;
4. display time matching that anchor's hour/minute;
5. exactly one visible endpoint-local IATA leaf.

`hidden`, `aria-hidden="true"`, `display:none`, and `visibility:hidden` duplicates do not create false ambiguity. Visible duplicate time/IATA evidence, malformed calendar/time values, or missing route provenance return a controlled diagnostic; both host commands convert that boundary to `CommandExecutionError` instead of silently dropping the card or returning a wrong route.

Local ISO components are strict round-trip validated. Their UTC calendar-day numbers are used only to compare local calendar dates, not as timezone instants. Same-day arrivals have no suffix, later local dates emit `+N`, and earlier local dates emit `-N`.

## Live evidence

- One-way and round-trip pages each exposed eight current cards matching the endpoint contract.
- `LON → NYC` one-way and round-trip both returned five valid rows after the fix.
- `CXI → HNL`, 2026-09-02, currently renders a valid International Date Line arrival with `-1`; the exact-head adapter returned `10:50 AM-1` rather than rejecting or clamping it.
- Reverse validation: the old `font-black` selector finds no codes; a naive card-wide leaf scan on a realistic `ANA` + `USD` card misroutes `ANA → LHR`, while the endpoint-provenance extractor returns `LHR → HND`.

## Tests

Behavior-level JSDOM coverage includes:

- realistic multi-card extraction and no adjacent-card leakage;
- airline/currency three-letter distractors;
- same-day, `+N`, `-N`, and year rollover;
- invalid calendar values and display/anchor mismatch;
- hidden route/endpoint/time/IATA duplicates;
- visible time/IATA ambiguity fail-closed;
- typed host boundaries for malformed extractor results.

The visibility regression was reverse-validated: disabling the visibility filter makes the hidden-duplicate case fail with `malformed flight card 0: route wrapper`.

## Verification

Exact head: `6f122271b902621ae9d3a73d413e993f2ae9fc77`  
Base/live main at validation: `5d102265e6276c0bd725a7519818c08aae119b2f`

- Trip adapter tests: `1 file / 122 tests` passed
- Typecheck passed
- Build/manifest passed: `1341` entries, manifest unchanged
- Docs build passed (existing chunk-size warning only)
- Touched-file and built-main syntax checks passed
- Typed-error lint: `new=0`, `resolved=7`
- Silent-column-drop: `new=0`, `resolved=2`
- Listing-id advisory unchanged at `14`
- Production audit: `0 vulnerabilities`
- Diff check and merge-tree clean
- Worktree clean except the pre-existing untracked dependency symlink

Hosted checks are tracked in GitHub Checks for this exact head; earlier heads and their checks are stale.
