### PR TITLE
fix(linkedin): make sent invitations and thread snapshots accurate

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -23207,10 +23207,10 @@
   {
     "site": "linkedin",
     "name": "thread-snapshot",
-    "description": "Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot",
+    "description": "Load a LinkedIn messaging thread and return a structured conversation snapshot",
     "access": "read",
     "domain": "www.linkedin.com",
-    "strategy": "ui",
+    "strategy": "cookie",
     "browser": true,
     "args": [
       {
@@ -23224,7 +23224,7 @@
         "type": "number",
         "default": 30,
         "required": false,
-        "help": "Maximum upward scroll attempts to load older messages"
+        "help": "Maximum upward scroll attempts used to request older message pages"
       },
       {
         "name": "json",
@@ -23244,7 +23244,7 @@
     "type": "js",
     "modulePath": "linkedin/thread-snapshot.js",
     "sourceFile": "linkedin/thread-snapshot.js",
-    "navigateBefore": true
+    "navigateBefore": "https://www.linkedin.com"
   },
   {
     "site": "linkedin",

--- a/clis/linkedin/sent-invitations.js
+++ b/clis/linkedin/sent-invitations.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { unwrapEvaluateResult } from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
@@ -19,35 +19,61 @@ function buildSentInvitationsScript() {
         .replace(/^(view\s+)?profile\s+of\s+/i, '')
         .replace(/\s*(?:View profile|LinkedIn|Pending|Sent|Withdraw).*$/i, ''));
     };
-    const cards = Array.from(document.querySelectorAll('li, div, section, article')).filter((el) => {
+    const explicitEmpty = /(?:no|don't have any|haven't sent any)\s+(?:pending\s+)?(?:sent\s+)?invitations?/i.test(text)
+      || /暂无(?:已发送|待处理)?邀请/.test(text);
+    const cards = Array.from(document.querySelectorAll('[role="listitem"], li, article')).filter((el) => {
       if (!el || el.offsetParent === null) return false;
-      const t = clean(el.innerText || el.textContent || '');
-      return t && /withdraw/i.test(t) && t.length < 1200;
+      const profileLink = el.querySelector('a[href*="/in/"]');
+      const actions = Array.from(el.querySelectorAll('a, button'));
+      const withdraw = actions.find((action) => {
+        const label = clean(action.getAttribute('aria-label') || action.innerText || action.textContent || '');
+        return /^withdraw(?:\s+invitation\s+sent\s+to\b|$)/i.test(label);
+      });
+      return Boolean(profileLink && withdraw);
     });
-    const byName = new Map();
+    const byProfile = new Map();
+    let malformedCount = 0;
     for (const card of cards) {
       const raw = card.innerText || card.textContent || '';
-      if (!/withdraw/i.test(raw)) continue;
       const lines = raw.split(/\n+/).map(clean).filter(Boolean);
       const link = card.querySelector('a[href*="/in/"]');
+      const withdraw = Array.from(card.querySelectorAll('a, button')).find((action) => {
+        const label = clean(action.getAttribute('aria-label') || action.innerText || action.textContent || '');
+        return /^withdraw(?:\s+invitation\s+sent\s+to\b|$)/i.test(label);
+      });
+      const withdrawLabel = clean(withdraw ? (withdraw.getAttribute('aria-label') || '') : '');
+      const actionName = cleanName((withdrawLabel.match(/^withdraw\s+invitation\s+sent\s+to\s+(.+)$/i) || [])[1] || '');
       const linkName = cleanName(link ? (link.innerText || link.textContent || link.getAttribute('aria-label') || '') : '');
-      const name = linkName
+      const name = actionName
+        || linkName
         || cleanName(lines.find((line) => !/^(pending|sent|withdraw|message|view profile|invitation|invited|ago|manage|received)\b/i.test(line)) || '');
-      if (!name) continue;
       const hrefAttr = link ? (link.getAttribute('href') || '') : '';
       const profile_url = hrefAttr ? new URL(hrefAttr, location.origin).toString().replace(/[?#].*$/, '') : '';
       const invited_date_text = clean((raw.match(/(?:Sent|Invited)\s+(?:\d+\s+\w+\s+ago|yesterday|today)/i) || [''])[0]);
-      const key = name.toLowerCase();
-      const existing = byName.get(key);
+      if (!name || !profile_url) {
+        malformedCount += 1;
+        continue;
+      }
+      const key = profile_url.toLowerCase();
+      const existing = byProfile.get(key);
       if (!existing) {
-        byName.set(key, { name, profile_url, invited_date_text });
+        byProfile.set(key, { name, profile_url, invited_date_text });
       } else {
-        if (!existing.profile_url && profile_url) existing.profile_url = profile_url;
         if (!existing.invited_date_text && invited_date_text) existing.invited_date_text = invited_date_text;
       }
     }
-    const rows = Array.from(byName.values());
-    return { url: href, title: document.title || '', authRequired, warning, count: rows.length, rows, bodyText: text.slice(0, 1000) };
+    const rows = Array.from(byProfile.values());
+    return {
+      url: href,
+      title: document.title || '',
+      authRequired,
+      warning,
+      explicitEmpty,
+      candidateCount: cards.length,
+      malformedCount,
+      count: rows.length,
+      rows,
+    };
   })()`;
 }
 
@@ -72,7 +98,19 @@ cli({
     if (result?.warning) {
       throw new CommandExecutionError('LinkedIn warning/restriction state visible on sent invitations page.');
     }
-    const rows = Array.isArray(result?.rows) ? result.rows : [];
+    if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.rows)) {
+      throw new CommandExecutionError('LinkedIn sent invitations returned a malformed extraction payload.');
+    }
+    if (result.malformedCount > 0) {
+      throw new CommandExecutionError('LinkedIn sent invitations contained a malformed invitation card.');
+    }
+    const rows = result.rows;
+    if (rows.length === 0) {
+      if (result.explicitEmpty) {
+        throw new EmptyResultError('linkedin sent-invitations', 'No pending sent invitations were found.');
+      }
+      throw new CommandExecutionError('LinkedIn sent invitation cards were not found; the page structure may have changed.');
+    }
     return rows.map((row, index) => ({
       rank: index + 1,
       name: row.name || '',

--- a/clis/linkedin/sent-invitations.test.js
+++ b/clis/linkedin/sent-invitations.test.js
@@ -13,19 +13,20 @@ describe('linkedin sent-invitations command', () => {
     expect(command.columns).toEqual(['rank', 'name', 'profile_url', 'invited_date_text']);
   });
 
-  it('extracts clean names and dedupes invitation cards by profile url', () => {
+  it('scopes extraction to semantic invitation rows and ignores navigation labels', () => {
     const dom = new JSDOM(`<!doctype html><body>
+      <header>
+        <a href="/in/olga-magere/">0 notifications</a>
+        <a href="/in/olga-magere/">Home</a>
+        <button>Withdraw</button>
+      </header>
       <ul>
-        <li>
-          <a href="/in/olga-magere/?miniProfileUrn=x"><span>Olga Magere</span></a>
-          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
-        </li>
-        <li>
-          <a href="/in/olga-magere/?trk=dup"><span>Olga Magere</span></a>
-          <span>Pending</span><button>Withdraw</button><span>Sent 2 weeks ago</span>
-        </li>
-        <li>
-          <div>Sam Founder\nSent yesterday\nWithdraw</div>
+        <li role="listitem">
+          <a href="/in/olga-magere/?miniProfileUrn=x"><span aria-label="Olga Magere's profile picture"></span></a>
+          <p>Olga Magere</p>
+          <span>Pending</span>
+          <button aria-label="Withdraw invitation sent to Olga Magere">Withdraw</button>
+          <span>Sent 2 weeks ago</span>
         </li>
       </ul>
     </body>`, { url: 'https://www.linkedin.com/mynetwork/invitation-manager/sent/' });
@@ -40,16 +41,13 @@ describe('linkedin sent-invitations command', () => {
       Object.defineProperty(dom.window.HTMLElement.prototype, 'offsetParent', { get() { return dom.window.document.body; }, configurable: true });
       const run = Function(`return ${buildSentInvitationsScript()}`);
       const result = run();
+      expect(result.candidateCount).toBe(1);
+      expect(result.malformedCount).toBe(0);
       expect(result.rows).toEqual([
         {
           name: 'Olga Magere',
           profile_url: 'https://www.linkedin.com/in/olga-magere/',
           invited_date_text: 'Sent 2 weeks ago',
-        },
-        {
-          name: 'Sam Founder',
-          profile_url: '',
-          invited_date_text: 'Sent yesterday',
         },
       ]);
       expect(result.rows[0]).not.toHaveProperty('raw');

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -235,7 +235,12 @@ function parseThreadPages(pages) {
       if (!entity || typeof entity !== 'object' || Array.isArray(entity)) {
         throw new CommandExecutionError('LinkedIn messengerMessages payload contains a malformed included entity.');
       }
-      if (entity.entityUrn) entities.set(entity.entityUrn, entity);
+      if (entity.entityUrn) {
+        const existing = entities.get(entity.entityUrn);
+        if (!existing || Object.keys(entity).length > Object.keys(existing).length) {
+          entities.set(entity.entityUrn, entity);
+        }
+      }
     }
     apiUrls.push(page.url);
   }
@@ -314,8 +319,18 @@ cli({
 
     let discovery = unwrapEvaluateResult(await page.evaluate(buildThreadApiDiscoveryScript(maxScrolls)));
     if (discovery && Array.isArray(discovery.apiUrls) && discovery.apiUrls.length === 0) {
+      const firstDiscovery = discovery;
       await page.wait(4);
-      discovery = unwrapEvaluateResult(await page.evaluate(buildThreadApiDiscoveryScript(maxScrolls)));
+      const retried = unwrapEvaluateResult(await page.evaluate(buildThreadApiDiscoveryScript(0)));
+      if (retried && typeof retried === 'object' && !Array.isArray(retried)) {
+        discovery = {
+          ...retried,
+          scrollAttempts: firstDiscovery.scrollAttempts,
+          scrollStable: firstDiscovery.scrollStable,
+        };
+      } else {
+        discovery = retried;
+      }
     }
     if (discovery?.authRequired) {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.');

--- a/clis/linkedin/thread-snapshot.js
+++ b/clis/linkedin/thread-snapshot.js
@@ -1,6 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { canonicalizeLinkedInThreadUrl, normalizeWhitespace, unwrapEvaluateResult } from './shared.js';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+  canonicalizeLinkedInThreadUrl,
+  normalizeWhitespace,
+  requireLinkedInCookie,
+  unwrapEvaluateResult,
+} from './shared.js';
 
 const LINKEDIN_DOMAIN = 'www.linkedin.com';
 
@@ -25,17 +30,13 @@ function parseMaxScrolls(value) {
   return scrolls;
 }
 
-function buildThreadSnapshotScript(maxScrolls) {
-  const scrolls = maxScrolls;
+function buildThreadApiDiscoveryScript(maxScrolls) {
   return String.raw`(async () => {
-    const marker = '__OPENCLI_LINKEDIN_THREAD_SNAPSHOT__';
-    void marker;
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-    const clean = (s) => String(s || '').replace(/[\u00a0\u202f]/g, ' ').replace(/\s+/g, ' ').trim();
-    const text = document.body ? (document.body.innerText || '') : '';
-    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(text)
-      || /linkedin\.com\/(login|checkpoint|authwall)/i.test(location.href)
-      || /captcha|verification required/i.test(text);
+    const pageText = document.body ? (document.body.innerText || '') : '';
+    const authRequired = /\b(sign in|log in|join linkedin)\b/i.test(pageText)
+      || /linkedin\.com\/(login|checkpoint|authwall|uas)/i.test(location.href)
+      || /captcha|verification required/i.test(pageText);
 
     const selectors = [
       '.msg-s-message-list',
@@ -46,88 +47,260 @@ function buildThreadSnapshotScript(maxScrolls) {
     ];
     let scroller = null;
     for (const selector of selectors) {
-      const el = document.querySelector(selector);
-      if (el && (el.scrollHeight > el.clientHeight || selector === 'main')) { scroller = el; break; }
+      const element = document.querySelector(selector);
+      if (element && (element.scrollHeight > element.clientHeight || selector === 'main')) {
+        scroller = element;
+        break;
+      }
     }
     scroller = scroller || document.scrollingElement || document.documentElement;
+
     let previousHeight = -1;
     let stable = 0;
-    for (let i = 0; i < ${scrolls}; i += 1) {
+    let attempts = 0;
+    for (let index = 0; index < ${maxScrolls}; index += 1) {
+      attempts += 1;
       scroller.scrollTop = 0;
       window.scrollTo(0, 0);
       await sleep(750);
       const height = scroller.scrollHeight || document.body.scrollHeight || 0;
-      if (height === previousHeight) stable += 1; else stable = 0;
+      if (height === previousHeight) stable += 1;
+      else stable = 0;
       previousHeight = height;
       if (stable >= 3) break;
     }
     await sleep(1000);
 
-    const headerCandidates = [];
-    const headerSelectors = [
-      '.msg-thread__link-to-profile',
-      '.msg-thread__link-to-profile span[aria-hidden="true"]',
-      '.msg-entity-lockup__entity-title',
-      '.msg-conversation-card__participant-names',
-      'main h1',
-      'main h2',
-      '[data-anonymize="person-name"]',
-      'a[href*="/in/"] span[aria-hidden="true"]',
-      'a[href*="/in/"]'
-    ];
-    for (const selector of headerSelectors) {
-      for (const el of Array.from(document.querySelectorAll(selector)).slice(0, 8)) {
-        const value = clean(el.innerText || el.textContent || el.getAttribute('aria-label'));
-        if (value && value.length <= 120 && !/^(message|messaging|send|profile|view profile)$/i.test(value)) {
-          headerCandidates.push(value);
-        }
-      }
-    }
-
+    const threadId = (location.pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i) || [])[1] || '';
+    const apiUrls = [];
     const seen = new Set();
-    const messages = [];
-    const nodes = Array.from(document.querySelectorAll('.msg-s-message-list__event, .msg-s-event-listitem, [data-event-urn], .msg-s-message-list-content'));
-    for (const [nodeIndex, el] of nodes.entries()) {
-      const raw = clean(el.innerText || el.textContent);
-      if (!raw || seen.has(raw)) continue;
-      seen.add(raw);
-      const lines = raw.split(/\n+/).map(clean).filter(Boolean);
-      const speaker = lines.length > 1 && lines[0].length <= 120 ? lines[0] : '';
-      messages.push({ index: messages.length, nodeIndex, speaker, text: raw });
+    for (const entry of performance.getEntriesByType('resource')) {
+      const url = String(entry && entry.name || '');
+      if (!/\/voyager\/api\/voyagerMessagingGraphQL\/graphql/i.test(url)) continue;
+      if (!/[?&]queryId=messengerMessages\.[a-f0-9]+/i.test(url)) continue;
+      let decoded = url;
+      try { decoded = decodeURIComponent(url); } catch {}
+      if (!threadId || !decoded.includes(threadId) || seen.has(url)) continue;
+      seen.add(url);
+      apiUrls.push(url);
     }
-
-    const refreshedText = document.body ? (document.body.innerText || '') : '';
-    const fallbackLines = refreshedText.split(/\n+/).map(clean).filter(Boolean);
-    const latestMessageText = messages.length
-      ? messages[messages.length - 1].text
-      : ([...fallbackLines].reverse().find((line) => !/^(send|reply|write a message|press enter to send)$/i.test(line)) || '');
 
     return {
       url: location.href,
       title: document.title || '',
-      headerNames: Array.from(new Set(headerCandidates)).slice(0, 10),
-      bodyText: refreshedText,
-      latestMessageText,
-      messages,
-      messageCount: messages.length,
       authRequired,
-      extractedAt: new Date().toISOString(),
-      maxScrolls: ${scrolls}
+      apiUrls,
+      scrollAttempts: attempts,
+      scrollStable: ${maxScrolls} === 0 ? null : stable >= 3,
     };
   })()`;
+}
+
+function buildFetchThreadPagesScript(apiUrls, csrf) {
+  return String.raw`(async () => {
+    const urls = ${JSON.stringify(apiUrls)};
+    const pages = [];
+    for (const url of urls) {
+      let response;
+      try {
+        response = await fetch(url, {
+          credentials: 'include',
+          headers: {
+            'csrf-token': ${JSON.stringify(csrf)},
+            accept: 'application/vnd.linkedin.normalized+json+2.1',
+            'x-restli-protocol-version': '2.0.0',
+          },
+        });
+      } catch (error) {
+        return { error: 'fetch failed: ' + ((error && error.message) || String(error)) };
+      }
+      if (response.status === 401 || response.status === 403) {
+        return { authRequired: true, error: 'HTTP ' + response.status };
+      }
+      if (!response.ok) return { error: 'HTTP ' + response.status };
+      const contentType = response.headers.get('content-type') || '';
+      if (!/json|linkedin\.normalized/i.test(contentType)) {
+        return { error: 'unexpected content-type: ' + contentType };
+      }
+      let json;
+      try {
+        json = await response.json();
+      } catch (error) {
+        return { error: 'invalid JSON: ' + ((error && error.message) || String(error)) };
+      }
+      pages.push({ url, json });
+    }
+    return { pages };
+  })()`;
+}
+
+function participantName(participant) {
+  const type = participant?.participantType || {};
+  const member = type.member;
+  if (member) {
+    return normalizeWhitespace([
+      member.firstName?.text,
+      member.lastName?.text,
+    ].filter(Boolean).join(' '));
+  }
+  if (type.organization) return normalizeWhitespace(type.organization.name?.text || type.organization.name);
+  if (type.agent) return normalizeWhitespace(type.agent.name?.text || type.agent.name);
+  if (type.custom) return normalizeWhitespace(type.custom.name?.text || type.custom.name);
+  return '';
+}
+
+function messageText(message) {
+  return normalizeWhitespace(
+    message?.body?.text
+    || message?.renderContentFallbackText?.text
+    || message?.renderContentFallbackText
+    || message?.subject?.text
+    || message?.subject
+    || '',
+  );
+}
+
+function ownerUrnFromApiUrls(apiUrls) {
+  for (const url of apiUrls) {
+    let decoded = url;
+    try { decoded = decodeURIComponent(url); } catch {}
+    const match = decoded.match(/conversationUrn:urn:li:msg_conversation:\((urn:li:fsd_profile:[^,)]+)/i);
+    if (match) return match[1];
+  }
+  return '';
+}
+
+function validateThreadApiUrls(apiUrls, threadUrl) {
+  const threadId = new URL(threadUrl).pathname.match(/^\/messaging\/thread\/([^/]+)\/?$/i)?.[1] || '';
+  if (!Array.isArray(apiUrls) || apiUrls.length === 0) {
+    throw new CommandExecutionError('LinkedIn did not issue a messengerMessages API request for this thread.');
+  }
+  for (const value of apiUrls) {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new CommandExecutionError('LinkedIn messengerMessages discovery returned an invalid URL.');
+    }
+    let decoded = value;
+    try { decoded = decodeURIComponent(value); } catch {}
+    if (url.protocol !== 'https:'
+      || url.hostname !== LINKEDIN_DOMAIN
+      || url.pathname !== '/voyager/api/voyagerMessagingGraphQL/graphql'
+      || !/^messengerMessages\.[a-f0-9]+$/i.test(url.searchParams.get('queryId') || '')
+      || !threadId
+      || !decoded.includes(threadId)) {
+      throw new CommandExecutionError('LinkedIn messengerMessages discovery returned an unsafe or mismatched URL.');
+    }
+  }
+  return apiUrls;
+}
+
+function parseThreadPages(pages) {
+  if (!Array.isArray(pages) || pages.length === 0) {
+    throw new CommandExecutionError('LinkedIn messengerMessages API returned no pages.');
+  }
+
+  const entities = new Map();
+  const apiUrls = [];
+  for (const page of pages) {
+    if (!page || typeof page !== 'object' || Array.isArray(page) || typeof page.url !== 'string') {
+      throw new CommandExecutionError('LinkedIn messengerMessages API returned a malformed page wrapper.');
+    }
+    const normalized = page.json;
+    if (!normalized || typeof normalized !== 'object' || Array.isArray(normalized)) {
+      throw new CommandExecutionError('LinkedIn messengerMessages API returned a malformed normalized payload.');
+    }
+    if (Array.isArray(normalized.errors) && normalized.errors.length > 0) {
+      throw new CommandExecutionError('LinkedIn messengerMessages GraphQL returned errors.');
+    }
+    if (!Array.isArray(normalized.included)) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload is missing the included entity array.');
+    }
+    const data = normalized.data?.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload is missing normalized data.');
+    }
+    const container = Object.entries(data).find(([key, value]) => (
+      /^messengerMessages/i.test(key)
+      && value
+      && typeof value === 'object'
+      && !Array.isArray(value)
+      && (Array.isArray(value['*elements']) || Array.isArray(value.elements))
+    ));
+    if (!container) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload is missing a message collection.');
+    }
+    for (const entity of normalized.included) {
+      if (!entity || typeof entity !== 'object' || Array.isArray(entity)) {
+        throw new CommandExecutionError('LinkedIn messengerMessages payload contains a malformed included entity.');
+      }
+      if (entity.entityUrn) entities.set(entity.entityUrn, entity);
+    }
+    apiUrls.push(page.url);
+  }
+
+  const ownerUrn = ownerUrnFromApiUrls(apiUrls);
+  if (!ownerUrn) {
+    throw new CommandExecutionError('LinkedIn messengerMessages URL is missing the conversation owner identity.');
+  }
+
+  const participants = Array.from(entities.values()).filter(
+    (entity) => entity.$type === 'com.linkedin.messenger.MessagingParticipant',
+  );
+  const recipientNames = Array.from(new Set(participants
+    .filter((participant) => participant.hostIdentityUrn !== ownerUrn)
+    .map(participantName)
+    .filter(Boolean)));
+  if (recipientNames.length === 0) {
+    throw new CommandExecutionError('LinkedIn messengerMessages payload is missing the counterparty participant.');
+  }
+
+  const byMessageId = new Map();
+  for (const entity of entities.values()) {
+    if (entity.$type !== 'com.linkedin.messenger.Message') continue;
+    const messageId = normalizeWhitespace(entity.entityUrn || entity.backendUrn || entity.originToken);
+    if (!messageId) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload contains a message without an id.');
+    }
+    const deliveredAt = Number(entity.deliveredAt);
+    if (!Number.isFinite(deliveredAt) || deliveredAt <= 0) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload contains a message without a valid timestamp.');
+    }
+    const senderUrn = normalizeWhitespace(entity['*sender'] || entity['*actor']);
+    const sender = senderUrn ? entities.get(senderUrn) : null;
+    const speaker = participantName(sender);
+    if (!speaker) {
+      throw new CommandExecutionError('LinkedIn messengerMessages payload contains a message with an unresolved sender.');
+    }
+    byMessageId.set(messageId, {
+      messageUrn: messageId,
+      speaker,
+      text: messageText(entity),
+      deliveredAt,
+    });
+  }
+
+  const messages = Array.from(byMessageId.values())
+    .sort((left, right) => left.deliveredAt - right.deliveredAt || left.messageUrn.localeCompare(right.messageUrn))
+    .map((message, index) => ({ index, ...message }));
+  if (messages.length === 0) {
+    throw new EmptyResultError('linkedin thread-snapshot', 'No messages were found in the LinkedIn thread.');
+  }
+  return { recipientNames, messages };
 }
 
 cli({
   site: 'linkedin',
   name: 'thread-snapshot',
   access: 'read',
-  description: 'Load a LinkedIn messaging thread, scroll for available history, and return a full context snapshot',
+  description: 'Load a LinkedIn messaging thread and return a structured conversation snapshot',
   domain: LINKEDIN_DOMAIN,
-  strategy: Strategy.UI,
+  strategy: Strategy.COOKIE,
   browser: true,
   args: [
     { name: 'thread-url', required: true, help: 'Exact LinkedIn messaging thread URL to open and snapshot' },
-    { name: 'max-scrolls', type: 'number', default: 30, help: 'Maximum upward scroll attempts to load older messages' },
+    { name: 'max-scrolls', type: 'number', default: 30, help: 'Maximum upward scroll attempts used to request older message pages' },
     { name: 'json', type: 'bool', default: false, help: 'Return only JSON snapshot string in the snapshot_json field' },
   ],
   columns: ['thread_url', 'recipient', 'message_count', 'latest_text', 'snapshot_json'],
@@ -136,39 +309,62 @@ cli({
     const threadUrl = requireLinkedInThreadUrl(requireStringArg(args, 'thread-url', '--thread-url'), '--thread-url');
     const maxScrolls = parseMaxScrolls(args['max-scrolls']);
 
-    await page.goto('https://www.linkedin.com/messaging/');
-    await page.wait(4);
     await page.goto(threadUrl);
     await page.wait(10);
 
-    const snapshot = unwrapEvaluateResult(await page.evaluate(buildThreadSnapshotScript(maxScrolls)));
-    if (snapshot?.authRequired) {
+    let discovery = unwrapEvaluateResult(await page.evaluate(buildThreadApiDiscoveryScript(maxScrolls)));
+    if (discovery && Array.isArray(discovery.apiUrls) && discovery.apiUrls.length === 0) {
+      await page.wait(4);
+      discovery = unwrapEvaluateResult(await page.evaluate(buildThreadApiDiscoveryScript(maxScrolls)));
+    }
+    if (discovery?.authRequired) {
       throw new AuthRequiredError(LINKEDIN_DOMAIN, 'LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.');
     }
-    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot) || !Array.isArray(snapshot.headerNames) || !Array.isArray(snapshot.messages)) {
-      throw new CommandExecutionError('LinkedIn thread-snapshot returned malformed snapshot payload');
+    if (!discovery || typeof discovery !== 'object' || Array.isArray(discovery) || !Array.isArray(discovery.apiUrls)) {
+      throw new CommandExecutionError('LinkedIn thread-snapshot returned a malformed API discovery payload.');
     }
 
-    const actualUrl = canonicalizeLinkedInThreadUrl(snapshot?.url || '');
+    const actualUrl = canonicalizeLinkedInThreadUrl(discovery.url || '');
     if (threadUrl && actualUrl && threadUrl !== actualUrl) {
       throw new CommandExecutionError('LinkedIn thread-snapshot blocked: thread_url_mismatch', `Expected ${threadUrl}; actual ${actualUrl}`);
     }
+    if (maxScrolls >= 4 && discovery.scrollAttempts >= maxScrolls && discovery.scrollStable === false) {
+      throw new CommandExecutionError('LinkedIn thread history did not stabilize before --max-scrolls; refusing to return a partial snapshot.');
+    }
 
-    const recipient = normalizeWhitespace(snapshot.headerNames[0] || '');
-    const messageCount = snapshot.messages.length;
+    const apiUrls = validateThreadApiUrls(discovery.apiUrls, threadUrl);
+    const csrf = await requireLinkedInCookie(page, 'LinkedIn thread-snapshot');
+    const fetched = unwrapEvaluateResult(
+      await page.evaluate(buildFetchThreadPagesScript(apiUrls, csrf)),
+    );
+    if (fetched?.authRequired) {
+      throw new AuthRequiredError(LINKEDIN_DOMAIN, `LinkedIn messengerMessages API authentication failed: ${fetched.error}`);
+    }
+    if (!fetched || fetched.error || !Array.isArray(fetched.pages)) {
+      throw new CommandExecutionError(`LinkedIn messengerMessages API returned an unexpected response: ${fetched?.error || 'no data'}`);
+    }
+
+    const parsed = parseThreadPages(fetched.pages);
+    const recipient = parsed.recipientNames.join(', ');
+    const latestMessageText = parsed.messages[parsed.messages.length - 1]?.text || '';
     const normalized = {
-      ...snapshot,
       url: actualUrl || threadUrl,
-      headerNames: snapshot.headerNames,
-      latestMessageText: normalizeWhitespace(snapshot?.latestMessageText || ''),
-      messages: snapshot.messages,
+      title: normalizeWhitespace(discovery.title),
+      headerNames: parsed.recipientNames,
+      latestMessageText,
+      messages: parsed.messages,
+      messageCount: parsed.messages.length,
+      authRequired: false,
+      extractedAt: new Date().toISOString(),
+      maxScrolls,
+      source: 'linkedin-messengerMessages',
     };
 
     return [{
       thread_url: normalized.url,
       recipient,
-      message_count: messageCount,
-      latest_text: normalized.latestMessageText,
+      message_count: normalized.messageCount,
+      latest_text: latestMessageText,
       snapshot_json: JSON.stringify(normalized),
     }];
   },
@@ -176,5 +372,8 @@ cli({
 
 export const __test__ = {
   parseMaxScrolls,
-  buildThreadSnapshotScript,
+  buildThreadApiDiscoveryScript,
+  buildFetchThreadPagesScript,
+  validateThreadApiUrls,
+  parseThreadPages,
 };

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -3,13 +3,83 @@ import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
 import './thread-snapshot.js';
 
-const { parseMaxScrolls } = await import('./thread-snapshot.js').then((m) => m.__test__);
+const {
+  parseMaxScrolls,
+  parseThreadPages,
+  validateThreadApiUrls,
+} = await import('./thread-snapshot.js').then((module) => module.__test__);
 
-function makeFakePage(snapshot) {
+const THREAD_URL = 'https://www.linkedin.com/messaging/thread/2-abc/';
+const API_URL = 'https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.abc123&variables=(conversationUrn:urn%3Ali%3Amsg_conversation%3A%28urn%3Ali%3Afsd_profile%3Aowner%2C2-abc%29)';
+const OWNER_URN = 'urn:li:fsd_profile:owner';
+const OWNER_PARTICIPANT = `urn:li:msg_messagingParticipant:${OWNER_URN}`;
+const OTHER_PARTICIPANT = 'urn:li:msg_messagingParticipant:urn:li:fsd_profile:other';
+
+function participant(entityUrn, hostIdentityUrn, firstName, lastName) {
+  return {
+    entityUrn,
+    hostIdentityUrn,
+    participantType: {
+      member: {
+        firstName: { text: firstName },
+        lastName: { text: lastName },
+      },
+    },
+    $type: 'com.linkedin.messenger.MessagingParticipant',
+  };
+}
+
+function message(entityUrn, senderUrn, deliveredAt, text) {
+  return {
+    entityUrn,
+    '*sender': senderUrn,
+    deliveredAt,
+    body: { text },
+    $type: 'com.linkedin.messenger.Message',
+  };
+}
+
+function normalizedPage(included, refs = included.filter((entity) => entity.$type === 'com.linkedin.messenger.Message').map((entity) => entity.entityUrn)) {
+  return {
+    data: {
+      data: {
+        messengerMessagesBySyncToken: {
+          metadata: { shouldClearCache: true },
+          '*elements': refs,
+        },
+      },
+    },
+    included,
+  };
+}
+
+function liveFixturePages() {
+  return [{
+    url: API_URL,
+    json: normalizedPage([
+      participant(OWNER_PARTICIPANT, OWNER_URN, 'Jie', 'Wen'),
+      participant(OTHER_PARTICIPANT, 'urn:li:fsd_profile:other', 'Neha', 'Rudraraju'),
+      message('urn:li:msg_message:2', OWNER_PARTICIPANT, 200, 'safe-send test from hermes. pls ignore :)'),
+      message('urn:li:msg_message:1', OTHER_PARTICIPANT, 100, 'damn i just saw ur msg sry sry'),
+    ]),
+  }];
+}
+
+function makeFakePage({ discovery, fetched } = {}) {
   return {
     goto: vi.fn(async () => undefined),
     wait: vi.fn(async () => undefined),
-    evaluate: vi.fn(async () => snapshot),
+    getCookies: vi.fn(async () => [{ name: 'JSESSIONID', value: '"ajax:123"' }]),
+    evaluate: vi.fn()
+      .mockResolvedValueOnce(discovery || {
+        url: THREAD_URL,
+        title: 'Messaging | LinkedIn',
+        authRequired: false,
+        apiUrls: [API_URL],
+        scrollAttempts: 4,
+        scrollStable: true,
+      })
+      .mockResolvedValueOnce(fetched || { pages: liveFixturePages() }),
   };
 }
 
@@ -22,45 +92,56 @@ describe('linkedin thread-snapshot command', () => {
     expect(() => parseMaxScrolls(1.5)).toThrow('--max-scrolls must be an integer between 0 and 80');
   });
 
-  it('registers as a read command for loading full thread context', () => {
+  it('registers as a read command for structured thread context', () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
     expect(command).toBeDefined();
     expect(command.access).toBe('read');
     expect(command.columns).toEqual(expect.arrayContaining(['thread_url', 'recipient', 'message_count', 'latest_text']));
   });
 
-  it('opens messaging first, then exact thread, and returns extracted messages', async () => {
+  it('opens the exact thread, discovers the live API, and returns deduped chronological messages', async () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
-    const page = makeFakePage({
-      url: 'https://www.linkedin.com/messaging/thread/abc/',
-      headerNames: ['Neha Rudraraju'],
-      latestMessageText: 'safe-send test from hermes. pls ignore :)',
-      messages: [
-        { index: 0, speaker: 'Neha Rudraraju', text: 'damn i just saw ur msg sry sry' },
-        { index: 1, speaker: 'Me', text: 'safe-send test from hermes. pls ignore :)' },
-      ],
-    });
+    const page = makeFakePage();
 
     const rows = await command.func(page, {
-      'thread-url': 'https://www.linkedin.com/messaging/thread/abc/',
+      'thread-url': THREAD_URL,
       'max-scrolls': 8,
       json: false,
     });
 
-    expect(page.goto).toHaveBeenNthCalledWith(1, 'https://www.linkedin.com/messaging/');
-    expect(page.goto).toHaveBeenNthCalledWith(2, 'https://www.linkedin.com/messaging/thread/abc/');
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.goto).toHaveBeenCalledWith(THREAD_URL);
+    expect(page.getCookies).toHaveBeenCalledWith({ url: 'https://www.linkedin.com' });
     expect(rows[0]).toMatchObject({
-      thread_url: 'https://www.linkedin.com/messaging/thread/abc/',
+      thread_url: THREAD_URL,
       recipient: 'Neha Rudraraju',
       message_count: 2,
       latest_text: 'safe-send test from hermes. pls ignore :)',
     });
-    expect(rows[0].snapshot_json).toContain('damn i just saw ur msg sry sry');
+    const snapshot = JSON.parse(rows[0].snapshot_json);
+    expect(snapshot.source).toBe('linkedin-messengerMessages');
+    expect(snapshot.messages.map((entry) => entry.text)).toEqual([
+      'damn i just saw ur msg sry sry',
+      'safe-send test from hermes. pls ignore :)',
+    ]);
+  });
+
+  it('dedupes the same normalized message entity across API pages', () => {
+    const pages = liveFixturePages();
+    pages.push({
+      url: API_URL.replace('abc123', 'def456').replace('variables=(', 'variables=(deliveredAt:100,countBefore:20,countAfter:0,'),
+      json: {
+        data: { data: { messengerMessagesByAnchorTimestamp: { metadata: { prevCursor: null }, elements: [] } } },
+        included: [message('urn:li:msg_message:1', OTHER_PARTICIPANT, 100, 'damn i just saw ur msg sry sry')],
+      },
+    });
+    const parsed = parseThreadPages(pages);
+    expect(parsed.messages).toHaveLength(2);
   });
 
   it('rejects invalid thread URL before navigation', async () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
-    const page = makeFakePage({});
+    const page = makeFakePage();
 
     await expect(command.func(page, {
       'thread-url': 'https://www.linkedin.com/feed/',
@@ -69,13 +150,39 @@ describe('linkedin thread-snapshot command', () => {
     expect(page.goto).not.toHaveBeenCalled();
   });
 
-  it('fails typed on malformed snapshot payloads', async () => {
+  it('rejects unsafe or mismatched discovered API URLs', () => {
+    expect(() => validateThreadApiUrls([
+      'https://evil.example/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.abc123&variables=(conversationUrn:2-abc)',
+    ], THREAD_URL)).toThrow('unsafe or mismatched');
+  });
+
+  it('fails typed on malformed normalized payloads', async () => {
     const command = getRegistry().get('linkedin/thread-snapshot');
-    const page = makeFakePage({ url: 'https://www.linkedin.com/messaging/thread/abc/', headerNames: ['Neha Rudraraju'] });
+    const page = makeFakePage({ fetched: { pages: [{ url: API_URL, json: {} }] } });
 
     await expect(command.func(page, {
-      'thread-url': 'https://www.linkedin.com/messaging/thread/abc/',
+      'thread-url': THREAD_URL,
       'max-scrolls': 8,
     })).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('refuses a partial snapshot when history never stabilizes at the scroll cap', async () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    const page = makeFakePage({
+      discovery: {
+        url: THREAD_URL,
+        title: 'Messaging | LinkedIn',
+        authRequired: false,
+        apiUrls: [API_URL],
+        scrollAttempts: 8,
+        scrollStable: false,
+      },
+    });
+
+    await expect(command.func(page, {
+      'thread-url': THREAD_URL,
+      'max-scrolls': 8,
+    })).rejects.toThrow('refusing to return a partial snapshot');
+    expect(page.getCookies).not.toHaveBeenCalled();
   });
 });

--- a/clis/linkedin/thread-snapshot.test.js
+++ b/clis/linkedin/thread-snapshot.test.js
@@ -132,11 +132,44 @@ describe('linkedin thread-snapshot command', () => {
       url: API_URL.replace('abc123', 'def456').replace('variables=(', 'variables=(deliveredAt:100,countBefore:20,countAfter:0,'),
       json: {
         data: { data: { messengerMessagesByAnchorTimestamp: { metadata: { prevCursor: null }, elements: [] } } },
-        included: [message('urn:li:msg_message:1', OTHER_PARTICIPANT, 100, 'damn i just saw ur msg sry sry')],
+        included: [{ entityUrn: 'urn:li:msg_message:1', $type: 'com.linkedin.messenger.Message' }],
       },
     });
     const parsed = parseThreadPages(pages);
     expect(parsed.messages).toHaveLength(2);
+  });
+
+  it('retries slow API discovery without repeating the configured scroll budget', async () => {
+    const command = getRegistry().get('linkedin/thread-snapshot');
+    const page = makeFakePage();
+    page.evaluate = vi.fn()
+      .mockResolvedValueOnce({
+        url: THREAD_URL,
+        title: 'Messaging | LinkedIn',
+        authRequired: false,
+        apiUrls: [],
+        scrollAttempts: 8,
+        scrollStable: true,
+      })
+      .mockResolvedValueOnce({
+        url: THREAD_URL,
+        title: 'Messaging | LinkedIn',
+        authRequired: false,
+        apiUrls: [API_URL],
+        scrollAttempts: 0,
+        scrollStable: null,
+      })
+      .mockResolvedValueOnce({ pages: liveFixturePages() });
+
+    const rows = await command.func(page, {
+      'thread-url': THREAD_URL,
+      'max-scrolls': 8,
+    });
+
+    expect(rows[0].message_count).toBe(2);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+    expect(page.evaluate.mock.calls[1][0]).toContain('index < 0');
+    expect(page.wait).toHaveBeenNthCalledWith(2, 4);
   });
 
   it('rejects invalid thread URL before navigation', async () => {


### PR DESCRIPTION
## Summary

- scope sent-invitation extraction to semantic invitation list items, so global navigation text cannot become duplicate people
- treat explicit empty, malformed-card, auth, and restriction states as typed outcomes
- replace nested message DOM counting with the page's natural rotating messengerMessages GraphQL requests
- replay every current-thread message page the UI naturally requested, validate same-origin URLs, dedupe normalized entities, sort by deliveredAt, and resolve recipient/sender identities from MessagingParticipant entities
- preserve the richer normalized entity when a later page repeats only a skeletal copy of the same URN
- retry slow GraphQL discovery without spending the caller's `--max-scrolls` budget a second time
- remove the unnecessary intermediate navigation through /messaging/ and regenerate the manifest

## Live evidence

- sent invitations: current page contains one pending invitation; old command returned five rows for the same profile, including navigation labels; new command returns exactly one correct row
- one-message thread: old DOM scan reported 3 messages; normalized API contains and new command returns 1
- three-message thread: old DOM scan reported 7 messages and polluted the recipient with a job title; normalized API contains and new command returns 3 with the clean recipient name
- natural GraphQL URLs are discovered from Performance entries by messengerMessages operation name, so no query hash is hard-coded
- the current account's anchor request was also observed: countBefore=20/countAfter=0, with a terminal empty page and null cursors

## Strategy

Sent invitations remain visible-UI extraction because the current LinkedIn SDUI route returns the complete card in its HTML and issues no invitation business API request. Thread snapshots use the page-owned session API because the visible nested DOM demonstrably double/triple-counts messages. JSESSIONID/CSRF stays on the existing LinkedIn browser boundary.

`--max-scrolls` values 1–3 intentionally return the pages loaded within that explicit caller budget; for values 4 and above, an exhausted unstable scroll is rejected as partial. A slow-response discovery retry performs no additional scrolling and preserves the first pass's budget/stability state.

## Verification

- focused tests: 11/11
- all LinkedIn tests: 24 files / 202 tests
- typecheck
- build: 1341 manifest entries
- validate linkedin: 25 commands, 0 errors / 0 warnings
- typed-error lint: new=0
- silent-column-drop: new=0
- git diff --check
