### PR TITLE
feat(youtube): paginate authenticated watch history

### DIFF
--- a/clis/youtube/history.js
+++ b/clis/youtube/history.js
@@ -1,8 +1,35 @@
 /**
- * YouTube history — watch history via InnerTube browse API (FEhistory).
+ * YouTube history via the authenticated InnerTube FEhistory browse surface.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import {
+    prepareYoutubeApiPage,
+    readYoutubeSapisid,
+    SAPISID_HASH_FN,
+} from './utils.js';
+
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 200;
+const MAX_PAGES = 20;
+const REQUEST_TIMEOUT_SECONDS = 15;
+
+function normalizeLimit(value) {
+    const limit = Number(value ?? DEFAULT_LIMIT);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError('youtube history limit must be a positive integer');
+    }
+    if (limit > MAX_LIMIT) {
+        throw new ArgumentError(`youtube history limit must be <= ${MAX_LIMIT}`);
+    }
+    return limit;
+}
 
 cli({
     site: 'youtube',
@@ -12,108 +39,231 @@ cli({
     domain: 'www.youtube.com',
     strategy: Strategy.COOKIE,
     args: [
-        { name: 'limit', type: 'int', default: 30, help: 'Max videos to return (default 30, max 200)' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Max videos to return (default 30, max 200)' },
     ],
     columns: ['rank', 'title', 'channel', 'views', 'duration', 'url'],
     func: async (page, kwargs) => {
-        const limit = Math.min(kwargs.limit || 30, 200);
-        await page.goto('https://www.youtube.com/feed/history');
-        await page.wait(3);
-        await page.autoScroll({ times: Math.min(Math.max(Math.ceil(limit / 20), 1), 8), delayMs: 1200 });
-        const data = await page.evaluate(`
+        const limit = normalizeLimit(kwargs.limit);
+        await prepareYoutubeApiPage(page);
+
+        const sapisid = await readYoutubeSapisid(page);
+        if (!sapisid) {
+            throw new AuthRequiredError('www.youtube.com', 'Not logged in (SAPISID cookie missing)');
+        }
+
+        const result = await page.evaluate(`
       (async () => {
+        ${SAPISID_HASH_FN}
+
         const limit = ${limit};
-
-        const videos = [];
-        const seen = new Set();
-        const root = document.querySelector('ytd-two-column-browse-results-renderer #primary ytd-section-list-renderer');
-        if (!root) return { error: 'YouTube history list not found' };
-
-        function text(el) {
-          return (el?.textContent || '').replace(/\\s+/g, ' ').trim();
+        const maxPages = ${MAX_PAGES};
+        const requestTimeoutMs = ${REQUEST_TIMEOUT_SECONDS * 1000};
+        const cfg = window.ytcfg?.data_ || {};
+        const apiKey = cfg.INNERTUBE_API_KEY;
+        const context = cfg.INNERTUBE_CONTEXT;
+        if (!apiKey || !context) {
+          return { error: 'config', message: 'YouTube InnerTube config not found' };
         }
 
-        function push(entry) {
-          if (!entry?.url || seen.has(entry.url) || videos.length >= limit) return;
-          seen.add(entry.url);
-          videos.push({ rank: videos.length + 1, ...entry });
+        const authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
+        if (!authHash) return { error: 'auth', message: 'Not logged in (SAPISID cookie missing)' };
+
+        function readText(value) {
+          if (!value) return '';
+          if (typeof value.simpleText === 'string') return value.simpleText;
+          if (Array.isArray(value.runs)) return value.runs.map(run => run?.text || '').join('');
+          return '';
         }
 
-        for (const section of root.querySelectorAll('ytd-item-section-renderer')) {
-          if (videos.length >= limit) break;
+        function absoluteWatchUrl(path, videoId) {
+          const value = path || (videoId ? '/watch?v=' + videoId : '');
+          if (!value) return '';
+          return value.startsWith('http') ? value : 'https://www.youtube.com' + value;
+        }
 
-          for (const renderer of section.querySelectorAll('yt-lockup-view-model, ytd-video-renderer, ytd-rich-item-renderer, ytd-grid-video-renderer, ytd-compact-video-renderer')) {
-            if (videos.length >= limit) break;
-            const link = renderer.querySelector('a[href^="/watch?v="]');
-            const href = link?.getAttribute('href') || '';
-            if (!href) continue;
-            const title =
-              link?.getAttribute('title')
-              || text(renderer.querySelector('#video-title'))
-              || text(renderer.querySelector('h3 a'))
-              || text(renderer.querySelector('h3'))
-              || text(link);
-            const channel =
-              text(renderer.querySelector('#channel-name a'))
-              || text(renderer.querySelector('[aria-label^="前往频道："]'))
-              || text(renderer.querySelector('[aria-label^="Go to channel:"]'))
-              || text(renderer.querySelector('ytd-channel-name'))
-              || text(renderer.querySelector('#metadata #byline-container'))
-              || '';
-            const metadata = Array.from(renderer.querySelectorAll('#metadata-line span, #metadata span, .metadata span'))
-              .map(node => text(node))
-              .filter(Boolean);
-            const lockupMetadata = Array.from(renderer.querySelectorAll('yt-content-metadata-view-model span, yt-lockup-metadata-view-model span'))
-              .map(node => text(node))
-              .filter(Boolean);
-            const combinedMetadata = (metadata.length ? metadata : lockupMetadata)
-              .filter(value => value && value !== title && value !== '•');
-            const inferredChannel = channel || combinedMetadata.find(value => !/观看|views|前|前に|ago|次观看|次查看|stream/i.test(value)) || '';
-            const inferredViews = combinedMetadata.find(value => /观看|views/i.test(value)) || '';
-            const inferredPublished = combinedMetadata.find(value => value !== inferredChannel && value !== inferredViews) || '';
-            const duration =
-              text(renderer.querySelector('ytd-thumbnail-overlay-time-status-renderer'))
-              || text(renderer.querySelector('yt-thumbnail-badge-view-model'))
-              || text(renderer.querySelector('badge-shape'))
-              || '';
-            push({
-              title,
-              channel: inferredChannel,
-              views: inferredViews,
-              duration,
-              published: inferredPublished,
-              url: href.startsWith('http') ? href : 'https://www.youtube.com' + href,
-            });
+        function fromLockup(lockup) {
+          const metadata = lockup?.metadata?.lockupMetadataViewModel;
+          const parts = (metadata?.metadata?.contentMetadataViewModel?.metadataRows || [])
+            .flatMap(row => (row.metadataParts || []).map(part => part.text?.content || '').filter(Boolean));
+          let duration = '';
+          for (const overlay of (lockup?.contentImage?.thumbnailViewModel?.overlays || [])) {
+            for (const badge of (overlay.thumbnailBottomOverlayViewModel?.badges || [])) {
+              if (badge.thumbnailBadgeViewModel?.text) duration = badge.thumbnailBadgeViewModel.text;
+            }
+          }
+          const commandUrl = lockup?.rendererContext?.commandContext?.onTap
+            ?.innertubeCommand?.commandMetadata?.webCommandMetadata?.url || '';
+          return [lockup?.contentId || '', {
+            title: metadata?.title?.content || '',
+            channel: parts[0] || '',
+            views: parts.find(part => /views|观看/i.test(part)) || parts[1] || '',
+            duration,
+            url: absoluteWatchUrl(commandUrl, lockup?.contentId),
+          }];
+        }
+
+        function fromVideoRenderer(video) {
+          const commandUrl = video?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url || '';
+          return [video?.videoId || '', {
+            title: readText(video?.title),
+            channel: readText(video?.ownerText) || readText(video?.shortBylineText),
+            views: readText(video?.viewCountText) || readText(video?.shortViewCountText),
+            duration: readText(video?.lengthText),
+            url: absoluteWatchUrl(commandUrl, video?.videoId),
+          }];
+        }
+
+        function extractPage(payload) {
+          const entries = [];
+          const pageIds = new Set();
+          const messages = [];
+          const cursors = [];
+          let malformed = 0;
+
+          function push(entry) {
+            const [historyId, row] = entry || [];
+            if (!historyId) return;
+            if (!row.title || !row.url) {
+              malformed += 1;
+              return;
+            }
+            if (pageIds.has(historyId)) return;
+            pageIds.add(historyId);
+            entries.push([historyId, row]);
           }
 
-          for (const shortLink of section.querySelectorAll('a[href^="/shorts/"]')) {
-            if (videos.length >= limit) break;
-            const card = shortLink.closest('ytm-shorts-lockup-view-model-v2, ytm-shorts-lockup-view-model, ytd-reel-item-renderer') || shortLink.parentElement;
-            const href = shortLink.getAttribute('href') || '';
-            if (!href) continue;
-            const title = shortLink.getAttribute('title') || text(card?.querySelector('h3')) || text(shortLink);
-            const stats = Array.from(card?.querySelectorAll('span') || []).map(node => text(node)).filter(Boolean);
-            push({
-              title,
-              channel: 'Shorts',
-              views: stats.find(value => /观看|views/i.test(value)) || '',
-              duration: 'SHORT',
-              published: '',
-              url: href.startsWith('http') ? href : 'https://www.youtube.com' + href,
-            });
+          function visit(value) {
+            if (!value || typeof value !== 'object') return;
+            if (value.lockupViewModel?.contentType === 'LOCKUP_CONTENT_TYPE_VIDEO') {
+              push(fromLockup(value.lockupViewModel));
+            }
+            const renderer = value.videoRenderer || value.gridVideoRenderer || value.compactVideoRenderer;
+            if (renderer?.videoId) push(fromVideoRenderer(renderer));
+
+            const cursor = value.continuationItemRenderer
+              ?.continuationEndpoint?.continuationCommand?.token;
+            if (cursor) cursors.push(cursor);
+
+            const message = readText(value.messageRenderer?.text);
+            if (message) messages.push(message);
+            for (const child of Object.values(value)) visit(child);
           }
+
+          visit(payload);
+          return {
+            entries,
+            nextCursor: cursors[cursors.length - 1] || null,
+            message: messages[0] || '',
+            malformed,
+          };
         }
 
-        return videos.length ? videos : { error: 'No watch history items found on youtube.com/feed/history' };
+        async function fetchPage(body) {
+          let response;
+          try {
+            response = await fetch('/youtubei/v1/browse?key=' + encodeURIComponent(apiKey) + '&prettyPrint=false', {
+              method: 'POST',
+              credentials: 'include',
+              signal: AbortSignal.timeout(requestTimeoutMs),
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': authHash,
+                'X-Origin': 'https://www.youtube.com',
+              },
+              body: JSON.stringify({ context, ...body }),
+            });
+          } catch (error) {
+            if (error?.name === 'AbortError' || error?.name === 'TimeoutError') {
+              return { error: 'timeout' };
+            }
+            return { error: 'transport', message: String(error?.message || error) };
+          }
+
+          if (response.status === 401 || response.status === 403) {
+            return { error: 'auth', message: 'YouTube history HTTP ' + response.status };
+          }
+          if (!response.ok) {
+            return { error: 'http', message: 'YouTube history HTTP ' + response.status };
+          }
+
+          let payload;
+          try {
+            payload = await response.json();
+          } catch (error) {
+            return { error: 'json', message: String(error?.message || error) };
+          }
+
+          const upstreamStatus = payload?.error?.status || '';
+          const upstreamCode = Number(payload?.error?.code || 0);
+          if (upstreamCode === 401 || upstreamCode === 403 || upstreamStatus === 'UNAUTHENTICATED') {
+            return { error: 'auth', message: upstreamStatus || 'YouTube history authentication failed' };
+          }
+          if (payload?.error) {
+            return { error: 'api', message: upstreamStatus || payload.error.message || 'YouTube history API error' };
+          }
+          if (payload?.responseContext?.mainAppWebResponseContext?.loggedOut === true) {
+            return { error: 'auth', message: 'YouTube history response is logged out' };
+          }
+          return { payload };
+        }
+
+        const rows = [];
+        const seenIds = new Set();
+        const seenCursors = new Set();
+        let requestBody = { browseId: 'FEhistory' };
+        let nextCursor = null;
+
+        for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
+          const fetched = await fetchPage(requestBody);
+          if (fetched.error) return fetched;
+
+          const pageData = extractPage(fetched.payload);
+          if (pageData.malformed > 0) {
+            return { error: 'malformed', message: 'YouTube history returned malformed video rows' };
+          }
+          for (const [historyId, row] of pageData.entries) {
+            if (seenIds.has(historyId)) continue;
+            seenIds.add(historyId);
+            rows.push({
+              rank: rows.length + 1,
+              title: row.title,
+              channel: row.channel,
+              views: row.views,
+              duration: row.duration,
+              url: row.url,
+            });
+            if (rows.length >= limit) return rows;
+          }
+
+          nextCursor = pageData.nextCursor;
+          if (!nextCursor) {
+            if (rows.length > 0) return rows;
+            return { error: 'empty', message: pageData.message || 'No watch history items found' };
+          }
+          if (seenCursors.has(nextCursor)) {
+            return { error: 'repeated-cursor', message: 'YouTube history repeated a continuation cursor' };
+          }
+          seenCursors.add(nextCursor);
+          requestBody = { continuation: nextCursor };
+        }
+
+        return {
+          error: 'page-cap',
+          message: 'YouTube history pagination stopped before satisfying the requested limit',
+        };
       })()
     `);
-        if (!Array.isArray(data)) {
-            const errMsg = data && typeof data === 'object' ? String(data.error || '') : '';
-            throw new CommandExecutionError(errMsg || 'Failed to fetch watch history — make sure you are logged into YouTube');
+
+        if (Array.isArray(result)) return result;
+        if (result?.error === 'auth') {
+            throw new AuthRequiredError('www.youtube.com', result.message || 'Not logged in to YouTube');
         }
-        if (data.length === 0) {
-            throw new EmptyResultError('youtube history');
+        if (result?.error === 'timeout') {
+            throw new TimeoutError('YouTube history request', REQUEST_TIMEOUT_SECONDS);
         }
-        return data;
+        if (result?.error === 'empty') {
+            throw new EmptyResultError('youtube history', result.message || 'No watch history items found');
+        }
+        throw new CommandExecutionError(result?.message || 'Failed to fetch YouTube history');
     },
 });

--- a/clis/youtube/history.test.js
+++ b/clis/youtube/history.test.js
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import './history.js';
+
+function response(payload, { status = 200, jsonError } = {}) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: jsonError
+            ? vi.fn().mockRejectedValue(jsonError)
+            : vi.fn().mockResolvedValue(payload),
+    };
+}
+
+function makePage({ responses = [], cookies, fetchImpl } = {}) {
+    const fetchMock = fetchImpl || vi.fn().mockImplementation(async () => responses.shift());
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue(cookies ?? [{ name: '__Secure-3PAPISID', value: 'secret-cookie' }]),
+        evaluate: vi.fn(async (script) => {
+            const previousWindow = globalThis.window;
+            const previousFetch = globalThis.fetch;
+            globalThis.window = {
+                ytcfg: {
+                    data_: {
+                        INNERTUBE_API_KEY: 'test-key',
+                        INNERTUBE_CONTEXT: { client: { clientName: 'WEB', clientVersion: '1.0' } },
+                    },
+                },
+            };
+            globalThis.fetch = fetchMock;
+            try {
+                return await eval(script);
+            }
+            finally {
+                globalThis.window = previousWindow;
+                globalThis.fetch = previousFetch;
+            }
+        }),
+        __fetchMock: fetchMock,
+    };
+}
+
+function lockup(id, {
+    title = 'First video',
+    channel = 'First channel',
+    views = '1K views',
+    duration = '10:00',
+    url = `/watch?v=${id}`,
+} = {}) {
+    return {
+        lockupViewModel: {
+            contentId: id,
+            contentType: 'LOCKUP_CONTENT_TYPE_VIDEO',
+            metadata: {
+                lockupMetadataViewModel: {
+                    title: { content: title },
+                    metadata: {
+                        contentMetadataViewModel: {
+                            metadataRows: [{
+                                metadataParts: [
+                                    { text: { content: channel } },
+                                    { text: { content: views } },
+                                ],
+                            }],
+                        },
+                    },
+                },
+            },
+            contentImage: {
+                thumbnailViewModel: {
+                    overlays: [{
+                        thumbnailBottomOverlayViewModel: {
+                            badges: [{ thumbnailBadgeViewModel: { text: duration } }],
+                        },
+                    }],
+                },
+            },
+            rendererContext: {
+                commandContext: {
+                    onTap: {
+                        innertubeCommand: {
+                            commandMetadata: { webCommandMetadata: { url } },
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function videoRenderer(id, {
+    title = 'Second video',
+    channel = 'Second channel',
+    views = '2K views',
+    duration = '11:00',
+    url = `/watch?v=${id}`,
+} = {}) {
+    return {
+        videoRenderer: {
+            videoId: id,
+            title: { runs: [{ text: title }] },
+            ownerText: { runs: [{ text: channel }] },
+            viewCountText: { simpleText: views },
+            lengthText: { simpleText: duration },
+            navigationEndpoint: { commandMetadata: { webCommandMetadata: { url } } },
+        },
+    };
+}
+
+function continuation(token) {
+    return {
+        continuationItemRenderer: {
+            continuationEndpoint: { continuationCommand: { token } },
+        },
+    };
+}
+
+function initialPayload(items, { loggedOut = false } = {}) {
+    return {
+        responseContext: { mainAppWebResponseContext: { loggedOut } },
+        contents: {
+            twoColumnBrowseResultsRenderer: {
+                tabs: [{
+                    tabRenderer: {
+                        content: {
+                            sectionListRenderer: {
+                                contents: [{ itemSectionRenderer: { contents: items } }],
+                            },
+                        },
+                    },
+                }],
+            },
+        },
+    };
+}
+
+function continuationPayload(items) {
+    return {
+        onResponseReceivedActions: [{
+            appendContinuationItemsAction: { continuationItems: items },
+        }],
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('youtube history', () => {
+    it('uses authenticated FEhistory pagination and preserves the public row contract', async () => {
+        const page = makePage({
+            responses: [
+                response(initialPayload([
+                    lockup('first', { url: '/watch?v=first&t=1s' }),
+                    continuation('next-token'),
+                ])),
+                response(continuationPayload([
+                    videoRenderer('second'),
+                    continuation('unused-token'),
+                ])),
+            ],
+        });
+
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 2 })).resolves.toEqual([
+            {
+                rank: 1,
+                title: 'First video',
+                channel: 'First channel',
+                views: '1K views',
+                duration: '10:00',
+                url: 'https://www.youtube.com/watch?v=first&t=1s',
+            },
+            {
+                rank: 2,
+                title: 'Second video',
+                channel: 'Second channel',
+                views: '2K views',
+                duration: '11:00',
+                url: 'https://www.youtube.com/watch?v=second',
+            },
+        ]);
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.youtube.com', { waitUntil: 'none' });
+        expect(page.wait).toHaveBeenCalledWith(2);
+        expect(page.__fetchMock).toHaveBeenCalledTimes(2);
+        const firstRequest = page.__fetchMock.mock.calls[0][1];
+        const secondRequest = page.__fetchMock.mock.calls[1][1];
+        expect(JSON.parse(firstRequest.body)).toMatchObject({ browseId: 'FEhistory' });
+        expect(JSON.parse(secondRequest.body)).toMatchObject({ continuation: 'next-token' });
+        expect(firstRequest.headers.Authorization).toMatch(/^SAPISIDHASH \d+_[a-f0-9]{40}$/);
+        expect(firstRequest.headers['X-Origin']).toBe('https://www.youtube.com');
+    });
+
+    it('does not follow an unused cursor after satisfying the requested limit', async () => {
+        const page = makePage({
+            responses: [response(initialPayload([lockup('first'), continuation('unused-token')]))],
+        });
+
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 })).resolves.toHaveLength(1);
+        expect(page.__fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([0, -1, 1.5, 201, 'bad'])('rejects invalid limit %s', async (limit) => {
+        const page = makePage();
+        await expect(getRegistry().get('youtube/history').func(page, { limit }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('requires a SAPISID cookie before evaluating page code', async () => {
+        const page = makePage({ cookies: [] });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        [response(initialPayload([], { loggedOut: true }))],
+        [response({}, { status: 401 })],
+        [response({ error: { code: 403, status: 'PERMISSION_DENIED' } })],
+    ])('classifies signed-out and rejected responses as AuthRequiredError', async (firstResponse) => {
+        const page = makePage({ responses: [firstResponse] });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it.each([
+        [response({}, { status: 500 })],
+        [response(null, { jsonError: new SyntaxError('bad json') })],
+        [response({ error: { code: 400, status: 'INVALID_ARGUMENT' } })],
+    ])('classifies HTTP, JSON, and upstream failures as CommandExecutionError', async (firstResponse) => {
+        const page = makePage({ responses: [firstResponse] });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('classifies request timeout as TimeoutError', async () => {
+        const timeout = Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+        const page = makePage({ fetchImpl: vi.fn().mockRejectedValue(timeout) });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(TimeoutError);
+    });
+
+    it('rejects a repeated continuation cursor instead of returning partial rows', async () => {
+        const page = makePage({
+            responses: [
+                response(initialPayload([lockup('first'), continuation('same-token')])),
+                response(continuationPayload([lockup('first'), continuation('same-token')])),
+            ],
+        });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects malformed video rows instead of silently dropping them', async () => {
+        const page = makePage({
+            responses: [response(initialPayload([lockup('first', { title: '' })]))],
+        });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('reports a valid empty history as EmptyResultError', async () => {
+        const payload = initialPayload([]);
+        payload.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content
+            .sectionListRenderer.contents[0].itemSectionRenderer.contents = [{
+                messageRenderer: { text: { runs: [{ text: 'No watch history' }] } },
+            }];
+        const page = makePage({ responses: [response(payload)] });
+        await expect(getRegistry().get('youtube/history').func(page, { limit: 1 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+});


### PR DESCRIPTION
## Summary

- replace capped DOM scrolling for `youtube history` with authenticated InnerTube `FEhistory` pagination
- reuse the existing YouTube SAPISIDHASH/ytcfg helpers; no new auth or signing mechanism
- preserve the six public columns and navigation URLs, validate limit instead of silently clamping, and reject auth/HTTP/JSON/upstream/timeout/malformed/repeated-cursor/partial-page failures with typed errors
- add production-script pagination and error-path tests

## Strategy note

Strategy: `PAGE_FETCH`
Contract: `internal-unstable`

Evidence:
- observed request/state: authenticated `POST /youtubei/v1/browse` with `{browseId:'FEhistory'}` and `{continuation}`
- auth source: existing YouTube page session + established `readYoutubeSapisid`/`SAPISID_HASH_FN`
- replay result: HTTP 200 JSON, `loggedOut:false`, 127 initial videos + one cursor, then 129 videos + one cursor

A plain cookie-only page fetch returned HTTP 200 with `loggedOut:true` and zero videos, so SAPISIDHASH is required. The first authenticated API row exactly matched the DOM row for `title`, `channel`, `views`, `duration`, and `url`.

Public API cannot expose private history; the old UI path returned only 130 rows for `--limit 200` after capped scrolling. The authenticated structured path returned 200/200 unique rows with all six columns.

## Live comparison

- old DOM `--limit 200`: 130 unique rows, 22.12s
- new InnerTube `--limit 200`: 200 unique rows, 11.30s
- new default limit: exactly 30 unique rows, all six columns

## Verification

- `npx vitest run clis/youtube/*.test.js` — 7 files / 69 tests pass
- `npm run typecheck` — pass
- `npm run build` — pass, manifest 1,335 entries
- `node dist/src/main.js validate youtube` — 17 commands, 0 errors/warnings
- typed-error lint — new=0 and removes both old `youtube/history` silent-clamp findings
- silent-column-drop — new=0
- `git diff --check` — pass
