### PR TITLE
feat(clarity): add Microsoft Clarity project settings adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -7319,6 +7319,103 @@
     "sourceFile": "chess/stats.js"
   },
   {
+    "site": "clarity",
+    "name": "audit",
+    "description": "Check Google Analytics / Google Tag Manager (and Ads) integration status across every Clarity project, and flag the ones that still need setting up. Read-only.",
+    "access": "read",
+    "example": "opencli clarity audit -f table",
+    "domain": "clarity.microsoft.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project-ids",
+        "type": "string",
+        "required": false,
+        "help": "Comma-separated project ids to check. Omit to auto-discover every project on the account."
+      },
+      {
+        "name": "required",
+        "type": "string",
+        "default": "Google Analytics,Google Tag Manager",
+        "required": false,
+        "help": "Comma-separated integrations that must be Connected. Default: Google Analytics,Google Tag Manager"
+      },
+      {
+        "name": "only-issues",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Return only projects whose verdict is not ok."
+      }
+    ],
+    "columns": [
+      "ProjectId",
+      "Name",
+      "GoogleAnalytics",
+      "GoogleTagManager",
+      "GoogleAds",
+      "MicrosoftAds",
+      "Verdict"
+    ],
+    "type": "js",
+    "modulePath": "clarity/audit.js",
+    "sourceFile": "clarity/audit.js",
+    "navigateBefore": false,
+    "siteSession": "ephemeral"
+  },
+  {
+    "site": "clarity",
+    "name": "integrations",
+    "description": "Read Microsoft Clarity Setup-tab integration status (GTM, Google Analytics, Google Ads, Microsoft Ads) for one project. Read-only; never connects or disconnects anything.",
+    "access": "read",
+    "example": "opencli clarity integrations a1b2c3d4e5 -f json",
+    "domain": "clarity.microsoft.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "project-id",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Clarity project id, e.g. a1b2c3d4e5 (from the /projects/view/<id>/ URL)."
+      }
+    ],
+    "columns": [
+      "Project",
+      "Integration",
+      "Status",
+      "Detail"
+    ],
+    "type": "js",
+    "modulePath": "clarity/integrations.js",
+    "sourceFile": "clarity/integrations.js",
+    "navigateBefore": false,
+    "siteSession": "ephemeral"
+  },
+  {
+    "site": "clarity",
+    "name": "projects",
+    "description": "List every Microsoft Clarity project this account can see, with its project id — the id `clarity integrations` and `clarity audit` take.",
+    "access": "read",
+    "example": "opencli clarity projects -f json",
+    "domain": "clarity.microsoft.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "ProjectId",
+      "Name",
+      "Site"
+    ],
+    "type": "js",
+    "modulePath": "clarity/projects.js",
+    "sourceFile": "clarity/projects.js",
+    "navigateBefore": false,
+    "siteSession": "ephemeral"
+  },
+  {
     "site": "claude",
     "name": "ask",
     "description": "Send a prompt to Claude and get the response",

--- a/clis/clarity/_ui.js
+++ b/clis/clarity/_ui.js
@@ -1,0 +1,325 @@
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+export const CLARITY_ORIGIN = 'https://clarity.microsoft.com';
+
+/**
+ * Microsoft Clarity has no public API for project settings — the official
+ * Data Export API and MCP server cover dashboard metrics only. The internal
+ * GraphQL endpoint (POST /api/v2) rejects hand-built requests with a flat
+ * `400 Bad Request` even for a valid named operation carrying the page's own
+ * X-CSRF-Token, so these commands read the rendered Settings surface instead.
+ */
+
+const PROJECT_ID_PATTERN = /^[a-z0-9]{6,20}$/i;
+
+export function normalizeProjectId(value, { required = true } = {}) {
+  if (value === undefined || value === null || value === '') {
+    if (required) throw new TypeError('project-id is required.');
+    return undefined;
+  }
+  const id = String(value).trim();
+  if (!PROJECT_ID_PATTERN.test(id)) {
+    throw new TypeError(`project-id must be a Clarity project id (alphanumeric), got: ${id}`);
+  }
+  return id;
+}
+
+function ensureObject(value, label) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  throw new CommandExecutionError(`${label} returned an unexpected payload shape from the Browser Bridge.`);
+}
+
+/**
+ * Navigate to a Clarity settings sub-tab and fail loudly when the profile is
+ * signed out. The `cb` cache-buster forces a real document load: Clarity is a
+ * hash-routed SPA, so navigating to a URL that differs only by `#fragment`
+ * changes nothing and would silently return the previous project's page.
+ */
+export async function gotoClaritySettings(page, projectId, hash, label) {
+  if (!page || typeof page.goto !== 'function' || typeof page.evaluate !== 'function') {
+    throw new CommandExecutionError(`${label} requires an OpenCLI Browser Bridge page with navigation and visible-DOM access.`);
+  }
+  const cb = `cb${projectId}`;
+  await page.goto(`${CLARITY_ORIGIN}/projects/view/${projectId}/settings?${cb}=1#${hash}`, { waitUntil: 'domcontentloaded' });
+
+  // Wait inside the page, not around it. `page.wait` is not available on every
+  // bridge page object, and when it is missing an out-of-page poll spins
+  // through every attempt in milliseconds and reads an unpainted document —
+  // which surfaces as "0 integration cards" rather than as "too early".
+  // Anchor on the block that renders *after* the integration cards. A card
+  // title is the wrong anchor twice over: a loose ' integration' matches a
+  // half-painted panel (which produced confident WRONG statuses), and a
+  // specific card title is not universal — many projects are never offered the
+  // Google Tag Manager card at all, so waiting for it always burns the budget.
+  const marker = hash === 'setup' ? 'Advanced settings' : '';
+  const state = ensureObject(await page.evaluate(`(async () => {
+    const marker = ${JSON.stringify(marker)};
+    const deadline = Date.now() + 20000;
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    let text = '';
+    while (Date.now() < deadline) {
+      text = document.body ? (document.body.innerText || '') : '';
+      if (marker === '' ? text.trim().length > 0 : text.includes(marker)) break;
+      if (/sign in|log in|welcome to clarity/i.test(document.title + ' ' + text)) break;
+      await sleep(750);
+    }
+    return {
+      title: document.title || '',
+      href: location.href,
+      text: text.replace(/\\s+/g, ' ').trim().slice(0, 600),
+      waitedMs: 20000 - Math.max(0, deadline - Date.now()),
+      textContentLen: document.body ? String(document.body.textContent || '').length : -1,
+    };
+  })()`), label);
+
+  if (!state.text) {
+    throw new CommandExecutionError(
+      `${label}: page at ${state.href} rendered no text after ${state.waitedMs}ms (title="${state.title}", ` +
+      `page.wait=${typeof page.wait}, page.goto=${typeof page.goto}, textContentLen=${state.textContentLen}).`,
+    );
+  }
+  if (/sign in|log in|welcome to clarity/i.test(`${state.title} ${state.text}`)) {
+    throw new CommandExecutionError(
+      'Clarity is not signed in in the selected Browser Bridge profile. Sign in at https://clarity.microsoft.com in that Chrome profile, then retry.',
+    );
+  }
+  // Clarity sends projects that have never received data to an onboarding
+  // route. That is a real, actionable state — "not installed yet" — and must
+  // not be reported as an unreadable page, nor as "no integrations".
+  if (/\/gettingstarted|\/getting-started/i.test(state.href)) {
+    throw new CommandExecutionError(
+      `NOT_INSTALLED: Clarity redirected project ${projectId} to its Getting Started page (${state.href}) — ` +
+      'the tracking code has never sent data, so the Setup tab has no integration cards yet.',
+    );
+  }
+  if (!/\/settings/i.test(state.href)) {
+    throw new CommandExecutionError(
+      `${label}: expected the settings route for ${projectId} but landed on ${state.href}.`,
+    );
+  }
+  if (!state.href.includes(`/projects/view/${projectId}/`)) {
+    throw new CommandExecutionError(
+      `Clarity redirected away from project ${projectId} (landed on ${state.href}). The project id may be wrong, or this account may not have access to it.`,
+    );
+  }
+  return state;
+}
+
+/**
+ * Read the integration cards off the Setup tab.
+ *
+ * Parsed from the panel's rendered line order rather than the DOM tree: the
+ * status pill is always the line directly above "<Name> integration", while
+ * the card's own element does not reliably contain its pill — walking up from
+ * the title lands on a container holding several cards, which reads as
+ * ambiguous and loses the status for exactly the connected ones.
+ */
+export async function readIntegrationCards(page) {
+  const payload = await page.evaluate(`(async () => {
+    const PILL = /^(Connected|Not Connected)$/i;
+    const TITLE = /^(.+?)\\s+integration$/i;
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+    const valueAfter = (body, label) => {
+      // Clarity renders "Account:Foo" inline but "Connected to:" on its own line.
+      for (let i = 0; i < body.length; i += 1) {
+        const line = body[i];
+        if (!line.toLowerCase().startsWith(label.toLowerCase())) continue;
+        const inline = line.slice(label.length).trim();
+        if (inline) return inline;
+        return (body[i + 1] || '').trim();
+      }
+      return '';
+    };
+
+    const parse = () => {
+      const lines = String(document.body ? document.body.innerText || '' : '')
+        .split('\\n').map((l) => l.trim()).filter((l) => l.length > 0);
+      const titleAt = [];
+      lines.forEach((line, i) => { const m = line.match(TITLE); if (m) titleAt.push({ i, name: m[1].trim() }); });
+
+      const cards = [];
+      for (let t = 0; t < titleAt.length; t += 1) {
+        const { i, name } = titleAt[t];
+        const prev = lines[i - 1] || '';
+        const status = PILL.test(prev) ? prev : 'Unknown';
+        const nextTitle = titleAt[t + 1];
+        const end = nextTitle ? Math.max(i + 1, nextTitle.i - 1) : lines.length;
+        const body = lines.slice(i + 1, end);
+        cards.push({
+          name,
+          status,
+          account: valueAfter(body, 'Account:'),
+          container: valueAfter(body, 'Container:'),
+          connectedTo: valueAfter(body, 'Connected to:'),
+        });
+      }
+      return { cards, lines, complete: lines.includes('Advanced settings') };
+    };
+
+    // Settle on the card count. The cards paint progressively and the
+    // "Advanced settings" block can appear BEFORE the last card lands — so
+    // end-marker-plus-one-card wrongly reported two present integrations as
+    // "not offered". Require the count to hold steady before trusting it.
+    let snap = parse();
+    let prev = -1;
+    let stable = 0;
+    const deadline = Date.now() + 25000;
+    while (Date.now() < deadline) {
+      snap = parse();
+      if (snap.complete && snap.cards.length > 0 && snap.cards.length === prev) {
+        stable += 1;
+        if (stable >= 2) break;
+      } else {
+        stable = 0;
+      }
+      prev = snap.cards.length;
+      await sleep(1200);
+    }
+
+    return {
+      cards: snap.cards,
+      complete: snap.complete,
+      settled: stable >= 2,
+      href: location.href,
+      lineCount: snap.lines.length,
+      sample: snap.lines.slice(0, 26).join(' | ').slice(0, 400),
+    };
+  })()`);
+
+  const obj = ensureObject(payload, 'Clarity integrations');
+  if (!Array.isArray(obj.cards)) {
+    throw new CommandExecutionError('Clarity integrations returned no card array from the Browser Bridge.');
+  }
+  // Refuse anything that did not settle. A partial panel does not degrade to
+  // "unknown" on its own — it silently turns present integrations into absent
+  // ones, which is a confident wrong answer.
+  if (obj.cards.length === 0 || !obj.complete || !obj.settled) {
+    throw new CommandExecutionError(
+      `Clarity Setup panel did not settle at ${obj.href} — ` +
+      `${obj.cards.length} card(s), ${obj.lineCount} lines, end-marker ${obj.complete ? 'present' : 'absent'}, ` +
+      `settled=${obj.settled}. First lines: ${obj.sample}`,
+    );
+  }
+  return obj.cards;
+}
+
+/**
+ * Enumerate every project on the account from the /projects grid.
+ *
+ * The grid is heavy enough to blow OpenCLI's hardcoded 120s per-action ceiling
+ * on a `load` wait, so commit early and poll the DOM until cards appear.
+ */
+export async function discoverProjects(page) {
+  await page.goto(`${CLARITY_ORIGIN}/projects`, { waitUntil: 'commit' });
+
+  let last = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    // Wait inside the page — see gotoClaritySettings for why an out-of-page
+    // poll is unreliable here. The grid also carries no <a href> per card, so
+    // ids have to come from React's own props when the markup has none.
+    const payload = await page.evaluate(`(async () => {
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      const deadline = Date.now() + 30000;
+      let lines = [];
+      while (Date.now() < deadline) {
+        lines = String(document.body ? document.body.innerText || '' : '')
+          .split('\\n').map((l) => l.trim()).filter(Boolean);
+        if (lines.length > 12) break;
+        await sleep(1000);
+      }
+
+      const SITE = /^(?:https?:\\/\\/)?(?:www\\.)?[a-z0-9-]+(?:\\.[a-z0-9-]+)+(?:\\/\\S*)?$/i;
+      const readLines = () => String(document.body ? document.body.innerText || '' : '')
+        .split('\\n').map((l) => l.trim()).filter(Boolean);
+
+      const ids = new Set();
+      const harvest = () => {
+        const html = document.documentElement.outerHTML;
+        for (const m of html.matchAll(/projects\\/view\\/([a-z0-9]{6,20})/gi)) ids.add(m[1]);
+        // Bounded fiber scan: the grid has no per-card href, and an unbounded
+        // querySelectorAll('*') walk over it freezes the renderer.
+        const nodes = [...document.querySelectorAll('[class*=card i],[class*=project i],li,article')].slice(0, 800);
+        for (const el of nodes) {
+          for (const k of Object.keys(el)) {
+            if (k.charCodeAt(0) !== 95 || !k.startsWith('__react')) continue;
+            let j = '';
+            try { j = JSON.stringify(el[k]); } catch (e) { j = ''; }
+            for (const m of String(j).matchAll(/"(?:id|projectId|pid)":"([a-z0-9]{8,14})"/gi)) ids.add(m[1]);
+          }
+        }
+        return html.length;
+      };
+
+      // Settle before reporting. A grid still mounting yields a partial id set,
+      // and a partial set is worse than none: the caller cannot tell 3-of-20
+      // from 3-in-total, and reports the short list as the whole account.
+      let htmlLen = 0, prev = -1, stable = 0;
+      const settleBy = Date.now() + 60000;
+      while (Date.now() < settleBy) {
+        lines = readLines();
+        htmlLen = harvest();
+        const cardLines = lines.filter((l) => SITE.test(l)).length;
+        if (ids.size > 0 && ids.size === prev && ids.size >= cardLines) {
+          stable += 1;
+          if (stable >= 2) break;
+        } else {
+          stable = 0;
+        }
+        prev = ids.size;
+        await sleep(1500);
+      }
+
+      return {
+        ids: [...ids],
+        cardLines: lines.filter((l) => SITE.test(l)).length,
+        lines: lines.slice(0, 400),
+        href: location.href,
+        title: document.title || '',
+        htmlLen,
+      };
+    })()`);
+    last = payload;
+
+    // A short list must never be returned as the whole account. If fewer ids
+    // than rendered cards came back, treat the sample as incomplete and retry.
+    if (payload && Array.isArray(payload.ids) && payload.ids.length > 0
+        && payload.ids.length >= (payload.cardLines || 0)) {
+      // The grid renders each card as "<Name>" then "<site url>" on the next
+      // line. Pair them in order; fall back to id-only when the text is short.
+      const SITE = /^(?:https?:\/\/)?(?:www\.)?[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:\/\S*)?$/i;
+      const pairs = [];
+      const lines = payload.lines || [];
+      for (let i = 0; i < lines.length - 1; i += 1) {
+        if (SITE.test(lines[i + 1]) && !SITE.test(lines[i])) pairs.push({ name: lines[i], site: lines[i + 1] });
+      }
+      return payload.ids.map((id, index) => ({
+        ProjectId: id,
+        Name: pairs[index] ? pairs[index].name : '',
+        Site: pairs[index] ? pairs[index].site : '',
+      }));
+    }
+  }
+
+  throw new CommandExecutionError(
+    'Could not read any project id from the Clarity projects grid. ' +
+    `Landed on ${last && last.href} (title="${last && last.title}", html=${last && last.htmlLen}B, ` +
+    `${last && last.lines ? last.lines.length : 0} lines). First lines: ${last && last.lines ? last.lines.slice(0, 20).join(' | ').slice(0, 300) : ''}. ` +
+    'Pass ids explicitly instead: opencli clarity audit --project-ids <a,b,c>',
+  );
+}
+
+/**
+ * Absent is not "not connected". A card the page never rendered is `Unknown`,
+ * which must stay distinguishable from a card that rendered "Not Connected" —
+ * a layout change that drops a card would otherwise read as a real finding and
+ * send the user to reconnect something that was fine.
+ */
+export function detailFor(card) {
+  if (card.account || card.container) {
+    return [card.account && `account=${card.account}`, card.container && `container=${card.container}`]
+      .filter(Boolean).join(' ');
+  }
+  if (card.connectedTo) return `url=${card.connectedTo}`;
+  return '';
+}

--- a/clis/clarity/audit.js
+++ b/clis/clarity/audit.js
@@ -1,0 +1,106 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { discoverProjects, gotoClaritySettings, normalizeProjectId, readIntegrationCards } from './_ui.js';
+
+const DEFAULT_REQUIRED = 'Google Analytics,Google Tag Manager';
+
+export function statusOf(cards, name) {
+  const hit = cards.find((c) => c.name.toLowerCase() === name.toLowerCase());
+  if (hit) return hit.status;
+  // The panel finished painting and this card was not on it — Clarity does not
+  // offer that integration for this project. That is a third state: it is not
+  // "Not Connected" (nothing to connect) and not "Unknown" (we did read it).
+  return 'Not offered';
+}
+
+export const auditCommand = cli({
+  site: 'clarity',
+  name: 'audit',
+  access: 'read',
+  description: 'Check Google Analytics / Google Tag Manager (and Ads) integration status across every Clarity project, and flag the ones that still need setting up. Read-only.',
+  example: 'opencli clarity audit -f table',
+  domain: 'clarity.microsoft.com',
+  strategy: Strategy.UI,
+  browser: true,
+  siteSession: 'ephemeral',
+  navigateBefore: false,
+  args: [
+    { name: 'project-ids', type: 'string', required: false, help: 'Comma-separated project ids to check. Omit to auto-discover every project on the account.' },
+    { name: 'required', type: 'string', required: false, default: DEFAULT_REQUIRED, help: `Comma-separated integrations that must be Connected. Default: ${DEFAULT_REQUIRED}` },
+    { name: 'only-issues', type: 'boolean', required: false, default: false, help: 'Return only projects whose verdict is not ok.' },
+  ],
+  columns: ['ProjectId', 'Name', 'GoogleAnalytics', 'GoogleTagManager', 'GoogleAds', 'MicrosoftAds', 'Verdict'],
+  func: async (page, kwargs) => {
+    const required = String(kwargs.required || DEFAULT_REQUIRED)
+      .split(',').map((s) => s.trim()).filter(Boolean);
+
+    let targets;
+    const explicit = String(kwargs['project-ids'] || '').trim();
+    if (explicit) {
+      targets = explicit.split(',').map((s) => ({ ProjectId: normalizeProjectId(s.trim()), Name: '' }));
+    } else {
+      targets = await discoverProjects(page);
+    }
+
+    const rows = [];
+    for (const target of targets) {
+      const projectId = target.ProjectId;
+      let cards = null;
+      let readError = '';
+      // Retry once: a partial render is transient, and the card guard turns it
+      // into a refusal rather than a wrong status — so a second look is cheap
+      // and converts most would-be `unknown` rows into real readings.
+      for (let attempt = 0; attempt < 2 && !cards; attempt += 1) {
+        try {
+          await gotoClaritySettings(page, projectId, 'setup', 'Clarity audit');
+          cards = await readIntegrationCards(page);
+          readError = '';
+        } catch (error) {
+          readError = String(error && error.message ? error.message : error).slice(0, 300);
+        }
+      }
+
+      const ga  = cards ? statusOf(cards, 'Google Analytics')    : 'Unknown';
+      const gtm = cards ? statusOf(cards, 'Google Tag Manager')  : 'Unknown';
+      const gad = cards ? statusOf(cards, 'Google Ads')          : 'Unknown';
+      const mad = cards ? statusOf(cards, 'Microsoft Ads')       : 'Unknown';
+
+      const byName = { 'Google Analytics': ga, 'Google Tag Manager': gtm, 'Google Ads': gad, 'Microsoft Ads': mad };
+      const missing = required.filter((r) => /^not connected$/i.test(byName[r] || ''));
+      const notOffered = required.filter((r) => /^not offered$/i.test(byName[r] || ''));
+      const unknown = required.filter((r) => !byName[r] || /^unknown$/i.test(byName[r]));
+
+      let verdict;
+      if (readError.startsWith('NOT_INSTALLED:')) verdict = 'not installed: Clarity has never received data from this site';
+      else if (readError) verdict = `unknown: ${readError}`;
+      else if (missing.length) verdict = `setup needed: ${missing.join(' + ')}`;
+      else if (unknown.length) verdict = `unknown: ${unknown.join(' + ')} not readable`;
+      else if (notOffered.length) verdict = `ok (${notOffered.join(' + ')} not offered for this project)`;
+      else verdict = 'ok';
+
+      rows.push({
+        ProjectId: projectId,
+        Name: target.Name || '',
+        GoogleAnalytics: ga,
+        GoogleTagManager: gtm,
+        GoogleAds: gad,
+        MicrosoftAds: mad,
+        Verdict: verdict,
+      });
+    }
+
+    // A "not signed in" reading is only credible if nothing else read either.
+    // When other projects in the same run succeeded, the session is fine and
+    // this project simply is not available to the account — a different fact,
+    // with a different fix (regain access, not sign in).
+    const anySucceeded = rows.some((r) => r.Verdict.startsWith('ok') || r.Verdict.startsWith('setup'));
+    if (anySucceeded) {
+      for (const row of rows) {
+        if (/not signed in/i.test(row.Verdict)) {
+          row.Verdict = 'no access: Clarity served its signed-out shell for this project while other projects in the same run read fine — the account likely cannot open it';
+        }
+      }
+    }
+
+    return kwargs['only-issues'] === true ? rows.filter((r) => !r.Verdict.startsWith('ok')) : rows;
+  },
+});

--- a/clis/clarity/audit.test.js
+++ b/clis/clarity/audit.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { statusOf } from './audit.js';
+import { detailFor, normalizeProjectId } from './_ui.js';
+import './audit.js';
+import './integrations.js';
+import './projects.js';
+
+describe('clarity adapter registration', () => {
+  it('registers all three read-only commands against the Clarity host', () => {
+    for (const name of ['audit', 'integrations', 'projects']) {
+      const command = getRegistry().get(`clarity/${name}`);
+      expect(command, `clarity/${name} should be registered`).toBeDefined();
+      expect(command?.access).toBe('read');
+      expect(command?.domain).toBe('clarity.microsoft.com');
+      expect(command?.browser).toBe(true);
+      // Clarity's settings pages render blank in a reused context whose
+      // document.title is the signed-out marketing page, so every command
+      // must take a fresh one.
+      expect(command?.siteSession).toBe('ephemeral');
+    }
+  });
+
+  it('declares audit columns matching the keys its func returns', () => {
+    expect(getRegistry().get('clarity/audit')?.columns).toEqual([
+      'ProjectId', 'Name', 'GoogleAnalytics', 'GoogleTagManager',
+      'GoogleAds', 'MicrosoftAds', 'Verdict',
+    ]);
+  });
+});
+
+describe('statusOf keeps the four states distinct', () => {
+  const cards = [
+    { name: 'Google Analytics', status: 'Connected' },
+    { name: 'Google Ads', status: 'Not Connected' },
+  ];
+
+  it('reports the status a rendered card carried', () => {
+    expect(statusOf(cards, 'Google Analytics')).toBe('Connected');
+    expect(statusOf(cards, 'Google Ads')).toBe('Not Connected');
+  });
+
+  it('matches a card name case-insensitively', () => {
+    expect(statusOf(cards, 'google analytics')).toBe('Connected');
+  });
+
+  // The whole point of the third state. A card Clarity never offers for a
+  // project must not read as one the user declined to connect — collapsing
+  // them sends someone to reconnect an integration that does not exist.
+  it('reports an absent card as Not offered, never as Not Connected', () => {
+    const absent = statusOf(cards, 'Google Tag Manager');
+    expect(absent).toBe('Not offered');
+    expect(absent).not.toBe('Not Connected');
+  });
+});
+
+describe('normalizeProjectId refuses anything that is not an id', () => {
+  it('accepts a Clarity project id', () => {
+    expect(normalizeProjectId('a1b2c3d4e5')).toBe('a1b2c3d4e5');
+    expect(normalizeProjectId('  a1b2c3d4e5  ')).toBe('a1b2c3d4e5');
+  });
+
+  // A bad id would otherwise be pasted into a URL and navigated to, and
+  // Clarity answers an unknown project with a redirect that reads like a
+  // signed-out page.
+  it('rejects punctuation, paths and empties rather than navigating to them', () => {
+    for (const bad of ['', '   ', 'not/an/id', 'abc', 'a1b2c3d4e5!', '../../etc']) {
+      expect(() => normalizeProjectId(bad), `should reject ${JSON.stringify(bad)}`).toThrow();
+    }
+  });
+
+  it('returns undefined for an optional id that was not supplied', () => {
+    expect(normalizeProjectId('', { required: false })).toBeUndefined();
+    expect(normalizeProjectId(undefined, { required: false })).toBeUndefined();
+  });
+});
+
+describe('detailFor', () => {
+  it('prefers the GTM account/container pair', () => {
+    expect(detailFor({ account: '123', container: 'GTM-XXXX' })).toBe('account=123 container=GTM-XXXX');
+  });
+
+  it('falls back to the connected URL, and to empty when there is nothing', () => {
+    expect(detailFor({ connectedTo: 'https://example.com' })).toBe('url=https://example.com');
+    expect(detailFor({})).toBe('');
+  });
+});

--- a/clis/clarity/integrations.js
+++ b/clis/clarity/integrations.js
@@ -1,0 +1,30 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { detailFor, gotoClaritySettings, normalizeProjectId, readIntegrationCards } from './_ui.js';
+
+export const integrationsCommand = cli({
+  site: 'clarity',
+  name: 'integrations',
+  access: 'read',
+  description: 'Read Microsoft Clarity Setup-tab integration status (GTM, Google Analytics, Google Ads, Microsoft Ads) for one project. Read-only; never connects or disconnects anything.',
+  example: 'opencli clarity integrations a1b2c3d4e5 -f json',
+  domain: 'clarity.microsoft.com',
+  strategy: Strategy.UI,
+  browser: true,
+  siteSession: 'ephemeral',
+  navigateBefore: false,
+  args: [
+    { name: 'project-id', type: 'string', required: true, positional: true, help: 'Clarity project id, e.g. a1b2c3d4e5 (from the /projects/view/<id>/ URL).' },
+  ],
+  columns: ['Project', 'Integration', 'Status', 'Detail'],
+  func: async (page, kwargs) => {
+    const projectId = normalizeProjectId(kwargs['project-id']);
+    await gotoClaritySettings(page, projectId, 'setup', 'Clarity integrations');
+    const cards = await readIntegrationCards(page);
+    return cards.map((card) => ({
+      Project: projectId,
+      Integration: card.name,
+      Status: card.status,
+      Detail: detailFor(card),
+    }));
+  },
+});

--- a/clis/clarity/projects.js
+++ b/clis/clarity/projects.js
@@ -1,0 +1,18 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { discoverProjects } from './_ui.js';
+
+export const projectsCommand = cli({
+  site: 'clarity',
+  name: 'projects',
+  access: 'read',
+  description: 'List every Microsoft Clarity project this account can see, with its project id — the id `clarity integrations` and `clarity audit` take.',
+  example: 'opencli clarity projects -f json',
+  domain: 'clarity.microsoft.com',
+  strategy: Strategy.UI,
+  browser: true,
+  siteSession: 'ephemeral',
+  navigateBefore: false,
+  args: [],
+  columns: ['ProjectId', 'Name', 'Site'],
+  func: async (page) => discoverProjects(page),
+});

--- a/docs/adapters/browser/clarity.md
+++ b/docs/adapters/browser/clarity.md
@@ -1,0 +1,104 @@
+# Microsoft Clarity
+
+**Mode**: 🔐 Browser · **Domain**: `clarity.microsoft.com`
+
+Read Microsoft Clarity **project settings**. Clarity's Data Export API returns
+aggregate metrics only — integrations, masking, IP blocking and team are
+dashboard-only, so this adapter reads the rendered Setup tab.
+
+All commands are `access: 'read'`. Nothing connects, disconnects, or changes any
+setting.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli clarity projects` | List every project the account can see, with its project id |
+| `opencli clarity integrations <project-id>` | Integration status for one project |
+| `opencli clarity audit` | GA / GTM / Ads status across every project, with a verdict |
+
+## projects
+
+Lists the projects on the account. Start here — the ids the other two commands
+take come from the `/projects/view/<id>/` URL, and this is how you get them
+without opening the dashboard.
+
+Columns: `ProjectId` `Name` `Site`
+
+```bash
+opencli clarity projects
+opencli clarity projects -f json
+```
+
+## integrations
+
+Reads the Setup tab for one project and reports each integration Clarity offers.
+
+Columns: `Project` `Integration` `Status` `Detail`
+
+```bash
+opencli clarity integrations a1b2c3d4e5
+opencli clarity integrations a1b2c3d4e5 -f json
+```
+
+`Status` is four-valued and never collapses:
+
+| Status | Meaning |
+|--------|---------|
+| `Connected` | Clarity reports the integration as connected |
+| `Not Connected` | The card is present and shows as not connected |
+| `Not offered` | Clarity does not show that card for this project |
+| `Unknown` | The card was read but its state could not be determined |
+
+`Not offered` and `Not Connected` are different facts — an integration Clarity
+never surfaced is not one the user declined to set up.
+
+## audit
+
+Answers "which of my projects still need Google Analytics or Tag Manager wired
+up" in one pass. Discovers every project automatically when `--project-ids` is
+omitted.
+
+Columns: `ProjectId` `Name` `GoogleAnalytics` `GoogleTagManager` `GoogleAds`
+`MicrosoftAds` `Verdict`
+
+```bash
+# Every project on the account
+opencli clarity audit
+
+# Only the ones that fail the requirement
+opencli clarity audit --only-issues
+
+# Specific projects
+opencli clarity audit --project-ids a1b2c3d4e5,f6g7h8i9j0
+
+# Change what counts as configured
+opencli clarity audit --required "Google Analytics,Google Ads"
+
+opencli clarity audit --only-issues -f json
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--project-ids` | auto-discover | Comma-separated project ids to check |
+| `--required` | `Google Analytics,Google Tag Manager` | Integrations that must be `Connected` for the verdict to be `ok` |
+| `--only-issues` | `false` | Return only projects whose verdict is not `ok` |
+
+## Notes
+
+- **`siteSession: 'ephemeral'`.** Clarity is a single-page app that keeps
+  per-project state in the tab, so a persistent session leaks one project's
+  settings into the next project's read.
+- **Partial reads are refused, not degraded.** A half-rendered dashboard
+  produces a confident wrong answer rather than a missing one, so every reader
+  settles first: card counts and project-id counts must hold steady across two
+  polls before anything is reported. A project whose page never settles is
+  reported as such instead of being read early.
+- **Signed-out and no-access are distinguished.** If Clarity serves its
+  signed-out shell for one project while other projects in the same run read
+  fine, that project is reported as `no access` rather than as a login failure
+  for the whole run.
+- Sign in to Clarity in the browser profile the Browser Bridge uses before
+  running any of these.


### PR DESCRIPTION
## What

Three read-only commands for a Microsoft Clarity surface that has no API:

| Command | Answers |
|---|---|
| `opencli clarity audit --only-issues -f table` | Which projects still need Google Analytics / Tag Manager connected |
| `opencli clarity integrations <projectId>` | The same for one project |
| `opencli clarity projects` | Enumerate project ids |

Nothing here connects, disconnects, or changes anything.

## Why the UI strategy

Clarity's settings genuinely are not reachable any other way:

- The documented **Data Export API** returns aggregate metrics only.
- The undocumented **`clarity.microsoft.com/mcp`** surface behind the official MCP server returns session-level behavioural data — dashboard query, recording list, docs search. No settings.
- The internal **GraphQL endpoint** (`POST /api/v2`) holds the right operation — `getProjectIntegrationsData`, recovered from the client bundle — but rejects every hand-built request with a flat `400`, **including a bare `{ __typename }`**. A minimal valid query being refused places the rejection *before* GraphQL parsing, i.e. a transport/signature gate rather than a query problem. Varying one input at a time (page-sourced `X-CSRF-Token`, `x-clarity-version`, batched array body, `operationName` + `variables`) never got past it.

So integrations, masking, IP blocking and team are dashboard-only, and this reads the rendered page.

## Notes for review

Each of these cost a confident wrong answer before it was fixed, so they are load-bearing rather than stylistic:

- **`siteSession: 'ephemeral'`.** Under a reused context Clarity served a signed-out shell whose `location.href` was the URL requested and whose `document.body.innerText` was empty while `textContent` was ~3.8 kB. `document.title` was the only field that told the truth, so the signed-out check reads the title.
- **Readers settle on a count, not a marker.** The Setup panel paints progressively and its end-of-content block can appear *before* the last card lands, so "end marker present" accepted half-painted panels and reported present integrations as absent. Card counts and project-id counts must now hold steady across polls, and a read that will not settle throws instead of returning a partial list.
- **Status is four-valued** — `Connected` / `Not Connected` / `Not offered` / `Unknown`. A card Clarity never offers for a project has to stay distinguishable from one the user has not connected and from one that failed to render; collapsing them sends someone to reconnect an integration that does not exist.
- **The settings URL carries a per-project cache-buster.** Clarity is hash-routed, so navigating between two projects' `#setup` without a differing query string does not reload — it silently re-reads the previous project.
- **Project ids come from React fiber props over a bounded node set.** The grid renders no per-card `<a href>`, and an unbounded `querySelectorAll('*')` walk over it freezes the renderer.
- Every wait is an in-page poll inside `page.evaluate`.

## Checks

```
npx tsc --noEmit          exit 0 (202 files)
npm run test:adapter      539 files, 5830 tests passed
opencli validate          PASS — 1378 commands, 0 errors (clarity clean)
```

`clis/clarity/audit.test.js` adds 10 tests covering registration, the audit column contract, project-id validation, and the four-state rule. The four-state test was verified **red** against a mutant that returns `'Not Connected'` for an absent card, and green when restored.

Also smoke-tested against live Clarity projects end to end.

## Licence

Contributed under Apache-2.0 per CONTRIBUTING. I maintain a standalone copy at [vecyang1/opencli-clarity](https://github.com/vecyang1/opencli-clarity) under AGPL-3.0-or-later; dual-licensed by me as the copyright holder. That repo also carries a fourth command (`traffic`) which is deliberately **not** proposed here — the `/mcp` surface does that job better for a single project.