### PR TITLE
fix(pipeline): reject invalid concurrency limits

### DIFF
--- a/src/pipeline/steps/fetch.test.ts
+++ b/src/pipeline/steps/fetch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CliError } from '../../errors.js';
+import { ArgumentError, CliError } from '../../errors.js';
 import type { IPage } from '../../types.js';
 import { stepFetch } from './fetch.js';
 
@@ -90,6 +90,20 @@ describe('stepFetch', () => {
       { error: 'HTTP 503 Service Unavailable from https://api.example.com/items/1' },
     ]);
     expect(jsonMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid browser batch concurrency before evaluating page code', async () => {
+    const page = {
+      evaluate: vi.fn(),
+    } as unknown as IPage;
+
+    await expect(stepFetch(
+      page,
+      { url: 'https://api.example.com/items/${{ item.id }}', concurrency: 0 },
+      [{ id: 1 }],
+      {},
+    )).rejects.toBeInstanceOf(ArgumentError);
+    expect(page.evaluate).not.toHaveBeenCalled();
   });
 
   it('stringifies non-Error batch browser failures consistently', async () => {

--- a/src/pipeline/steps/fetch.ts
+++ b/src/pipeline/steps/fetch.ts
@@ -2,7 +2,7 @@
  * Pipeline step: fetch — HTTP API requests.
  */
 
-import { CliError, getErrorMessage } from '../../errors.js';
+import { ArgumentError, CliError, getErrorMessage } from '../../errors.js';
 import { log } from '../../logger.js';
 import type { IPage } from '../../types.js';
 import { render } from '../template.js';
@@ -95,6 +95,9 @@ export async function stepFetch(page: IPage | null, params: unknown, data: unkno
   // Per-item fetch when data is array and URL references item
   if (Array.isArray(data) && urlTemplate.includes('item')) {
     const concurrency = typeof paramObject.concurrency === 'number' ? paramObject.concurrency : 5;
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new ArgumentError(`Concurrency limit must be a positive integer. Received: "${String(concurrency)}"`);
+    }
 
     // Render all URLs upfront
     const renderedHeaders: Record<string, string> = {};

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
+  mapConcurrent,
   parseJsonOrThrowLoginWall,
   throwIfLoginWall,
   BROWSER_JSON_SNIFF_FN,
   type LoginWallSignal,
 } from './utils.js';
-import { LoginWallError } from './errors.js';
+import { ArgumentError, LoginWallError } from './errors.js';
 
 function makeResponse(body: string, opts: { status?: number; contentType?: string; url?: string } = {}): Response {
   return new Response(body, {
@@ -13,6 +14,17 @@ function makeResponse(body: string, opts: { status?: number; contentType?: strin
     headers: { 'content-type': opts.contentType ?? 'application/json' },
   });
 }
+
+describe('mapConcurrent', () => {
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid concurrency limit %s instead of skipping work',
+    async (limit) => {
+      const worker = async (value: number) => value * 2;
+
+      await expect(mapConcurrent([1, 2], limit, worker)).rejects.toBeInstanceOf(ArgumentError);
+    },
+  );
+});
 
 describe('parseJsonOrThrowLoginWall', () => {
   it('returns parsed JSON on a normal application/json response', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import TurndownService from 'turndown';
-import { LoginWallError } from './errors.js';
+import { ArgumentError, LoginWallError } from './errors.js';
 
 /** Type guard: checks if a value is a non-null, non-array object. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -18,6 +18,10 @@ export async function mapConcurrent<T, R>(
   limit: number,
   fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new ArgumentError(`Concurrency limit must be a positive integer. Received: "${String(limit)}"`);
+  }
+
   const results: R[] = new Array(items.length);
   let index = 0;
 


### PR DESCRIPTION
## Summary

- reject non-positive, fractional, and non-finite concurrency limits instead of silently skipping work
- validate browser batch fetch concurrency before evaluating page code
- cover the shared utility and browser pipeline path with regression tests

## Validation

- `npx vitest run --project unit src/utils.test.ts src/pipeline/steps/fetch.test.ts`
- `npx vitest run --project unit src/pipeline/steps/download.test.ts`
- `npm run typecheck`