### PR TITLE
fix(linux-do): use current session for whoami

### DIFF
--- a/clis/linux-do/auth.js
+++ b/clis/linux-do/auth.js
@@ -14,30 +14,39 @@ async function verifyLinuxDoIdentity(page) {
   await page.wait(2);
   const probe = await page.evaluate(`(async () => {
     try {
-      const u = document.querySelector('meta[name="current-user-username"]')?.getAttribute('content') || '';
-      if (!u) return { kind: 'auth', detail: 'Linux.do meta[current-user-username] missing — anonymous' };
-      const r = await fetch('/u/' + encodeURIComponent(u) + '.json', {
+      const r = await fetch('/session/current.json', {
         credentials: 'include',
         headers: { Accept: 'application/json' },
       });
       if (r.status === 401 || r.status === 403) {
-        return { kind: 'auth', detail: 'Linux.do /u/<self>.json HTTP ' + r.status };
+        return { kind: 'auth', detail: 'Linux.do /session/current.json HTTP ' + r.status };
       }
       if (!r.ok) return { kind: 'http', httpStatus: r.status };
       const d = await r.json();
-      const user = d?.user;
-      if (!user || !user.id) return { kind: 'auth', detail: 'Linux.do /u/<self>.json missing user.id' };
-      return { ok: true, user_id: String(user.id), username: String(user.username || u), name: String(user.name || '') };
+      const user = d?.current_user;
+      if (!user || !user.id || !user.username) {
+        return { kind: 'auth', detail: 'Linux.do /session/current.json missing current_user' };
+      }
+      return {
+        ok: true,
+        user_id: String(user.id),
+        username: String(user.username),
+        name: String(user.name || ''),
+      };
     } catch (e) {
       return { kind: 'exception', detail: String(e && e.message || e) };
     }
   })()`);
   if (probe?.kind === 'auth') throw new AuthRequiredError('linux.do', probe.detail);
-  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Linux.do /u/<self>.json`);
+  if (probe?.kind === 'http') throw new CommandExecutionError(`HTTP ${probe.httpStatus} from Linux.do /session/current.json`);
   if (probe?.kind === 'exception') throw new CommandExecutionError(`Linux.do whoami failed: ${probe.detail}`);
-  if (!probe?.ok) throw new CommandExecutionError(`Unexpected Linux.do probe: ${JSON.stringify(probe)}`);
+  if (!probe?.ok || !probe.user_id || !probe.username) {
+    throw new CommandExecutionError(`Unexpected Linux.do probe: ${JSON.stringify(probe)}`);
+  }
   return { user_id: probe.user_id, username: probe.username, name: probe.name };
 }
+
+export const __test__ = { verifyLinuxDoIdentity };
 
 registerSiteAuthCommands({
   site: 'linux-do',

--- a/clis/linux-do/auth.test.js
+++ b/clis/linux-do/auth.test.js
@@ -14,11 +14,11 @@ function makePage({ cookies = [{ name: '_t', value: 'session' }], probe } = {}) 
 describe('linux-do auth identity probe', () => {
   it('uses Discourse session/current.json instead of the removed username meta tag', async () => {
     const page = makePage({
-      probe: { ok: true, user_id: '246112', username: 'alice', name: '' },
+      probe: { ok: true, user_id: '42', username: 'alice', name: '' },
     });
 
     await expect(__test__.verifyLinuxDoIdentity(page)).resolves.toEqual({
-      user_id: '246112',
+      user_id: '42',
       username: 'alice',
       name: '',
     });

--- a/clis/linux-do/auth.test.js
+++ b/clis/linux-do/auth.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { __test__ } from './auth.js';
+
+function makePage({ cookies = [{ name: '_t', value: 'session' }], probe } = {}) {
+  return {
+    getCookies: vi.fn().mockResolvedValue(cookies),
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(probe),
+  };
+}
+
+describe('linux-do auth identity probe', () => {
+  it('uses Discourse session/current.json instead of the removed username meta tag', async () => {
+    const page = makePage({
+      probe: { ok: true, user_id: '246112', username: 'alice', name: '' },
+    });
+
+    await expect(__test__.verifyLinuxDoIdentity(page)).resolves.toEqual({
+      user_id: '246112',
+      username: 'alice',
+      name: '',
+    });
+
+    const script = page.evaluate.mock.calls[0][0];
+    expect(script).toContain('/session/current.json');
+    expect(script).toContain('current_user');
+    expect(script).not.toContain('current-user-username');
+    expect(script).not.toContain("fetch('/u/'");
+  });
+
+  it('fails before navigation when the Linux.do session cookie is missing', async () => {
+    const page = makePage({ cookies: [] });
+
+    await expect(__test__.verifyLinuxDoIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ kind: 'auth', detail: 'anonymous' }, AuthRequiredError],
+    [{ kind: 'http', httpStatus: 500 }, CommandExecutionError],
+    [{ kind: 'exception', detail: 'boom' }, CommandExecutionError],
+    [{ ok: true, username: 'alice', name: '' }, CommandExecutionError],
+  ])('maps malformed and failed probes to typed errors', async (probe, errorType) => {
+    const page = makePage({ probe });
+    await expect(__test__.verifyLinuxDoIdentity(page)).rejects.toBeInstanceOf(errorType);
+  });
+});


### PR DESCRIPTION
## Summary

- replace Linux.do's removed `meta[name="current-user-username"]` identity check with Discourse's authenticated `/session/current.json`
- validate `current_user.id` and `current_user.username` before returning a successful `whoami` result
- add adapter regression tests for the endpoint choice, missing session cookies, typed failures, and malformed success payloads

## Problem

On OpenCLI 1.8.7, a valid Linux.do session can have the `_t` cookie and visibly logged-in account controls while the page no longer exposes `meta[name="current-user-username"]`. `opencli linux-do whoami` therefore reports `AUTH_REQUIRED` even though the user is logged in. The subsequent `/u/<self>.json` path is also unnecessary for identifying the current session.

Discourse's `/session/current.json` remains available with the same authenticated browser session and returns the canonical `current_user` identity.

## Verification

- `npx vitest run --project adapter clis/linux-do/auth.test.js` — 6 passed
- `npm run typecheck` — passed
- `node dist/src/main.js validate linux-do` — 10 commands checked, 0 errors, 0 warnings
- `node dist/src/main.js linux-do whoami -f json` — verified against a real logged-in Linux.do session
- `npm test` — 625 test files passed; 7,248 tests passed, 1 skipped
