### PR TITLE
fix(chatgpt): recognize accessible upload previews

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2366,6 +2366,11 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
                 const scope = root || document.body;
                 if (!scope) return false;
 
+                const accessibleNames = Array.from(scope.querySelectorAll('[role="group"][aria-label]'))
+                    .map(node => node.getAttribute('aria-label') || '');
+                const matchedAccessibleNames = names.filter(name => accessibleNames.some(label => label.includes(name))).length;
+                if (matchedAccessibleNames >= names.length) return true;
+
                 const isVisibleMedia = (node) => {
                     if (!(node instanceof HTMLElement)) return false;
                     const style = window.getComputedStyle(node);

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1789,6 +1789,31 @@ describe('chatgpt image upload helper', () => {
         expect(result.reason).toContain('image upload preview did not appear');
     });
 
+    it('accepts an upload preview whose filename is only exposed as an accessible name', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'cat.png');
+        fs.writeFileSync(filePath, 'fake-png');
+
+        const dom = new JSDOM(`
+            <!doctype html>
+            <main>
+              <div aria-label="Chat with ChatGPT">
+                <input id="upload-files" type="file">
+                <div role="group" aria-label="cat.png"></div>
+              </div>
+            </main>
+        `, { url: 'https://chatgpt.com/new', runScripts: 'outside-only' });
+        const page = {
+            setFileInput: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => Promise.resolve(dom.window.eval(String(script)))),
+        };
+
+        await expect(uploadChatGPTImages(page, [filePath])).resolves.toEqual({ ok: true, files: [filePath] });
+    });
+
     it('accepts a real uploaded media preview even when the filename text is absent', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
         tempDirs.push(dir);


### PR DESCRIPTION
## Description

ChatGPT's current upload preview can expose an uploaded filename only through the accessible name of a `role="group"` chip. `waitForChatGPTUploadPreview` previously checked only visible body text or media larger than 32 pixels, so a successful upload could still time out with `image upload preview did not appear`.

This change recognizes matching filenames on those accessible upload-preview groups while keeping the existing text and media signals unchanged.

Related issue: Fixes #2302

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

Not applicable: this fixes upload-readiness detection without adding or changing an adapter command, schema, failure type, or discoverability surface.

## Screenshots / Output

- Before: the focused regression test exited `1` because the accessible-name-only preview was not detected.
- After: the same regression test exits `0`; the complete affected test file passes `120/120` tests.

## Regression evidence

- Before: `npx vitest run --project adapter clis/chatgpt/utils.test.js -t 'accepts an upload preview whose filename is only exposed as an accessible name' --reporter=verbose` exited `1`.
- After: the same command exited `0`.

## Verification

- `npx vitest run --project adapter clis/chatgpt/utils.test.js`
- `npx --yes -p node@22 node node_modules/vitest/vitest.mjs run --project unit --project extension --project adapter --no-file-parallelism` (`7204` passed, `1` skipped)
- `bun vitest run --project unit` (`1334` passed, `1` skipped)
- `npm run typecheck`
- `npm run build`
- `git diff --exit-code -- cli-manifest.json`
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`
- `bash scripts/check-doc-coverage.sh --strict` (`177/177`)
- `npm run docs:build`
- `npm audit --omit=dev --audit-level=high` (`0` vulnerabilities)
- `git diff --cached --check`

The complete Node 22 suite was run without file parallelism because the default parallel run exposed an unrelated shared-`~/.opencli/plugins` race between existing plugin and engine tests. The exact failing engine test passed in isolation; no tests were omitted from the serial run.

## Scope

- 2 files changed, +30 / -0 lines
