### PR TITLE
fix(ctrip): read structured flight results

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -9108,7 +9108,7 @@
     "description": "搜索携程一程机票（按出发/到达 IATA 三字码 + 日期）",
     "access": "read",
     "domain": "flights.ctrip.com",
-    "strategy": "cookie",
+    "strategy": "intercept",
     "browser": true,
     "args": [
       {

--- a/clis/ctrip/ctrip.test.js
+++ b/clis/ctrip/ctrip.test.js
@@ -51,7 +51,7 @@ import {
     WAIT_FOR_HOTEL_DETAIL_JS,
 } from './utils.js';
 
-function createPageMock(evaluateResults) {
+function createPageMock(evaluateResults, networkCaptures = []) {
     const evaluate = vi.fn();
     for (const result of evaluateResults) {
         evaluate.mockResolvedValueOnce(result);
@@ -63,6 +63,10 @@ function createPageMock(evaluateResults) {
         scroll: vi.fn().mockResolvedValue(undefined),
         autoScroll: vi.fn().mockResolvedValue(undefined),
         getCookies: vi.fn().mockResolvedValue([]),
+        startNetworkCapture: vi.fn().mockResolvedValue(true),
+        readNetworkCapture: vi.fn()
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(networkCaptures),
     };
 }
 
@@ -558,24 +562,45 @@ describe('ctrip hotel-search command (registry-level)', () => {
 describe('ctrip flight command (registry-level)', () => {
     const cmd = getRegistry().get('ctrip/flight');
 
-    const FLIGHT_RAW = {
-        airline: '厦门航空',
-        flightNo: 'MF8561',
-        aircraft: '空客321(中)',
-        departureTime: '07:50',
-        departureAirport: '大兴国际机场',
-        arrivalTime: '09:45',
-        arrivalAirport: '浦东国际机场',
-        terminal: 'T2',
-        price: 487,
-        currency: '¥',
-        cabin: '经济舱',
-    };
+    function itinerary({
+        id = 'MF8561_1', airline = '厦门航空', flightNo = 'MF8561', aircraft = '空客321(中)',
+        departure = '2026-06-15 07:50:00', departureAirport = '大兴国际机场',
+        arrival = '2026-06-15 09:45:00', arrivalAirport = '浦东国际机场', terminal = 'T2',
+        price = 487, cabin = 'Y', legs,
+    } = {}) {
+        const flightList = legs || [{
+            flightNo,
+            aircraftName: aircraft,
+            departureDateTime: departure,
+            departureAirportName: departureAirport,
+            arrivalDateTime: arrival,
+            arrivalAirportName: arrivalAirport,
+            arrivalTerminal: terminal,
+        }];
+        return {
+            itineraryId: id,
+            flightSegments: [{ airlineName: airline, flightList }],
+            priceList: [{ sortPrice: price, adultPrice: price, cabin }],
+        };
+    }
 
-    it('declares Strategy.COOKIE + browser:true + navigateBefore:false + access:read', () => {
+    function batchPayload(flightItineraryList, { finished = true, status = 0, msg = 'success' } = {}) {
+        return { status, msg, data: { context: { finished }, flightItineraryList } };
+    }
+
+    function batchCapture(payload, overrides = {}) {
+        return {
+            url: 'https://flights.ctrip.com/international/search/api/search/batchSearch?v=1',
+            responseStatus: 200,
+            responsePreview: JSON.stringify(payload),
+            ...overrides,
+        };
+    }
+
+    it('declares Strategy.INTERCEPT + browser:true + navigateBefore:false + access:read', () => {
         expect(cmd.access).toBe('read');
         expect(cmd.browser).toBe(true);
-        expect(String(cmd.strategy)).toContain('cookie');
+        expect(String(cmd.strategy)).toContain('intercept');
         expect(cmd.navigateBefore).toBe(false);
         expect(cmd.domain).toBe('flights.ctrip.com');
     });
@@ -590,63 +615,80 @@ describe('ctrip flight command (registry-level)', () => {
             .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--date') });
         await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 0 }))
             .rejects.toMatchObject({ code: 'ARGUMENT', message: expect.stringContaining('--limit') });
+        expect(page.startNetworkCapture).not.toHaveBeenCalled();
         expect(page.goto).not.toHaveBeenCalled();
     });
 
-    it('throws AuthRequired when captcha gate is detected', async () => {
+    it('throws AuthRequired when no capture arrives behind a captcha gate', async () => {
         const page = createPageMock(['captcha']);
         await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
             .rejects.toThrow('Ctrip is asking for a captcha');
         expect(page.evaluate).toHaveBeenCalledTimes(1);
     });
 
-    it('throws EmptyResultError when DOM extraction returns no flights', async () => {
-        const page = createPageMock(['content', 0, []]);
+    it('throws TimeoutError when no capture arrives without a captcha', async () => {
+        const page = createPageMock(['timeout']);
+        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
+            .rejects.toMatchObject({ code: 'TIMEOUT', message: expect.stringContaining('Ctrip flight API capture') });
+    });
+
+    it('throws EmptyResultError only for a completed empty search', async () => {
+        const page = createPageMock([], [batchCapture(batchPayload([]))]);
         await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
             .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
     });
 
-    it('throws CommandExecutionError when visible cards render but parser finds no flight anchors', async () => {
-        const page = createPageMock(['content', 2, []]);
-        await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
-            .rejects.toMatchObject({
-                code: 'COMMAND_EXEC',
-                message: expect.stringContaining('parser did not find required flight anchors'),
-            });
-    });
-
-    it('throws CommandExecutionError when flight render waits timeout or extraction is malformed', async () => {
-        await expect(cmd.func(createPageMock(['timeout']), { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
-            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('did not render flight cards') });
-        await expect(cmd.func(createPageMock(['content', 1, { rows: [] }]), { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
-            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed rows') });
+    it('rejects auth HTTP, other HTTP, invalid JSON, upstream, malformed, truncated, and unfinished responses', async () => {
+        const args = { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 };
+        await expect(cmd.func(createPageMock([], [batchCapture({}, { responseStatus: 401 })]), args))
+            .rejects.toMatchObject({ code: 'AUTH_REQUIRED', message: expect.stringContaining('HTTP 401') });
+        await expect(cmd.func(createPageMock([], [batchCapture({}, { responseStatus: 500 })]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('HTTP 500') });
+        await expect(cmd.func(createPageMock([], [batchCapture({}, { responsePreview: '{' })]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('invalid JSON') });
+        await expect(cmd.func(createPageMock([], [batchCapture(batchPayload([], { status: 7, msg: 'denied' }))]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('status=7') });
+        await expect(cmd.func(createPageMock([], [batchCapture({ status: 0, data: {} })]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed batchSearch') });
+        await expect(cmd.func(createPageMock([], [batchCapture({}, { responseBodyTruncated: true })]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('capture limit') });
+        await expect(cmd.func(createPageMock([], [batchCapture(batchPayload([itinerary()], { finished: false }))]), args))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('reported completion') });
     });
 
     it('builds URL with lowercase IATA codes and Y_S_C_F cabin', async () => {
-        const page = createPageMock(['content', 1, [FLIGHT_RAW]]);
+        const page = createPageMock([], [batchCapture(batchPayload([itinerary()]))]);
         await cmd.func(page, { from: 'pek', to: 'sha', date: '2026-06-15', limit: 1 });
         const url = page.goto.mock.calls[0][0];
         expect(url).toContain('oneway-pek-sha');
         expect(url).toContain('depdate=2026-06-15');
         expect(url).toContain('cabin=Y_S_C_F');
         expect(url).toContain('adult=1');
+        expect(page.startNetworkCapture).toHaveBeenCalledWith('/international/search/api/search/batchSearch');
+        expect(page.startNetworkCapture.mock.invocationCallOrder[0])
+            .toBeLessThan(page.goto.mock.invocationCallOrder[0]);
     });
 
-    it('maps DOM-extracted rows and respects --limit', async () => {
-        const page = createPageMock([
-            'content',
-            2,
-            [FLIGHT_RAW, { ...FLIGHT_RAW, flightNo: 'CA1234', airline: '国航' }],
-        ]);
+    it('maps and sorts structured itineraries, fixes overnight fields, and respects --limit', async () => {
+        const laterCheap = itinerary({
+            id: 'Y87596_2', airline: '新海航｜金鹏航空', flightNo: 'Y87596', aircraft: '波音737(中)',
+            departure: '2026-06-15 22:55:00', departureAirport: '首都国际机场',
+            arrival: '2026-06-16 00:55:00', arrivalAirport: '浦东国际机场', price: 450,
+        });
+        const page = createPageMock([], [batchCapture(batchPayload([
+            itinerary({ id: 'MF8561_1', price: 487 }), laterCheap,
+        ]))]);
         const rows = await cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 1 });
         expect(rows).toHaveLength(1);
         expect(rows[0]).toMatchObject({
             rank: 1,
-            airline: '厦门航空',
-            flightNo: 'MF8561',
-            departureTime: '07:50',
-            arrivalTime: '09:45',
-            price: 487,
+            airline: '新海航｜金鹏航空',
+            flightNo: 'Y87596',
+            aircraft: '波音737(中)',
+            departureTime: '22:55',
+            arrivalTime: '00:55',
+            arrivalAirport: '浦东国际机场',
+            price: 450,
             currency: '¥',
             cabin: '经济舱',
         });
@@ -655,24 +697,54 @@ describe('ctrip flight command (registry-level)', () => {
         }
     });
 
-    it('filters out flight rows missing core anchors (no silent partial rows)', async () => {
-        const page = createPageMock(['content', 2, [{ ...FLIGHT_RAW, departureTime: '' }, FLIGHT_RAW]]);
-        const rows = await cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 });
-        expect(rows).toHaveLength(1);
-        expect(rows[0].departureTime).toBe('07:50');
-    });
-
-    it('throws CommandExecutionError when every flight row misses core anchors', async () => {
-        const page = createPageMock(['content', 2, [{ ...FLIGHT_RAW, departureAirport: '' }, { ...FLIGHT_RAW, arrivalTime: '' }]]);
+    it('rejects any malformed itinerary instead of returning accumulated partial rows', async () => {
+        const malformed = itinerary({ id: 'MF8561_2' });
+        malformed.flightSegments[0].flightList[0].arrivalAirportName = '';
+        const page = createPageMock([], [batchCapture(batchPayload([itinerary(), malformed]))]);
         await expect(cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 }))
-            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('required airline/flight/time/airport anchors') });
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('index 1') });
     });
 
-    it('keeps a row whose .flight-item card omits the flight number (flightNo null, not dropped)', async () => {
-        const page = createPageMock(['content', 1, [{ ...FLIGHT_RAW, flightNo: null }]]);
+    it('merges multiple completed batches, deduplicates itineraries, and joins connecting legs', async () => {
+        const connecting = itinerary({
+            id: 'MU1_MU2', airline: '东方航空', price: 750, cabin: '@Y-Y',
+            legs: [
+                { flightNo: 'MU1', aircraftName: '空客320(中)', departureDateTime: '2026-06-15 17:15:00', departureAirportName: '大兴国际机场', arrivalDateTime: '2026-06-15 19:00:00', arrivalAirportName: '武汉天河机场', arrivalTerminal: 'T3' },
+                { flightNo: 'MU2', aircraftName: '空客320(中)', departureDateTime: '2026-06-15 20:00:00', departureAirportName: '武汉天河机场', arrivalDateTime: '2026-06-15 21:55:00', arrivalAirportName: '虹桥国际机场', arrivalTerminal: 'T2' },
+            ],
+        });
+        const page = createPageMock([]);
+        page.readNetworkCapture
+            .mockReset()
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                batchCapture(batchPayload([connecting], { finished: false })),
+                batchCapture(batchPayload([connecting], { finished: true }), { url: 'https://flights.ctrip.com/international/search/api/search/batchSearch?v=2' }),
+            ]);
         const rows = await cmd.func(page, { from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 5 });
         expect(rows).toHaveLength(1);
-        expect(rows[0].flightNo).toBeNull();
+        expect(rows[0]).toMatchObject({
+            flightNo: 'MU1 / MU2',
+            aircraft: '空客320(中)',
+            departureAirport: '大兴国际机场',
+            arrivalAirport: '虹桥国际机场',
+            cabin: '经济舱',
+        });
+    });
+
+    it('keeps direct flights ahead of cheaper transfers, matching the page grouping', async () => {
+        const direct = itinerary({ id: 'DIRECT', price: 600 });
+        const transfer = itinerary({
+            id: 'TRANSFER', price: 450,
+            legs: [
+                { flightNo: 'MU1', aircraftName: '空客320(中)', departureDateTime: '2026-06-15 08:00:00', departureAirportName: '大兴国际机场', arrivalDateTime: '2026-06-15 10:00:00', arrivalAirportName: '武汉天河机场', arrivalTerminal: 'T3' },
+                { flightNo: 'MU2', aircraftName: '空客320(中)', departureDateTime: '2026-06-15 11:00:00', departureAirportName: '武汉天河机场', arrivalDateTime: '2026-06-15 13:00:00', arrivalAirportName: '虹桥国际机场', arrivalTerminal: 'T2' },
+            ],
+        });
+        const rows = await cmd.func(createPageMock([], [batchCapture(batchPayload([transfer, direct]))]), {
+            from: 'PEK', to: 'SHA', date: '2026-06-15', limit: 2,
+        });
+        expect(rows.map((row) => row.flightNo)).toEqual(['MF8561', 'MU1 / MU2']);
     });
 });
 

--- a/clis/ctrip/flight.js
+++ b/clis/ctrip/flight.js
@@ -1,58 +1,146 @@
 /**
  * 携程机票 oneway search — domestic + international flight search by route + date.
  *
- * Unlike `hotel-search`, the flight rows are NOT in `__NEXT_DATA__` — they
- * arrive via a post-load XHR that the daemon network buffer currently can't
- * capture (see MEMORY `daemon_capture_pipeline_bug_2026_05_07`). We instead
- * extract from the rendered `.flight-item` cards, which Ctrip migrated the flight
- * list to and which omit a text flight number, using a position-anchored innerText
- * parser (see `buildFlightExtractJs` in utils).
+ * Flight rows arrive in the page's natural `batchSearch` response. Capture that
+ * response through CDP so Ctrip remains responsible for request parameters,
+ * trace ids, risk controls, and session state; do not reconstruct its request.
  *
  * Round-trip search lives in the sibling `flight-round` command; advanced filters
  * (airline whitelist, cabin selection beyond 全舱位) remain out of scope here.
  */
-import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { buildFlightExtractJs, buildScrollUntilJs, parseIataCode, parseIsoDate, parseStrictIntegerRange } from './utils.js';
+import { parseIataCode, parseIsoDate, parseStrictIntegerRange } from './utils.js';
 
 const MIN_LIMIT = 1;
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 20;
-
-// Ctrip migrated the flight list to `.flight-item` cards (which omit a text flight
-// number), so the command reads those with the flight-number requirement relaxed.
-const FLIGHT_CARD_SELECTOR = '.flight-item';
+const CAPTURE_PATTERN = '/international/search/api/search/batchSearch';
+const CAPTURE_TIMEOUT_SECONDS = 12;
+const WAIT_FOR_BATCH_CAPTURE_JS = `
+  new Promise((resolve) => {
+    const detect = () => {
+      if (location.pathname.includes('captcha') || /验证码|verify the human|安全验证/i.test(document.body?.innerText || '')) return 'captcha';
+      if (document.querySelector('.flight-item')) return 'content';
+      return null;
+    };
+    const found = detect();
+    if (found) return resolve(found);
+    const observer = new MutationObserver(() => {
+      const result = detect();
+      if (result) { observer.disconnect(); resolve(result); }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(() => { observer.disconnect(); resolve('timeout'); }, ${CAPTURE_TIMEOUT_SECONDS * 1000});
+  })
+`;
 
 function parseFlightLimit(raw) {
     return parseStrictIntegerRange('limit', raw, DEFAULT_LIMIT, MIN_LIMIT, MAX_LIMIT);
 }
 
-/**
- * Wait for the flight cards to finish rendering, or detect a captcha/login
- * redirect. The post-load XHR settles 1-3s after navigation and the cards fill in
- * progressively, so this polls the count of cards carrying a time + price and
- * resolves `content` only once that count has held steady, rather than firing on
- * the first card and under-reading the rest.
- */
-const WAIT_FOR_FLIGHTS_JS = `
-  new Promise((resolve) => {
-    const isCaptcha = () => location.pathname.includes('captcha') || /验证码|verify the human/i.test(document.body?.innerText || '');
-    const fullCount = () => [...document.querySelectorAll('.flight-item')]
-      .filter((el) => { const t = el.textContent || ''; return /\\d{1,2}:\\d{2}/.test(t) && /[¥$€£]/.test(t); }).length;
-    let last = -1;
-    let stable = 0;
-    let elapsed = 0;
-    const iv = setInterval(() => {
-      elapsed += 400;
-      if (isCaptcha()) { clearInterval(iv); return resolve('captcha'); }
-      const c = fullCount();
-      if (c > 0 && c === last) {
-        if (++stable >= 2) { clearInterval(iv); return resolve('content'); }
-      } else { last = c; stable = 0; }
-      if (elapsed >= 18000) { clearInterval(iv); return resolve('timeout'); }
-    }, 400);
-  })
-`;
+function cleanString(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function timePart(value) {
+    const match = cleanString(value).match(/(?:^|\s)([0-2]\d:[0-5]\d)(?::[0-5]\d)?$/);
+    return match?.[1] || '';
+}
+
+function cabinLabel(value) {
+    const labels = { Y: '经济舱', S: '超级经济舱', C: '公务舱', F: '头等舱' };
+    const codes = [...new Set(cleanString(value).toUpperCase().match(/[YSCF]/g) || [])];
+    return codes.length > 0 ? codes.map((code) => labels[code]).join('/') : (cleanString(value) || null);
+}
+
+function parseBatchSearchCaptures(entries) {
+    if (!Array.isArray(entries)) {
+        throw new CommandExecutionError('Ctrip flight network capture returned malformed entries');
+    }
+    const captured = entries.filter((entry) => String(entry?.url || '').includes(CAPTURE_PATTERN));
+    if (captured.length === 0) return null;
+
+    const byId = new Map();
+    let finished = false;
+    for (const entry of captured) {
+        const status = Number(entry?.responseStatus || 0);
+        if (status === 401 || status === 403) {
+            throw new AuthRequiredError('flights.ctrip.com', `Ctrip flight API returned HTTP ${status}; complete any verification in the browser and retry`);
+        }
+        if (status !== 200) {
+            throw new CommandExecutionError(`Ctrip flight API returned HTTP ${status || 'unknown'}`);
+        }
+        if (entry?.responseBodyTruncated === true) {
+            throw new CommandExecutionError('Ctrip flight API response exceeded the browser capture limit');
+        }
+        if (typeof entry?.responsePreview !== 'string') {
+            throw new CommandExecutionError('Ctrip flight API response body was unavailable');
+        }
+        let payload;
+        try {
+            payload = JSON.parse(entry.responsePreview);
+        }
+        catch {
+            throw new CommandExecutionError('Ctrip flight API returned invalid JSON');
+        }
+        if (payload?.status !== 0) {
+            throw new CommandExecutionError(`Ctrip flight API failed (status=${String(payload?.status)}): ${cleanString(payload?.msg) || 'unknown error'}`);
+        }
+        const itineraries = payload?.data?.flightItineraryList;
+        if (!Array.isArray(itineraries) || typeof payload?.data?.context?.finished !== 'boolean') {
+            throw new CommandExecutionError('Ctrip flight API returned a malformed batchSearch payload');
+        }
+        for (const itinerary of itineraries) {
+            const id = cleanString(itinerary?.itineraryId);
+            if (!id) throw new CommandExecutionError('Ctrip flight API returned an itinerary without an id');
+            byId.set(id, itinerary);
+        }
+        finished = payload.data.context.finished;
+    }
+    if (!finished) {
+        throw new CommandExecutionError('Ctrip flight batchSearch ended before the upstream search reported completion');
+    }
+    return [...byId.values()];
+}
+
+function mapItinerary(itinerary, searchUrl, index) {
+    const segments = itinerary?.flightSegments;
+    const prices = itinerary?.priceList;
+    if (!Array.isArray(segments) || segments.length === 0 || !Array.isArray(prices) || prices.length === 0) {
+        throw new CommandExecutionError(`Ctrip flight API returned malformed itinerary at index ${index}`);
+    }
+    const legs = segments.flatMap((segment) => Array.isArray(segment?.flightList) ? segment.flightList : []);
+    const first = legs[0];
+    const last = legs.at(-1);
+    const airline = [...new Set(segments.map((segment) => cleanString(segment?.airlineName)).filter(Boolean))].join(' / ');
+    const flightNo = [...new Set(legs.map((leg) => cleanString(leg?.flightNo)).filter(Boolean))].join(' / ');
+    const aircraft = [...new Set(legs.map((leg) => cleanString(leg?.aircraftName)).filter(Boolean))].join(' / ') || null;
+    const departureTime = timePart(first?.departureDateTime);
+    const arrivalTime = timePart(last?.arrivalDateTime);
+    const departureAirport = cleanString(first?.departureAirportName);
+    const arrivalAirport = cleanString(last?.arrivalAirportName);
+    const price = Number(prices[0]?.sortPrice ?? prices[0]?.adultPrice);
+    if (!airline || !flightNo || !departureTime || !arrivalTime || !departureAirport || !arrivalAirport || !Number.isFinite(price)) {
+        throw new CommandExecutionError(`Ctrip flight API returned malformed itinerary at index ${index}`);
+    }
+    const row = {
+        airline,
+        flightNo,
+        aircraft,
+        departureTime,
+        departureAirport,
+        arrivalTime,
+        arrivalAirport,
+        terminal: cleanString(last?.arrivalTerminal) || null,
+        price,
+        currency: '¥',
+        cabin: cabinLabel(prices[0]?.cabin),
+        url: searchUrl,
+    };
+    const isConnecting = legs.length > 1 || segments.some((segment) => Number(segment?.transferCount || 0) > 0);
+    return [row, isConnecting, cleanString(first?.departureDateTime), cleanString(itinerary.itineraryId)];
+}
 
 cli({
     site: 'ctrip',
@@ -60,7 +148,7 @@ cli({
     access: 'read',
     description: '搜索携程一程机票（按出发/到达 IATA 三字码 + 日期）',
     domain: 'flights.ctrip.com',
-    strategy: Strategy.COOKIE,
+    strategy: Strategy.INTERCEPT,
     browser: true,
     navigateBefore: false,
     args: [
@@ -89,50 +177,52 @@ cli({
         const searchUrl =
             `https://flights.ctrip.com/online/list/oneway-${fromCode.toLowerCase()}-${toCode.toLowerCase()}` +
             `?depdate=${date}&cabin=Y_S_C_F&adult=1&child=0&infant=0`;
+        if (typeof page?.startNetworkCapture !== 'function' ||
+            typeof page?.readNetworkCapture !== 'function' ||
+            !await page.startNetworkCapture(CAPTURE_PATTERN)) {
+            throw new CommandExecutionError('Ctrip flight requires browser response interception');
+        }
+        await page.readNetworkCapture();
         await page.goto(searchUrl);
-        const waitResult = await page.evaluate(WAIT_FOR_FLIGHTS_JS);
-        if (waitResult === 'captcha') {
+        // The initial document can finish before the large batchSearch body.
+        // The first rendered card is only a readiness signal; row data still
+        // comes exclusively from the structured response below.
+        const readiness = await page.evaluate(WAIT_FOR_BATCH_CAPTURE_JS);
+        if (readiness === 'captcha') {
             throw new AuthRequiredError('flights.ctrip.com', 'Ctrip is asking for a captcha; complete it in your browser session and retry');
         }
-        if (waitResult !== 'content') {
-            throw new CommandExecutionError(`Ctrip flight page did not render flight cards (state=${String(waitResult)})`);
+        const itineraries = parseBatchSearchCaptures(await page.readNetworkCapture());
+        if (!itineraries) {
+            throw new TimeoutError('Ctrip flight API capture', CAPTURE_TIMEOUT_SECONDS, 'No batchSearch response was observed after opening the results page.');
         }
-        // Scroll until enough flight cards rendered (Ctrip lazy-loads beyond ~8).
-        const renderedCardCount = await page.evaluate(buildScrollUntilJs(FLIGHT_CARD_SELECTOR, limit));
-        const raw = await page.evaluate(buildFlightExtractJs(FLIGHT_CARD_SELECTOR, false));
-        if (!Array.isArray(raw)) {
-            throw new CommandExecutionError('Ctrip flight DOM extraction returned malformed rows');
-        }
-        const rows = raw;
-        if (rows.length === 0) {
-            if (Number(renderedCardCount) > 0) {
-                throw new CommandExecutionError('Ctrip flight cards rendered but parser did not find required flight anchors');
-            }
+        if (itineraries.length === 0) {
             throw new EmptyResultError('ctrip flight', `No flights for ${fromCode}→${toCode} on ${date}`);
         }
-        const completeRows = rows
-            .filter((r) => r.departureTime && r.departureAirport && r.arrivalTime && r.arrivalAirport && r.airline)
+        const rows = itineraries
+            .map((itinerary, index) => mapItinerary(itinerary, searchUrl, index))
+            // The page groups direct flights before transfers, then applies its
+            // displayed starting price and departure-time order inside each group.
+            .sort(([rowA, connectingA, departureA, idA], [rowB, connectingB, departureB, idB]) =>
+                Number(connectingA) - Number(connectingB) || rowA.price - rowB.price ||
+                departureA.localeCompare(departureB) || idA.localeCompare(idB))
             .slice(0, limit)
-            .map((r, i) => ({
-                rank: i + 1,
-                airline: r.airline,
-                flightNo: r.flightNo,
-                aircraft: r.aircraft,
-                departureTime: r.departureTime,
-                departureAirport: r.departureAirport,
-                arrivalTime: r.arrivalTime,
-                arrivalAirport: r.arrivalAirport,
-                terminal: r.terminal,
-                price: r.price,
-                currency: r.currency,
-                cabin: r.cabin,
-                url: searchUrl,
+            .map(([row], index) => ({
+                rank: index + 1,
+                airline: row.airline,
+                flightNo: row.flightNo,
+                aircraft: row.aircraft,
+                departureTime: row.departureTime,
+                departureAirport: row.departureAirport,
+                arrivalTime: row.arrivalTime,
+                arrivalAirport: row.arrivalAirport,
+                terminal: row.terminal,
+                price: row.price,
+                currency: row.currency,
+                cabin: row.cabin,
+                url: row.url,
             }));
-        if (completeRows.length === 0) {
-            throw new CommandExecutionError('Ctrip flight rows were missing required airline/flight/time/airport anchors');
-        }
-        return completeRows;
+        return rows;
     },
 });
 
-export const __test__ = { parseFlightLimit, WAIT_FOR_FLIGHTS_JS };
+export const __test__ = { parseFlightLimit };


### PR DESCRIPTION
## Summary

- replace lossy `.flight-item` DOM parsing with the page-owned `batchSearch` response captured through CDP
- preserve Ctrip's request/signing/risk-control ownership; the adapter does not reconstruct the private POST
- map all 13 existing columns from structured itineraries, including connecting legs and overnight arrivals
- reject incomplete, truncated, malformed, unauthorized, and unfinished captures with typed errors instead of returning partial rows

## Live evidence

Read-only live comparison for `BJS → SHA`, `2026-08-26`, `--limit 50`:

- old DOM path: 13/50 rows in 10.59s; 2 missing flight numbers, 2 missing aircraft values, and one `arrivalAirport="+1天"` misparse
- new capture path: exactly 50 rows on three runs (7.86s / 4.28s / 7.10s), no missing flight numbers, and no overnight airport misparse
- the natural final response was HTTP 200 / `status: 0` / `context.finished: true` with 173 structured itineraries; body size was about 5.2 MB, below the 8 MB CDP capture limit
- the first visible direct-flight ordering remained `KN5977`, `HO1254`, `CZ8882`; transfers remain grouped after direct flights, matching the page

## Verification

- `npx vitest run clis/ctrip/*.test.js` — 171/171
- `npm run typecheck`
- `npm run build` — manifest 1,341 entries
- `node dist/src/main.js validate ctrip` — 15 commands, 0 errors / 0 warnings
- `npm run check:typed-error-lint` — new=0
- `npm run check:silent-column-drop` — new=0
- `git diff --check`
