### PR TITLE
feat(dribbble): add browser adapter commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12954,6 +12954,232 @@
     "siteSession": "persistent"
   },
   {
+    "site": "dribbble",
+    "name": "designer",
+    "description": "Browse Dribbble designers and freelance agencies",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "positional": true,
+        "help": "Optional designer or skill keyword"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of designers (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "username",
+      "name",
+      "rating",
+      "projectCount",
+      "budgetText",
+      "location",
+      "responseTime",
+      "serviceCount",
+      "skills",
+      "url",
+      "avatarUrl"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/designer.js",
+    "sourceFile": "dribbble/designer.js"
+  },
+  {
+    "site": "dribbble",
+    "name": "login",
+    "description": "Open dribbble login and wait until the browser session is authenticated",
+    "access": "write",
+    "domain": "dribbble.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 300,
+        "required": false,
+        "help": "Maximum seconds to wait for the user to finish login"
+      }
+    ],
+    "columns": [
+      "status",
+      "logged_in",
+      "site",
+      "username",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/auth.js",
+    "sourceFile": "dribbble/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent",
+    "defaultWindowMode": "foreground"
+  },
+  {
+    "site": "dribbble",
+    "name": "profile",
+    "description": "Show a public Dribbble designer profile",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "designer",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Dribbble username or profile slug (for example: halolab)"
+      }
+    ],
+    "columns": [
+      "username",
+      "name",
+      "intro",
+      "followersCount",
+      "followingCount",
+      "likesCount",
+      "availableForWork",
+      "website",
+      "url",
+      "avatarUrl"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/profile.js",
+    "sourceFile": "dribbble/profile.js"
+  },
+  {
+    "site": "dribbble",
+    "name": "service",
+    "description": "List services offered by a Dribbble designer",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "designer",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Dribbble username or profile slug (for example: halolab)"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Optional service title filter"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of services (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "priceText",
+      "duration",
+      "description",
+      "quickHire",
+      "url",
+      "imageUrl",
+      "designer"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/service.js",
+    "sourceFile": "dribbble/service.js"
+  },
+  {
+    "site": "dribbble",
+    "name": "shot",
+    "description": "Search public Dribbble shots by keyword",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "public",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Search keyword"
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "default": "popular",
+        "required": false,
+        "help": "Sort order: following, popular, or recent (New & Noteworthy)",
+        "choices": [
+          "following",
+          "popular",
+          "recent"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of shots (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "designer",
+      "likes",
+      "views",
+      "imageUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/shot.js",
+    "sourceFile": "dribbble/shot.js"
+  },
+  {
+    "site": "dribbble",
+    "name": "whoami",
+    "description": "Show the current logged-in dribbble account",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "logged_in",
+      "site",
+      "username",
+      "profile_url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/auth.js",
+    "sourceFile": "dribbble/auth.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
     "site": "duckduckgo",
     "name": "search",
     "description": "Search DuckDuckGo",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12955,11 +12955,48 @@
   },
   {
     "site": "dribbble",
+    "name": "collection",
+    "description": "List public collections curated by a Dribbble designer",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "designer",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Dribbble username or profile slug"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of collections (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "shotCount",
+      "designerCount",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/collection.js",
+    "sourceFile": "dribbble/collection.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "dribbble",
     "name": "designer",
     "description": "Browse Dribbble designers and freelance agencies",
     "access": "read",
     "domain": "dribbble.com",
-    "strategy": "public",
+    "strategy": "ui",
     "browser": true,
     "args": [
       {
@@ -12994,7 +13031,8 @@
     ],
     "type": "js",
     "modulePath": "dribbble/designer.js",
-    "sourceFile": "dribbble/designer.js"
+    "sourceFile": "dribbble/designer.js",
+    "navigateBefore": true
   },
   {
     "site": "dribbble",
@@ -13029,11 +13067,99 @@
   },
   {
     "site": "dribbble",
+    "name": "member",
+    "description": "List public members of a Dribbble team profile",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "designer",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Dribbble team username or profile slug"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of members (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "username",
+      "name",
+      "location",
+      "url",
+      "avatarUrl",
+      "recentShotUrls"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/member.js",
+    "sourceFile": "dribbble/member.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "dribbble",
+    "name": "portfolio",
+    "description": "List a Dribbble designer's published or liked shots",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "designer",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Dribbble username or profile slug"
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "default": "work",
+        "required": false,
+        "help": "Portfolio type: work or likes",
+        "choices": [
+          "work",
+          "likes"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of shots (max 30)"
+      }
+    ],
+    "columns": [
+      "rank",
+      "id",
+      "title",
+      "designer",
+      "likes",
+      "views",
+      "imageUrl",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/portfolio.js",
+    "sourceFile": "dribbble/portfolio.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "dribbble",
     "name": "profile",
     "description": "Show a public Dribbble designer profile",
     "access": "read",
     "domain": "dribbble.com",
-    "strategy": "public",
+    "strategy": "ui",
     "browser": true,
     "args": [
       {
@@ -13048,17 +13174,24 @@
       "username",
       "name",
       "intro",
+      "biography",
       "followersCount",
       "followingCount",
       "likesCount",
       "availableForWork",
+      "location",
+      "memberSince",
+      "skills",
+      "languages",
+      "socialLinks",
       "website",
       "url",
       "avatarUrl"
     ],
     "type": "js",
     "modulePath": "dribbble/profile.js",
-    "sourceFile": "dribbble/profile.js"
+    "sourceFile": "dribbble/profile.js",
+    "navigateBefore": true
   },
   {
     "site": "dribbble",
@@ -13066,7 +13199,7 @@
     "description": "List services offered by a Dribbble designer",
     "access": "read",
     "domain": "dribbble.com",
-    "strategy": "public",
+    "strategy": "ui",
     "browser": true,
     "args": [
       {
@@ -13105,7 +13238,8 @@
     ],
     "type": "js",
     "modulePath": "dribbble/service.js",
-    "sourceFile": "dribbble/service.js"
+    "sourceFile": "dribbble/service.js",
+    "navigateBefore": true
   },
   {
     "site": "dribbble",
@@ -13113,7 +13247,7 @@
     "description": "Search public Dribbble shots by keyword",
     "access": "read",
     "domain": "dribbble.com",
-    "strategy": "public",
+    "strategy": "ui",
     "browser": true,
     "args": [
       {
@@ -13155,7 +13289,43 @@
     ],
     "type": "js",
     "modulePath": "dribbble/shot.js",
-    "sourceFile": "dribbble/shot.js"
+    "sourceFile": "dribbble/shot.js",
+    "navigateBefore": true
+  },
+  {
+    "site": "dribbble",
+    "name": "shot-detail",
+    "description": "Show details and media for a Dribbble shot",
+    "access": "read",
+    "domain": "dribbble.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "shot",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Numeric shot id or dribbble.com/shots URL"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "designer",
+      "designerUrl",
+      "team",
+      "description",
+      "imageUrl",
+      "mediaUrls",
+      "colors",
+      "availableForWork",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "dribbble/shot-detail.js",
+    "sourceFile": "dribbble/shot-detail.js",
+    "navigateBefore": true
   },
   {
     "site": "dribbble",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -12964,10 +12964,9 @@
     "args": [
       {
         "name": "query",
-        "type": "str",
+        "type": "string",
         "default": "",
         "required": false,
-        "positional": true,
         "help": "Optional designer or skill keyword"
       },
       {

--- a/clis/dribbble/auth.js
+++ b/clis/dribbble/auth.js
@@ -1,22 +1,19 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { registerSiteAuthCommands } from '../_shared/site-auth.js';
-import { DRIBBBLE_HOST, DRIBBBLE_ORIGIN } from './utils.js';
-
-async function hasDribbbleSessionCookie(page) {
-    const cookies = await page.getCookies({ url: DRIBBBLE_ORIGIN });
-    const names = new Set((cookies || []).map((cookie) => cookie.name));
-    return names.has('window._drbbbv_sess') || names.has('has_logged_in');
-}
+import { DRIBBBLE_HOST, DRIBBBLE_ORIGIN, hasDribbbleSessionCookie } from './utils.js';
 
 async function verifyDribbbleIdentity(page) {
     if (!await hasDribbbleSessionCookie(page)) {
         throw new AuthRequiredError(DRIBBBLE_HOST, 'Dribbble session cookies are missing');
     }
     await page.goto(DRIBBBLE_ORIGIN);
-    await page.wait(2);
+    // Dribbble serves an AWS WAF challenge before the real document on fresh
+    // tabs. Three seconds is not enough consistently; probing early turns a
+    // valid session into a false AUTH_REQUIRED result.
+    await page.wait(5);
     const result = await page.evaluate(`(() => {
         const profile = document.querySelector('a[title="Open profile"]');
-        const signOut = document.querySelector('form[action="/session"] input[name="_method"][value="delete"]');
+        const signOut = document.querySelector('form[action$="/session"] input[name="_method"][value="delete"]');
         const href = profile?.getAttribute('href') || '';
         if (!signOut || !/^\\/[^/]+$/.test(href)) {
             return { kind: 'auth', detail: 'Dribbble header does not show a logged-in profile' };

--- a/clis/dribbble/auth.js
+++ b/clis/dribbble/auth.js
@@ -1,0 +1,48 @@
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { registerSiteAuthCommands } from '../_shared/site-auth.js';
+import { DRIBBBLE_HOST, DRIBBBLE_ORIGIN } from './utils.js';
+
+async function hasDribbbleSessionCookie(page) {
+    const cookies = await page.getCookies({ url: DRIBBBLE_ORIGIN });
+    const names = new Set((cookies || []).map((cookie) => cookie.name));
+    return names.has('window._drbbbv_sess') || names.has('has_logged_in');
+}
+
+async function verifyDribbbleIdentity(page) {
+    if (!await hasDribbbleSessionCookie(page)) {
+        throw new AuthRequiredError(DRIBBBLE_HOST, 'Dribbble session cookies are missing');
+    }
+    await page.goto(DRIBBBLE_ORIGIN);
+    await page.wait(2);
+    const result = await page.evaluate(`(() => {
+        const profile = document.querySelector('a[title="Open profile"]');
+        const signOut = document.querySelector('form[action="/session"] input[name="_method"][value="delete"]');
+        const href = profile?.getAttribute('href') || '';
+        if (!signOut || !/^\\/[^/]+$/.test(href)) {
+            return { kind: 'auth', detail: 'Dribbble header does not show a logged-in profile' };
+        }
+        return {
+            ok: true,
+            username: href.slice(1),
+            profile_url: new URL(href, location.href).href,
+        };
+    })()`);
+    if (result?.kind === 'auth') throw new AuthRequiredError(DRIBBBLE_HOST, result.detail);
+    if (!result?.ok) throw new CommandExecutionError(`Unexpected Dribbble identity response: ${JSON.stringify(result)}`);
+    return { username: result.username, profile_url: result.profile_url };
+}
+
+registerSiteAuthCommands({
+    site: 'dribbble',
+    domain: DRIBBBLE_HOST,
+    loginUrl: `${DRIBBBLE_ORIGIN}/session/new`,
+    columns: ['username', 'profile_url'],
+    quickCheck: hasDribbbleSessionCookie,
+    verify: verifyDribbbleIdentity,
+    poll: async (page) => {
+        if (!await hasDribbbleSessionCookie(page)) {
+            throw new AuthRequiredError(DRIBBBLE_HOST, 'Waiting for Dribbble session cookies');
+        }
+        return verifyDribbbleIdentity(page);
+    },
+});

--- a/clis/dribbble/collection.js
+++ b/clis/dribbble/collection.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractCollectionRows,
+    normalizeLimit,
+    requireDesigner,
+    requireRows,
+    runBrowserTask,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'collection',
+    description: 'List public collections curated by a Dribbble designer',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.UI,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'designer', positional: true, required: true, help: 'Dribbble username or profile slug' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of collections (max 30)' },
+    ],
+    columns: ['rank', 'id', 'title', 'shotCount', 'designerCount', 'url'],
+    func: async (page, args) => {
+        const designer = requireDesigner(args.designer);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        return runBrowserTask('Dribbble collection extraction', async () => {
+            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/collections`);
+            await page.wait(5);
+            const payload = await page.evaluate(extractCollectionRows, designer, limit);
+            return requireRows(payload, 'dribbble collection');
+        });
+    },
+});

--- a/clis/dribbble/designer.js
+++ b/clis/dribbble/designer.js
@@ -1,5 +1,4 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     DRIBBBLE_HOST,
     DRIBBBLE_ORIGIN,
@@ -7,6 +6,7 @@ import {
     normalizeLimit,
     optionalQuery,
     requireRows,
+    runBrowserTask,
 } from './utils.js';
 
 cli({
@@ -14,7 +14,7 @@ cli({
     name: 'designer',
     description: 'Browse Dribbble designers and freelance agencies',
     domain: DRIBBBLE_HOST,
-    strategy: Strategy.PUBLIC,
+    strategy: Strategy.UI,
     access: 'read',
     browser: true,
     args: [
@@ -30,14 +30,11 @@ cli({
         const limit = normalizeLimit(args.limit, 20, 30);
         const url = new URL(`${DRIBBBLE_ORIGIN}/hire`);
         if (query) url.searchParams.set('keywords', query);
-        try {
+        return runBrowserTask('Dribbble designer extraction', async () => {
             await page.goto(url.href);
-            await page.wait(3);
+            await page.wait(5);
             const payload = await page.evaluate(extractDesignerRows, limit);
             return requireRows(payload, 'dribbble designer');
-        } catch (error) {
-            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
-            throw new CommandExecutionError(`Dribbble designer extraction failed: ${error?.message ?? error}`);
-        }
+        });
     },
 });

--- a/clis/dribbble/designer.js
+++ b/clis/dribbble/designer.js
@@ -1,0 +1,43 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractDesignerRows,
+    normalizeLimit,
+    optionalQuery,
+    requireRows,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'designer',
+    description: 'Browse Dribbble designers and freelance agencies',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.PUBLIC,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'query', positional: true, default: '', help: 'Optional designer or skill keyword' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of designers (max 30)' },
+    ],
+    columns: [
+        'rank', 'id', 'username', 'name', 'rating', 'projectCount',
+        'budgetText', 'location', 'responseTime', 'serviceCount', 'skills', 'url', 'avatarUrl',
+    ],
+    func: async (page, args) => {
+        const query = optionalQuery(args.query);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        const url = new URL(`${DRIBBBLE_ORIGIN}/hire`);
+        if (query) url.searchParams.set('keywords', query);
+        try {
+            await page.goto(url.href);
+            await page.wait(3);
+            const payload = await page.evaluate(extractDesignerRows, limit);
+            return requireRows(payload, 'dribbble designer');
+        } catch (error) {
+            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
+            throw new CommandExecutionError(`Dribbble designer extraction failed: ${error?.message ?? error}`);
+        }
+    },
+});

--- a/clis/dribbble/designer.js
+++ b/clis/dribbble/designer.js
@@ -18,7 +18,7 @@ cli({
     access: 'read',
     browser: true,
     args: [
-        { name: 'query', positional: true, default: '', help: 'Optional designer or skill keyword' },
+        { name: 'query', type: 'string', default: '', help: 'Optional designer or skill keyword' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of designers (max 30)' },
     ],
     columns: [

--- a/clis/dribbble/dribbble.test.js
+++ b/clis/dribbble/dribbble.test.js
@@ -1,0 +1,304 @@
+import { JSDOM } from 'jsdom';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import {
+    extractCollectionRows,
+    extractMemberRows,
+    extractProfileRow,
+    extractServiceRows,
+    extractShotDetailRow,
+    extractShotRows,
+    normalizeLimit,
+    requireDesigner,
+    requireShotTarget,
+} from './utils.js';
+
+const MODULES = [
+    './auth.js',
+    './collection.js',
+    './designer.js',
+    './member.js',
+    './portfolio.js',
+    './profile.js',
+    './service.js',
+    './shot-detail.js',
+    './shot.js',
+];
+
+beforeAll(async () => {
+    await Promise.all(MODULES.map((module) => import(module)));
+});
+
+function command(name) {
+    return getRegistry().get(`dribbble/${name}`);
+}
+
+function runInDom(extractor, html, args = [], url = 'https://dribbble.com/') {
+    const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+    const callArgs = args.map((arg) => JSON.stringify(arg)).join(', ');
+    return dom.window.eval(`(${extractor.toString()})(${callArgs})`);
+}
+
+function pageFor(html, url) {
+    const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (source, ...args) => {
+            if (typeof source === 'string') return dom.window.eval(source);
+            const callArgs = args.map((arg) => JSON.stringify(arg)).join(', ');
+            return dom.window.eval(`(${source.toString()})(${callArgs})`);
+        }),
+        getCookies: vi.fn().mockResolvedValue([{ name: '_dribbble_session', value: 'redacted' }]),
+    };
+}
+
+describe('dribbble command contracts', () => {
+    it('registers the complete public read surface with UI strategy', () => {
+        const uiCommands = ['collection', 'designer', 'member', 'portfolio', 'profile', 'service', 'shot-detail', 'shot'];
+        for (const name of uiCommands) {
+            expect(command(name)).toMatchObject({ site: 'dribbble', name, browser: true, strategy: 'ui', access: 'read' });
+        }
+        expect(command('whoami')).toMatchObject({ strategy: 'cookie', access: 'read' });
+        expect(command('login')).toMatchObject({ strategy: 'cookie', access: 'write' });
+    });
+
+    it('validates limits, profile slugs, and shot ids without silent coercion', () => {
+        expect(normalizeLimit(undefined, 20, 30)).toBe(20);
+        expect(() => normalizeLimit('2.5', 20, 30)).toThrow(/positive integer/);
+        expect(() => normalizeLimit(31, 20, 30)).toThrow(/<= 30/);
+        expect(requireDesigner('halo-lab_2')).toBe('halo-lab_2');
+        expect(() => requireDesigner('../account')).toThrow(/username or profile slug/);
+        expect(requireShotTarget('27679566')).toBe('27679566');
+        expect(requireShotTarget('https://dribbble.com/shots/27679566-Example')).toBe('27679566');
+        expect(() => requireShotTarget('https://example.com/shots/1')).toThrow(/dribbble\.com/);
+    });
+
+    it('recognizes a logged-in account when the sign-out form has an absolute action URL', async () => {
+        const page = pageFor(`
+          <a href="/vin-jake" title="Open profile"><img alt="vin jake"></a>
+          <form action="https://dribbble.com/session"><input name="_method" value="delete"></form>
+        `, 'https://dribbble.com/');
+
+        await expect(command('whoami').func(page, {})).resolves.toEqual({
+            logged_in: true,
+            site: 'dribbble',
+            username: 'vin-jake',
+            profile_url: 'https://dribbble.com/vin-jake',
+        });
+    });
+
+    it('requires authentication before opening the personalized following search', async () => {
+        const page = pageFor('<main id="content"></main>', 'https://dribbble.com/');
+        page.getCookies.mockResolvedValue([]);
+
+        await expect(command('shot').func(page, {
+            query: 'mobile', sort: 'following', limit: 2,
+        })).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});
+
+describe('dribbble production DOM extractors', () => {
+    it('extracts canonical shot rows from the live semantic card shape', () => {
+        const payload = runInDom(extractShotRows, `
+          <main id="content">
+            <li id="screenshot-25381404" data-thumbnail-id="25381404">
+              <img alt="Banking Mobile App" src="https://cdn.example/shot.png">
+              <a class="shot-thumbnail-link" href="/shots/25381404-Banking-Mobile-App"></a>
+              <div class="shot-title">Banking Mobile App</div>
+              <div class="user-information"><a href="/ronasit">Ronas IT</a></div>
+              <span data-shot-like-count>1.1k</span>
+              <span class="js-shot-views-count">660k</span>
+            </li>
+          </main>
+        `, [5], 'https://dribbble.com/search/shots/popular?q=mobile');
+
+        expect(payload.rows).toEqual([{
+            rank: 1,
+            id: '25381404',
+            title: 'Banking Mobile App',
+            designer: 'Ronas IT',
+            likes: 1100,
+            views: 660000,
+            imageUrl: 'https://cdn.example/shot.png',
+            url: 'https://dribbble.com/shots/25381404-Banking-Mobile-App',
+        }]);
+    });
+
+    it('extracts the exact profile heading and rich about fields without badge text', () => {
+        const payload = runInDom(extractProfileRow, `
+          <div class="profile-masthead" data-profile-masthead-container>
+            <div class="masthead-profile-name"><h1>HALO LAB</h1><span>Dribbble Select agencies are vetted</span></div>
+            <h2>Design & Tech Agency</h2>
+            <span>54,361 followers</span><span>541 following</span><span>14,660 likes</span>
+            <img src="https://cdn.example/avatar.png">
+          </div>
+          <main>
+            <section><h2>Biography</h2><p>First paragraph.</p><p>Second paragraph.</p></section>
+            <section><h2>Languages</h2><ul><li>English</li><li>French</li></ul></section>
+            <section><h2>Skills</h2><a href="/skills/product%20design">product design</a></section>
+            <section><h2>Social</h2><a href="https://github.com/halo-lab">GitHub</a></section>
+            <p>New York City, NY</p><p>Member since Dec 2013</p><p>Available for new projects</p>
+            <a href="https://halo-lab.com">Website</a>
+          </main>
+        `, ['halolab'], 'https://dribbble.com/halolab/about');
+
+        expect(payload.row).toMatchObject({
+            username: 'halolab',
+            name: 'HALO LAB',
+            intro: 'Design & Tech Agency',
+            biography: 'First paragraph.\n\nSecond paragraph.',
+            followersCount: 54361,
+            followingCount: 541,
+            likesCount: 14660,
+            availableForWork: true,
+            location: 'New York City, NY',
+            memberSince: 'Dec 2013',
+            skills: ['product design'],
+            languages: ['English', 'French'],
+            socialLinks: ['https://github.com/halo-lab'],
+            website: 'https://halo-lab.com/',
+            url: 'https://dribbble.com/halolab',
+        });
+    });
+
+    it('classifies a missing profile as empty instead of returning the 404 heading as a name', async () => {
+        const page = pageFor('<main><h1>Whoops, that page is gone.</h1></main>', 'https://dribbble.com/missing/about');
+        await expect(command('profile').func(page, { designer: 'missing' })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+
+    it('ignores the visual separator and extracts the real service duration', () => {
+        const payload = runInDom(extractServiceRows, `
+          <main id="content">
+            <article class="service-card" role="article">
+              <button data-remote-route-url="/services/31160-Brand-Strategy" aria-label="View service: Brand Strategy">
+                <img src="https://cdn.example/service.png">
+                <div class="service-card__content"><div class="display-flex gap-8">
+                  <span>From $25,000</span><span>|</span><span>10 weeks</span>
+                </div></div>
+                <h3 class="service-card__title">Brand Strategy</h3>
+                <p class="service-card__description">A durable brand package.</p>
+                <span>Quick Hire</span>
+              </button>
+            </article>
+          </main>
+        `, ['halolab'], 'https://dribbble.com/halolab/services');
+
+        expect(payload.rows[0]).toMatchObject({
+            id: '31160',
+            priceText: 'From $25,000',
+            duration: '10 weeks',
+            quickHire: true,
+        });
+    });
+
+    it('filters the complete service page before applying the requested limit', async () => {
+        const page = pageFor(`
+          <main id="content">
+            <article class="service-card" role="article">
+              <button data-remote-route-url="/services/1-Logo"><h3 class="service-card__title">Logo</h3></button>
+            </article>
+            <article class="service-card" role="article">
+              <button data-remote-route-url="/services/2-Identity"><h3 class="service-card__title">Identity System</h3></button>
+            </article>
+          </main>
+        `, 'https://dribbble.com/halolab/services');
+
+        await expect(command('service').func(page, {
+            designer: 'halolab', query: 'identity', limit: 1,
+        })).resolves.toMatchObject([{ id: '2', title: 'Identity System', rank: 1 }]);
+    });
+
+    it('fills a portfolio card without an author label from the requested profile', async () => {
+        const page = pageFor(`
+          <main id="content">
+            <li id="screenshot-27679566" data-thumbnail-id="27679566">
+              <img alt="PooPrints" src="https://cdn.example/shot.png">
+              <a href="/shots/27679566-PooPrints"></a>
+            </li>
+          </main>
+        `, 'https://dribbble.com/halolab/shots');
+
+        await expect(command('portfolio').func(page, {
+            designer: 'halolab', type: 'work', limit: 1,
+        })).resolves.toMatchObject([{ id: '27679566', designer: 'halolab' }]);
+    });
+
+    it('does not misattribute a liked shot to the profile that liked it', async () => {
+        const page = pageFor(`
+          <main id="content">
+            <li id="screenshot-27679566" data-thumbnail-id="27679566">
+              <img alt="PooPrints" src="https://cdn.example/shot.png">
+              <a href="/shots/27679566-PooPrints"></a>
+            </li>
+          </main>
+        `, 'https://dribbble.com/halolab/likes');
+
+        await expect(command('portfolio').func(page, {
+            designer: 'halolab', type: 'likes', limit: 1,
+        })).resolves.toMatchObject([{ id: '27679566', designer: '' }]);
+    });
+
+    it('classifies a shot 404 before requiring the normal result root', () => {
+        expect(runInDom(extractShotRows, '<h1>Whoops, that page is gone.</h1>', [5],
+            'https://dribbble.com/shots/999999999')).toMatchObject({ ok: true, empty: true });
+    });
+
+    it('extracts shot detail media, authors, and palette from the visible shot contract', () => {
+        const payload = runInDom(extractShotDetailRow, `
+          <meta property="og:image" content="https://cdn.example/cover.png">
+          <main id="content" class="shot-container">
+            <header class="shot-header"><h1 class="shot-header__title">PooPrints</h1></header>
+            <header class="user-sticky-header">
+              <div class="user-sticky-header__name"><span>
+                <a href="/haloweb">Halo UI/UX</a> for <a href="/halolab">HALO LAB</a>
+              </span></div>
+              <button class="user-sticky-header__available">Available for work</button>
+            </header>
+            <section data-screenshot_id="27679566"></section>
+            <div class="shot-description-container">Case study</div>
+            <div class="shot-media-container"><img src="https://cdn.example/media.png"></div>
+            <div class="shot-content"><a href="https://cdn.dribbble.com/userupload/full.png">Full size</a></div>
+            <a href="/shots?color=E5DDCE">#E5DDCE</a>
+          </main>
+        `, ['27679566'], 'https://dribbble.com/shots/27679566-PooPrints');
+
+        expect(payload.row).toMatchObject({
+            id: '27679566',
+            title: 'PooPrints',
+            designer: 'Halo UI/UX',
+            designerUrl: 'https://dribbble.com/haloweb',
+            team: 'HALO LAB',
+            description: 'Case study',
+            imageUrl: 'https://cdn.example/cover.png',
+            mediaUrls: ['https://cdn.example/media.png', 'https://cdn.dribbble.com/userupload/full.png'],
+            colors: ['E5DDCE'],
+            availableForWork: true,
+        });
+    });
+
+    it('extracts collections and team members from public profile routes', () => {
+        const collections = runInDom(extractCollectionRows, `
+          <main><a href="/halolab/collections/7879510-Manufacturing">
+            <h3>Manufacturing</h3><span>6 Shots • 1 Designer</span>
+          </a></main>
+        `, ['halolab', 5], 'https://dribbble.com/halolab/collections');
+        expect(collections.rows[0]).toMatchObject({
+            id: '7879510', title: 'Manufacturing', shotCount: 6, designerCount: 1,
+        });
+
+        const members = runInDom(extractMemberRows, `
+          <main><ul><li>
+            <a href="/haloweb"><img alt="Halo UI/UX" src="https://cdn.example/member.png">Halo UI/UX</a>
+            <span class="user-location">San Francisco, CA</span>
+            <a href="/haloweb/followers">Follow</a>
+            <a href="/shots/1-One"></a><a href="/shots/2-Two"></a>
+          </li></ul></main>
+        `, ['halolab', 5], 'https://dribbble.com/halolab/members');
+        expect(members.rows[0]).toMatchObject({
+            username: 'haloweb', name: 'Halo UI/UX', location: 'San Francisco, CA',
+            recentShotUrls: ['https://dribbble.com/shots/1-One', 'https://dribbble.com/shots/2-Two'],
+        });
+    });
+});

--- a/clis/dribbble/member.js
+++ b/clis/dribbble/member.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractMemberRows,
+    normalizeLimit,
+    requireDesigner,
+    requireRows,
+    runBrowserTask,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'member',
+    description: 'List public members of a Dribbble team profile',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.UI,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'designer', positional: true, required: true, help: 'Dribbble team username or profile slug' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of members (max 30)' },
+    ],
+    columns: ['rank', 'username', 'name', 'location', 'url', 'avatarUrl', 'recentShotUrls'],
+    func: async (page, args) => {
+        const designer = requireDesigner(args.designer);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        return runBrowserTask('Dribbble member extraction', async () => {
+            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/members`);
+            await page.wait(5);
+            const payload = await page.evaluate(extractMemberRows, designer, limit);
+            return requireRows(payload, 'dribbble member');
+        });
+    },
+});

--- a/clis/dribbble/portfolio.js
+++ b/clis/dribbble/portfolio.js
@@ -1,0 +1,53 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractShotRows,
+    normalizeLimit,
+    requireDesigner,
+    requireRows,
+    runBrowserTask,
+} from './utils.js';
+
+const PORTFOLIO_TYPES = ['work', 'likes'];
+
+function normalizePortfolioType(value) {
+    const type = String(value ?? 'work').trim().toLowerCase();
+    if (!PORTFOLIO_TYPES.includes(type)) {
+        throw new ArgumentError(`type must be one of: ${PORTFOLIO_TYPES.join(', ')}`);
+    }
+    return type;
+}
+
+cli({
+    site: 'dribbble',
+    name: 'portfolio',
+    description: 'List a Dribbble designer\'s published or liked shots',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.UI,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'designer', positional: true, required: true, help: 'Dribbble username or profile slug' },
+        { name: 'type', type: 'string', default: 'work', choices: PORTFOLIO_TYPES, help: 'Portfolio type: work or likes' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of shots (max 30)' },
+    ],
+    columns: ['rank', 'id', 'title', 'designer', 'likes', 'views', 'imageUrl', 'url'],
+    func: async (page, args) => {
+        const designer = requireDesigner(args.designer);
+        const type = normalizePortfolioType(args.type);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        const suffix = type === 'work' ? 'shots' : 'likes';
+        return runBrowserTask('Dribbble portfolio extraction', async () => {
+            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/${suffix}`);
+            await page.wait(5);
+            const payload = await page.evaluate(extractShotRows, limit);
+            return requireRows(payload, 'dribbble portfolio')
+                .map((row) => ({
+                    ...row,
+                    designer: row.designer || (type === 'work' ? designer : ''),
+                }));
+        });
+    },
+});

--- a/clis/dribbble/profile.js
+++ b/clis/dribbble/profile.js
@@ -1,10 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
 import {
     DRIBBBLE_HOST,
     DRIBBBLE_ORIGIN,
     extractProfileRow,
+    requireRow,
     requireDesigner,
+    runBrowserTask,
 } from './utils.js';
 
 cli({
@@ -12,26 +13,24 @@ cli({
     name: 'profile',
     description: 'Show a public Dribbble designer profile',
     domain: DRIBBBLE_HOST,
-    strategy: Strategy.PUBLIC,
+    strategy: Strategy.UI,
     access: 'read',
     browser: true,
     args: [
         { name: 'designer', positional: true, required: true, help: 'Dribbble username or profile slug (for example: halolab)' },
     ],
-    columns: ['username', 'name', 'intro', 'followersCount', 'followingCount', 'likesCount', 'availableForWork', 'website', 'url', 'avatarUrl'],
+    columns: [
+        'username', 'name', 'intro', 'biography', 'followersCount', 'followingCount', 'likesCount',
+        'availableForWork', 'location', 'memberSince', 'skills', 'languages', 'socialLinks',
+        'website', 'url', 'avatarUrl',
+    ],
     func: async (page, args) => {
         const designer = requireDesigner(args.designer);
-        try {
-            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}`);
-            await page.wait(2);
+        return runBrowserTask('Dribbble profile extraction', async () => {
+            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/about`);
+            await page.wait(5);
             const payload = await page.evaluate(extractProfileRow, designer);
-            if (!payload?.ok || !payload.row) {
-                throw new CommandExecutionError(`Dribbble profile selector drift: ${payload?.reason ?? 'profile payload was unreadable'}`);
-            }
-            return [payload.row];
-        } catch (error) {
-            if (error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT' || error?.code === 'EMPTY_RESULT') throw error;
-            throw new CommandExecutionError(`Dribbble profile extraction failed: ${error?.message ?? error}`);
-        }
+            return [requireRow(payload, 'dribbble profile')];
+        });
     },
 });

--- a/clis/dribbble/profile.js
+++ b/clis/dribbble/profile.js
@@ -1,0 +1,37 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractProfileRow,
+    requireDesigner,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'profile',
+    description: 'Show a public Dribbble designer profile',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.PUBLIC,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'designer', positional: true, required: true, help: 'Dribbble username or profile slug (for example: halolab)' },
+    ],
+    columns: ['username', 'name', 'intro', 'followersCount', 'followingCount', 'likesCount', 'availableForWork', 'website', 'url', 'avatarUrl'],
+    func: async (page, args) => {
+        const designer = requireDesigner(args.designer);
+        try {
+            await page.goto(`${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}`);
+            await page.wait(2);
+            const payload = await page.evaluate(extractProfileRow, designer);
+            if (!payload?.ok || !payload.row) {
+                throw new CommandExecutionError(`Dribbble profile selector drift: ${payload?.reason ?? 'profile payload was unreadable'}`);
+            }
+            return [payload.row];
+        } catch (error) {
+            if (error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT' || error?.code === 'EMPTY_RESULT') throw error;
+            throw new CommandExecutionError(`Dribbble profile extraction failed: ${error?.message ?? error}`);
+        }
+    },
+});

--- a/clis/dribbble/service.js
+++ b/clis/dribbble/service.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { EmptyResultError } from '@jackwener/opencli/errors';
 import {
     DRIBBBLE_HOST,
     DRIBBBLE_ORIGIN,
@@ -8,6 +8,7 @@ import {
     optionalQuery,
     requireDesigner,
     requireRows,
+    runBrowserTask,
 } from './utils.js';
 
 cli({
@@ -15,7 +16,7 @@ cli({
     name: 'service',
     description: 'List services offered by a Dribbble designer',
     domain: DRIBBBLE_HOST,
-    strategy: Strategy.PUBLIC,
+    strategy: Strategy.UI,
     access: 'read',
     browser: true,
     args: [
@@ -29,10 +30,10 @@ cli({
         const query = optionalQuery(args.query);
         const limit = normalizeLimit(args.limit, 20, 30);
         const url = `${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/services`;
-        try {
+        return runBrowserTask('Dribbble service extraction', async () => {
             await page.goto(url);
-            await page.wait(2);
-            const payload = await page.evaluate(extractServiceRows, designer, limit);
+            await page.wait(5);
+            const payload = await page.evaluate(extractServiceRows, designer);
             let rows = requireRows(payload, 'dribbble service');
             if (query) {
                 const needle = query.toLowerCase();
@@ -42,9 +43,6 @@ cli({
                 }
             }
             return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
-        } catch (error) {
-            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
-            throw new CommandExecutionError(`Dribbble service extraction failed: ${error?.message ?? error}`);
-        }
+        });
     },
 });

--- a/clis/dribbble/service.js
+++ b/clis/dribbble/service.js
@@ -1,0 +1,50 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractServiceRows,
+    normalizeLimit,
+    optionalQuery,
+    requireDesigner,
+    requireRows,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'service',
+    description: 'List services offered by a Dribbble designer',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.PUBLIC,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'designer', positional: true, required: true, help: 'Dribbble username or profile slug (for example: halolab)' },
+        { name: 'query', type: 'string', default: '', help: 'Optional service title filter' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of services (max 30)' },
+    ],
+    columns: ['rank', 'id', 'title', 'priceText', 'duration', 'description', 'quickHire', 'url', 'imageUrl', 'designer'],
+    func: async (page, args) => {
+        const designer = requireDesigner(args.designer);
+        const query = optionalQuery(args.query);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        const url = `${DRIBBBLE_ORIGIN}/${encodeURIComponent(designer)}/services`;
+        try {
+            await page.goto(url);
+            await page.wait(2);
+            const payload = await page.evaluate(extractServiceRows, designer, limit);
+            let rows = requireRows(payload, 'dribbble service');
+            if (query) {
+                const needle = query.toLowerCase();
+                rows = rows.filter((row) => `${row.title} ${row.description ?? ''}`.toLowerCase().includes(needle));
+                if (rows.length === 0) {
+                    throw new EmptyResultError('dribbble service', `No services matching "${query}" for designer "${designer}"`);
+                }
+            }
+            return rows.slice(0, limit).map((row, index) => ({ ...row, rank: index + 1 }));
+        } catch (error) {
+            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
+            throw new CommandExecutionError(`Dribbble service extraction failed: ${error?.message ?? error}`);
+        }
+    },
+});

--- a/clis/dribbble/shot-detail.js
+++ b/clis/dribbble/shot-detail.js
@@ -1,0 +1,35 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractShotDetailRow,
+    requireRow,
+    requireShotTarget,
+    runBrowserTask,
+} from './utils.js';
+
+cli({
+    site: 'dribbble',
+    name: 'shot-detail',
+    description: 'Show details and media for a Dribbble shot',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.UI,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'shot', positional: true, required: true, help: 'Numeric shot id or dribbble.com/shots URL' },
+    ],
+    columns: [
+        'id', 'title', 'designer', 'designerUrl', 'team', 'description',
+        'imageUrl', 'mediaUrls', 'colors', 'availableForWork', 'url',
+    ],
+    func: async (page, args) => {
+        const shotId = requireShotTarget(args.shot);
+        return runBrowserTask('Dribbble shot detail extraction', async () => {
+            await page.goto(`${DRIBBBLE_ORIGIN}/shots/${shotId}`);
+            await page.wait(5);
+            const payload = await page.evaluate(extractShotDetailRow, shotId);
+            return [requireRow(payload, 'dribbble shot-detail')];
+        });
+    },
+});

--- a/clis/dribbble/shot.js
+++ b/clis/dribbble/shot.js
@@ -1,0 +1,58 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    DRIBBBLE_HOST,
+    DRIBBBLE_ORIGIN,
+    extractShotRows,
+    normalizeLimit,
+    requireQuery,
+    requireRows,
+} from './utils.js';
+
+const SHOT_SORT_OPTIONS = ['following', 'popular', 'recent'];
+
+function normalizeShotSort(value) {
+    const sort = String(value ?? 'popular').trim().toLowerCase();
+    if (!SHOT_SORT_OPTIONS.includes(sort)) {
+        throw new ArgumentError(`sort must be one of: ${SHOT_SORT_OPTIONS.join(', ')}`);
+    }
+    return sort;
+}
+
+cli({
+    site: 'dribbble',
+    name: 'shot',
+    description: 'Search public Dribbble shots by keyword',
+    domain: DRIBBBLE_HOST,
+    strategy: Strategy.PUBLIC,
+    access: 'read',
+    browser: true,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Search keyword' },
+        {
+            name: 'sort',
+            type: 'string',
+            default: 'popular',
+            choices: SHOT_SORT_OPTIONS,
+            help: 'Sort order: following, popular, or recent (New & Noteworthy)',
+        },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of shots (max 30)' },
+    ],
+    columns: ['rank', 'id', 'title', 'designer', 'likes', 'views', 'imageUrl', 'url'],
+    func: async (page, args) => {
+        const query = requireQuery(args.query);
+        const limit = normalizeLimit(args.limit, 20, 30);
+        const sort = normalizeShotSort(args.sort);
+        const url = new URL(`${DRIBBBLE_ORIGIN}/search/shots/${sort}`);
+        url.searchParams.set('q', query);
+        try {
+            await page.goto(url.href);
+            await page.wait(3);
+            const payload = await page.evaluate(extractShotRows, limit);
+            return requireRows(payload, 'dribbble shot');
+        } catch (error) {
+            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
+            throw new CommandExecutionError(`Dribbble shot extraction failed: ${error?.message ?? error}`);
+        }
+    },
+});

--- a/clis/dribbble/shot.js
+++ b/clis/dribbble/shot.js
@@ -1,12 +1,14 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { ArgumentError, AuthRequiredError } from '@jackwener/opencli/errors';
 import {
     DRIBBBLE_HOST,
     DRIBBBLE_ORIGIN,
     extractShotRows,
+    hasDribbbleSessionCookie,
     normalizeLimit,
     requireQuery,
     requireRows,
+    runBrowserTask,
 } from './utils.js';
 
 const SHOT_SORT_OPTIONS = ['following', 'popular', 'recent'];
@@ -24,7 +26,7 @@ cli({
     name: 'shot',
     description: 'Search public Dribbble shots by keyword',
     domain: DRIBBBLE_HOST,
-    strategy: Strategy.PUBLIC,
+    strategy: Strategy.UI,
     access: 'read',
     browser: true,
     args: [
@@ -43,16 +45,16 @@ cli({
         const query = requireQuery(args.query);
         const limit = normalizeLimit(args.limit, 20, 30);
         const sort = normalizeShotSort(args.sort);
+        if (sort === 'following' && !await hasDribbbleSessionCookie(page)) {
+            throw new AuthRequiredError(DRIBBBLE_HOST, 'Following search requires a signed-in Dribbble browser session');
+        }
         const url = new URL(`${DRIBBBLE_ORIGIN}/search/shots/${sort}`);
         url.searchParams.set('q', query);
-        try {
+        return runBrowserTask('Dribbble shot search', async () => {
             await page.goto(url.href);
-            await page.wait(3);
+            await page.wait(5);
             const payload = await page.evaluate(extractShotRows, limit);
             return requireRows(payload, 'dribbble shot');
-        } catch (error) {
-            if (error?.code === 'EMPTY_RESULT' || error?.code === 'COMMAND_EXEC' || error?.code === 'ARGUMENT') throw error;
-            throw new CommandExecutionError(`Dribbble shot extraction failed: ${error?.message ?? error}`);
-        }
+        });
     },
 });

--- a/clis/dribbble/utils.js
+++ b/clis/dribbble/utils.js
@@ -1,0 +1,210 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const DRIBBBLE_ORIGIN = 'https://dribbble.com';
+export const DRIBBBLE_HOST = 'dribbble.com';
+
+export function normalizeLimit(value, defaultValue = 20, maxValue = 30, label = 'limit') {
+    const raw = value ?? defaultValue;
+    const limit = Number(raw);
+    if (!Number.isInteger(limit) || limit <= 0) {
+        throw new ArgumentError(`${label} must be a positive integer`);
+    }
+    if (limit > maxValue) {
+        throw new ArgumentError(`${label} must be <= ${maxValue}`);
+    }
+    return limit;
+}
+
+export function requireQuery(value, label = 'query') {
+    const query = String(value ?? '').trim();
+    if (!query) throw new ArgumentError(`${label} is required`);
+    if (query.length > 100) throw new ArgumentError(`${label} must be <= 100 characters`);
+    return query;
+}
+
+export function optionalQuery(value, label = 'query') {
+    const query = String(value ?? '').trim();
+    if (query.length > 100) throw new ArgumentError(`${label} must be <= 100 characters`);
+    return query;
+}
+
+export function requireDesigner(value) {
+    const designer = String(value ?? '').trim();
+    if (!designer) throw new ArgumentError('designer is required (for example: halolab)');
+    if (designer.length > 100 || designer.includes('/') || designer.includes('?') || designer.includes('#')) {
+        throw new ArgumentError('designer must be a Dribbble username or profile slug');
+    }
+    return designer;
+}
+
+export function requireRows(payload, command) {
+    if (!payload || typeof payload !== 'object') {
+        throw new CommandExecutionError(`${command} returned an unreadable browser payload`);
+    }
+    if (!payload.ok) {
+        const reason = payload.reason ? `: ${payload.reason}` : '';
+        throw new CommandExecutionError(`${command} selector drift${reason}`);
+    }
+    if (!Array.isArray(payload.rows) || payload.rows.length === 0) {
+        throw new EmptyResultError(command, `${command} page loaded but no matching rows were found`);
+    }
+    return payload.rows;
+}
+
+export function extractShotRows(limit) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const count = (value) => {
+        const text = clean(value).replace(/,/g, '');
+        const match = text.match(/^(\d+(?:\.\d+)?)\s*([kmb])?$/i);
+        if (!match) return null;
+        const multiplier = { k: 1e3, m: 1e6, b: 1e9 }[String(match[2] ?? '').toLowerCase()] ?? 1;
+        return Number(match[1]) * multiplier;
+    };
+    const root = document.querySelector('#content');
+    const cards = [...document.querySelectorAll('li[id^="screenshot-"]')];
+    if (!root) {
+        return { ok: false, reason: 'shot result root #content was not found', title: document.title || '' };
+    }
+
+    const rows = cards.map((el, index) => {
+        const shotLink = [...el.querySelectorAll('a[href]')]
+            .find((anchor) => /^\/shots\/[^/]+/.test(anchor.getAttribute('href') || ''));
+        if (!shotLink) return null;
+        const profileLink = [...el.querySelectorAll('a[href]')]
+            .find((anchor) => /^\/[^/]+$/.test(anchor.getAttribute('href') || ''));
+        const image = el.querySelector('img');
+        return {
+            rank: index + 1,
+            id: clean(el.getAttribute('data-thumbnail-id') || el.id.replace(/^screenshot-/, '')),
+            title: clean(el.querySelector('.shot-title')?.textContent || image?.getAttribute('alt') || ''),
+            designer: clean(profileLink?.textContent || ''),
+            likes: count(el.querySelector('.js-shot-likes-container')?.textContent),
+            views: count(el.querySelector('.js-shot-views-count')?.textContent),
+            imageUrl: clean(image?.currentSrc || image?.getAttribute('src') || image?.getAttribute('data-src') || ''),
+            url: new URL(shotLink.getAttribute('href'), location.href).href,
+        };
+    }).filter((row) => row && row.id && row.title && row.url);
+
+    return { ok: true, rows: rows.slice(0, limit) };
+}
+
+export function extractDesignerRows(limit) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const numberFrom = (value) => {
+        const match = clean(value).replace(/,/g, '').match(/\d+(?:\.\d+)?/);
+        return match ? Number(match[0]) : null;
+    };
+    const root = document.querySelector('.designer-search-results');
+    const cards = [...document.querySelectorAll('[data-resume-user-card]')];
+    if (!root) {
+        return { ok: false, reason: 'designer result root was not found', title: document.title || '' };
+    }
+
+    const rows = cards.map((el, index) => {
+        const profilePath = el.getAttribute('data-profile-path') || '';
+        const subheading = [...el.querySelectorAll('.user-card-profile__subheading-item')]
+            .map((item) => clean(item.textContent))
+            .filter(Boolean);
+        const budget = subheading.find((item) => /\$|project/i.test(item)) || '';
+        const responseTime = subheading.find((item) => /responds/i.test(item)) || '';
+        const locationText = subheading.find((item) => item !== budget && item !== responseTime && item !== '');
+        const ratingText = clean(el.querySelector('.designer-ratings-score__link')?.textContent || '');
+        const projectText = clean(el.querySelector('.designer-ratings__project-count')?.textContent || '');
+        const serviceLink = [...el.querySelectorAll('a[href]')]
+            .find((anchor) => /\/services$/.test(anchor.getAttribute('href') || ''));
+        const serviceText = clean(serviceLink?.textContent || '');
+        const skills = [...el.querySelectorAll('.user-skills__item')]
+            .map((item) => clean(item.textContent))
+            .filter(Boolean);
+        return {
+            rank: index + 1,
+            id: clean(el.getAttribute('data-id') || ''),
+            username: clean(el.getAttribute('data-username') || ''),
+            name: clean(el.getAttribute('data-display-name') || el.querySelector('.user-card-profile__heading-name')?.textContent || ''),
+            rating: numberFrom(ratingText),
+            projectCount: numberFrom(projectText),
+            budgetText: budget || null,
+            location: locationText || null,
+            responseTime: responseTime || null,
+            serviceCount: numberFrom(serviceText),
+            skills,
+            url: profilePath ? new URL(profilePath, document.location.href).href : '',
+            avatarUrl: clean(el.querySelector('img')?.src || ''),
+        };
+    }).filter((row) => row.username && row.name && row.url);
+
+    return { ok: true, rows: rows.slice(0, limit) };
+}
+
+export function extractProfileRow(username) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const numberFrom = (value) => {
+        const match = clean(value).replace(/,/g, '').match(/\d+(?:\.\d+)?/);
+        return match ? Number(match[0]) : null;
+    };
+    const profile = document.querySelector('.profile-masthead, .masthead-profile-name')?.closest('main, body') || document.body;
+    const name = clean(document.querySelector('.masthead-profile-name, .profile-masthead h1, h1')?.textContent || '');
+    if (!name || !profile) {
+        return { ok: false, reason: 'profile identity was not found', title: document.title || '' };
+    }
+
+    const stats = [...document.querySelectorAll('.masthead-stats .stat, .profile-masthead .stat')];
+    const statValue = (pattern) => numberFrom(stats.find((stat) => pattern.test(clean(stat.textContent)))?.textContent);
+    const website = [...document.querySelectorAll('.user-contact-info a[href], .profile-masthead a[href]')]
+        .map((anchor) => anchor.getAttribute('href') || '')
+        .find((href) => /^https?:\/\//i.test(href) && !/dribbble\.com/i.test(href)) || '';
+    const avatar = document.querySelector('.masthead-avatar img, .profile-masthead img')?.currentSrc
+        || document.querySelector('.masthead-avatar img, .profile-masthead img')?.src
+        || '';
+    const availableText = clean(document.querySelector('.user-sticky-header__available, .profile-masthead [class*="available"]')?.textContent || '');
+    const intro = clean(document.querySelector('.masthead-intro, .profile-masthead .bio')?.textContent || '');
+
+    return {
+        ok: true,
+        row: {
+            username,
+            name,
+            intro: intro || null,
+            followersCount: statValue(/followers/i),
+            followingCount: statValue(/following/i),
+            likesCount: statValue(/likes/i),
+            availableForWork: /available for work/i.test(availableText),
+            website: website || null,
+            url: document.location.href,
+            avatarUrl: clean(avatar) || null,
+        },
+    };
+}
+
+export function extractServiceRows(designer, limit) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const root = document.querySelector('#content');
+    const cards = [...document.querySelectorAll('.service-card[role="article"]')];
+    if (!root) {
+        return { ok: false, reason: 'service result root #content was not found', title: document.title || '' };
+    }
+
+    const rows = cards.map((el, index) => {
+        const button = el.querySelector('button[data-remote-url], button[data-remote-route-url]');
+        const detailPath = button?.getAttribute('data-remote-route-url') || button?.getAttribute('data-remote-url') || '';
+        const meta = [...el.querySelectorAll('.service-card__content .display-flex.gap-8 span')]
+            .map((item) => clean(item.textContent))
+            .filter(Boolean);
+        const description = clean(el.querySelector('.service-card__description, .text-clip-2')?.textContent || '');
+        const cardText = clean(el.textContent);
+        return {
+            rank: index + 1,
+            id: clean(button?.getAttribute('data-search-service-clicked') || detailPath.match(/\/services\/(\d+)/)?.[1] || ''),
+            title: clean(el.querySelector('.service-card__title, h3')?.textContent || button?.getAttribute('aria-label')?.replace(/^View service:\s*/i, '') || ''),
+            priceText: meta[0] || null,
+            duration: meta[1] || null,
+            description: description ? description.slice(0, 800) : null,
+            quickHire: /quick hire/i.test(cardText),
+            url: detailPath ? new URL(detailPath, location.href).href : '',
+            imageUrl: clean(el.querySelector('img')?.currentSrc || el.querySelector('img')?.src || el.querySelector('img')?.getAttribute('data-src') || ''),
+            designer,
+        };
+    }).filter((row) => row.id && row.title && row.url);
+
+    return { ok: true, rows: rows.slice(0, limit) };
+}

--- a/clis/dribbble/utils.js
+++ b/clis/dribbble/utils.js
@@ -3,6 +3,14 @@ import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwen
 export const DRIBBBLE_ORIGIN = 'https://dribbble.com';
 export const DRIBBBLE_HOST = 'dribbble.com';
 
+const TYPED_ERROR_CODES = new Set(['ARGUMENT', 'AUTH_REQUIRED', 'COMMAND_EXEC', 'EMPTY_RESULT', 'TIMEOUT']);
+
+export async function hasDribbbleSessionCookie(page) {
+    const cookies = await page.getCookies({ url: DRIBBBLE_ORIGIN });
+    const names = new Set((cookies || []).map((cookie) => cookie.name));
+    return names.has('_dribbble_session') || names.has('window._drbbbv_sess') || names.has('has_logged_in');
+}
+
 export function normalizeLimit(value, defaultValue = 20, maxValue = 30, label = 'limit') {
     const raw = value ?? defaultValue;
     const limit = Number(raw);
@@ -31,24 +39,72 @@ export function optionalQuery(value, label = 'query') {
 export function requireDesigner(value) {
     const designer = String(value ?? '').trim();
     if (!designer) throw new ArgumentError('designer is required (for example: halolab)');
-    if (designer.length > 100 || designer.includes('/') || designer.includes('?') || designer.includes('#')) {
+    if (!/^[A-Za-z0-9_-]{1,100}$/.test(designer)) {
         throw new ArgumentError('designer must be a Dribbble username or profile slug');
     }
     return designer;
+}
+
+export function requireShotTarget(value) {
+    const target = String(value ?? '').trim();
+    if (!target) throw new ArgumentError('shot is required (numeric id or dribbble.com/shots URL)');
+    if (/^\d+$/.test(target)) return target;
+
+    let url;
+    try {
+        url = new URL(target);
+    } catch {
+        throw new ArgumentError('shot must be a numeric id or dribbble.com/shots URL');
+    }
+    if (!/(^|\.)dribbble\.com$/i.test(url.hostname)) {
+        throw new ArgumentError('shot URL must use dribbble.com');
+    }
+    const match = url.pathname.match(/^\/shots\/(\d+)(?:-|\/|$)/);
+    if (!match) throw new ArgumentError('shot URL must match dribbble.com/shots/<id>');
+    return match[1];
 }
 
 export function requireRows(payload, command) {
     if (!payload || typeof payload !== 'object') {
         throw new CommandExecutionError(`${command} returned an unreadable browser payload`);
     }
+    if (payload.empty) {
+        throw new EmptyResultError(command, payload.reason || `${command} returned no results`);
+    }
     if (!payload.ok) {
         const reason = payload.reason ? `: ${payload.reason}` : '';
         throw new CommandExecutionError(`${command} selector drift${reason}`);
     }
-    if (!Array.isArray(payload.rows) || payload.rows.length === 0) {
+    if (!Array.isArray(payload.rows)) {
+        throw new CommandExecutionError(`${command} returned a malformed rows payload`);
+    }
+    if (payload.rows.length === 0) {
         throw new EmptyResultError(command, `${command} page loaded but no matching rows were found`);
     }
     return payload.rows;
+}
+
+export function requireRow(payload, command) {
+    if (!payload || typeof payload !== 'object') {
+        throw new CommandExecutionError(`${command} returned an unreadable browser payload`);
+    }
+    if (payload.empty) {
+        throw new EmptyResultError(command, payload.reason || `${command} was not found`);
+    }
+    if (!payload.ok || !payload.row) {
+        const reason = payload.reason ? `: ${payload.reason}` : '';
+        throw new CommandExecutionError(`${command} selector drift${reason}`);
+    }
+    return payload.row;
+}
+
+export async function runBrowserTask(label, task) {
+    try {
+        return await task();
+    } catch (error) {
+        if (TYPED_ERROR_CODES.has(error?.code)) throw error;
+        throw new CommandExecutionError(`${label} failed: ${error?.message ?? error}`);
+    }
 }
 
 export function extractShotRows(limit) {
@@ -60,25 +116,27 @@ export function extractShotRows(limit) {
         const multiplier = { k: 1e3, m: 1e6, b: 1e9 }[String(match[2] ?? '').toLowerCase()] ?? 1;
         return Number(match[1]) * multiplier;
     };
-    const root = document.querySelector('#content');
+    const root = document.querySelector('#content, main, [role="main"]');
     const cards = [...document.querySelectorAll('li[id^="screenshot-"]')];
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: 'Dribbble profile or shot page was not found' };
+    }
     if (!root) {
-        return { ok: false, reason: 'shot result root #content was not found', title: document.title || '' };
+        return { ok: false, reason: 'shot result root was not found', title: document.title || '' };
     }
 
     const rows = cards.map((el, index) => {
         const shotLink = [...el.querySelectorAll('a[href]')]
-            .find((anchor) => /^\/shots\/[^/]+/.test(anchor.getAttribute('href') || ''));
+            .find((anchor) => /^\/shots\/\d+(?:-|\/|$)/.test(anchor.getAttribute('href') || ''));
         if (!shotLink) return null;
-        const profileLink = [...el.querySelectorAll('a[href]')]
-            .find((anchor) => /^\/[^/]+$/.test(anchor.getAttribute('href') || ''));
+        const profileLink = el.querySelector('.user-information a[href], a[data-search-profile-clicked][href]');
         const image = el.querySelector('img');
         return {
             rank: index + 1,
             id: clean(el.getAttribute('data-thumbnail-id') || el.id.replace(/^screenshot-/, '')),
             title: clean(el.querySelector('.shot-title')?.textContent || image?.getAttribute('alt') || ''),
             designer: clean(profileLink?.textContent || ''),
-            likes: count(el.querySelector('.js-shot-likes-container')?.textContent),
+            likes: count(el.querySelector('[data-shot-like-count], .js-shot-likes-container')?.textContent),
             views: count(el.querySelector('.js-shot-views-count')?.textContent),
             imageUrl: clean(image?.currentSrc || image?.getAttribute('src') || image?.getAttribute('data-src') || ''),
             url: new URL(shotLink.getAttribute('href'), location.href).href,
@@ -108,11 +166,8 @@ export function extractDesignerRows(limit) {
         const budget = subheading.find((item) => /\$|project/i.test(item)) || '';
         const responseTime = subheading.find((item) => /responds/i.test(item)) || '';
         const locationText = subheading.find((item) => item !== budget && item !== responseTime && item !== '');
-        const ratingText = clean(el.querySelector('.designer-ratings-score__link')?.textContent || '');
-        const projectText = clean(el.querySelector('.designer-ratings__project-count')?.textContent || '');
         const serviceLink = [...el.querySelectorAll('a[href]')]
             .find((anchor) => /\/services$/.test(anchor.getAttribute('href') || ''));
-        const serviceText = clean(serviceLink?.textContent || '');
         const skills = [...el.querySelectorAll('.user-skills__item')]
             .map((item) => clean(item.textContent))
             .filter(Boolean);
@@ -121,12 +176,12 @@ export function extractDesignerRows(limit) {
             id: clean(el.getAttribute('data-id') || ''),
             username: clean(el.getAttribute('data-username') || ''),
             name: clean(el.getAttribute('data-display-name') || el.querySelector('.user-card-profile__heading-name')?.textContent || ''),
-            rating: numberFrom(ratingText),
-            projectCount: numberFrom(projectText),
+            rating: numberFrom(el.querySelector('.designer-ratings-score__link')?.textContent),
+            projectCount: numberFrom(el.querySelector('.designer-ratings__project-count')?.textContent),
             budgetText: budget || null,
             location: locationText || null,
             responseTime: responseTime || null,
-            serviceCount: numberFrom(serviceText),
+            serviceCount: numberFrom(serviceLink?.textContent),
             skills,
             url: profilePath ? new URL(profilePath, document.location.href).href : '',
             avatarUrl: clean(el.querySelector('img')?.src || ''),
@@ -142,46 +197,87 @@ export function extractProfileRow(username) {
         const match = clean(value).replace(/,/g, '').match(/\d+(?:\.\d+)?/);
         return match ? Number(match[0]) : null;
     };
-    const profile = document.querySelector('.profile-masthead, .masthead-profile-name')?.closest('main, body') || document.body;
-    const name = clean(document.querySelector('.masthead-profile-name, .profile-masthead h1, h1')?.textContent || '');
-    if (!name || !profile) {
-        return { ok: false, reason: 'profile identity was not found', title: document.title || '' };
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: `Dribbble profile "${username}" was not found` };
     }
 
-    const stats = [...document.querySelectorAll('.masthead-stats .stat, .profile-masthead .stat')];
-    const statValue = (pattern) => numberFrom(stats.find((stat) => pattern.test(clean(stat.textContent)))?.textContent);
-    const website = [...document.querySelectorAll('.user-contact-info a[href], .profile-masthead a[href]')]
-        .map((anchor) => anchor.getAttribute('href') || '')
-        .find((href) => /^https?:\/\//i.test(href) && !/dribbble\.com/i.test(href)) || '';
-    const avatar = document.querySelector('.masthead-avatar img, .profile-masthead img')?.currentSrc
-        || document.querySelector('.masthead-avatar img, .profile-masthead img')?.src
-        || '';
-    const availableText = clean(document.querySelector('.user-sticky-header__available, .profile-masthead [class*="available"]')?.textContent || '');
-    const intro = clean(document.querySelector('.masthead-intro, .profile-masthead .bio')?.textContent || '');
+    const masthead = document.querySelector('[data-profile-masthead-container], .profile-masthead');
+    const name = clean(masthead?.querySelector('.masthead-profile-name h1, h1')?.textContent || '');
+    if (!masthead || !name) {
+        return { ok: false, reason: 'profile masthead identity was not found', title: document.title || '' };
+    }
+
+    const mastheadText = clean(masthead.textContent);
+    const statValue = (label) => numberFrom(mastheadText.match(new RegExp(`([\\d,.]+(?:[kmb])?)\\s+${label}`, 'i'))?.[1]);
+    const main = document.querySelector('main, [role="main"]');
+    const mainText = clean(main?.textContent || '');
+    const headingContainer = (label) => [...(main?.querySelectorAll('h2, h3') || [])]
+        .find((heading) => clean(heading.textContent).toLowerCase() === label.toLowerCase())?.parentElement;
+    const biography = [...(headingContainer('Biography')?.querySelectorAll('p') || [])]
+        .map((item) => clean(item.textContent))
+        .filter(Boolean)
+        .join('\n\n');
+    const skills = [...(main?.querySelectorAll('a[href^="/skills/"]') || [])]
+        .map((anchor) => clean(anchor.textContent))
+        .filter(Boolean);
+    const languages = [...(headingContainer('Languages')?.querySelectorAll('li') || [])]
+        .map((item) => clean(item.textContent))
+        .filter(Boolean);
+    const socialLinks = [...(headingContainer('Social')?.querySelectorAll('a[href]') || [])]
+        .map((anchor) => anchor.href)
+        .filter(Boolean);
+    const locationText = [...(main?.querySelectorAll('p') || [])]
+        .map((item) => clean(item.textContent))
+        .find((text) => /,\s*[A-Z]{2}$|,\s*[A-Za-z ]+$/.test(text) && text.length < 100) || '';
+    const memberSince = [...(main?.querySelectorAll('p') || [])]
+        .map((item) => clean(item.textContent))
+        .find((text) => /^Member since\s+/i.test(text))
+        ?.replace(/^Member since\s+/i, '') || '';
+    const socialHosts = /(^|\.)(?:twitter|x|facebook|instagram|github|behance|linkedin)\.com$/i;
+    const socialWebsite = socialLinks.find((href) => {
+        const host = new URL(href).hostname;
+        return !/(^|\.)dribbble\.com$/i.test(host) && !socialHosts.test(host) && host !== 'cal.com';
+    });
+    const website = socialWebsite || [...(main?.querySelectorAll('a[href^="http"]') || [])]
+        .map((anchor) => anchor.href)
+        .find((href) => {
+            const host = new URL(href).hostname;
+            return !/(^|\.)dribbble\.com$/i.test(host) && !socialHosts.test(host) && host !== 'cal.com';
+        }) || '';
+    const avatar = masthead.querySelector('img[src]')?.currentSrc || masthead.querySelector('img[src]')?.src || '';
 
     return {
         ok: true,
         row: {
             username,
             name,
-            intro: intro || null,
-            followersCount: statValue(/followers/i),
-            followingCount: statValue(/following/i),
-            likesCount: statValue(/likes/i),
-            availableForWork: /available for work/i.test(availableText),
+            intro: clean(masthead.querySelector('.masthead-intro, .profile-masthead h2')?.textContent) || null,
+            biography: biography || null,
+            followersCount: statValue('followers'),
+            followingCount: statValue('following'),
+            likesCount: statValue('likes'),
+            availableForWork: /available for (?:new )?(?:work|projects)/i.test(`${mastheadText} ${mainText}`),
+            location: locationText || null,
+            memberSince: memberSince || null,
+            skills,
+            languages,
+            socialLinks,
             website: website || null,
-            url: document.location.href,
+            url: document.location.href.replace(/\/about\/?$/, ''),
             avatarUrl: clean(avatar) || null,
         },
     };
 }
 
-export function extractServiceRows(designer, limit) {
+export function extractServiceRows(designer) {
     const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
-    const root = document.querySelector('#content');
+    const root = document.querySelector('#content, main, [role="main"]');
     const cards = [...document.querySelectorAll('.service-card[role="article"]')];
     if (!root) {
-        return { ok: false, reason: 'service result root #content was not found', title: document.title || '' };
+        return { ok: false, reason: 'service result root was not found', title: document.title || '' };
+    }
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: `Dribbble profile "${designer}" was not found` };
     }
 
     const rows = cards.map((el, index) => {
@@ -190,14 +286,15 @@ export function extractServiceRows(designer, limit) {
         const meta = [...el.querySelectorAll('.service-card__content .display-flex.gap-8 span')]
             .map((item) => clean(item.textContent))
             .filter(Boolean);
+        const duration = meta.find((item) => /\b(?:day|days|week|weeks|month|months)\b/i.test(item)) || null;
         const description = clean(el.querySelector('.service-card__description, .text-clip-2')?.textContent || '');
         const cardText = clean(el.textContent);
         return {
             rank: index + 1,
             id: clean(button?.getAttribute('data-search-service-clicked') || detailPath.match(/\/services\/(\d+)/)?.[1] || ''),
             title: clean(el.querySelector('.service-card__title, h3')?.textContent || button?.getAttribute('aria-label')?.replace(/^View service:\s*/i, '') || ''),
-            priceText: meta[0] || null,
-            duration: meta[1] || null,
+            priceText: meta.find((item) => /\$/.test(item)) || null,
+            duration,
             description: description ? description.slice(0, 800) : null,
             quickHire: /quick hire/i.test(cardText),
             url: detailPath ? new URL(detailPath, location.href).href : '',
@@ -206,5 +303,135 @@ export function extractServiceRows(designer, limit) {
         };
     }).filter((row) => row.id && row.title && row.url);
 
-    return { ok: true, rows: rows.slice(0, limit) };
+    return { ok: true, rows };
+}
+
+export function extractShotDetailRow(shotId) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: `Dribbble shot "${shotId}" was not found` };
+    }
+    const root = document.querySelector('#content')
+        || document.querySelector('.shot-container')
+        || document.querySelector('main, [role="main"]');
+    const title = clean(root?.querySelector('.shot-header__title, .shot-header h1, h1')?.textContent || '');
+    const pageShotId = root?.querySelector('[data-shot-id], [data-screenshot_id]')?.getAttribute('data-shot-id')
+        || root?.querySelector('[data-screenshot_id]')?.getAttribute('data-screenshot_id')
+        || document.location.pathname.match(/^\/shots\/(\d+)/)?.[1]
+        || '';
+    if (!root || !title || pageShotId !== String(shotId)) {
+        return { ok: false, reason: 'shot identity was not found', title: document.title || '' };
+    }
+
+    const profileLinks = [...root.querySelectorAll('.user-sticky-header__name a[href]')]
+        .map((anchor) => ({ name: clean(anchor.textContent), href: anchor.getAttribute('href') || '' }))
+        .filter((item) => item.name && /^\/[A-Za-z0-9_-]+$/.test(item.href));
+    const distinctProfiles = profileLinks.filter((item, index, items) => items.findIndex((entry) => entry.href === item.href) === index);
+    const mediaUrls = [
+        ...[...root.querySelectorAll('.shot-media-container img, .shot-media-container video, .shot-media-container source')]
+            .map((media) => media.currentSrc || media.src || media.getAttribute('src') || ''),
+        ...[...root.querySelectorAll('.shot-content a[href^="https://cdn.dribbble.com/"]')]
+            .map((anchor) => anchor.href),
+    ]
+        .filter(Boolean)
+        .filter((url, index, urls) => urls.indexOf(url) === index);
+    const imageUrl = document.querySelector('meta[property="og:image"]')?.content || mediaUrls[0] || '';
+    const colors = [...root.querySelectorAll('a[href*="?color="]')]
+        .map((anchor) => clean(anchor.textContent).replace(/^#/, '').toUpperCase())
+        .filter((value) => /^[0-9A-F]{6}$/.test(value))
+        .filter((value, index, values) => values.indexOf(value) === index);
+
+    return {
+        ok: true,
+        row: {
+            id: String(shotId),
+            title,
+            designer: distinctProfiles[0]?.name || null,
+            designerUrl: distinctProfiles[0] ? new URL(distinctProfiles[0].href, location.href).href : null,
+            team: distinctProfiles[1]?.name || null,
+            description: clean(root.querySelector('.shot-description-container')?.textContent) || null,
+            imageUrl: imageUrl || null,
+            mediaUrls,
+            colors,
+            availableForWork: /available for work/i.test(
+                root.querySelector('.user-sticky-header__available')?.textContent || '',
+            ),
+            url: document.location.href,
+        },
+    };
+}
+
+export function extractCollectionRows(designer, limit) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const root = document.querySelector('main, [role="main"]');
+    if (!root) return { ok: false, reason: 'collection result root was not found' };
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: `Dribbble profile "${designer}" was not found` };
+    }
+
+    const prefix = `/${designer}/collections/`.toLowerCase();
+    const rows = [...root.querySelectorAll('a[href]')]
+        .map((anchor) => ({ anchor, href: anchor.getAttribute('href') || '' }))
+        .filter(({ href }) => href.toLowerCase().startsWith(prefix))
+        .map(({ anchor, href }, index) => {
+            const id = href.match(/\/collections\/(\d+)/)?.[1] || '';
+            const text = clean(anchor.textContent);
+            const shotCount = Number(text.replace(/,/g, '').match(/(\d+)\s+Shots?/i)?.[1] || NaN);
+            const designerCount = Number(text.replace(/,/g, '').match(/(\d+)\s+Designers?/i)?.[1] || NaN);
+            const title = clean(anchor.querySelector('h2, h3, [class*="title"]')?.textContent)
+                || text.replace(/\s+\d[\d,]*\s+Shots?.*$/i, '').trim();
+            return {
+                rank: index + 1,
+                id,
+                title,
+                shotCount: Number.isFinite(shotCount) ? shotCount : null,
+                designerCount: Number.isFinite(designerCount) ? designerCount : null,
+                url: new URL(href, location.href).href,
+            };
+        })
+        .filter((row) => row.id && row.title)
+        .filter((row, index, rows) => rows.findIndex((entry) => entry.id === row.id) === index)
+        .slice(0, limit);
+    return { ok: true, rows };
+}
+
+export function extractMemberRows(designer, limit) {
+    const clean = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+    const root = document.querySelector('main, [role="main"]');
+    if (!root) return { ok: false, reason: 'member result root was not found' };
+    if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
+        return { ok: true, empty: true, reason: `Dribbble profile "${designer}" was not found` };
+    }
+
+    const rows = [...root.querySelectorAll('li')].map((card, index) => {
+        const follow = card.querySelector('a[href$="/followers"]');
+        const profile = follow ? [...card.querySelectorAll('a[href]')].find((anchor) => {
+            const href = anchor.getAttribute('href') || '';
+            return /^\/[A-Za-z0-9_-]+$/.test(href) && href !== '/pro';
+        }) : null;
+        const href = profile?.getAttribute('href') || '';
+        if (!profile || !href) return null;
+        const shotUrls = [...card.querySelectorAll('a[href^="/shots/"]')]
+            .map((anchor) => new URL(anchor.getAttribute('href'), location.href).href)
+            .filter((url, shotIndex, urls) => urls.indexOf(url) === shotIndex);
+        const locationText = clean(card.querySelector('[class*="location"]')?.textContent || '') || null;
+        return {
+            rank: index + 1,
+            username: href.slice(1),
+            name: clean(profile.textContent) || clean(profile.querySelector('img')?.alt || ''),
+            location: locationText,
+            url: new URL(href, location.href).href,
+            avatarUrl: card.querySelector('img')?.currentSrc || card.querySelector('img')?.src || null,
+            recentShotUrls: shotUrls,
+        };
+    }).filter((row) => row && row.username && row.name);
+
+    const uniqueRows = rows
+        .filter((row, index, items) => items.findIndex((item) => item.username === row.username) === index)
+        .slice(0, limit)
+        .map((row, index) => ({ ...row, rank: index + 1 }));
+    return {
+        ok: true,
+        rows: uniqueRows,
+    };
 }

--- a/docs/adapters/browser/dribbble.md
+++ b/docs/adapters/browser/dribbble.md
@@ -1,0 +1,56 @@
+# Dribbble
+
+**Mode**: 🌐 Browser · **Domain**: `dribbble.com`
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli dribbble shot <query>` | Search shots by keyword |
+| `opencli dribbble shot-detail <shot>` | Show one shot's authorship, media, palette, and availability |
+| `opencli dribbble designer` | Browse designers and agencies |
+| `opencli dribbble profile <designer>` | Show a designer's public profile and about fields |
+| `opencli dribbble portfolio <designer>` | List a designer's published or liked shots |
+| `opencli dribbble service <designer>` | List and filter a designer's services |
+| `opencli dribbble collection <designer>` | List a designer's public collections |
+| `opencli dribbble member <designer>` | List a team profile's public members |
+| `opencli dribbble whoami` | Show the signed-in Dribbble identity |
+| `opencli dribbble login` | Open Dribbble's sign-in flow |
+
+## Usage Examples
+
+```bash
+# Search Dribbble's public popular or New & Noteworthy views
+opencli dribbble shot "mobile ui" --sort popular --limit 10 -f json
+opencli dribbble shot "mobile ui" --sort recent --limit 10 -f json
+
+# The personalized Following view requires a signed-in browser session
+opencli dribbble shot "mobile ui" --sort following --limit 10 -f json
+
+# Inspect a shot and a designer's public surfaces
+opencli dribbble shot-detail 27679566 -f json
+opencli dribbble profile halolab -f json
+opencli dribbble portfolio halolab --type work --limit 10 -f json
+opencli dribbble service halolab --query branding --limit 10 -f json
+opencli dribbble collection halolab --limit 10 -f json
+opencli dribbble member halolab --limit 10 -f json
+
+# Browse designers and verify authentication
+opencli dribbble designer --query product --limit 10 -f json
+opencli dribbble whoami -f json
+```
+
+`shot-detail` accepts either a numeric shot id or a full `dribbble.com/shots/...` URL. Designer arguments are Dribbble usernames or profile slugs. List limits must be positive integers and cannot exceed 30.
+
+For `portfolio --type likes`, `designer` identifies each shot's author, not the profile that liked it. It remains empty when Dribbble omits the author label; OpenCLI does not guess ownership.
+
+## Output
+
+Shot commands return stable identity and URL fields plus the metadata visible on Dribbble, such as author, likes, views, media URLs, palette, or work availability. Profile output includes biography, counts, location, membership date, skills, languages, social links, website, and avatar. The remaining list commands preserve rank plus the visible identity and metadata for each service, collection, or team member.
+
+Public reads use Dribbble's server-rendered browser pages. Direct HTTP requests are challenged by AWS WAF, and the official Dribbble API requires a separate OAuth application and token, so the adapter does not depend on a private web API.
+
+## Prerequisites
+
+- Chrome running with the [Browser Bridge extension](/guide/browser-bridge) installed
+- A Dribbble login only for `whoami`, `login`, and `shot --sort following`


### PR DESCRIPTION
## Dribbble adapter

Adds a browser-backed Dribbble adapter with ten commands:

| Command | Purpose |
|---|---|
| `shot <query>` | Search shots with Dribbble's following, popular, or recent route |
| `shot-detail <shot>` | Read one shot's identity, authorship, media, palette, and availability |
| `designer [--query]` | Browse designers and agencies |
| `profile <designer>` | Read a rich public profile and about page |
| `portfolio <designer>` | List published or liked shots |
| `service <designer>` | List and filter offered services |
| `collection <designer>` | List public collections |
| `member <designer>` | List public team members and their recent shots |
| `whoami` | Verify the current Dribbble browser identity |
| `login` | Establish and verify a browser session |

## Contract and strategy

- Public reads use the visible server-rendered DOM through Browser Bridge and declare `Strategy.UI`.
- Direct HTTP receives an AWS WAF challenge (HTTP 202 with no business document), and browser network capture exposed no reusable business JSON API.
- Dribbble's official API requires a separate OAuth application and token; the signed-in web session does not provide that contract.
- The adapter therefore does not depend on an unstable private endpoint or mislabel browser automation as `Strategy.PUBLIC`.
- Argument validation, typed empty/drift failures, browser error wrapping, and DOM extractors are shared in `utils.js`.

## Correctness fixes from live review

- `whoami` recognizes the live absolute sign-out form action and `_dribbble_session` cookie instead of falsely returning `AUTH_REQUIRED`.
- Missing profiles and shots return `EmptyResultError` rather than successful rows built from Dribbble's 404 heading.
- Profile identity is scoped to the exact `h1`; biography, counts, location, membership date, skills, languages, social links, website, and avatar are preserved.
- Service duration reads duration units rather than the visual `|` separator; keyword filtering now examines the complete visible service page before applying `--limit`.
- Shot detail follows the live `#content` / sticky-author / CDN-media DOM contract and verifies the requested shot id.
- Portfolio cards without a repeated author label fall back to the explicitly requested profile.

## Verification

- Focused Dribbble tests: 14/14 pass (real DOM shapes plus command-level auth, 404, filtering, and work/likes fallback contracts).
- Full adapter suite: 539 files / 5,834 tests pass.
- `npm run typecheck`: pass.
- `npm run build`: pass; manifest contains 1,366 entries.
- `opencli validate dribbble`: 10 commands, 0 errors, 0 warnings.
- Strict adapter documentation coverage: 179/179.
- Typed-error lint and silent-column-drop gates: no new violations.
- `git diff --check`: pass.

Live browser replay passed for authenticated identity, popular/recent shot search, designer search, profile, service, published/liked portfolios, shot detail, collections, and team members. The test account's following search is a legitimate empty result because it follows no designers. A deliberately missing profile returns exit 66 with a precise not-found explanation.
