### PR TITLE
docs(skill): add evidence-first Deep Recon workflow

### DIFF
--- a/skills/opencli-adapter-author/SKILL.md
+++ b/skills/opencli-adapter-author/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: opencli-adapter-author
 description: Use when writing an OpenCLI adapter for a new site or adding a new command to an existing site. Guides end-to-end from first recon through field decoding, adapter coding, and verify. Replaces opencli-oneshot / opencli-explorer. For ad-hoc browser driving (no adapter), see opencli-browser instead; for a top-level orientation to opencli, see opencli-usage.
-allowed-tools: Bash(opencli:*), Read, Edit, Write, Grep
+allowed-tools: Bash(opencli:*), Bash(jsluice:*), Read, Edit, Write, Grep
 ---
 
 # opencli-adapter-author
 
-你是要给一个站点写 adapter 的 agent。这份 skill 目标：**从零到通过 `opencli browser verify` 的 30 分钟内闭环**。
+你是要给一个站点写 adapter 的 agent。这份 skill 目标：简单站点争取 **30 分钟内从零到通过 `opencli browser verify`**；复杂、私有协议或写操作站点以证据完整和安全为先，不为了时限猜接口。
 
 全程用现有工具：`opencli browser *` / `opencli doctor` / `opencli browser init` / `opencli browser verify`。没有新命令。
 
@@ -92,9 +92,15 @@ START
   │ 拿到候选 endpoint
   ▼
 ┌────────────────────────────────────────────┐
-│ 直接 fetch 验证 endpoint（memory 命中也要跑）│── 401/403 ──→ 回到 §4 排 token
-│ 数据非空 + 200                              │── 空/HTML ──→ 回到 site-recon 换 Pattern
-│ memory 里的值还活着吗？                     │── 站点换版 ──→ 标记旧 endpoint，回 api-discovery
+│ 需要 Deep Recon？                          │  无文档私有 API / DOM 丢数据 / 写操作 / 证据冲突
+│ → references/deep-recon.md                 │  intent matrix → 因果 diff → 候选账本 → contract gate
+└────────────────────────────────────────────┘
+  │ 候选通过合同证明；不通过则记录拒绝与 lift condition
+  ▼
+┌────────────────────────────────────────────┐
+│ 验证候选合同（memory 命中也要跑）           │── 401/403 ──→ 回到 §4 排 token
+│ safe replay；不可 replay 的 read 用自然截获 │── 空/HTML ──→ 回到 site-recon 换 Pattern
+│ 数据非空、identity 对、分页/错误语义完整     │── 站点换版 ──→ 标记旧 endpoint，回 api-discovery
 └────────────────────────────────────────────┘
   │ OK
   ▼
@@ -155,9 +161,18 @@ DONE
        [ ] Pattern C → §3 bundle / script src 搜索
        [ ] Pattern D → §4 token 来源 + 降级 §5
        [ ] Pattern E → 找 HTTP 轮询接口；找不到才 §5
-[ ] 5. 直接 fetch 候选 endpoint 验证：
-       [ ] 返回 200
-       [ ] 响应含目标数据（不是 HTML / 广告）
+       [ ] 无文档 API / DOM 丢数据 / 写操作 / bundle 与 network 冲突 → `deep-recon.md`
+           [ ] 写 intent matrix 和明确的 mutation boundary
+           [ ] baseline → 单一动作 → 新请求 diff；至少一组 changed-input 对照
+           [ ] jsluice 只扩大候选面；候选必须进入 evidence ledger
+           [ ] read 候选过 occurrence/replay/completeness/auth/pagination/failure gate
+           [ ] write 候选有明确授权、目标绑定、幂等/不确定性与不可自动重试语义
+[ ] 5. 候选合同验证（memory 命中也要重跑）：
+       [ ] `PUBLIC_API / COOKIE_API / PAGE_FETCH`：safe replay 跨两个输入返回成功
+       [ ] `INTERCEPT`：两次自然页面动作都截到属于目标 identity 的完整响应
+       [ ] 响应含目标数据（不是 HTML / 广告 / 推荐侧栏），字段与网页对得上
+       [ ] 分页达到 exact limit 或证明 upstream exhaustion；失败不返回 partial
+       [ ] write 不自动 replay，必须过 `deep-recon.md` 的额外合同门禁
 [ ] 6. 写 strategy note（写代码前的强制产物）：
        [ ] 从 `PUBLIC_API / COOKIE_API / PAGE_FETCH / INTERCEPT / DOM_STATE / UI_SELECTOR` 选一个
        [ ] 填 Contract：`stable / visible-ui / internal-unstable`
@@ -186,8 +201,16 @@ DONE
         [ ] `field-map.json`：只追加新代号。key = 字段代号，value = `{meaning, verified_at: YYYY-MM-DD, source}`；**已存在的 key 不要覆盖**，有冲突先和网页肉眼值对齐再写
         [ ] `notes.md`：顶部追加一段 `## YYYY-MM-DD by <agent/user>`，写本次写 adapter 时遇到的新坑 / 新结论
         [ ] `verify/<cmd>.json`：**必填。** `opencli browser verify` 的期望值（args / rowCount / columns / types / patterns / notEmpty），Step 10 已经让你生成了，这里只是 checklist
-        [ ] `fixtures/<cmd>-<YYYYMMDDHHMM>.json`：存一份该 endpoint 的完整响应样本（去掉 cookie / token / 用户私有字段再存），给后续字段对比 / 离线 replay 用
-        [ ] 调试过程中如果在 repo / adapter 目录 dump 过临时文件（`.dbg-*.html` / `raw-*.json` / 等），**在 commit 前清干净**——这些本来就该落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`
+        [ ] `fixtures/<cmd>-<YYYYMMDDHHMM>.json`：仅保存公开数据或可证明完成脱敏的样本；私人邮箱/消息/账号等高敏响应改用合成 fixture，不落盘
+        [ ] 原始 dump/capture 只短暂落 `/tmp/` 或受控 cache；安全分级后的长期样本才进 `fixtures/`，任务结束清理原始文件
+[ ] 13. repo 贡献收口（私人 adapter 可跳过）：
+        [ ] production-path tests，不只测 parser/helper
+        [ ] `npm run typecheck` + focused/site tests + `npm run build`
+        [ ] `node dist/src/main.js validate <site>`
+        [ ] `npm run check:typed-error-lint` + `npm run check:silent-column-drop`
+        [ ] adapter 文档；若 sitemap/site memory 有稳定新知识则同步
+        [ ] `git diff --check` + 敏感数据扫描 + 删除 raw capture/cache + 释放 browser session
+        [ ] 写操作或私有协议请独立 review exact head 后再合入
 ```
 
 ---
@@ -220,6 +243,7 @@ DONE
 | `references/coverage-matrix.md` | 动手前做"是否在范围内"自测 |
 | `references/site-recon.md` | Step 3 定站点类型 |
 | `references/api-discovery.md` | Step 4 找 endpoint |
+| `references/deep-recon.md` | 复杂无文档站：动作归因、jsluice 候选扩展、合同证明、读写安全与交付净账 |
 | `references/strategy-selection.md` | Step 6 填 strategy note 之前：契约模型 + 实测 fix 频率 + `api_candidates` 证据用法 + 反例 |
 | `references/field-conventions.md` | Step 7 查已知字段代号 |
 | `references/field-decode-playbook.md` | Step 7 字段不在词典时 |
@@ -242,7 +266,8 @@ DONE
 - 已知失败按 [`references/typed-errors.md`](./references/typed-errors.md) 5-classification 抛对应 typed error；**不要** silent `return []`，**不要** silent `return [{sentinel}]`，**不要** `Math.max/min` silent clamp 外部参数
 - 写私人 adapter 用 `~/.opencli/clis/<site>/<name>.js`（免 build）；要提 PR 才 copy 到 `clis/<site>/<name>.js`
 - 站点记忆每轮回写：没记忆 → 用 skill → 产生记忆 → 下次变 5 分钟
-- **调试过程中的原始 dump / 抓包 / HTML 样本只能落在 `~/.opencli/sites/<site>/fixtures/` 或 `/tmp/`。严禁在 repo 根目录、`clis/<site>/` 或当前工作目录留 `.dbg-*.html / raw-*.json / sample.*` 这类临时文件**（PR diff 会带上去，别人 review 时很烦）。
+- **“真实发生过”不等于“可作为 production contract 重放”**。私有写请求、一次性风控 token、页面 runtime controller 都必须过 `deep-recon.md` 的 contract gate；过不了就记录 blocker/lift condition，不生成伪 API 命令。
+- **调试过程中的原始 dump / 抓包 / HTML 样本只能短暂落在系统 `/tmp/` 或受控 cache，任务结束删除。只有通过 `site-memory.md` 数据分级、准备长期保留的公开/合成/已脱敏样本才进入 `~/.opencli/sites/<site>/fixtures/`。严禁在 repo 根目录、`clis/<site>/` 或当前工作目录留 `.dbg-*.html / raw-*.json / sample.*`。**
 - **JSDOM unit-test fixture（`clis/<site>/__fixtures__/<command>.html`）是上面那条的例外**——它是有意 commit 进 repo 的 review artifact，不是临时 dump。但因此 quality bar 要更高：必须按 `references/jsdom-fixture-pattern.md` 的 5 步做完（含 mandatory `awk 'NF>0'` 空白行收紧），并 reverse-validate 一道证明 regression guard 真能挂。
 
 ---

--- a/skills/opencli-adapter-author/references/api-discovery.md
+++ b/skills/opencli-adapter-author/references/api-discovery.md
@@ -2,7 +2,7 @@
 
 **Layer 2：这个站的目标数据 endpoint 是什么？** 已经分完类（`site-recon.md`）再进来。
 
-五种手段。按优先级降级用，命中即走。
+五种手段。按优先级降级用；命中只代表“进入验证”，不代表可以直接写 adapter。复杂/私有/写入候选还要过 [`deep-recon.md`](./deep-recon.md) 的 contract gate。
 
 ---
 
@@ -102,6 +102,8 @@ opencli browser network --detail <key>
 
 capture 会持久化到 `~/.opencli/cache/browser-network/<session>.json`（默认 TTL 24h），所以 `--detail` 即使跨多条其他命令也还在。
 
+这也意味着私有页面的 response 可能落在本地 cache。侦察结束要删除相关 session capture 并释放 browser session；不要依赖 24h TTL 代替清理。
+
 ### 关键 request headers
 
 `browser network` 当前只抓响应（body + status + ct），抓不到请求头。要看请求头就在 DevTools Network 面板里点这条 request，或用 `browser eval` 手动 `fetch(url)` 复现一次观察浏览器发出去的头：
@@ -183,6 +185,19 @@ opencli browser eval "(async()=>{const s=[...document.querySelectorAll('script[s
 
 命中 `baseURL:"https://api.foo.com"` 直接拿 host 拼 endpoint。
 
+### 用 jsluice 扩大候选面（可选）
+
+手工搜 `baseURL` 只适合小 bundle。站点脚本多、压缩重或 endpoint 通过 `fetch` / XHR / 字符串拼接生成时，可以把**已经加载的脚本文本**通过 stdin 交给本机可选的 [jsluice](https://github.com/BishopFox/jsluice) 做语法感知扫描。
+
+```bash
+# bundle 只短暂落 /tmp；扫描后删除
+jsluice urls < /tmp/example-bundle.js
+```
+
+边界：jsluice 输出是 candidate，不是 contract。`EXPR` 表示动态值未知；扫描无法证明 token、签名、CORS、权限、分页、字段语义或副作用。不要把命中 URL 直接写进 adapter，更不要把扫描到的疑似 secret 原值保存到 trace/site memory。
+
+每个候选至少记录：来源 bundle + 代码位置、method/path、触发它的可见动作、动态 network 是否发生、replay status/content-type/shape、选择或拒绝原因。复杂站直接转 [`deep-recon.md`](./deep-recon.md) 的 evidence ledger。
+
 ### 直接试候选 endpoint
 
 像 eastmoney 这种经验 endpoint 可以直接喂：
@@ -191,7 +206,7 @@ opencli browser eval "(async()=>{const s=[...document.querySelectorAll('script[s
 opencli browser eval "fetch('https://push2.eastmoney.com/api/qt/clist/get?fs=m:1+t:2&pn=1&pz=5&fltt=2&fid=f3&po=1&fields=f2,f3,f12,f14').then(r=>r.json())"
 ```
 
-200 且数据对得上就认。
+200 只是 transport 成功。至少换一个输入再试，并核 content-type、目标 identity、非空 shape、分页和可见页面值；写入或复杂私有协议转 `deep-recon.md`，不能“数据看起来像”就认。
 
 ### URL 后缀探测
 
@@ -214,7 +229,7 @@ opencli browser eval "fetch(location.pathname.replace(/\\/$/,'')+'.json').then(r
 ### Cookie 里
 
 ```bash
-opencli browser eval "document.cookie.split('; ').reduce((o,x)=>{const[k,v]=x.split('=');o[k]=v;return o},{})"
+opencli browser eval "document.cookie.split('; ').map(x=>x.slice(0,x.indexOf('='))).filter(Boolean)"
 ```
 
 常见 token cookie 名：`ct0`（Twitter CSRF）、`xq_a_token`（雪球）、`SESSDATA`（B 站）、`_csrf / csrfToken`（通用）。
@@ -226,49 +241,53 @@ opencli browser eval "document.cookie.split('; ').reduce((o,x)=>{const[k,v]=x.sp
 ### localStorage / sessionStorage 里
 
 ```bash
-opencli browser eval "Object.keys(localStorage).map(k=>k+' => '+localStorage.getItem(k).slice(0,50))"
+opencli browser eval "Object.keys(localStorage).filter(k=>/token|auth|jwt|bearer|csrf/i.test(k))"
 ```
 
-找 `token / auth / jwt / bearer` 关键字。
+先只列 key 名，找 `token / auth / jwt / bearer / csrf`。只有选定 production auth source 后才在页面内使用对应值；不要把值打印进聊天、trace、shell history 或 site memory。
 
 ### Bundle 硬编码
 
 有些站的 Bearer 是全站一个常量（Twitter 的匿名 Bearer）。在 bundle 里搜：
 
 ```bash
-opencli browser eval "(async()=>{const s=[...document.querySelectorAll('script[src]')].map(e=>e.src).find(s=>/main|app|bundle/.test(s));const t=await fetch(s).then(r=>r.text());const m=t.match(/Bearer\\s+[\\w-]{20,}/g);return m?.slice(0,3)||'not found'})()"
+opencli browser eval "(async()=>{const s=[...document.querySelectorAll('script[src]')].map(e=>e.src).find(s=>/main|app|bundle/.test(s));const t=await fetch(s).then(r=>r.text());const m=[...t.matchAll(/Bearer\\s+[\\w-]{20,}/g)];return {count:m.length,positions:m.slice(0,3).map(x=>x.index)}})()"
 ```
 
-### Store action 绕签名
+只返回数量/位置，不返回 token 原值。即使 bundle 中是公共匿名 Bearer，也先确认它是否是预期公开合同；不要复制未知 credential-shaped string。
 
-Vue + Pinia / Redux / React Context 有时直接调 store method 能绕过签名逻辑（method 内部会自己拿签名再发请求）：
+### 调用页面 runtime 让站点自己生成请求（只读、最后手段）
+
+Vue + Pinia / Redux / React Context 有时能调用页面自己的只读 store method，让站点 runtime 自己生成签名和请求：
 
 ```bash
 # Pinia
 opencli browser eval "typeof __pinia !== 'undefined' ? Object.keys(__pinia.state.value) : 'no pinia'"
 
-# 直接调 store action（每个站点具体 action 名要查）
+# 只调用已证明是 read-only 的 store action（每个站点具体 action 名要查）
 opencli browser eval "window.__pinia.state.value.someStore.someMethod({...})"
 ```
 
+这不是“绕签名”，也不是 direct API contract：它仍依赖页面 controller/runtime，production strategy 通常是 `INTERCEPT`。只有动作语义被可见 UI 和动态请求证明为 read-only 才能在侦察中调用。未知 effect 或 write action 禁止自动调用；写入只观察用户明确授权的一次自然操作，按 `deep-recon.md` 处理。
+
 ---
 
-## §5 installInterceptor（最后降级）
+## §5 让页面自然发请求并截获 response（最后降级）
 
-所有手段都试过还拿不到请求签名时，让页面自己发请求，adapter 做 MITM 拦截响应：
+所有手段都试过还拿不到请求签名时，让页面自己自然发请求，adapter 用现有 Browser Bridge capture/interceptor 读取响应。优先 CDP network capture；只有已存在站点实现依赖 XHR interceptor 时才复用它，不要再写页面内 fetch/XHR monkey patch。
 
 ```javascript
-// func 里
-await page.evaluateWithArgs(installInterceptorCode, {
-  config: { domain: 'api.xxx.com', path: '/foo' },
-});
+// func 里：capture 必须先于触发动作安装，并先 drain stale entries
+await page.startNetworkCapture('/api/foo');
+await page.readNetworkCapture();
 await page.goto('https://xxx.com/trigger-page');
-// 等页面自己发那条请求
-const intercepted = await page.evaluate('window.__opencli_intercepted');
-return intercepted.response;
+// 等页面自己发请求，再读取所有相关完整 response
+const entries = await page.readNetworkCapture();
 ```
 
-代价是要等页面真的触发请求，慢、不稳。只在 §1-4 都不行时用。
+capture queue 可能是破坏性 drain：过滤 relevant URL 后，只要看到 bodyless/truncated relevant entry 就拒绝 partial；多 response 要按业务 identity 合并，不能只取最后一个。分页、缓存和 no-partial 规则见 `deep-recon.md`。
+
+代价是要等页面真的触发请求，慢且依赖内部合同。只在 §1-4 都不行时用。
 
 ---
 

--- a/skills/opencli-adapter-author/references/deep-recon.md
+++ b/skills/opencli-adapter-author/references/deep-recon.md
@@ -1,0 +1,148 @@
+# Deep Recon: evidence-first discovery for undocumented sites
+
+Use this when a site has no documented API, the DOM is lossy, a command needs more than one page, writes are requested, or bundle/network/UI evidence conflicts. The goal is the smallest reproducible contract—not the largest endpoint inventory and not a demo that only works once.
+
+## 1. Freeze the command surface and mutation boundary
+
+Before browsing, make an intent matrix:
+
+| Command | User intent | Read/write | Completeness | Exact target | Allowed live action |
+|---|---|---|---|---|---|
+| `search` | find matching entities | read | exact limit or upstream exhaustion | query | safe replay after proof |
+| `send` | create external side effect | write | one confirmed mutation | recipient + content | only with explicit authorization |
+
+Group aliases that share one proven query primitive; do not create many commands by cloning scripts. A “rich” CLI is broad in verified user goals, not broad in unproven endpoints.
+
+Write the mutation boundary in one sentence. Passive observation and clearly read-only actions are normally safe. Any send/delete/publish/follow/payment action needs explicit authorization that names the target and permitted count. Authorization to observe one write is not authorization to replay it repeatedly.
+
+## 2. Build an evidence ledger, not a traffic dump
+
+Track one row per candidate:
+
+| Intent | Visible action | Source | Method/path | Effect | Auth/signing | Response shape | Replay result | Decision |
+|---|---|---|---|---|---|---|---|---|---|
+
+`Source` is one of `dynamic`, `state`, `bundle`, or `memory`. `Effect` is `read`, `write`, or `uncertain`; HTTP method does not decide it. `Decision` is `chosen`, `rejected`, or `blocked`, with the exact reason and lift condition.
+
+Never paste credentials or response bodies into the ledger. Store structural facts: status, content type, arity/paths, row counts, cursor behavior, and source location.
+
+## 3. Triangulate three evidence planes
+
+1. **Visible truth**: page rows, counts, URLs, identity, and semantic controls.
+2. **Dynamic truth**: DevTools requests caused by one controlled action.
+3. **Static candidates**: loaded bundles scanned manually or with syntax-aware tools such as jsluice.
+
+Dynamic evidence proves that a request occurred. Static scanning expands recall to lazy pagination, detail, search, and routes that this session did not trigger. Neither alone proves a production contract.
+
+jsluice is optional and stays outside adapter runtime. Feed it script text through stdin, keep source locations, and treat `EXPR` as unknown. Do not persist suspected secret values. A candidate becomes useful only after dynamic occurrence or a safe replay verifies its shape and semantics.
+
+## 4. Attribute requests with causal diffs
+
+For each intent:
+
+1. establish a network/state baseline;
+2. perform exactly one visible action;
+3. inspect only newly added requests/state;
+4. repeat with one changed input;
+5. run a negative control when ambiguity remains.
+
+The changed-input run should reveal which field controls query, filter, cursor, or target identity. If several requests arrive, do not select the largest response or last URL by guess—compare payload identity against visible results.
+
+For writes, the user performs or authorizes exactly one natural action. Capture before and after state, confirmation UI, and any request/response pair. Do not auto-replay the captured write during discovery or tests.
+
+## 5. Rank candidates before decoding
+
+Prefer a candidate that:
+
+- contains the user-visible target data or mutation identity;
+- works across two inputs without copying ephemeral values;
+- has a safe, explainable auth source;
+- paginates to the requested completeness;
+- returns typed, distinguishable auth/HTTP/upstream failures;
+- is cheaper to maintain than the strongest UI/DOM alternative.
+
+Penalize opaque signatures, rotating query IDs, positional writes, one-time tokens, page-only controllers, responses unrelated to the visible action, and candidates whose only evidence is a bundle string.
+
+## 6. Pass the contract gate
+
+A read contract must prove all of these:
+
+1. **Occurrence**: the page naturally sends it, or it is documented/public.
+2. **Reproducibility**: a safe replay works across two non-empty inputs; if replay is impossible, `INTERCEPT` preserves the page-owned request.
+3. **Identity**: returned rows match visible target identity, not adjacent recommendations/ads/sidebars.
+4. **Completeness**: pagination reaches exact limit or proven upstream exhaustion.
+5. **Auth boundary**: cookies/CSRF/origin/runtime requirements are explicit and do not leak secrets.
+6. **Failure semantics**: auth, HTTP, malformed/truncated body, repeated cursor/page, timeout, and partial data fail typed.
+
+A direct API-backed write contract additionally must prove:
+
+1. target identity is deterministically bound in the request;
+2. auth/CSRF/signing can be reproduced without fabricating or exfiltrating runtime secrets;
+3. idempotency or duplicate-risk semantics are known;
+4. pre-write failure is distinguishable from post-write uncertainty;
+5. success is verified independently of the edited control/request echo;
+6. retries are disabled after an uncertain write unless the user first checks state.
+
+“The browser sent it once” is not enough. A page-generated one-time anti-abuse token, an opaque positional write, or a controller method that clicks/dispatches UI means there is no direct URL/API contract yet. If the requested surface requires direct API and this gate fails, do not substitute UI automation: record the blocker and lift condition (for example, official OAuth scopes).
+
+## 7. Handle capture, pagination, and cache explicitly
+
+Browser capture queues may be destructive drains. Before relying on them:
+
+- install capture before the action and drain stale entries;
+- allow in-flight responses to settle;
+- treat bodyless or truncated relevant entries as possible data loss;
+- merge all relevant completed responses in the action window;
+- identify pages/cursors by content, not arrival order alone;
+- deduplicate by stable entity ID;
+- reject repeated pages/cursors and page-cap exhaustion rather than return accumulated partial rows.
+
+A cached page may render without a fresh request. A DOM fallback is valid only when it is strictly scoped to the target container, preserves the public columns, and can distinguish empty state from structure drift. Do not silently switch to a weaker page-wide selector.
+
+## 8. Choose strategy per command
+
+Use the repository strategy ladder after the contract gate. One site may legitimately mix strategies:
+
+- `PUBLIC_API` / `COOKIE_API` for reproducible contracts;
+- `PAGE_FETCH` for a verified same-origin read contract that must execute in page context;
+- `DOM_STATE` for stable hydration or cached state;
+- `INTERCEPT` when page-owned signing is unavoidable for reads;
+- `UI_SELECTOR` for user-visible writes only when that surface is allowed and safer;
+- no command when the requested contract cannot be proved.
+
+Preserve page-owned auth/signing rather than reimplementing adversarial logic. “API-first” means prefer a verified structured contract for completeness and maintainability; it does not mean force every command onto an internal endpoint.
+
+## 9. Decode and test against invariants
+
+For positional payloads, freeze only verified indexes, assert outer arity and required identifiers, and fail typed on drift. For object payloads, validate the minimum required keys and distinguish legitimate null from missing/malformed.
+
+Validation set:
+
+- two non-empty inputs plus one true empty result;
+- more than one page when pagination exists;
+- exact limit and upstream exhaustion;
+- cache/repeat behavior;
+- auth, HTTP, JSON/shape, truncated/bodyless capture, timeout, repeated cursor/page, and page cap;
+- every public column and target identity.
+
+Tests must exercise the production navigation/capture/fetch path, not only a parser helper. Use sanitized synthetic fixtures; high-sensitivity live responses never enter the repository. When fixing a silent bug, reverse-validate that the new regression test fails against the old implementation.
+
+## 10. Deliver a clean, reviewable artifact set
+
+Leave durable outputs at the right layer:
+
+- **adapter**: executable contract, shared helpers, typed errors;
+- **tests**: production-path behavior and structural invariants;
+- **docs**: command surface, limits, auth, uncertainty, examples;
+- **site memory/sitemap**: verified routes, triggers, fallbacks, rejected strategies, pitfalls, and verification date;
+- **recon conclusion**: evidence ledger without secrets or private bodies.
+
+Before PR:
+
+1. regenerate manifest and validate the site;
+2. run focused/site tests, typecheck, build, docs coverage, typed-error and silent-column gates;
+3. scan the diff for live addresses, account IDs, tokens, message IDs, bodies, attachments, raw captures, and temporary dumps;
+4. delete raw capture/cache artifacts and release browser sessions;
+5. obtain independent exact-head review for writes, auth/signing, positional schemas, or no-partial pagination.
+
+Record rejected approaches with a concrete lift condition. A well-proven “no safe command yet” is a successful Deep Recon outcome; it prevents the next author from repeating unsafe dead ends.

--- a/skills/opencli-adapter-author/references/site-memory.md
+++ b/skills/opencli-adapter-author/references/site-memory.md
@@ -9,7 +9,7 @@
 ```
 skills/opencli-adapter-author/references/site-memory/<site>.md
     — 公共种子。手写 + PR 审核进入。多 agent 共享的第一批起点。
-    — 已铺：eastmoney / xueqiu / bilibili / tonghuashun
+    — 已铺：eastmoney / xueqiu / bilibili / tonghuashun / gmail
 
 ~/.opencli/sites/<site>/
     — 本地累积。agent 跑 adapter 过程里自动写入，跨 session 复用。
@@ -63,14 +63,14 @@ agent 每跑一次相关 adapter 就可以自动写/读：
   field-map.json         — 字段代号 → 含义（key 为字段代号，value 为 {meaning, verified_at, source}）
   verify/                — `opencli browser verify` 期望值（值级校验锚点，每个 adapter 一份）
     <cmd>.json
-  fixtures/              — 完整响应样本（给字段对比 / 离线 replay；**调试时的原始 dump 也只能落在这里或 /tmp/**）
+  fixtures/              — 公开/合成/已完成脱敏的响应样本（给字段对比 / 离线 replay；高敏私人响应不落盘）
     <cmd>-<ts>.json
   last-probe.log         — 最近一次侦察输出（下次接着用）
 ```
 
 `verify/` vs `fixtures/` 别混：
 - `verify/<cmd>.json` 是**结构期望**（rowCount / columns / types / patterns / notEmpty），每 adapter 一份、会被 verify 读。
-- `fixtures/<cmd>-<ts>.json` 是**原始响应样本**，给人 / 下一个 agent 做字段比对用，verify 不会读。
+- `fixtures/<cmd>-<ts>.json` 是**可安全持久化的响应样本**，给人 / 下一个 agent 做字段比对用，verify 不会读；高敏私人响应只用合成 fixture。
 
 ### `endpoints.json` 格式（schema 锁死）
 
@@ -182,12 +182,18 @@ key = 字段代号（`f237` / `f152`），value 三件套：
 
 ### `fixtures/<cmd>-<YYYYMMDDHHMM>.json` 格式
 
-一份该 endpoint 的**完整**响应样本。用途：
+一份该 endpoint 的**可安全持久化**响应样本。优先级：合成 fixture > 公开响应 > 可证明完成脱敏的真实响应。用途：
 
 - 未来字段代号再变时，拿样本和 `field-map.json` 做 regression 对比
 - 站点换版时，新响应和旧 fixture 做 diff 看哪个字段结构变了
 
-**存之前脱敏**：去掉 cookie / token / 登录态相关 header、去掉用户自己的 uid / 用户名 / 手机号 / 邮箱。
+**存之前做数据分级**：
+
+- 公开列表/行情等无账户私有内容：可保存，仍需移除 cookie/token/header。
+- 低敏账号数据：只有完成字段级脱敏且不会从正文、snippet、URL、附件名反推个人时才保存。
+- 邮箱、私信、通讯录、支付、健康、草稿、上传文件等高敏内容：不要保存真实 response，即使“删了邮箱地址”也不够；用保持 shape/arity 的合成 fixture。
+
+原始 capture 只在 `/tmp/` 或受控本地 cache 中短暂存在，任务结束删除；不要把 raw private response 当成“完整 fixture”长期积累。
 
 ---
 
@@ -207,7 +213,7 @@ Step 11 肉眼对比通过后 → 写 ~/.opencli/sites/<site>/
                         - endpoints.json：按 schema 追加或更新 verified_at
                         - field-map.json：只追加新 key，已有的不默默覆盖
                         - notes.md：顶部追加一段
-                        - fixtures/：脱敏后存一份完整响应样本（区别于 verify/）
+                        - fixtures/：按数据分级保存公开/合成/已脱敏样本（区别于 verify/）
 ```
 
 **回写是 commit，不是 stash**：不过 Step 10 verify + Step 11 肉眼对比不写，防止把错的映射喂给下一轮。
@@ -217,12 +223,12 @@ Step 11 肉眼对比通过后 → 写 ~/.opencli/sites/<site>/
 ## 不要写进 `~/.opencli/sites/` 的东西
 
 - 真实账户 cookie / token — 不要保存任何鉴权凭据
-- 用户私有数据（返回体里有个人敏感字段的 → 脱敏再存 fixtures）
+- 用户私有数据：高敏内容一律不存；低敏内容只有完成字段级脱敏才可存
 - 过期超过 30 天的 last-probe.log（自动清）
 
 ## 不要写进 **repo / adapter 目录** 的东西
 
-调试过程里的临时 dump（`.dbg-*.html` / `raw-*.json` / `sample-*` / `trace-*.txt`）**只能**落在 `~/.opencli/sites/<site>/fixtures/` 或系统 `/tmp/`。PR diff 会把 repo 根目录和 `clis/<site>/` 下的文件一起带走——别人 review 时看到一堆调试副产物会很烦。
+调试过程里的临时 dump（`.dbg-*.html` / `raw-*.json` / `sample-*` / `trace-*.txt`）**只能**落在系统 `/tmp/`；只有通过上面数据分级、准备长期保留的安全样本才进入 `~/.opencli/sites/<site>/fixtures/`。PR diff 会把 repo 根目录和 `clis/<site>/` 下的文件一起带走；任务结束还要删除原始 capture/cache。
 
 ---
 

--- a/skills/opencli-adapter-author/references/site-memory/gmail.md
+++ b/skills/opencli-adapter-author/references/site-memory/gmail.md
@@ -1,0 +1,40 @@
+# gmail
+
+## Domain and auth
+
+- Desktop UI: `mail.google.com/mail/u/<account>/`.
+- Requires Google session cookies and a signed-in Gmail surface.
+- The official Gmail API requires separate OAuth; browser cookies are not an official API credential.
+
+## Verified read paths
+
+- `POST /sync/u/<account>/i/bv`: natural search/list response. Positional array, arity 19. Labels may appear at `[1]`, threads at `[2]`, counts at `[6]`.
+- `POST /sync/u/<account>/i/fd`: natural thread/message detail response. Cached threads may render without a fresh request.
+- `POST /sync/u/<account>/i/s`: incremental synchronization; not needed by the initial adapter.
+- Legacy `POST /mail/u/<account>/?ui=2` still appears during bootstrap. Do not assume a single transport variant.
+
+## Positional fields verified in 2026-08
+
+- Thread: subject `[0]`, snippet `[1]`, timestamp `[2]`, sync id `[3]`, summaries `[4]`.
+- Summary: sender card `[1]`, label ids `[10]`.
+- FD thread: id `[0]`, message wrappers `[2]`; wrapper is `[messageId, record]`.
+- Message: to `[0]`, cc `[1]`, subject `[4]`, body `[5]`, snippet `[6]`, sender `[10]`, attachments `[13]`, date `[16]`, legacy id `[34]`.
+- Sender: display name `[14]`, address `[16]`.
+- Attachment node: id `[1]`, data `[3]`; data contains name `[2]`, MIME `[3]`, size `[4]`.
+
+## Strategy
+
+- Reads: `INTERCEPT`. Let Gmail submit the visible search/open action, then parse the natural `bv/fd` response. Never reconstruct private XSRF/BTAI request bodies.
+- Cached thread fallback: rendered message containers (`data-message-id`, `.a3s`, scoped attachment cards).
+- Writes: no supported browser-session API contract is currently available. Gmail's private `/sync` operations require page-runtime state, and the official Gmail API requires separate OAuth credentials and scopes.
+
+## Durable pitfalls
+
+1. Synthetic `.value` + synthetic key events do not reliably submit Gmail search. Use native insertion and raw CDP Enter; verify the exact field value before submission.
+2. `thread-f:<decimal>` converts to legacy hex with `BigInt(decimal).toString(16)`; never use Number.
+3. `bv` search responses may omit label definitions. The complete visible fallback is `#settings/labels`.
+4. A new `/fd` response is not guaranteed for cached messages. Treat rendered content as a legitimate visible-ui fallback.
+5. Responses are anti-XSSI-prefixed positional arrays. Enforce arity/required-field guards and fail typed on drift.
+6. Network capture is a destructive drain; a relevant bodyless/truncated entry means possible data loss, not an empty/short page.
+7. Never store live subjects, addresses, message bodies, attachment names, cookies, or account-specific ids in fixtures/site memory.
+8. Do not replay legacy `?ui=2` write actions or fabricate `/sync` write payloads. Current send commits include a page-generated WAA anti-abuse token; supported API-backed writes require Google OAuth.

--- a/skills/opencli-adapter-author/references/strategy-selection.md
+++ b/skills/opencli-adapter-author/references/strategy-selection.md
@@ -143,6 +143,7 @@ Why the maintenance cost is acceptable: <因为业务需求要 raw timeline curs
 | 文件 | 关系 |
 |---|---|
 | [`api-discovery.md`](./api-discovery.md) | §1-5 是 endpoint 发现的具体方法。本文件指它，但本文件管"用 endpoint 证据填 strategy note"，那边管"怎么先找到 endpoint" |
+| [`deep-recon.md`](./deep-recon.md) | 无文档私有协议、写入、分页/缓存或证据冲突时，先做动作归因和 contract gate；只有通过后才进入本文件选 strategy |
 | [`site-recon.md`](./site-recon.md) | Pattern A-E 是 site classification。Pattern A 命中 ≠ `PAGE_FETCH` 必然合适 — 还要看 `api_candidates` 是不是 `likely_data` |
 | [`coverage-matrix.md`](./coverage-matrix.md) | 鉴权列已对齐 6 档 strategy enum |
 | [`adapter-template.md`](./adapter-template.md) | 写代码模板。strategy note 应该在打开 template 之前已经定好 |


### PR DESCRIPTION
## Summary

- add an evidence-first Deep Recon workflow for undocumented/private sites, lossy DOMs, pagination/cache ambiguity, and write commands
- integrate optional `jsluice urls` bundle scanning as candidate expansion only; every hit enters a causal evidence ledger and contract gate before strategy selection
- require intent/mutation boundaries, baseline → single-action → changed-input attribution, read completeness/no-partial proof, and stricter direct-API write guarantees
- replace unsafe discovery defaults: endpoint hit no longer means "use it", cookie/storage/bundle probes no longer print credential values, page runtime actions are not described as "signature bypass", and native Browser Bridge capture is preferred over new fetch/XHR monkey patches
- harden fixture/privacy guidance: high-sensitivity mail/message/payment/health data uses synthetic fixtures; raw captures live temporarily in `/tmp`/cache and are deleted with browser leases
- add repository contribution closure gates and verified Gmail site memory from the workflow's first real application

## Why

The Gmail adapter exercise showed three gaps in the old author flow:

1. syntax-aware bundle scanning is useful for recall, but cannot prove dynamic positional schemas, auth/signing, pagination, or side effects;
2. a request naturally occurring once does not make it a reproducible production contract—especially for private writes and one-time anti-abuse tokens;
3. destructive capture drains, cached views, multiple responses, and private response artifacts need explicit no-partial and cleanup rules.

The new workflow treats a proven "no safe command yet" plus a concrete lift condition as a valid outcome instead of encouraging a plausible-but-fake API implementation.

## Checks

- `git diff --check`
- all new/changed relative Markdown links resolve locally
- diff contains skill/reference documentation only
- no live response bodies, account identifiers, tokens, or raw captures
