### PR TITLE
fix(youtube): paginate search results

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46742,7 +46742,7 @@
   {
     "site": "youtube",
     "name": "search",
-    "description": "Search YouTube videos",
+    "description": "Search YouTube videos, Shorts, channels, and playlists",
     "access": "read",
     "domain": "www.youtube.com",
     "strategy": "cookie",

--- a/clis/youtube/search.js
+++ b/clis/youtube/search.js
@@ -1,100 +1,354 @@
 /**
- * YouTube search — innertube API via browser session.
+ * YouTube search via initial page state and authenticated InnerTube continuations.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import { readYoutubeSapisid, SAPISID_HASH_FN } from './utils.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+const MAX_PAGES = 10;
+const REQUEST_TIMEOUT_SECONDS = 15;
+
+const TYPE_FILTERS = {
+    shorts: 'EgIQCQ%3D%3D',
+    video: 'EgIQAQ%3D%3D',
+    channel: 'EgIQAg%3D%3D',
+    playlist: 'EgIQAw%3D%3D',
+};
+const UPLOAD_FILTERS = {
+    hour: 'EgIIAQ%3D%3D',
+    today: 'EgIIAg%3D%3D',
+    week: 'EgIIAw%3D%3D',
+    month: 'EgIIBA%3D%3D',
+    year: 'EgIIBQ%3D%3D',
+};
+const SORT_FILTERS = {
+    relevance: '',
+    date: 'CAI%3D',
+    views: 'CAM%3D',
+    rating: 'CAE%3D',
+};
+
+function normalizeChoice(value, choices, label) {
+    const normalized = String(value || '').trim();
+    if (normalized && !Object.hasOwn(choices, normalized)) {
+        throw new ArgumentError(`youtube search ${label} must be one of: ${Object.keys(choices).join(', ')}`);
+    }
+    return normalized;
+}
+
+function normalizeLimit(value) {
+    const limit = Number(value ?? DEFAULT_LIMIT);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError('youtube search limit must be a positive integer');
+    }
+    if (limit > MAX_LIMIT) {
+        throw new ArgumentError(`youtube search limit must be <= ${MAX_LIMIT}`);
+    }
+    return limit;
+}
+
 cli({
     site: 'youtube',
     name: 'search',
     access: 'read',
-    description: 'Search YouTube videos',
+    description: 'Search YouTube videos, Shorts, channels, and playlists',
     domain: 'www.youtube.com',
     strategy: Strategy.COOKIE,
     args: [
         { name: 'query', required: true, positional: true, help: 'Search query' },
-        { name: 'limit', type: 'int', default: 20, help: 'Max results (max 50)' },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT, help: 'Max results (max 50)' },
         { name: 'type', default: '', help: 'Filter type: shorts, video, channel, playlist' },
         { name: 'upload', default: '', help: 'Upload date: hour, today, week, month, year' },
         { name: 'sort', default: '', help: 'Sort by: relevance, date, views, rating' },
     ],
     columns: ['rank', 'title', 'channel', 'views', 'duration', 'published', 'url'],
     func: async (page, kwargs) => {
-        const limit = Math.min(kwargs.limit || 20, 50);
-        const query = encodeURIComponent(kwargs.query);
-        // Build search URL with filter params
-        // YouTube uses sp= parameter for filters — we use the URL approach for reliability
-        const spMap = {
-            // type filters
-            'shorts': 'EgIQCQ%3D%3D', // Shorts (type=9)
-            'video': 'EgIQAQ%3D%3D',
-            'channel': 'EgIQAg%3D%3D',
-            'playlist': 'EgIQAw%3D%3D',
-            // upload date filters (can be combined with type via URL)
-            'hour': 'EgIIAQ%3D%3D',
-            'today': 'EgIIAg%3D%3D',
-            'week': 'EgIIAw%3D%3D',
-            'month': 'EgIIBA%3D%3D',
-            'year': 'EgIIBQ%3D%3D',
-        };
-        const sortMap = {
-            'date': 'CAI%3D',
-            'views': 'CAM%3D',
-            'rating': 'CAE%3D',
-        };
-        // YouTube only supports a single sp= parameter — pick the most specific filter.
-        // Priority: type > upload > sort (type is the most common use case)
-        let sp = '';
-        if (kwargs.type && spMap[kwargs.type])
-            sp = spMap[kwargs.type];
-        else if (kwargs.upload && spMap[kwargs.upload])
-            sp = spMap[kwargs.upload];
-        else if (kwargs.sort && sortMap[kwargs.sort])
-            sp = sortMap[kwargs.sort];
-        let url = `https://www.youtube.com/results?search_query=${query}`;
-        if (sp)
-            url += `&sp=${sp}`;
+        const query = String(kwargs.query || '').trim();
+        if (!query) throw new ArgumentError('youtube search query cannot be empty');
+        const limit = normalizeLimit(kwargs.limit);
+        const resultType = normalizeChoice(kwargs.type, TYPE_FILTERS, 'type');
+        const upload = normalizeChoice(kwargs.upload, UPLOAD_FILTERS, 'upload');
+        const sort = normalizeChoice(kwargs.sort, SORT_FILTERS, 'sort');
+
+        // YouTube accepts one sp parameter. Preserve the existing priority:
+        // type > upload > sort.
+        const sp = TYPE_FILTERS[resultType] || UPLOAD_FILTERS[upload] || SORT_FILTERS[sort] || '';
+        let url = `https://www.youtube.com/results?search_query=${encodeURIComponent(query)}`;
+        if (sp) url += `&sp=${sp}`;
         await page.goto(url);
         await page.wait(3);
-        const data = await page.evaluate(`
-      (async () => {
-        const data = window.ytInitialData;
-        if (!data) return {error: 'YouTube data not found'};
 
-        const contents = data.contents?.twoColumnSearchResultsRenderer?.primaryContents?.sectionListRenderer?.contents || [];
-        const videos = [];
-        for (const section of contents) {
-          const items = section.itemSectionRenderer?.contents || section.reelShelfRenderer?.items || [];
-          for (const item of items) {
-            if (videos.length >= ${limit}) break;
-            if (item.videoRenderer) {
-              const v = item.videoRenderer;
-              videos.push({
-                rank: videos.length + 1,
-                title: v.title?.runs?.[0]?.text || '',
-                channel: v.ownerText?.runs?.[0]?.text || '',
-                views: v.viewCountText?.simpleText || v.shortViewCountText?.simpleText || '',
-                duration: v.lengthText?.simpleText || 'LIVE',
-                published: v.publishedTimeText?.simpleText || '',
-                url: 'https://www.youtube.com/watch?v=' + v.videoId
-              });
-            } else if (item.reelItemRenderer) {
-              const r = item.reelItemRenderer;
-              videos.push({
-                rank: videos.length + 1,
-                title: r.headline?.simpleText || '',
-                channel: r.navigationEndpoint?.reelWatchEndpoint?.overlay?.reelPlayerOverlayRenderer?.reelPlayerHeaderSupportedRenderers?.reelPlayerHeaderRenderer?.channelTitleText?.runs?.[0]?.text || '',
-                views: r.viewCountText?.simpleText || '',
-                duration: 'SHORT',
-                published: r.publishedTimeText?.simpleText || '',
-                url: 'https://www.youtube.com/shorts/' + r.videoId
-              });
-            }
-          }
+        const sapisid = await readYoutubeSapisid(page);
+        const result = await page.evaluate(`
+      (async () => {
+        ${SAPISID_HASH_FN}
+
+        const limit = ${limit};
+        const resultType = ${JSON.stringify(resultType)};
+        const maxPages = ${MAX_PAGES};
+        const requestTimeoutMs = ${REQUEST_TIMEOUT_SECONDS * 1000};
+        const cfg = window.ytcfg?.data_ || {};
+        const apiKey = cfg.INNERTUBE_API_KEY;
+        const context = cfg.INNERTUBE_CONTEXT;
+        const initialData = window.ytInitialData;
+        if (!apiKey || !context || !initialData) {
+          return { error: 'config', message: 'YouTube search bootstrap data not found' };
         }
-        return videos;
+        const signedIn = cfg.LOGGED_IN === true || window.ytcfg?.get?.('LOGGED_IN') === true;
+
+        function readText(value) {
+          if (!value) return '';
+          if (typeof value.content === 'string') return value.content;
+          if (typeof value.simpleText === 'string') return value.simpleText;
+          if (Array.isArray(value.runs)) return value.runs.map(run => run?.text || '').join('');
+          return '';
+        }
+
+        function absoluteUrl(path) {
+          if (!path) return '';
+          return path.startsWith('http') ? path : 'https://www.youtube.com' + path;
+        }
+
+        function fromVideo(video) {
+          const path = video?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url
+            || (video?.videoId ? '/watch?v=' + video.videoId : '');
+          return [video?.videoId || '', {
+            title: readText(video?.title),
+            channel: readText(video?.ownerText) || readText(video?.shortBylineText),
+            views: readText(video?.viewCountText) || readText(video?.shortViewCountText),
+            duration: readText(video?.lengthText) || 'LIVE',
+            published: readText(video?.publishedTimeText),
+            url: absoluteUrl(path),
+          }];
+        }
+
+        function fromLegacyShort(reel) {
+          return [reel?.videoId || '', {
+            title: readText(reel?.headline),
+            channel: readText(reel?.navigationEndpoint?.reelWatchEndpoint?.overlay?.reelPlayerOverlayRenderer
+              ?.reelPlayerHeaderSupportedRenderers?.reelPlayerHeaderRenderer?.channelTitleText),
+            views: readText(reel?.viewCountText),
+            duration: 'SHORT',
+            published: readText(reel?.publishedTimeText),
+            url: reel?.videoId ? 'https://www.youtube.com/shorts/' + reel.videoId : '',
+          }];
+        }
+
+        function fromShortLockup(short) {
+          const command = short?.onTap?.innertubeCommand;
+          const videoId = command?.reelWatchEndpoint?.videoId
+            || short?.inlinePlayerData?.onVisible?.innertubeCommand?.watchEndpoint?.videoId
+            || '';
+          const path = command?.commandMetadata?.webCommandMetadata?.url
+            || (videoId ? '/shorts/' + videoId : '');
+          return [videoId, {
+            title: readText(short?.overlayMetadata?.primaryText),
+            channel: '',
+            views: readText(short?.overlayMetadata?.secondaryText),
+            duration: 'SHORT',
+            published: '',
+            url: absoluteUrl(path),
+          }];
+        }
+
+        function fromChannel(channel) {
+          const path = channel?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url
+            || channel?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl
+            || (channel?.channelId ? '/channel/' + channel.channelId : '');
+          const handleCandidate = readText(channel?.subscriberCountText);
+          return [channel?.channelId || channel?.navigationEndpoint?.browseEndpoint?.browseId || '', {
+            title: readText(channel?.title),
+            channel: handleCandidate.startsWith('@') ? handleCandidate : '',
+            views: readText(channel?.videoCountText) || (!handleCandidate.startsWith('@') ? handleCandidate : ''),
+            duration: 'CHANNEL',
+            published: '',
+            url: absoluteUrl(path),
+          }];
+        }
+
+        function fromPlaylist(playlist) {
+          const playlistId = playlist?.playlistId || playlist?.navigationEndpoint?.watchEndpoint?.playlistId || '';
+          return [playlistId, {
+            title: readText(playlist?.title),
+            channel: readText(playlist?.shortBylineText) || readText(playlist?.longBylineText),
+            views: readText(playlist?.videoCountText),
+            duration: 'PLAYLIST',
+            published: '',
+            url: playlistId ? 'https://www.youtube.com/playlist?list=' + playlistId : '',
+          }];
+        }
+
+        function fromPlaylistLockup(lockup) {
+          const metadata = lockup?.metadata?.lockupMetadataViewModel;
+          const parts = (metadata?.metadata?.contentMetadataViewModel?.metadataRows || [])
+            .flatMap(row => (row.metadataParts || []).map(part => readText(part?.text)).filter(Boolean));
+          const playlistId = lockup?.contentId || '';
+          return [playlistId, {
+            title: readText(metadata?.title),
+            channel: parts[0] || '',
+            views: '',
+            duration: 'PLAYLIST',
+            published: '',
+            url: playlistId ? 'https://www.youtube.com/playlist?list=' + playlistId : '',
+          }];
+        }
+
+        function extractPage(payload) {
+          const entries = [];
+          const pageIds = new Set();
+          const cursors = [];
+          const messages = [];
+          let malformed = 0;
+
+          function push(entry) {
+            const [searchId, row] = entry || [];
+            if (!searchId) return;
+            if (!row?.title || !row?.url) {
+              malformed += 1;
+              return;
+            }
+            if (pageIds.has(searchId)) return;
+            pageIds.add(searchId);
+            entries.push([searchId, row]);
+          }
+
+          function visit(value) {
+            if (!value || typeof value !== 'object') return;
+            if (!resultType || resultType === 'video') {
+              if (value.videoRenderer?.videoId) push(fromVideo(value.videoRenderer));
+            } else if (resultType === 'shorts') {
+              if (value.reelItemRenderer?.videoId) push(fromLegacyShort(value.reelItemRenderer));
+              if (value.shortsLockupViewModel) push(fromShortLockup(value.shortsLockupViewModel));
+            } else if (resultType === 'channel') {
+              if (value.channelRenderer) push(fromChannel(value.channelRenderer));
+            } else if (resultType === 'playlist') {
+              if (value.playlistRenderer) push(fromPlaylist(value.playlistRenderer));
+              if (value.lockupViewModel?.contentType === 'LOCKUP_CONTENT_TYPE_PLAYLIST') {
+                push(fromPlaylistLockup(value.lockupViewModel));
+              }
+            }
+
+            const cursor = value.continuationItemRenderer?.continuationEndpoint?.continuationCommand?.token;
+            if (cursor) cursors.push(cursor);
+            const message = readText(value.messageRenderer?.text);
+            if (message) messages.push(message);
+            for (const child of Object.values(value)) visit(child);
+          }
+
+          visit(payload);
+          return {
+            entries,
+            nextCursor: cursors[cursors.length - 1] || null,
+            message: messages[0] || '',
+            malformed,
+          };
+        }
+
+        async function fetchContinuation(cursor) {
+          let authHash = null;
+          if (${JSON.stringify(sapisid)}) {
+            authHash = await getSapisidHash(${JSON.stringify(sapisid)}, 'https://www.youtube.com');
+          }
+          if (signedIn && !authHash) {
+            return { error: 'auth', message: 'Signed-in YouTube search session has no SAPISID cookie' };
+          }
+          const headers = { 'Content-Type': 'application/json' };
+          if (authHash) {
+            headers.Authorization = authHash;
+            headers['X-Origin'] = 'https://www.youtube.com';
+          }
+
+          let response;
+          try {
+            response = await fetch('/youtubei/v1/search?key=' + encodeURIComponent(apiKey) + '&prettyPrint=false', {
+              method: 'POST',
+              credentials: 'include',
+              signal: AbortSignal.timeout(requestTimeoutMs),
+              headers,
+              body: JSON.stringify({ context, continuation: cursor }),
+            });
+          } catch (error) {
+            if (error?.name === 'AbortError' || error?.name === 'TimeoutError') return { error: 'timeout' };
+            return { error: 'transport', message: String(error?.message || error) };
+          }
+
+          if (response.status === 401 || (response.status === 403 && signedIn)) {
+            return { error: 'auth', message: 'YouTube search HTTP ' + response.status };
+          }
+          if (!response.ok) return { error: 'http', message: 'YouTube search HTTP ' + response.status };
+
+          let payload;
+          try {
+            payload = await response.json();
+          } catch (error) {
+            return { error: 'json', message: String(error?.message || error) };
+          }
+          const upstreamStatus = payload?.error?.status || '';
+          const upstreamCode = Number(payload?.error?.code || 0);
+          if (upstreamCode === 401 || upstreamStatus === 'UNAUTHENTICATED') {
+            return { error: 'auth', message: upstreamStatus || 'YouTube search authentication failed' };
+          }
+          if (payload?.error) {
+            return { error: 'api', message: upstreamStatus || payload.error.message || 'YouTube search API error' };
+          }
+          if (signedIn && payload?.responseContext?.mainAppWebResponseContext?.loggedOut === true) {
+            return { error: 'auth', message: 'YouTube search continuation response is logged out' };
+          }
+          return { payload };
+        }
+
+        const rows = [];
+        const seenIds = new Set();
+        const seenCursors = new Set();
+        let pageData = extractPage(initialData);
+
+        for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
+          if (pageData.malformed > 0) {
+            return { error: 'malformed', message: 'YouTube search returned malformed result rows' };
+          }
+          for (const [searchId, row] of pageData.entries) {
+            if (seenIds.has(searchId)) continue;
+            seenIds.add(searchId);
+            rows.push({ rank: rows.length + 1, ...row });
+            if (rows.length >= limit) return rows;
+          }
+
+          const cursor = pageData.nextCursor;
+          if (!cursor) {
+            if (rows.length > 0) return rows;
+            return { error: 'empty', message: pageData.message || 'No YouTube search results found' };
+          }
+          if (seenCursors.has(cursor)) {
+            return { error: 'repeated-cursor', message: 'YouTube search repeated a continuation cursor' };
+          }
+          seenCursors.add(cursor);
+          const fetched = await fetchContinuation(cursor);
+          if (fetched.error) return fetched;
+          pageData = extractPage(fetched.payload);
+        }
+
+        return { error: 'page-cap', message: 'YouTube search pagination stopped before satisfying the requested limit' };
       })()
     `);
-        if (!Array.isArray(data))
-            return [];
-        return data;
+
+        if (Array.isArray(result)) return result;
+        if (result?.error === 'auth') {
+            throw new AuthRequiredError('www.youtube.com', result.message || 'Not logged in to YouTube');
+        }
+        if (result?.error === 'timeout') {
+            throw new TimeoutError('YouTube search request', REQUEST_TIMEOUT_SECONDS);
+        }
+        if (result?.error === 'empty') {
+            throw new EmptyResultError('youtube search', result.message || 'No YouTube search results found');
+        }
+        throw new CommandExecutionError(result?.message || 'Failed to search YouTube');
     },
 });

--- a/clis/youtube/search.test.js
+++ b/clis/youtube/search.test.js
@@ -1,0 +1,411 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    EmptyResultError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+import './search.js';
+
+function response(payload, { status = 200, jsonError } = {}) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: jsonError
+            ? vi.fn().mockRejectedValue(jsonError)
+            : vi.fn().mockResolvedValue(payload),
+    };
+}
+
+function makePage({ initialData, responses = [], cookies, loggedIn = true, fetchImpl } = {}) {
+    const fetchMock = fetchImpl || vi.fn().mockImplementation(async () => responses.shift());
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn().mockResolvedValue(cookies ?? [{ name: '__Secure-3PAPISID', value: 'secret-cookie' }]),
+        evaluate: vi.fn(async (script) => {
+            const previousWindow = globalThis.window;
+            const previousFetch = globalThis.fetch;
+            globalThis.window = {
+                ytInitialData: initialData ?? payload([]),
+                ytcfg: {
+                    data_: {
+                        INNERTUBE_API_KEY: 'test-key',
+                        INNERTUBE_CONTEXT: { client: { clientName: 'WEB', clientVersion: '1.0' } },
+                        LOGGED_IN: loggedIn,
+                    },
+                    get: (key) => key === 'LOGGED_IN' ? loggedIn : undefined,
+                },
+            };
+            globalThis.fetch = fetchMock;
+            try {
+                return await eval(script);
+            }
+            finally {
+                globalThis.window = previousWindow;
+                globalThis.fetch = previousFetch;
+            }
+        }),
+        __fetchMock: fetchMock,
+    };
+}
+
+function text(value) {
+    return { runs: [{ text: value }] };
+}
+
+function video(id, {
+    title = 'First video',
+    channel = 'First channel',
+    views = '1K views',
+    duration = '10:00',
+    published = '1 day ago',
+    url = `/watch?v=${id}`,
+} = {}) {
+    return {
+        videoRenderer: {
+            videoId: id,
+            title: text(title),
+            ownerText: text(channel),
+            viewCountText: { simpleText: views },
+            lengthText: { simpleText: duration },
+            publishedTimeText: { simpleText: published },
+            navigationEndpoint: { commandMetadata: { webCommandMetadata: { url } } },
+        },
+    };
+}
+
+function channel(id = 'channel-id') {
+    return {
+        channelRenderer: {
+            channelId: id,
+            title: { simpleText: 'OpenAI' },
+            subscriberCountText: { simpleText: '@OpenAI' },
+            videoCountText: { simpleText: '2M subscribers' },
+            navigationEndpoint: {
+                browseEndpoint: { browseId: id, canonicalBaseUrl: '/@OpenAI' },
+                commandMetadata: { webCommandMetadata: { url: '/@OpenAI' } },
+            },
+        },
+    };
+}
+
+function playlistLockup(id = 'playlist-id') {
+    return {
+        lockupViewModel: {
+            contentId: id,
+            contentType: 'LOCKUP_CONTENT_TYPE_PLAYLIST',
+            metadata: {
+                lockupMetadataViewModel: {
+                    title: { content: 'OpenAI for Business' },
+                    metadata: {
+                        contentMetadataViewModel: {
+                            metadataRows: [{
+                                metadataParts: [
+                                    { text: { content: 'OpenAI' } },
+                                    { text: { content: 'Playlist' } },
+                                ],
+                            }],
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function shortLockup(id = 'short-id') {
+    return {
+        shortsLockupViewModel: {
+            onTap: {
+                innertubeCommand: {
+                    commandMetadata: { webCommandMetadata: { url: `/shorts/${id}` } },
+                    reelWatchEndpoint: { videoId: id },
+                },
+            },
+            overlayMetadata: {
+                primaryText: { content: 'OpenAI short' },
+                secondaryText: { content: '1.1K views' },
+            },
+        },
+    };
+}
+
+function continuation(token) {
+    return {
+        continuationItemRenderer: {
+            continuationEndpoint: { continuationCommand: { token } },
+        },
+    };
+}
+
+function message(value) {
+    return { messageRenderer: { text: text(value) } };
+}
+
+function payload(items, { loggedOut = false } = {}) {
+    return {
+        responseContext: { mainAppWebResponseContext: { loggedOut } },
+        contents: { items },
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('youtube search', () => {
+    it('paginates authenticated continuations and preserves the seven-column contract', async () => {
+        const page = makePage({
+            initialData: payload([
+                video('first', { url: '/watch?v=first&t=1s' }),
+                continuation('next-token'),
+            ]),
+            responses: [response(payload([
+                video('second', {
+                    title: 'Second video',
+                    channel: 'Second channel',
+                    views: '2K views',
+                    duration: '11:00',
+                    published: '2 days ago',
+                }),
+                continuation('unused-token'),
+            ]))],
+        });
+
+        await expect(getRegistry().get('youtube/search').func(page, {
+            query: 'open cli',
+            limit: 2,
+        })).resolves.toEqual([
+            {
+                rank: 1,
+                title: 'First video',
+                channel: 'First channel',
+                views: '1K views',
+                duration: '10:00',
+                published: '1 day ago',
+                url: 'https://www.youtube.com/watch?v=first&t=1s',
+            },
+            {
+                rank: 2,
+                title: 'Second video',
+                channel: 'Second channel',
+                views: '2K views',
+                duration: '11:00',
+                published: '2 days ago',
+                url: 'https://www.youtube.com/watch?v=second',
+            },
+        ]);
+
+        expect(page.goto).toHaveBeenCalledWith('https://www.youtube.com/results?search_query=open%20cli');
+        expect(page.wait).toHaveBeenCalledWith(3);
+        expect(page.__fetchMock).toHaveBeenCalledTimes(1);
+        const request = page.__fetchMock.mock.calls[0][1];
+        expect(JSON.parse(request.body)).toMatchObject({ continuation: 'next-token' });
+        expect(request.headers.Authorization).toMatch(/^SAPISIDHASH \d+_[a-f0-9]{40}$/);
+        expect(request.headers['X-Origin']).toBe('https://www.youtube.com');
+    });
+
+    it('does not fetch an unused cursor after satisfying the limit', async () => {
+        const page = makePage({ initialData: payload([video('first'), continuation('unused')]) });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 1 }))
+            .resolves.toHaveLength(1);
+        expect(page.__fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('supports a signed-out public continuation without an Authorization header', async () => {
+        const page = makePage({
+            loggedIn: false,
+            cookies: [],
+            initialData: payload([video('first'), continuation('next')], { loggedOut: true }),
+            responses: [response(payload([video('second')], { loggedOut: true }))],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .resolves.toHaveLength(2);
+        expect(page.__fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+    });
+
+    it('requires SAPISID only when a signed-in result needs a continuation', async () => {
+        const page = makePage({
+            cookies: [],
+            initialData: payload([video('first'), continuation('next')]),
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.__fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps a logged-out continuation from a signed-in page to AuthRequiredError', async () => {
+        const page = makePage({
+            initialData: payload([video('first'), continuation('next')]),
+            responses: [response(payload([video('second')], { loggedOut: true }))],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it.each([0, -1, 1.5, 51, 'bad'])('rejects invalid limit %s before navigation', async (limit) => {
+        const page = makePage();
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit }))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { query: '' },
+        { query: 'test', type: 'movie' },
+        { query: 'test', upload: 'decade' },
+        { query: 'test', sort: 'popular' },
+    ])('rejects invalid args before navigation: %o', async (kwargs) => {
+        const page = makePage();
+        await expect(getRegistry().get('youtube/search').func(page, kwargs))
+            .rejects.toBeInstanceOf(ArgumentError);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('preserves type > upload > sort filter priority', async () => {
+        const page = makePage({ initialData: payload([shortLockup()]) });
+        await getRegistry().get('youtube/search').func(page, {
+            query: 'test',
+            type: 'shorts',
+            upload: 'today',
+            sort: 'views',
+            limit: 1,
+        });
+        expect(page.goto).toHaveBeenCalledWith(
+            'https://www.youtube.com/results?search_query=test&sp=EgIQCQ%3D%3D',
+        );
+    });
+
+    it('normalizes current channel renderer results', async () => {
+        const page = makePage({ initialData: payload([channel()]) });
+        await expect(getRegistry().get('youtube/search').func(page, {
+            query: 'OpenAI', type: 'channel', limit: 1,
+        })).resolves.toEqual([{
+            rank: 1,
+            title: 'OpenAI',
+            channel: '@OpenAI',
+            views: '2M subscribers',
+            duration: 'CHANNEL',
+            published: '',
+            url: 'https://www.youtube.com/@OpenAI',
+        }]);
+    });
+
+    it('normalizes current playlist lockup results', async () => {
+        const page = makePage({ initialData: payload([playlistLockup()]) });
+        await expect(getRegistry().get('youtube/search').func(page, {
+            query: 'OpenAI', type: 'playlist', limit: 1,
+        })).resolves.toEqual([{
+            rank: 1,
+            title: 'OpenAI for Business',
+            channel: 'OpenAI',
+            views: '',
+            duration: 'PLAYLIST',
+            published: '',
+            url: 'https://www.youtube.com/playlist?list=playlist-id',
+        }]);
+    });
+
+    it('normalizes current shorts lockup results', async () => {
+        const page = makePage({ initialData: payload([shortLockup()]) });
+        await expect(getRegistry().get('youtube/search').func(page, {
+            query: 'OpenAI', type: 'shorts', limit: 1,
+        })).resolves.toEqual([{
+            rank: 1,
+            title: 'OpenAI short',
+            channel: '',
+            views: '1.1K views',
+            duration: 'SHORT',
+            published: '',
+            url: 'https://www.youtube.com/shorts/short-id',
+        }]);
+    });
+
+    it.each([
+        [response({}, { status: 500 })],
+        [response(null, { jsonError: new SyntaxError('bad json') })],
+        [response({ error: { code: 400, status: 'INVALID_ARGUMENT' } })],
+    ])('maps HTTP, JSON, and upstream failures to CommandExecutionError', async (nextResponse) => {
+        const page = makePage({
+            initialData: payload([video('first'), continuation('next')]),
+            responses: [nextResponse],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps continuation transport failure to CommandExecutionError', async () => {
+        const page = makePage({
+            initialData: payload([video('first'), continuation('next')]),
+            fetchImpl: vi.fn().mockRejectedValue(new Error('network down')),
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('maps a signed-out HTTP 403 to CommandExecutionError instead of an auth failure', async () => {
+        const page = makePage({
+            loggedIn: false,
+            cookies: [],
+            initialData: payload([video('first'), continuation('next')], { loggedOut: true }),
+            responses: [response({}, { status: 403 })],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it.each([401, 403])('maps signed-in HTTP %s to AuthRequiredError', async (status) => {
+        const page = makePage({
+            initialData: payload([video('first'), continuation('next')]),
+            responses: [response({}, { status })],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('maps request timeout to TimeoutError', async () => {
+        const timeout = Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+        const page = makePage({
+            initialData: payload([video('first'), continuation('next')]),
+            fetchImpl: vi.fn().mockRejectedValue(timeout),
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(TimeoutError);
+    });
+
+    it('rejects a repeated continuation cursor instead of returning partial rows', async () => {
+        const page = makePage({
+            initialData: payload([video('first'), continuation('same')]),
+            responses: [response(payload([video('first'), continuation('same')]))],
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects the page cap instead of returning accumulated partial rows', async () => {
+        const responses = Array.from({ length: 10 }, (_, index) =>
+            response(payload([continuation(`cursor-${index + 1}`)])));
+        const page = makePage({
+            initialData: payload([video('first'), continuation('cursor-0')]),
+            responses,
+        });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 2 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+        expect(page.__fetchMock).toHaveBeenCalledTimes(10);
+    });
+
+    it('rejects malformed rows instead of silently dropping them', async () => {
+        const page = makePage({ initialData: payload([video('first', { title: '' })]) });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'test', limit: 1 }))
+            .rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('reports valid empty results as EmptyResultError', async () => {
+        const page = makePage({ initialData: payload([message('No results found')]) });
+        await expect(getRegistry().get('youtube/search').func(page, { query: 'nothing', limit: 1 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+});


### PR DESCRIPTION
## Summary
- paginate `youtube search` beyond `ytInitialData` through the existing authenticated InnerTube/SAPISIDHASH boundary
- keep public signed-out search working while rejecting a signed-in continuation that silently falls back to `loggedOut:true`
- normalize current video, Shorts, channel, and playlist renderer shapes without changing the seven public columns or `type > upload > sort` priority
- validate query/filter/limit inputs and map empty/auth/timeout/HTTP/JSON/upstream/malformed/repeated-cursor/page-cap outcomes to typed errors

## Live evidence
- before: `youtube search music --limit 50` returned 20 rows because only the initial state was read
- after: the same command returns exactly 50 unique rows
- cookie-only continuation was HTTP 200 with 17 videos and another cursor, but explicitly `loggedOut:true`; authenticated continuation stayed in the signed-in search context
- before: `--type channel`, `playlist`, and `shorts` each returned successful `[]`
- after: live samples returned 2 channels, 20 playlists, and 20 Shorts; channel/playlist/Shorts keep the existing seven-column schema using `CHANNEL` / `PLAYLIST` / `SHORT` in the duration discriminator

## Verification
- `npx vitest run clis/youtube/*.test.js` — 8 files / 96 tests
- `npm run typecheck`
- `npm run build` — 1,335 manifest entries
- `node dist/src/main.js validate youtube` — 17 commands, 0 errors / 0 warnings
- typed-error lint — new=0; resolves the old search silent-clamp finding
- silent-column-drop — new=0
- `git diff --cached --check`
