### PR TITLE
feat(instagram): expose public contact fields on profile

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -18980,7 +18980,10 @@
       "following",
       "posts",
       "verified",
-      "bio"
+      "bio",
+      "email",
+      "phone",
+      "website"
     ],
     "type": "js",
     "modulePath": "instagram/profile.js",

--- a/clis/instagram/instagram.test.js
+++ b/clis/instagram/instagram.test.js
@@ -535,6 +535,9 @@ describe('instagram business-account endpoint fallback', () => {
             following: 510,
             posts: 1493,
             verified: 'Yes',
+            email: '',
+            phone: '',
+            website: '',
         }]);
         expect(fetchFn.mock.calls[2][0]).toContain('/api/v1/users/4213518589/info/');
     });
@@ -563,6 +566,69 @@ describe('instagram business-account endpoint fallback', () => {
 
         expect(result[0]).toMatchObject({ username: 'personal', followers: 10, following: 20, posts: 30 });
         expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('profile reads the public contact fields from both endpoints', async () => {
+        const gatedFetch = vi.fn()
+            .mockResolvedValueOnce(gatedResponse)
+            .mockResolvedValueOnce(feedResponse)
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({
+                    user: {
+                        username: 'bizaccount',
+                        full_name: 'Biz Account',
+                        biography: '',
+                        follower_count: 1,
+                        following_count: 2,
+                        media_count: 3,
+                        is_verified: false,
+                        public_email: 'hello@biz.example',
+                        contact_phone_number: '+390000000000',
+                        external_url: 'https://biz.example',
+                    },
+                }),
+            });
+
+        const gated = await runCommandEvaluate('profile', gatedFetch, {
+            '${{ args.username | json }}': JSON.stringify('bizaccount'),
+        });
+
+        expect(gated[0]).toMatchObject({
+            email: 'hello@biz.example',
+            phone: '+390000000000',
+            website: 'https://biz.example',
+        });
+
+        const webFetch = vi.fn().mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({
+                data: {
+                    user: {
+                        username: 'personal',
+                        full_name: 'Personal User',
+                        biography: '',
+                        edge_followed_by: { count: 10 },
+                        edge_follow: { count: 20 },
+                        edge_owner_to_timeline_media: { count: 30 },
+                        is_verified: false,
+                        business_email: 'shop@personal.example',
+                        business_phone_number: '+391111111111',
+                        external_url: 'https://personal.example',
+                    },
+                },
+            }),
+        });
+
+        const web = await runCommandEvaluate('profile', webFetch, {
+            '${{ args.username | json }}': JSON.stringify('personal'),
+        });
+
+        expect(web[0]).toMatchObject({
+            email: 'shop@personal.example',
+            phone: '+391111111111',
+            website: 'https://personal.example',
+        });
     });
 
     it('following paginates after resolving the id through the fallback', async () => {

--- a/clis/instagram/profile.js
+++ b/clis/instagram/profile.js
@@ -8,7 +8,7 @@ cli({
     args: [
         { name: 'username', required: true, positional: true, help: 'Instagram username' },
     ],
-    columns: ['username', 'name', 'followers', 'following', 'posts', 'verified', 'bio'],
+    columns: ['username', 'name', 'followers', 'following', 'posts', 'verified', 'bio', 'email', 'phone', 'website'],
     pipeline: [
         { navigate: 'https://www.instagram.com' },
         { evaluate: `(async () => {
@@ -33,6 +33,12 @@ cli({
     }
     throw new Error(label + ' failed: HTTP ' + response.status);
   }
+  function firstText(...values) {
+    for (const value of values) {
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+    return '';
+  }
   function mapProfileUser(u, countFields) {
     if (!u || typeof u !== 'object' || typeof u.username !== 'string' || !u.username.trim()) {
       throw new Error('Instagram profile returned malformed user payload for: ' + username);
@@ -45,6 +51,9 @@ cli({
       following: countFields.following(u),
       posts: countFields.posts(u),
       verified: u.is_verified ? 'Yes' : 'No',
+      email: countFields.email(u),
+      phone: countFields.phone(u),
+      website: firstText(u.external_url),
     };
   }
   const r1 = await fetch(
@@ -60,6 +69,8 @@ cli({
       followers: (user) => user.edge_followed_by?.count ?? 0,
       following: (user) => user.edge_follow?.count ?? 0,
       posts: (user) => user.edge_owner_to_timeline_media?.count ?? 0,
+      email: (user) => firstText(user.business_email),
+      phone: (user) => firstText(user.business_phone_number),
     })];
   }
   // web_profile_info answers HTTP 400 for business/professional accounts.
@@ -78,6 +89,8 @@ cli({
     followers: (user) => user.follower_count ?? 0,
     following: (user) => user.following_count ?? 0,
     posts: (user) => user.media_count ?? 0,
+    email: (user) => firstText(user.public_email),
+    phone: (user) => firstText(user.contact_phone_number),
   })];
 })()
 ` },


### PR DESCRIPTION
## What

`instagram profile` now returns the account's public **email**, **phone** and **website**.

## Why

Business and creator accounts publish those three fields on their profile, and both endpoints the command already calls carry them:

| endpoint | email | phone | website |
|---|---|---|---|
| `users/web_profile_info` | `business_email` | `business_phone_number` | `external_url` |
| `users/<id>/info` | `public_email` | `contact_phone_number` | `external_url` |

They were simply dropped while mapping the payload, so reading a club's or a shop's published contact meant opening the page in a browser — which is what the CLI exists to avoid.

## How

Three new columns, mapped per endpoint through the existing `countFields` indirection, so the gated business path and the plain web path stay symmetric. Accounts that publish nothing return empty strings, and the column set is unchanged for them.

Verified against a live business account:

```
$ opencli instagram profile <club> -f yaml
  email: <address>@gmail.com
  phone: '<number>'
  website: http://facebook.com/<club>
```

## Checks

- `npx vitest run clis/instagram/instagram.test.js` — 30 passed (2 new assertions covering both endpoints)
- `npm test` — 624 files, 7243 passed
- `npx tsc --noEmit` — clean
- `npx opencli validate` — 0 errors (8 pre-existing warnings, none on `instagram/profile`)
