### PR TITLE
fix(deepseek): guarantee ask --new starts a fresh conversation

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -10179,7 +10179,7 @@
     "site": "deepseek",
     "name": "new",
     "description": "Start a new conversation in DeepSeek",
-    "access": "read",
+    "access": "write",
     "domain": "chat.deepseek.com",
     "strategy": "cookie",
     "browser": true,

--- a/clis/deepseek/ask.js
+++ b/clis/deepseek/ask.js
@@ -1,10 +1,15 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CliError, CommandExecutionError, EXIT_CODES, TimeoutError } from '@jackwener/opencli/errors';
 import {
-    DEEPSEEK_DOMAIN, DEEPSEEK_URL, ensureOnDeepSeek, selectModel, setFeature,
+    DEEPSEEK_DOMAIN, ensureOnDeepSeek, ensureFreshConversation, selectModel, setFeature,
     sendMessage, sendWithFile, getBubbleCount, waitForResponse, parseBoolFlag, withRetry,
     pickResumeUrl, TEXTAREA_SELECTOR,
 } from './utils.js';
+
+const restoredConversationError = (reason) => new CommandExecutionError(
+    `DeepSeek restored the previous conversation, so --new could not start a fresh thread (${reason})`,
+    'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+);
 
 export const askCommand = cli({
     site: 'deepseek',
@@ -32,6 +37,7 @@ export const askCommand = cli({
         const timeoutMs = (kwargs.timeout || 120) * 1000;
         const wantThink = parseBoolFlag(kwargs.think);
         const wantSearch = parseBoolFlag(kwargs.search);
+        const wantNew = parseBoolFlag(kwargs.new);
         const wantModel = kwargs.model || 'instant';
 
         if ((wantModel === 'vision' || wantModel === 'expert') && wantSearch) {
@@ -43,15 +49,20 @@ export const askCommand = cli({
             );
         }
 
-        if (parseBoolFlag(kwargs.new)) {
-            await page.goto(DEEPSEEK_URL);
-            // Wait for the composer to mount instead of a fixed 3 s sleep.
-            try {
-                await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
-            } catch {
-                // Selector still missing → downstream selectModel/sendMessage
-                // will surface the failure with a typed error.
+        if (wantNew) {
+            const fresh = await ensureFreshConversation(page);
+            if (!fresh.ok && fresh.reason !== 'composer-missing') {
+                // DeepSeek auto-restored the previous thread and the escape
+                // failed. Sending now would append to the old conversation —
+                // the exact silent-corruption --new exists to prevent. The
+                // reason distinguishes a restore race from a missing sidebar
+                // control (i.e. a DeepSeek UI change).
+                throw restoredConversationError(fresh.reason);
             }
+            // composer-missing → fall through so downstream selectModel/
+            // sendMessage surface the failure with a typed error — the same
+            // logged-out behavior --new had before the freshness guard,
+            // kept unchanged on purpose.
         } else {
             const navigated = await ensureOnDeepSeek(page);
             if (navigated) {
@@ -79,6 +90,18 @@ export const askCommand = cli({
         const currentUrl = await page.evaluate('window.location.href') || '';
         const inConversation = currentUrl.includes('/a/chat/s/');
         const modelExplicit = kwargs.__opencliOptionSources?.model === 'cli';
+
+        // Early exit so a restore detected here fails before the model/feature
+        // toggles run (and before the misleading model-switch usage error
+        // below). Not redundant with the empty-baseline guard before the
+        // send: a restore flips the URL before its old messages render, so
+        // this check catches "on a thread, bubbles still 0" while the
+        // baseline catches "bubbles rendered, URL snapshot stale". Each
+        // covers a window the other misses — neither can be demoted to a
+        // hint.
+        if (wantNew && inConversation) {
+            throw restoredConversationError('conversation-restored');
+        }
 
         if (inConversation && modelExplicit) {
             throw new CliError(
@@ -116,8 +139,23 @@ export const askCommand = cli({
         // No settle wait after toggles: the next CDP eval below already gives
         // React time to flush the aria-checked state.
 
+        // --new must send into an empty conversation. The URL checks above are
+        // racy snapshots (the SPA can restore the old thread at any point up
+        // to here), but a restored thread always carries its old messages, so
+        // a zero bubble baseline right before the send is a timing-independent
+        // test of the same invariant. Rests on one live-verified fact
+        // (2026-08): a fresh chat page renders zero .ds-message elements. If
+        // DeepSeek ever ships welcome bubbles, every --new fails loudly here
+        // — never silently. The remaining exposure is the gap between this
+        // check and the actual send click (upload-sized on the --file path);
+        // it is irreducible without an atomic in-page check-and-send, and
+        // restores are empirically a load-time behavior, long past by now.
+        const baseline = await withRetry(() => getBubbleCount(page));
+        if (wantNew && baseline > 0) {
+            throw restoredConversationError('conversation-restored');
+        }
+
         if (kwargs.file) {
-            const baseline = await withRetry(() => getBubbleCount(page));
             try {
                 const fileResult = await sendWithFile(page, kwargs.file, prompt);
                 if (fileResult && !fileResult.ok) {
@@ -139,7 +177,6 @@ export const askCommand = cli({
             return [{ response: result }];
         }
 
-        const baseline = await withRetry(() => getBubbleCount(page));
         const sendResult = await withRetry(() => sendMessage(page, prompt));
         if (!sendResult?.ok) {
             throw new CommandExecutionError(sendResult?.reason || 'Failed to send message');

--- a/clis/deepseek/ask.test.js
+++ b/clis/deepseek/ask.test.js
@@ -3,6 +3,7 @@ import { CliError, CommandExecutionError, EXIT_CODES, TimeoutError } from '@jack
 
 const {
   mockEnsureOnDeepSeek,
+  mockEnsureFreshConversation,
   mockSelectModel,
   mockSetFeature,
   mockSendMessage,
@@ -14,6 +15,7 @@ const {
   mockPickResumeUrl,
 } = vi.hoisted(() => ({
   mockEnsureOnDeepSeek: vi.fn(),
+  mockEnsureFreshConversation: vi.fn(),
   mockSelectModel: vi.fn(),
   mockSetFeature: vi.fn(),
   mockSendMessage: vi.fn(),
@@ -27,8 +29,9 @@ const {
 
 vi.mock('./utils.js', () => ({
   DEEPSEEK_DOMAIN: 'chat.deepseek.com',
-  DEEPSEEK_URL: 'https://chat.deepseek.com/',
+  TEXTAREA_SELECTOR: 'textarea[placeholder*="DeepSeek"]',
   ensureOnDeepSeek: mockEnsureOnDeepSeek,
+  ensureFreshConversation: mockEnsureFreshConversation,
   selectModel: mockSelectModel,
   setFeature: mockSetFeature,
   sendMessage: mockSendMessage,
@@ -362,6 +365,162 @@ describe('deepseek ask conversation resume', () => {
     expect(mockSetFeature).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(mockSendWithFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('deepseek ask --new session guarantee', () => {
+  const page = {
+    wait: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/');
+    mockEnsureFreshConversation.mockResolvedValue({ ok: true, escaped: false });
+    mockSelectModel.mockResolvedValue({ ok: true, toggled: false });
+    mockSetFeature.mockResolvedValue({ ok: true, toggled: false });
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockGetBubbleCount.mockResolvedValue(0);
+    mockWaitForResponse.mockResolvedValue('fresh reply');
+  });
+
+  it('delegates --new navigation to ensureFreshConversation', async () => {
+    const rows = await askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    });
+
+    expect(rows).toEqual([{ response: 'fresh reply' }]);
+    expect(mockEnsureFreshConversation).toHaveBeenCalledWith(page);
+    // Navigation is owned by the helper now; the command must not race it
+    // with its own goto or fall back to the resume path.
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(mockEnsureOnDeepSeek).not.toHaveBeenCalled();
+    expect(mockPickResumeUrl).not.toHaveBeenCalled();
+  });
+
+  it('fails fast instead of appending to the restored conversation', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'conversation-restored' });
+
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    })).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation, so --new could not start a fresh thread (conversation-restored)',
+      'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+    ));
+
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the SPA restores the thread after the helper reported success', async () => {
+    // The helper's settle wait is best-effort, so the restore can land after
+    // it returned ok — the settled URL is the last line of defense.
+    page.evaluate.mockResolvedValue('https://chat.deepseek.com/a/chat/s/some-id');
+
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    })).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation, so --new could not start a fresh thread (conversation-restored)',
+      'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+    ));
+
+    expect(mockSelectModel).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the baseline shows the send would land in a non-empty conversation', async () => {
+    // URL checks are racy snapshots; the empty-baseline check right before
+    // the send is the timing-independent --new guard. A restore that slips
+    // past every URL check still surfaces here as pre-existing bubbles.
+    mockGetBubbleCount.mockResolvedValue(4);
+
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    })).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation, so --new could not start a fresh thread (conversation-restored)',
+      'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+    ));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('applies the baseline guard to --file sends too', async () => {
+    // The baseline is collected once, before the file/plain branch split;
+    // this locks the guard in front of sendWithFile so a refactor cannot
+    // move the collection back inside only the plain-text path.
+    mockGetBubbleCount.mockResolvedValue(4);
+
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+      file: 'C:/tmp/report.pdf',
+    })).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation, so --new could not start a fresh thread (conversation-restored)',
+      'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+    ));
+
+    expect(mockSendWithFile).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when the sidebar offers no new-chat control, and names that reason', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'new-chat-control-not-found' });
+
+    // The reason distinguishes a DeepSeek UI change (missing control) from a
+    // restore race, so it must survive into the user-facing error.
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    })).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation, so --new could not start a fresh thread (new-chat-control-not-found)',
+      'Retry, or open chat.deepseek.com and start a new chat manually before re-running.',
+    ));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the login-page behavior: composer-missing defers to downstream typed errors', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'composer-missing' });
+    mockSelectModel.mockResolvedValue({ ok: false });
+
+    await expect(askCommand.func(page, {
+      prompt: 'sample question',
+      timeout: 120,
+      new: true,
+      model: 'instant',
+      think: false,
+      search: false,
+    })).rejects.toThrow(new CommandExecutionError('Could not switch to instant model'));
   });
 });
 

--- a/clis/deepseek/new.js
+++ b/clis/deepseek/new.js
@@ -1,11 +1,11 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { DEEPSEEK_DOMAIN, DEEPSEEK_URL, TEXTAREA_SELECTOR } from './utils.js';
+import { DEEPSEEK_DOMAIN, ensureFreshConversation } from './utils.js';
 
 export const newCommand = cli({
     site: 'deepseek',
     name: 'new',
-    access: 'read',
+    access: 'write',
     description: 'Start a new conversation in DeepSeek',
     domain: DEEPSEEK_DOMAIN,
     strategy: Strategy.COOKIE,
@@ -16,16 +16,23 @@ export const newCommand = cli({
     columns: ['Status'],
 
     func: async (page) => {
-        await page.goto(DEEPSEEK_URL);
-        // Confirm the composer mounted before reporting success. The previous
-        // 2 s blind sleep would return "New chat started" even when the page
-        // was still loading or the user was logged out.
-        try {
-            await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
-        } catch {
+        // "New chat started" must mean a confirmed fresh thread. A bare goto
+        // is not enough: DeepSeek auto-restores the previous conversation
+        // after the home page loads, which used to make this command report
+        // success while the composer sat inside the old thread.
+        const fresh = await ensureFreshConversation(page);
+        if (!fresh.ok) {
+            if (fresh.reason === 'composer-missing') {
+                throw new CommandExecutionError(
+                    'DeepSeek composer did not mount within 8 s',
+                    'Verify you are logged into chat.deepseek.com.',
+                );
+            }
+            // The reason distinguishes a restore race from a missing sidebar
+            // control (i.e. a DeepSeek UI change).
             throw new CommandExecutionError(
-                'DeepSeek composer did not mount within 8 s',
-                'Verify you are logged into chat.deepseek.com.',
+                `DeepSeek restored the previous conversation instead of starting a new chat (${fresh.reason})`,
+                'Retry, or start a new chat manually at chat.deepseek.com.',
             );
         }
         return [{ Status: 'New chat started' }];

--- a/clis/deepseek/new.test.js
+++ b/clis/deepseek/new.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+
+const { mockEnsureFreshConversation } = vi.hoisted(() => ({
+  mockEnsureFreshConversation: vi.fn(),
+}));
+
+vi.mock('./utils.js', () => ({
+  DEEPSEEK_DOMAIN: 'chat.deepseek.com',
+  ensureFreshConversation: mockEnsureFreshConversation,
+}));
+
+import { newCommand } from './new.js';
+
+describe('deepseek new', () => {
+  const page = {
+    wait: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers command shape', () => {
+    expect(newCommand.site).toBe('deepseek');
+    expect(newCommand.name).toBe('new');
+    expect(newCommand.strategy).toBe('cookie');
+    expect(newCommand.browser).toBe(true);
+    // Starting a new chat mutates session state, and only write commands get
+    // the persistent-session lease.
+    expect(newCommand.access).toBe('write');
+  });
+
+  it('reports success only after the helper confirms a fresh thread', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: true, escaped: true });
+
+    const rows = await newCommand.func(page, {});
+
+    expect(rows).toEqual([{ Status: 'New chat started' }]);
+    expect(mockEnsureFreshConversation).toHaveBeenCalledWith(page);
+  });
+
+  it('throws when the composer never mounts (login or error page)', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'composer-missing' });
+
+    await expect(newCommand.func(page, {})).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek composer did not mount within 8 s',
+      'Verify you are logged into chat.deepseek.com.',
+    ));
+  });
+
+  it('no longer reports success when DeepSeek restored the previous conversation', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'conversation-restored' });
+
+    await expect(newCommand.func(page, {})).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation instead of starting a new chat (conversation-restored)',
+      'Retry, or start a new chat manually at chat.deepseek.com.',
+    ));
+  });
+
+  it('names the missing new-chat control so a DeepSeek UI change is diagnosable', async () => {
+    mockEnsureFreshConversation.mockResolvedValue({ ok: false, reason: 'new-chat-control-not-found' });
+
+    await expect(newCommand.func(page, {})).rejects.toThrow(new CommandExecutionError(
+      'DeepSeek restored the previous conversation instead of starting a new chat (new-chat-control-not-found)',
+      'Retry, or start a new chat manually at chat.deepseek.com.',
+    ));
+  });
+});

--- a/clis/deepseek/utils.js
+++ b/clis/deepseek/utils.js
@@ -54,6 +54,95 @@ export async function ensureOnDeepSeek(page) {
     return true;
 }
 
+// An unreadable URL is UNCONFIRMED, so it counts as not-fresh: callers must
+// keep escaping and ultimately fail closed rather than green-light a send.
+async function isOnConversationThread(page) {
+    const url = await page.evaluate('window.location.href').catch(() => null);
+    if (typeof url !== 'string') return true;
+    return url.includes('/a/chat/s/');
+}
+
+// A single off-thread snapshot can race the restore redirect, so a fresh
+// verdict requires the URL to stay off any conversation thread across a
+// settle. Short-circuits without the settle when already on a thread.
+// Deliberately verifies off-thread rather than on-home: off-thread is the
+// only invariant --new needs, pinning a home path would break on any
+// DeepSeek routing change, and a click that lands somewhere unexpected
+// still fails closed downstream (composer / model-switch checks).
+async function confirmedOffThread(page) {
+    if (await isOnConversationThread(page)) return false;
+    await page.wait(1);
+    return !(await isOnConversationThread(page));
+}
+
+function clickNewChatControl(page) {
+    return page.evaluate(`(() => {
+        const label = (el) => {
+            const aria = (el.getAttribute('aria-label') || el.getAttribute('title') || '').trim();
+            return aria || (el.innerText || '').trim();
+        };
+        // startsWith: the button text may carry a shortcut hint ("开启新对话 ⌘J").
+        const matches = (text) => text.startsWith('开启新对话') || text.startsWith('New chat');
+        const matched = Array.from(document.querySelectorAll('a, button, [role="button"], div'))
+            // Skip sidebar history entries: a saved conversation titled
+            // "New chat" would otherwise win the deepest-match pick below and
+            // navigate straight back into the old thread.
+            .filter((el) => !el.closest('a[href*="/a/chat/s/"]'))
+            .filter((el) => matches(label(el)));
+        if (matched.length === 0) return { ok: false, reason: 'new-chat-control-not-found' };
+        // Deepest match: an outer page container's innerText also starts with
+        // the sidebar's first label, and clicking that container does nothing.
+        // find() cannot miss: a non-empty finite set always has a
+        // containment-minimal element.
+        const target = matched.find((el) => !matched.some((other) => other !== el && el.contains(other)));
+        const clickable = target.closest('a, button, [role="button"], [tabindex]') || target;
+        clickable.click();
+        return { ok: true };
+    })()`);
+}
+
+/**
+ * Navigate to the DeepSeek home page and confirm the composer is on a fresh
+ * conversation before the caller sends anything.
+ *
+ * A bare goto does NOT guarantee a new thread: DeepSeek's SPA auto-restores
+ * the most recent conversation shortly after the home page loads (the URL
+ * silently becomes /a/chat/s/<id>), so a send would append to the old
+ * thread. Detect the restore and escape through the sidebar's
+ * "开启新对话" / "New chat" control, re-checking the URL after each click.
+ *
+ * Returns { ok: true, escaped } once the URL is confirmed stable off any
+ * conversation thread across a settle, or { ok: false, reason: 'composer-missing' |
+ * 'new-chat-control-not-found' | 'conversation-restored' } so callers can
+ * fail with a typed error instead of silently posting into the wrong thread.
+ */
+export async function ensureFreshConversation(page) {
+    await page.goto(DEEPSEEK_URL);
+    try {
+        await page.wait({ selector: TEXTAREA_SELECTOR, timeout: 8 });
+    } catch {
+        return { ok: false, reason: 'composer-missing' };
+    }
+    // The restore redirect fires after the composer mounts; give the router a
+    // beat before trusting the URL.
+    await page.wait(1);
+    if (await confirmedOffThread(page)) return { ok: true, escaped: false };
+    let lastReason = 'conversation-restored';
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const clicked = await clickNewChatControl(page).catch(() => null);
+        // Keep polling on a miss: the sidebar may still be mounting. Only an
+        // explicit ok:false means the control is missing — a rejected evaluate
+        // (the route transition collects the promise) leaves the click outcome
+        // unknown and must not masquerade as a missing control.
+        lastReason = clicked && !clicked.ok
+            ? (clicked.reason || 'new-chat-control-not-found')
+            : 'conversation-restored';
+        await page.wait(1);
+        if (await confirmedOffThread(page)) return { ok: true, escaped: true };
+    }
+    return { ok: false, reason: lastReason };
+}
+
 export async function getPageState(page) {
     return page.evaluate(`(() => {
         const url = window.location.href;

--- a/clis/deepseek/utils.test.js
+++ b/clis/deepseek/utils.test.js
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { ArgumentError } from '@jackwener/opencli/errors';
 import {
   selectModel,
@@ -9,6 +10,7 @@ import {
   parseThinkingResponse,
   parseDeepSeekConversationId,
   pickResumeUrl,
+  ensureFreshConversation,
 } from './utils.js';
 
 describe('deepseek parseDeepSeekConversationId', () => {
@@ -299,6 +301,242 @@ describe('deepseek sendWithFile Not allowed fallback', () => {
     expect(result).toEqual({ ok: false, reason: 'file preview did not appear' });
     expect(page.evaluate.mock.calls[1][0]).toContain('img[src], canvas, video');
     expect(page.evaluate.mock.calls[1][0]).not.toContain("aria-disabled') === 'false'");
+  });
+});
+
+describe('deepseek ensureFreshConversation', () => {
+  const HOME = 'https://chat.deepseek.com/';
+  const THREAD = 'https://chat.deepseek.com/a/chat/s/749e6bbd-6a45-4440-beaa-ae5238bf06d8';
+  const URL_CHECK = 'window.location.href';
+
+  function createPage() {
+    return {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn(),
+    };
+  }
+
+  it('reports a fresh thread when the home page URL stays stable across the settle', async () => {
+    const page = createPage();
+    page.evaluate.mockResolvedValue(HOME);
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: true, escaped: false });
+    expect(page.goto).toHaveBeenCalledWith(HOME);
+    // Composer wait + router settle + stability settle, and two URL reads —
+    // ok:true means the URL stayed off-thread, not that it was checked once.
+    expect(page.wait).toHaveBeenCalledTimes(3);
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it('escapes an auto-restored conversation through the new-chat control', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(THREAD)       // settled on the restored thread
+      .mockResolvedValueOnce({ ok: true }) // new-chat control clicked
+      .mockResolvedValueOnce(HOME)         // off the thread…
+      .mockResolvedValueOnce(HOME);        // …and still off after the settle
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: true, escaped: true });
+    expect(page.evaluate).toHaveBeenCalledTimes(4);
+  });
+
+  it('escapes when the restore lands during the stability confirmation', async () => {
+    const page = createPage();
+    page.evaluate
+      .mockResolvedValueOnce(HOME)         // first read looks fresh
+      .mockResolvedValueOnce(THREAD)       // restore fired during the settle
+      .mockResolvedValueOnce({ ok: true }) // escape via the new-chat control
+      .mockResolvedValueOnce(HOME)
+      .mockResolvedValueOnce(HOME);
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: true, escaped: true });
+  });
+
+  it('fails closed when the restored conversation cannot be escaped', async () => {
+    const page = createPage();
+    page.evaluate.mockImplementation(async (script) =>
+      script === URL_CHECK ? THREAD : { ok: true });
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: false, reason: 'conversation-restored' });
+    // Initial URL check + 3 click/re-check rounds.
+    expect(page.evaluate).toHaveBeenCalledTimes(7);
+  });
+
+  it('reports the missing control when the sidebar never offers a new-chat entry', async () => {
+    const page = createPage();
+    page.evaluate.mockImplementation(async (script) =>
+      script === URL_CHECK ? THREAD : { ok: false, reason: 'new-chat-control-not-found' });
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: false, reason: 'new-chat-control-not-found' });
+  });
+
+  it('keeps conversation-restored as the reason when the click evaluate is collected', async () => {
+    const page = createPage();
+    page.evaluate.mockImplementation(async (script) => {
+      if (script === URL_CHECK) return THREAD;
+      throw new Error('Promise was collected');
+    });
+
+    const result = await ensureFreshConversation(page);
+
+    // A rejected click evaluate leaves the click outcome unknown; it must not
+    // be misreported as a missing new-chat control.
+    expect(result).toEqual({ ok: false, reason: 'conversation-restored' });
+  });
+
+  it('treats an unreadable URL as not-fresh instead of green-lighting a send', async () => {
+    const page = createPage();
+    page.evaluate.mockImplementation(async (script) => {
+      if (script === URL_CHECK) throw new Error('Promise was collected');
+      return { ok: true };
+    });
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: false, reason: 'conversation-restored' });
+  });
+
+  it('reports composer-missing without inspecting the URL on login/error pages', async () => {
+    const page = createPage();
+    page.wait.mockRejectedValueOnce(new Error('selector timeout'));
+
+    const result = await ensureFreshConversation(page);
+
+    expect(result).toEqual({ ok: false, reason: 'composer-missing' });
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('embeds both localized new-chat labels in the click script', async () => {
+    const page = createPage();
+    page.evaluate.mockImplementation(async (script) =>
+      script === URL_CHECK ? THREAD : { ok: false, reason: 'new-chat-control-not-found' });
+
+    await ensureFreshConversation(page);
+
+    const clickSrc = page.evaluate.mock.calls
+      .map(([js]) => js)
+      .find((js) => typeof js === 'string' && js.includes('new-chat-control-not-found'));
+    expect(clickSrc, 'expected a new-chat click evaluate call').toBeDefined();
+    // Label matching must cover both UI languages (class names are unstable).
+    expect(clickSrc).toContain('开启新对话');
+    expect(clickSrc).toContain('New chat');
+  });
+});
+
+describe('deepseek clickNewChatControl DOM behavior (jsdom fixtures)', () => {
+  const THREAD = 'https://chat.deepseek.com/a/chat/s/749e6bbd-6a45-4440-beaa-ae5238bf06d8';
+  let clickScript;
+
+  // The click script is a static string; capture it once through the same
+  // mock-page path the ensureFreshConversation tests use, then execute it
+  // against fixture DOMs so selector-logic regressions fail here instead of
+  // only against the live site.
+  beforeAll(async () => {
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      wait: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockImplementation(async (script) =>
+        script === 'window.location.href' ? THREAD : { ok: false, reason: 'new-chat-control-not-found' }),
+    };
+    await ensureFreshConversation(page);
+    clickScript = page.evaluate.mock.calls
+      .map(([js]) => js)
+      .find((js) => typeof js === 'string' && js.includes('new-chat-control-not-found'));
+    expect(clickScript, 'expected a new-chat click evaluate call').toBeDefined();
+  });
+
+  function runClickScript(html) {
+    const dom = new JSDOM(html, { url: THREAD, runScripts: 'outside-only' });
+    // jsdom has no innerText; both the label fallback and the
+    // outer-container prefix match read it, so alias it to textContent.
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'innerText', {
+      configurable: true,
+      get() {
+        return this.textContent || '';
+      },
+    });
+    const clicked = [];
+    dom.window.document.addEventListener('click', (e) => clicked.push(e.target.id));
+    const result = dom.window.eval(clickScript);
+    return { result, clicked };
+  }
+
+  it('clicks the sidebar control whose aria-label carries a shortcut hint', () => {
+    const { result, clicked } = runClickScript(`
+      <div id="sidebar">
+        <button id="new-chat" aria-label="开启新对话 ⌘J"></button>
+        <a id="history" href="/a/chat/s/aaa">旧的讨论</a>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true });
+    expect(clicked).toEqual(['new-chat']);
+  });
+
+  it('never clicks a saved conversation titled "New chat" back into the old thread', () => {
+    const { result, clicked } = runClickScript(`
+      <a id="history-trap" href="/a/chat/s/bbb">New chat about pandas</a>
+    `);
+
+    expect(result).toEqual({ ok: false, reason: 'new-chat-control-not-found' });
+    expect(clicked).toEqual([]);
+  });
+
+  it('prefers the real control over a same-label history entry', () => {
+    const { result, clicked } = runClickScript(`
+      <div id="sidebar">
+        <a id="history-trap" href="/a/chat/s/ccc">New chat</a>
+        <button id="new-chat">New chat</button>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true });
+    expect(clicked).toEqual(['new-chat']);
+  });
+
+  it('clicks the deepest match, not an outer container sharing the text prefix', () => {
+    const { result, clicked } = runClickScript(`
+      <div id="container">
+        <button id="new-chat">New chat</button>
+        <p>Ask anything to start.</p>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true });
+    expect(clicked).toEqual(['new-chat']);
+  });
+
+  it('resolves a plain label div up to its role=button wrapper before clicking', () => {
+    const { result, clicked } = runClickScript(`
+      <div id="wrapper" role="button">
+        <div id="label">开启新对话</div>
+      </div>
+    `);
+
+    expect(result).toEqual({ ok: true });
+    expect(clicked).toEqual(['wrapper']);
+  });
+
+  it('lets an explicit aria-label veto a matching innerText', () => {
+    // aria-label wins over innerText, so a control announced as something
+    // else must not match even when its visible text starts with the label.
+    const { result, clicked } = runClickScript(`
+      <button id="decoy" aria-label="Settings">New chat tips</button>
+    `);
+
+    expect(result).toEqual({ ok: false, reason: 'new-chat-control-not-found' });
+    expect(clicked).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #2401.

`deepseek ask --new` only did `goto(home)` + wait-for-composer. DeepSeek's SPA can auto-restore the most recent conversation shortly after the home page loads (the URL silently becomes `/a/chat/s/<id>`), so the send appended to the old thread — while every run still "succeeded". For independent-sampling workloads (the GEO monitoring case in #2401) this silently cross-contaminates context.

`deepseek new` has the same defect, and worse: it reported `New chat started` even when the composer was sitting inside the restored thread.

## What this PR does

- **`ensureFreshConversation(page)`** (new shared helper in `utils.js`): goto home → wait for the composer → require the URL to stay off any conversation thread **across a settle** (a single snapshot can race the restore redirect). If restored, escape via the sidebar's "开启新对话" / "New chat" control, re-verify after each click, give up after 3 attempts with a structured reason. An unreadable URL counts as *not fresh* — the helper fails closed rather than green-lighting a send.
- **`ask --new`** fails with a typed `CommandExecutionError` (reason included) instead of sending when the helper cannot confirm a fresh thread. Two later-stage guards catch a restore landing after the helper returns: a URL re-check before the model/feature toggles, and a zero-message baseline right before the send — a restored thread always carries its old messages, so this is a timing-independent test of the same invariant. Logged-out behavior (`composer-missing` → downstream typed errors) is unchanged on purpose.
- **`new`** reports `New chat started` only after a confirmed fresh thread, and now declares `access: 'write'` — it creates a conversation in the account.

### Relation to the fix sketched in #2401

The reporter's verified approach (detect `/a/chat/s/` after goto, click the new-chat control by text) is the right shape; this PR hardens the parts flagged as fragile:

| Sketch | This PR |
| --- | --- |
| scan `div,button,a` by exact innerText | aria-label/title/innerText, both UI languages, tolerates the shortcut-hint suffix ("开启新对话 ⌘J") |
| first text match wins | sidebar history entries excluded (a saved conversation titled "New chat" must never win), deepest match picked, then climbed to the nearest clickable ancestor |
| click once, wait, proceed | re-verify off-thread across a settle after each click; fail closed with a typed error if the escape never lands |
| — | a rejected click evaluate (route transitions collect promises) is not misreported as a missing control |

No class names anywhere — CSS-module names are randomized per build (same convention as `pickResumeUrl`).

## Live evidence (2026-08-26, logged-in session, extension v1.0.23)

- Patched `ask --new` twice in a row: `"Test C: what is 5+5?"` → `/a/chat/s/64eff395-…` → `{"response":"10"}`; `"Test D: what is 7+7?"` → `/a/chat/s/52cdbc15-…` → `{"response":"14"}`. `deepseek history` shows two separate threads.
- The restore redirect is a load-time SPA behavior, so the escape path was verified directly against the live DOM: on a real conversation page, the exact `clickNewChatControl` script matched the sidebar control (`div[tabindex="0"]` wrapping `<span>开启新对话</span>`), clicked it, and the URL left `/a/chat/s/<id>`. The restore orchestration around it is pinned by the unit tests below.
- Patched `deepseek new` → `[{"Status":"New chat started"}]`.

## Tests

84 adapter tests pass (`npx vitest run --project adapter clis/deepseek/`):

- `utils.test.js` — ensureFreshConversation: clean path, escape path, restore landing during the stability confirmation, restore-not-escapable (fails closed), unreadable URL treated as not-fresh, collected click evaluate not misreported, composer-missing, localized labels pinned; plus jsdom DOM fixtures for `clickNewChatControl` (shortcut-hint aria-label, history entry titled "New chat" never clicked, deepest-match pick, clickable-ancestor climb).
- `ask.test.js` — `--new` delegates navigation to the helper; fails fast on restore with the reason named; post-helper URL guard and zero-baseline guard (including the `--file` path); composer-missing behavior preserved.
- `new.test.js` (new) — success only after a confirmed fresh thread; typed errors for composer-missing / conversation-restored / control-not-found.

Also ran: `npm run typecheck`, full `npm test` (15 pre-existing Windows-path failures in unrelated adapters, identical on clean `main`), `check:typed-error-lint` / `check:silent-column-drop` (no new findings), `opencli validate` (clean for deepseek).
