### PR TITLE
feat(jike): use structured APIs for search and notifications

### DIFF
--- a/clis/jike/auth-read.test.js
+++ b/clis/jike/auth-read.test.js
@@ -87,34 +87,30 @@ describe('Jike identity guard', () => {
     expect(page.evaluate).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    [
-      'jike/feed',
-      { limit: 1 },
-      [{ id: 'post-1', author: 'Alice', content: 'hello', likes: 2, comments: 1, time: 'now', url: 'https://web.okjike.com/originalPost/post-1' }],
-    ],
-    [
-      'jike/search',
-      { query: 'OpenCLI', limit: 1 },
-      [{ id: 'post-2', author: 'Bob', content: 'result', likes: 3, comments: 4, time: 'later', url: 'https://web.okjike.com/originalPost/post-2' }],
-    ],
-  ])('continues %s extraction after a successful identity probe', async (commandName, args, rows) => {
+  it('continues feed extraction after a successful identity probe', async () => {
+    const rows = [{ id: 'post-1', author: 'Alice', content: 'hello', likes: 2, comments: 1, time: 'now', url: 'https://web.okjike.com/originalPost/post-1' }];
     const page = makePage(identity, rows);
 
-    await expect(getRegistry().get(commandName).func(page, args)).resolves.toEqual(rows);
+    await expect(getRegistry().get('jike/feed').func(page, { limit: 1 })).resolves.toEqual(rows);
     expect(page.evaluate).toHaveBeenCalledTimes(2);
   });
 
   it('continues notification extraction after a successful identity probe', async () => {
-    const page = makePage(identity, [{
-      actionType: 'LIKE_ORIGINAL_POST',
-      fromUser: 'Bob',
-      content: 'hello\nworld',
-      time: 'now',
-    }]);
+    const page = makePage(identity, {
+      kind: 'response',
+      status: 200,
+      body: {
+        data: [{
+          id: 'notification-1',
+          type: 'LIKE_PERSONAL_UPDATE',
+          createdAt: 'now',
+          actionItem: { users: [{ screenName: 'Bob' }], content: 'hello\nworld' },
+        }],
+      },
+    });
 
     await expect(getRegistry().get('jike/notifications').func(page, { limit: 1 })).resolves.toEqual([{
-      type: '赞了你',
+      type: '赞了你的动态',
       user: 'Bob',
       content: 'hello world',
       time: 'now',

--- a/clis/jike/notifications.js
+++ b/clis/jike/notifications.js
@@ -1,24 +1,128 @@
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireJikeIdentity } from './utils.js';
-// 将通知类型代码映射为中文标签
-function resolveActionLabel(type) {
-    if (!type)
-        return '通知';
-    const upper = type.toUpperCase();
-    if (upper.includes('LIKE'))
-        return '赞了你';
-    if (upper.includes('COMMENT'))
-        return '评论了你';
-    if (upper.includes('FOLLOW'))
-        return '关注了你';
-    if (upper.includes('REPOST'))
-        return '转发了你';
-    if (upper.includes('MENTION'))
-        return '提到了你';
-    if (upper.includes('REPLY'))
-        return '回复了你';
-    return type;
+import { normalizeJikeLimit, postJikeApi, requireJikeIdentity } from './utils.js';
+
+const API_PATH = '/1.0/notifications/list';
+const PAGE_SIZE = 20;
+const DEFAULT_LIMIT = 20;
+const MAX_PAGES = 50;
+
+const TYPE_LABELS = {
+    AVATAR_GREET: '弹了你的头像',
+    LIKE_AVATAR: '弹了你的头像',
+    USER_FOLLOWED: '关注了你',
+    USER_SILENT_FOLLOWED: '关注了你',
+    LIKE_PERSONAL_UPDATE: '赞了你的动态',
+    LIKE_PERSONAL_UPDATE_COMMENT: '赞了你的评论',
+    LIKE_STORY: '赞了你的故事',
+    REPLIED_TO_PERSONAL_UPDATE_COMMENT: '回复了你的评论',
+    REPLIED_TO_STORY_COMMENT: '回复了你的评论',
+    COMMENT_PERSONAL_UPDATE: '评论了你的动态',
+    COMMENT_AND_REPOST: '评论了你的动态',
+    COMMENT_STORY: '评论了你的故事',
+    PERSONAL_UPDATE_REPOSTED: '转发了你的动态',
+    MENTION: '@了你',
+    MENTION_FROM_UNFOLLOWED_USER: '@了你',
+    SILENT_MENTION: '悄悄提到了你',
+    ENDOW: '给你的动态赠送了礼物',
+    USER_RESPECT: '夸了夸你🎉',
+};
+
+function resolveActionLabel(notification, actionItem) {
+    if (typeof TYPE_LABELS[notification.type] === 'string') return TYPE_LABELS[notification.type];
+    if (typeof actionItem.behavior === 'string' && actionItem.behavior.trim()) return actionItem.behavior.trim();
+    const sourceType = String(actionItem.type || notification.actionType || notification.type || '').toUpperCase();
+    if (sourceType.includes('LIKE')) return '赞了你';
+    if (sourceType.includes('COMMENT')) return '评论了你';
+    if (sourceType.includes('FOLLOW')) return '关注了你';
+    if (sourceType.includes('REPOST')) return '转发了你';
+    if (sourceType.includes('MENTION')) return '提到了你';
+    if (sourceType.includes('REPLY')) return '回复了你';
+    return notification.type;
 }
+
+function cleanContent(value) {
+    return typeof value === 'string' ? value.replace(/\n/g, ' ').slice(0, 100) : '';
+}
+
+function mapNotification(notification) {
+    if (!notification || typeof notification !== 'object' || typeof notification.id !== 'string' || !notification.id) {
+        throw new CommandExecutionError('Jike notifications API returned a malformed notification');
+    }
+    if (typeof notification.type !== 'string' || !notification.type) {
+        throw new CommandExecutionError('Jike notifications API returned a notification without a type');
+    }
+    const actionItem = notification.actionItem;
+    if (!actionItem || typeof actionItem !== 'object' || Array.isArray(actionItem)) {
+        throw new CommandExecutionError('Jike notifications API returned a malformed action item');
+    }
+    if (!Array.isArray(actionItem.users)) {
+        throw new CommandExecutionError('Jike notifications API returned a malformed users list');
+    }
+    const names = actionItem.users.map((user) => {
+        if (!user || typeof user !== 'object') {
+            throw new CommandExecutionError('Jike notifications API returned a malformed user');
+        }
+        return typeof user.screenName === 'string' ? user.screenName : '';
+    }).filter(Boolean);
+    const referenceItem = notification.referenceItem;
+    const referenceContent = referenceItem && typeof referenceItem === 'object' && !Array.isArray(referenceItem)
+        ? referenceItem.content
+        : '';
+    const time = typeof notification.createdAt === 'string'
+        ? notification.createdAt
+        : (typeof notification.updatedAt === 'string' ? notification.updatedAt : '');
+    return {
+        type: resolveActionLabel(notification, actionItem),
+        user: names.join('、'),
+        content: cleanContent(actionItem.content || referenceContent),
+        time,
+    };
+}
+
+async function fetchNotificationsPage(page, loadMoreKey) {
+    const body = await postJikeApi(page, API_PATH, {
+        limit: PAGE_SIZE,
+        ...(loadMoreKey ? { loadMoreKey } : {}),
+    }, 'Jike notifications API');
+    if (!body || typeof body !== 'object' || body.success === false || !Array.isArray(body.data)) {
+        throw new CommandExecutionError(`Jike notifications API failed: ${String(body?.error || body?.message || 'malformed response')}`);
+    }
+    return body;
+}
+
+async function listNotifications(page, limit) {
+    const rows = [];
+    const seenIds = new Set();
+    const seenCursors = new Set();
+    let loadMoreKey = null;
+    for (let pageIndex = 0; pageIndex < MAX_PAGES; pageIndex++) {
+        const body = await fetchNotificationsPage(page, loadMoreKey);
+        for (const notification of body.data) {
+            const row = mapNotification(notification);
+            if (seenIds.has(notification.id)) continue;
+            seenIds.add(notification.id);
+            rows.push(row);
+            if (rows.length >= limit) return rows;
+        }
+        const next = body.loadMoreKey;
+        if (next == null) {
+            if (rows.length === 0) throw new EmptyResultError('jike notifications', 'No notifications found');
+            return rows;
+        }
+        if (typeof next !== 'object' || Array.isArray(next)) {
+            throw new CommandExecutionError('Jike notifications API returned a malformed pagination cursor');
+        }
+        const cursorKey = JSON.stringify(next);
+        if (seenCursors.has(cursorKey)) {
+            throw new CommandExecutionError('Jike notifications pagination returned a repeated cursor');
+        }
+        seenCursors.add(cursorKey);
+        loadMoreKey = next;
+    }
+    throw new CommandExecutionError(`Jike notifications pagination exceeded ${MAX_PAGES} pages before satisfying --limit`);
+}
+
 cli({
     site: 'jike',
     name: 'notifications',
@@ -28,144 +132,13 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     args: [
-        { name: 'limit', type: 'int', default: 20 },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT },
     ],
     columns: ['type', 'user', 'content', 'time'],
     func: async (page, kwargs) => {
-        const limit = kwargs.limit || 20;
-        // 1. 直接导航到通知页
+        const limit = normalizeJikeLimit(kwargs.limit, DEFAULT_LIMIT);
         await page.goto('https://web.okjike.com/notification');
         await requireJikeIdentity(page);
-        // 3. 优先用 React fiber 提取通知数据
-        //    通知 fiber 数据结构与帖子不同，需查找含 type + user 字段的 props
-        const fiberResults = (await page.evaluate(`(() => {
-      // 从 React fiber 树中提取通知数据，向上最多走 15 层
-      function getNotificationData(element) {
-        for (const key of Object.keys(element)) {
-          if (key.startsWith('__reactFiber$') || key.startsWith('__reactInternalInstance$')) {
-            let fiber = element[key];
-            for (let i = 0; i < 15 && fiber; i++) {
-              const props = fiber.memoizedProps || fiber.pendingProps;
-              if (props && props.data) {
-                const d = props.data;
-                // 通知条目特征：含 type/actionType 字段，以及来源用户字段
-                if (d.type || d.actionType || d.notificationType) return d;
-              }
-              fiber = fiber.return;
-            }
-          }
-        }
-        return null;
-      }
-
-      const results = [];
-      const seen = new Set();
-
-      // 通知页使用 _item_ 类前缀作为条目容器
-      const elements = Array.from(document.querySelectorAll('[class*="_item_"]'));
-
-      for (const el of elements) {
-        const data = getNotificationData(el);
-        if (!data) continue;
-
-        const actionType = data.actionType || data.type || data.notificationType || '';
-        const fromUser =
-          (data.sourceUser && data.sourceUser.screenName) ||
-          (data.user && data.user.screenName) ||
-          (data.actionUser && data.actionUser.screenName) ||
-          (data.actor && data.actor.screenName) ||
-          '';
-        const targetContent =
-          (data.targetPost && data.targetPost.content) ||
-          (data.post && data.post.content) ||
-          '';
-        const commentContent =
-          (data.comment && data.comment.content) ||
-          data.commentContent ||
-          '';
-        const content = commentContent || targetContent;
-        const time = data.createdAt || data.updatedAt || '';
-
-        // 用 user+time+type 去重，避免同一用户同一时间不同类型通知被合并
-        const key = fromUser + '\x00' + time + '\x00' + (data.type || data.actionType || '');
-        if (seen.has(key)) continue;
-        seen.add(key);
-
-        if (!fromUser && !content) continue;
-
-        results.push({ actionType, fromUser, content, time });
-      }
-
-      return results;
-    })()`));
-        // 4. fiber 提取成功，映射类型标签后返回
-        if (fiberResults.length > 0) {
-            const notifications = fiberResults.map((r) => ({
-                type: resolveActionLabel(r.actionType),
-                user: r.fromUser,
-                content: r.content.replace(/\n/g, ' ').slice(0, 100),
-                time: r.time,
-            }));
-            return notifications.slice(0, limit);
-        }
-        // 5. 回退：解析通知条目的 innerText（格式: 用户名\n操作描述\n日期）
-        await page.autoScroll({ times: Math.ceil(limit / 10), delayMs: 2000 });
-        const domResults = (await page.evaluate(`(() => {
-      const results = [];
-      const items = document.querySelectorAll('[class*="_item_"]');
-
-      // 动作关键词，用于定位通知类型行
-      // 长模式优先匹配，避免"赞了你"截断"赞了你的动态"
-      const actionPatterns = [
-        '赞了你的动态', '赞了你的评论', '赞了你的转发',
-        '评论了你的动态', '评论了你的转发',
-        '回复了你的评论', '回复了你',
-        '转发了你的动态',
-        '提到了你', '关注了你',
-        '赞了你', '评论了你', '转发了你',
-      ];
-
-      for (const item of items) {
-        const text = item.innerText || '';
-        const lines = text.split('\\n').map(l => l.trim()).filter(Boolean);
-        if (lines.length < 2) continue;
-
-        // 策略：在全文中搜索动作关键词来定位类型
-        let type = '';
-        let user = '';
-        let time = '';
-        let content = '';
-
-        const fullText = lines.join(' ');
-        for (const pattern of actionPatterns) {
-          const idx = fullText.indexOf(pattern);
-          if (idx >= 0) {
-            // 关键词前面是用户名（可能多人用、分隔）
-            user = fullText.slice(0, idx).replace(/[、,]/g, ' ').trim();
-            type = pattern;
-            // 关键词后面可能是时间和原帖内容
-            const rest = fullText.slice(idx + pattern.length).trim();
-            // 时间通常以数字或"刚刚"/"分钟前"等开头
-            const timeMatch = rest.match(/^[\\S]*?(?:刚刚|\\d+.*?前|\\d{4}\\/\\d{2}\\/\\d{2})/);
-            time = timeMatch ? timeMatch[0] : '';
-            content = rest.slice(time.length).trim().slice(0, 100);
-            break;
-          }
-        }
-
-        // 没匹配到动作关键词，回退到简单行序
-        if (!type) {
-          user = lines[0] || '';
-          type = lines[1] || '';
-          time = lines[2] || '';
-        }
-
-        if (!user && !type) continue;
-        results.push({ type, user, content, time });
-      }
-
-      return results;
-    })()`));
-        return domResults.slice(0, limit);
+        return listNotifications(page, limit);
     },
 });

--- a/clis/jike/notifications.test.js
+++ b/clis/jike/notifications.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './notifications.js';
+
+const identity = {
+    ok: true,
+    user_id: 'user-1',
+    screen_name: 'Alice',
+    username: 'alice',
+};
+
+function makePage(...evaluateResults) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(async () => evaluateResults.shift()),
+    };
+}
+
+function notification(id, type, overrides = {}) {
+    return {
+        id,
+        type,
+        createdAt: '2026-08-25T00:00:00.000Z',
+        actionItem: {
+            users: [{ screenName: 'Bob' }],
+        },
+        ...overrides,
+    };
+}
+
+function apiPage(data, loadMoreKey = null, overrides = {}) {
+    return {
+        kind: 'response',
+        status: 200,
+        body: { data, loadMoreKey, ...overrides },
+    };
+}
+
+function command() {
+    return getRegistry().get('jike/notifications');
+}
+
+describe('jike notifications API pagination', () => {
+    it('maps the live avatar notification shape and preserves the four-column contract', async () => {
+        const page = makePage(identity, apiPage([
+            notification('notification-1', 'LIKE_AVATAR', {
+                actionType: 'USER_LIST',
+                actionItem: {
+                    type: 'LIKE',
+                    users: [{ screenName: 'Bob' }],
+                    usersCount: 1,
+                },
+                referenceItem: { type: 'AVATAR', referenceImageUrl: 'https://example.com/avatar.png' },
+            }),
+        ], { skip: 20 }));
+
+        await expect(command().func(page, { limit: 1 })).resolves.toEqual([{
+            type: '弹了你的头像',
+            user: 'Bob',
+            content: '',
+            time: '2026-08-25T00:00:00.000Z',
+        }]);
+        expect(command().columns).toEqual(['type', 'user', 'content', 'time']);
+        expect(page.goto).toHaveBeenCalledWith('https://web.okjike.com/notification');
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+    });
+
+    it('maps current bundle action types and content fields without DOM parsing', async () => {
+        const page = makePage(identity, apiPage([
+            notification('notification-1', 'COMMENT_PERSONAL_UPDATE', {
+                actionItem: { users: [{ screenName: 'Bob' }], content: 'hello\nworld' },
+            }),
+            notification('notification-2', 'MENTION', {
+                actionItem: { users: [{ screenName: 'Carol' }], content: '@Alice hi' },
+            }),
+            notification('notification-3', 'PRODUCT_PAGE_VOTED', {
+                actionItem: { users: [{ screenName: 'Dave' }], behavior: '赞了你的产品页' },
+                referenceItem: { content: 'OpenCLI' },
+            }),
+        ]));
+
+        await expect(command().func(page, { limit: 20 })).resolves.toEqual([
+            { type: '评论了你的动态', user: 'Bob', content: 'hello world', time: '2026-08-25T00:00:00.000Z' },
+            { type: '@了你', user: 'Carol', content: '@Alice hi', time: '2026-08-25T00:00:00.000Z' },
+            { type: '赞了你的产品页', user: 'Dave', content: 'OpenCLI', time: '2026-08-25T00:00:00.000Z' },
+        ]);
+    });
+
+    it('follows loadMoreKey, deduplicates notifications, and stops at upstream exhaustion', async () => {
+        const page = makePage(
+            identity,
+            apiPage([notification('notification-1', 'USER_FOLLOWED')], { skip: 20 }),
+            apiPage([
+                notification('notification-1', 'USER_FOLLOWED'),
+                notification('notification-2', 'PERSONAL_UPDATE_REPOSTED'),
+            ]),
+        );
+
+        const rows = await command().func(page, { limit: 50 });
+        expect(rows.map((row) => row.type)).toEqual(['关注了你', '转发了你的动态']);
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        expect(page.evaluate.mock.calls[2][0]).toContain('"skip":20');
+    });
+
+    it('does not validate an unused cursor after satisfying --limit', async () => {
+        const page = makePage(identity, apiPage([notification('notification-1', 'USER_FOLLOWED')], 'future-cursor-shape'));
+        await expect(command().func(page, { limit: 1 })).resolves.toHaveLength(1);
+    });
+
+    it('returns EmptyResult only for a valid exhausted empty response', async () => {
+        await expect(command().func(makePage(identity, apiPage([])), { limit: 20 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it.each([
+        [{ kind: 'auth', detail: 'expired' }, AuthRequiredError],
+        [{ kind: 'response', status: 403, body: {} }, AuthRequiredError],
+        [{ kind: 'transport', detail: 'offline' }, CommandExecutionError],
+        [{ kind: 'json', status: 200, detail: 'bad json' }, CommandExecutionError],
+        [{ kind: 'response', status: 500, body: {} }, CommandExecutionError],
+        [{ unexpected: true }, CommandExecutionError],
+        [{ kind: 'response', status: 200, body: { error: 'denied' } }, CommandExecutionError],
+        [{ kind: 'response', status: 200, body: { data: null } }, CommandExecutionError],
+    ])('maps API failure %# to a typed error', async (outcome, ErrorType) => {
+        const page = makePage(identity, outcome);
+        await expect(command().func(page, { limit: 20 })).rejects.toBeInstanceOf(ErrorType);
+    });
+
+    it('rejects malformed notifications, users, and cursors instead of returning partial rows', async () => {
+        await expect(command().func(makePage(identity, apiPage([
+            notification('notification-1', 'USER_FOLLOWED'),
+            { type: 'USER_FOLLOWED', actionItem: { users: [] } },
+        ])), { limit: 20 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command().func(makePage(identity, apiPage([
+            notification('notification-1', 'USER_FOLLOWED', { actionItem: { users: null } }),
+        ])), { limit: 20 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command().func(makePage(identity, apiPage([], 'bad-cursor')), { limit: 20 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed pagination cursor') });
+    });
+
+    it('rejects repeated cursors and page-budget exhaustion without returning accumulated rows', async () => {
+        const cursor = { skip: 20 };
+        await expect(command().func(makePage(
+            identity,
+            apiPage([notification('notification-1', 'USER_FOLLOWED')], cursor),
+            apiPage([], cursor),
+        ), { limit: 20 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('repeated cursor'),
+        });
+
+        const pages = Array.from({ length: 50 }, (_, index) => apiPage([], { skip: index + 1 }));
+        await expect(command().func(makePage(identity, ...pages), { limit: 20 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('exceeded 50 pages') });
+    });
+
+    it.each([
+        [{ limit: 0 }, ArgumentError],
+        [{ limit: 1.5 }, ArgumentError],
+        [{ limit: '20' }, ArgumentError],
+    ])('validates --limit before browser work: %#', async (args, ErrorType) => {
+        const page = makePage();
+        await expect(command().func(page, args)).rejects.toBeInstanceOf(ErrorType);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+});

--- a/clis/jike/search.js
+++ b/clis/jike/search.js
@@ -1,11 +1,74 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getPostDataJs, requireJikeIdentity } from './utils.js';
-/**
- * 即刻搜索适配器
- *
- * 策略：直接导航到 web.okjike.com 搜索页，
- * 通过 React fiber 树提取帖子数据。
- */
+import { normalizeJikeLimit, postJikeApi, requireJikeIdentity } from './utils.js';
+
+const API_PATH = '/1.0/search/integrate';
+const PAGE_SIZE = 20;
+const DEFAULT_LIMIT = 20;
+const MAX_PAGES = 50;
+
+async function fetchSearchPage(page, keyword, loadMoreKey) {
+    const requestBody = {
+        keywords: keyword,
+        limit: PAGE_SIZE,
+        ...(loadMoreKey ? { loadMoreKey } : {}),
+    };
+    const body = await postJikeApi(page, API_PATH, requestBody, 'Jike search API');
+    if (!body || typeof body !== 'object' || body.success !== true || !Array.isArray(body.data)) {
+        throw new CommandExecutionError(`Jike search API failed: ${String(body?.message || 'malformed response')}`);
+    }
+    return body;
+}
+
+function mapPost(post) {
+    if (!post || typeof post !== 'object' || typeof post.id !== 'string' || !post.id) {
+        throw new CommandExecutionError('Jike search API returned a malformed post');
+    }
+    const content = typeof post.content === 'string' ? post.content : '';
+    return {
+        id: post.id,
+        author: typeof post.user?.screenName === 'string' ? post.user.screenName : '',
+        content: content.replace(/\n/g, ' ').slice(0, 120),
+        likes: Number.isFinite(Number(post.likeCount)) ? Number(post.likeCount) : 0,
+        comments: Number.isFinite(Number(post.commentCount)) ? Number(post.commentCount) : 0,
+        time: typeof post.actionTime === 'string' ? post.actionTime : (typeof post.createdAt === 'string' ? post.createdAt : ''),
+        url: `https://web.okjike.com/originalPost/${post.id}`,
+    };
+}
+
+async function searchPosts(page, keyword, limit) {
+    const rows = [];
+    const seenIds = new Set();
+    const seenCursors = new Set();
+    let loadMoreKey = null;
+    for (let pageIndex = 0; pageIndex < MAX_PAGES; pageIndex++) {
+        const body = await fetchSearchPage(page, keyword, loadMoreKey);
+        for (const item of body.data) {
+            if (item?.type !== 'ORIGINAL_POST') continue;
+            const row = mapPost(item);
+            if (seenIds.has(row.id)) continue;
+            seenIds.add(row.id);
+            rows.push(row);
+            if (rows.length >= limit) return rows;
+        }
+        const next = body.loadMoreKey;
+        if (next == null) {
+            if (rows.length === 0) throw new EmptyResultError('jike search', `No posts found for "${keyword}"`);
+            return rows;
+        }
+        if (typeof next !== 'object' || Array.isArray(next)) {
+            throw new CommandExecutionError('Jike search API returned a malformed pagination cursor');
+        }
+        const cursorKey = JSON.stringify(next);
+        if (seenCursors.has(cursorKey)) {
+            throw new CommandExecutionError('Jike search pagination returned a repeated cursor');
+        }
+        seenCursors.add(cursorKey);
+        loadMoreKey = next;
+    }
+    throw new CommandExecutionError(`Jike search pagination exceeded ${MAX_PAGES} pages before satisfying --limit`);
+}
+
 cli({
     site: 'jike',
     name: 'search',
@@ -16,54 +79,15 @@ cli({
     browser: true,
     args: [
         { name: 'query', type: 'string', required: true, positional: true, help: '即刻搜索关键词' },
-        { name: 'limit', type: 'int', default: 20 },
+        { name: 'limit', type: 'int', default: DEFAULT_LIMIT },
     ],
     columns: ['id', 'author', 'content', 'likes', 'comments', 'time', 'url'],
     func: async (page, kwargs) => {
-        const keyword = kwargs.query;
-        const limit = kwargs.limit || 20;
-        // 1. 直接导航到搜索页
-        const encodedKeyword = encodeURIComponent(keyword);
-        await page.goto(`https://web.okjike.com/search?q=${encodedKeyword}`);
+        const keyword = String(kwargs.query || '').trim();
+        if (!keyword) throw new ArgumentError('Jike search query cannot be empty');
+        const limit = normalizeJikeLimit(kwargs.limit, DEFAULT_LIMIT);
+        await page.goto(`https://web.okjike.com/search?q=${encodeURIComponent(keyword)}`);
         await requireJikeIdentity(page);
-        // 2. 通过 React fiber 提取帖子数据
-        const extract = async () => {
-            return (await page.evaluate(`(() => {
-        ${getPostDataJs}
-
-        const results = [];
-        const seen = new Set();
-        const elements = document.querySelectorAll('[class*="_post_"], [class*="_postItem_"]');
-
-        for (const el of elements) {
-          const data = getPostData(el);
-          if (!data || !data.id || seen.has(data.id)) continue;
-          seen.add(data.id);
-
-          const author = data.user?.screenName || data.target?.user?.screenName || '';
-          const content = data.content || data.target?.content || '';
-          if (!author && !content) continue;
-
-          results.push({
-            id: data.id,
-            author,
-            content: content.replace(/\\n/g, ' ').slice(0, 120),
-            likes: data.likeCount || 0,
-            comments: data.commentCount || 0,
-            time: data.actionTime || data.createdAt || '',
-            url: 'https://web.okjike.com/originalPost/' + data.id,
-          });
-        }
-
-        return results;
-      })()`));
-        };
-        let posts = await extract();
-        // 3. 数量不足时自动滚动加载更多
-        if (posts.length < limit) {
-            await page.autoScroll({ times: Math.ceil(limit / 10), delayMs: 2000 });
-            posts = await extract();
-        }
-        return posts.slice(0, limit);
+        return searchPosts(page, keyword, limit);
     },
 });

--- a/clis/jike/search.test.js
+++ b/clis/jike/search.test.js
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './search.js';
+
+const identity = {
+    ok: true,
+    user_id: 'user-1',
+    screen_name: 'Alice',
+    username: 'alice',
+};
+
+function makePage(...evaluateResults) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(async () => evaluateResults.shift()),
+    };
+}
+
+function post(id, overrides = {}) {
+    return {
+        id,
+        type: 'ORIGINAL_POST',
+        content: `post ${id}`,
+        likeCount: 2,
+        commentCount: 3,
+        createdAt: '2026-08-25T00:00:00.000Z',
+        user: { screenName: 'Alice' },
+        ...overrides,
+    };
+}
+
+function apiPage(data, loadMoreKey = null, overrides = {}) {
+    return {
+        kind: 'response',
+        status: 200,
+        body: { success: true, data, loadMoreKey, ...overrides },
+    };
+}
+
+function command() {
+    return getRegistry().get('jike/search');
+}
+
+describe('jike search API pagination', () => {
+    it('preserves the seven-column contract and maps structured posts', async () => {
+        const page = makePage(identity, apiPage([
+            { type: 'SECTION_HEADER', title: 'posts' },
+            post('post-1', { content: 'hello\nworld', likeCount: '4', commentCount: null }),
+        ], { skip: 20 }));
+
+        await expect(command().func(page, { query: 'OpenCLI', limit: 1 })).resolves.toEqual([{
+            id: 'post-1',
+            author: 'Alice',
+            content: 'hello world',
+            likes: 4,
+            comments: 0,
+            time: '2026-08-25T00:00:00.000Z',
+            url: 'https://web.okjike.com/originalPost/post-1',
+        }]);
+        expect(command().columns).toEqual(['id', 'author', 'content', 'likes', 'comments', 'time', 'url']);
+        expect(page.goto).toHaveBeenCalledWith('https://web.okjike.com/search?q=OpenCLI');
+        expect(page.evaluate).toHaveBeenCalledTimes(2);
+    });
+
+    it('follows loadMoreKey, filters non-post results, deduplicates, and stops at upstream exhaustion', async () => {
+        const page = makePage(
+            identity,
+            apiPage([post('post-1'), { type: 'TOPIC', id: 'topic-1' }], { skip: 20 }),
+            apiPage([post('post-1'), post('post-2')]),
+        );
+
+        const rows = await command().func(page, { query: 'open cli', limit: 50 });
+        expect(rows.map((row) => row.id)).toEqual(['post-1', 'post-2']);
+        expect(page.goto).toHaveBeenCalledWith('https://web.okjike.com/search?q=open%20cli');
+        expect(page.evaluate).toHaveBeenCalledTimes(3);
+        expect(page.evaluate.mock.calls[2][0]).toContain('"skip":20');
+    });
+
+    it('does not validate an unused cursor after satisfying --limit', async () => {
+        const page = makePage(identity, apiPage([post('post-1')], 'future-cursor-shape'));
+        await expect(command().func(page, { query: 'OpenCLI', limit: 1 })).resolves.toHaveLength(1);
+    });
+
+    it('returns EmptyResult only for a valid exhausted response with no posts', async () => {
+        const page = makePage(identity, apiPage([{ type: 'SECTION_HEADER' }]));
+        await expect(command().func(page, { query: 'no-results', limit: 20 }))
+            .rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it.each([
+        [{ kind: 'auth', detail: 'expired' }, AuthRequiredError],
+        [{ kind: 'response', status: 403, body: {} }, AuthRequiredError],
+        [{ kind: 'transport', detail: 'offline' }, CommandExecutionError],
+        [{ kind: 'json', status: 200, detail: 'bad json' }, CommandExecutionError],
+        [{ kind: 'response', status: 500, body: {} }, CommandExecutionError],
+        [{ unexpected: true }, CommandExecutionError],
+        [{ kind: 'response', status: 200, body: { success: false, message: 'denied' } }, CommandExecutionError],
+        [{ kind: 'response', status: 200, body: { success: true, data: null } }, CommandExecutionError],
+    ])('maps API failure %# to a typed error', async (outcome, ErrorType) => {
+        const page = makePage(identity, outcome);
+        await expect(command().func(page, { query: 'OpenCLI', limit: 20 })).rejects.toBeInstanceOf(ErrorType);
+    });
+
+    it('rejects malformed posts and cursors instead of returning partial rows', async () => {
+        await expect(command().func(makePage(identity, apiPage([
+            post('post-1'),
+            { type: 'ORIGINAL_POST', content: 'missing id' },
+        ])), { query: 'OpenCLI', limit: 20 })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        await expect(command().func(makePage(identity, apiPage([], 'bad-cursor')), {
+            query: 'OpenCLI', limit: 20,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('malformed pagination cursor') });
+    });
+
+    it('rejects repeated cursors and page-budget exhaustion without returning accumulated rows', async () => {
+        const cursor = { skip: 20 };
+        await expect(command().func(makePage(
+            identity,
+            apiPage([post('post-1')], cursor),
+            apiPage([], cursor),
+        ), { query: 'OpenCLI', limit: 20 })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            message: expect.stringContaining('repeated cursor'),
+        });
+
+        const pages = Array.from({ length: 50 }, (_, index) => apiPage([], { skip: index + 1 }));
+        await expect(command().func(makePage(identity, ...pages), { query: 'OpenCLI', limit: 20 }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('exceeded 50 pages') });
+    });
+
+    it.each([
+        [{ query: '', limit: 20 }, ArgumentError],
+        [{ query: 'OpenCLI', limit: 0 }, ArgumentError],
+        [{ query: 'OpenCLI', limit: 1.5 }, ArgumentError],
+        [{ query: 'OpenCLI', limit: '20' }, ArgumentError],
+    ])('validates arguments before browser work: %#', async (args, ErrorType) => {
+        const page = makePage();
+        await expect(command().func(page, args)).rejects.toBeInstanceOf(ErrorType);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+});

--- a/clis/jike/utils.js
+++ b/clis/jike/utils.js
@@ -1,4 +1,4 @@
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 
 /**
  * 即刻适配器公共定义
@@ -32,6 +32,62 @@ export async function requireJikeIdentity(page) {
   if (probe?.kind === 'exception') throw new CommandExecutionError(`Jike identity probe failed: ${probe.detail}`);
   if (!probe?.ok) throw new CommandExecutionError(`Unexpected Jike identity probe: ${JSON.stringify(probe)}`);
   return { user_id: probe.user_id, screen_name: probe.screen_name, username: probe.username };
+}
+
+export function normalizeJikeLimit(raw, defaultValue = 20) {
+  const limit = raw ?? defaultValue;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new ArgumentError('--limit must be a positive integer');
+  }
+  return limit;
+}
+
+export async function postJikeApi(page, path, requestBody, label) {
+  const url = `https://api.ruguoapp.com${path}`;
+  const outcome = await page.evaluate(`(async () => {
+    const token = localStorage.getItem('JK_ACCESS_TOKEN') || '';
+    const deviceId = localStorage.getItem('JK_DEVICE_ID') || '';
+    if (!token) return { kind: 'auth', detail: 'Jike access token is missing' };
+    const headers = {
+      'content-type': 'application/json',
+      'x-jike-access-token': token,
+      platform: 'web',
+    };
+    if (deviceId) headers['x-jike-device-id'] = deviceId;
+    try {
+      const response = await fetch(${JSON.stringify(url)}, {
+        method: 'POST',
+        credentials: 'include',
+        headers,
+        body: JSON.stringify(${JSON.stringify(requestBody)}),
+      });
+      let body;
+      try {
+        body = await response.json();
+      } catch (error) {
+        return { kind: 'json', status: response.status, detail: String(error?.message || error) };
+      }
+      return { kind: 'response', status: response.status, body };
+    } catch (error) {
+      return { kind: 'transport', detail: String(error?.message || error) };
+    }
+  })()`);
+  if (outcome?.kind === 'auth' || outcome?.status === 401 || outcome?.status === 403) {
+    throw new AuthRequiredError('web.okjike.com', outcome?.detail || `${label} returned HTTP ${outcome?.status}`);
+  }
+  if (outcome?.kind === 'transport') {
+    throw new CommandExecutionError(`${label} request failed: ${outcome.detail}`);
+  }
+  if (outcome?.kind === 'json') {
+    throw new CommandExecutionError(`${label} returned invalid JSON: ${outcome.detail}`);
+  }
+  if (outcome?.kind !== 'response' || !Number.isInteger(outcome.status)) {
+    throw new CommandExecutionError(`${label} returned an unexpected response`);
+  }
+  if (outcome.status < 200 || outcome.status >= 300) {
+    throw new CommandExecutionError(`${label} returned HTTP ${outcome.status}`);
+  }
+  return outcome.body;
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace Jike search's React Fiber + auto-scroll path with the page-owned `POST /1.0/search/integrate` endpoint and strict `loadMoreKey` pagination
- replace notifications' Fiber/localized DOM fallback with the page-owned `POST /1.0/notifications/list` endpoint
- share the authenticated page-realm POST transport and positive-integer limit validation in `clis/jike/utils.js`
- keep feed unchanged because the current signed-in account returned only a recommendation group, not real feed posts

## Strategy

`PAGE_FETCH` / internal-unstable. Both endpoints are literal request/query definitions in the current Jike web bundle and were replayed from the signed-in page with non-empty responses. Authentication comes from the page's existing `JK_ACCESS_TOKEN` / optional device id; cookie-only Node fetch is not sufficient. The old visible-data path is demonstrably lossy: search stops at one 20-row screen and notifications returns `[]` despite a real API item. No token is exported and no signature is copied or reverse-engineered.

## Live evidence

- search `OpenCLI --limit 50`: old path returned 20 rows in ~13.03s; new path followed `{skip:20}` then terminal `null`, returning all 24 unique upstream posts in ~3.36s
- the first 20 search rows preserve the existing seven-column output; the extra four are previously unreachable continuation rows
- notifications: old path returned `[]`; natural `notifications/list` returned HTTP 200 with one `LIKE_AVATAR`, and the new command returns that one row through the existing four-column contract
- current web bundle defines the same 20-row notification query, `loadMoreKey` pagination, and renderer field contracts for its supported notification types

## Verification

- `npx vitest run clis/jike/*.test.js` — 4 files / 52 tests
- `npm run typecheck`
- `npm run build` — 1,341 manifest entries
- `node dist/src/main.js validate jike` — 12 commands, 0 errors / 0 warnings
- `npm run check:typed-error-lint` — new=0
- `npm run check:silent-column-drop` — new=0 (resolves the old Jike notifications finding)
- `git diff --cached --check`
