### PR TITLE
fix(zhihu): modernize hot adapter and handle empty responses

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -48658,14 +48658,15 @@
         "type": "int",
         "default": 20,
         "required": false,
-        "help": "Number of items to return"
+        "help": "Number of items to return (1-50)"
       }
     ],
     "columns": [
       "rank",
       "title",
       "heat",
-      "answers"
+      "answers",
+      "url"
     ],
     "type": "js",
     "modulePath": "zhihu/hot.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -48671,7 +48671,7 @@
     "type": "js",
     "modulePath": "zhihu/hot.js",
     "sourceFile": "zhihu/hot.js",
-    "navigateBefore": "https://www.zhihu.com"
+    "navigateBefore": false
   },
   {
     "site": "zhihu",

--- a/clis/zhihu/hot.js
+++ b/clis/zhihu/hot.js
@@ -52,6 +52,7 @@ cli({
     description: '知乎热榜',
     domain: 'www.zhihu.com',
     strategy: Strategy.COOKIE,
+    navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of items to return (1-50)' },
     ],

--- a/clis/zhihu/hot.js
+++ b/clis/zhihu/hot.js
@@ -1,44 +1,117 @@
-import { cli } from '@jackwener/opencli/registry';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const MAX_LIMIT = 50;
+
+export function normalizeHotItem(item) {
+    if (!item) return null;
+    const t = item.target || {};
+    const cardId = item.card_id || '';
+    let questionId = t.id != null ? String(t.id) : '';
+    if (!questionId && cardId.startsWith('Q_')) {
+        questionId = cardId.slice(2);
+    }
+    const title = t.title || t.question?.title || item.title || '';
+    if (!title) return null;
+
+    let url = '';
+    if (t.type === 'article' && (t.id != null || cardId.startsWith('A_'))) {
+        const articleId = t.id != null ? String(t.id) : cardId.slice(2);
+        url = `https://zhuanlan.zhihu.com/p/${articleId}`;
+    } else if (questionId) {
+        url = `https://www.zhihu.com/question/${questionId}`;
+    } else if (typeof t.url === 'string' && t.url.startsWith('http')) {
+        url = t.url;
+    } else if (typeof item.link_url === 'string' && item.link_url.startsWith('http')) {
+        url = item.link_url;
+    }
+
+    const heat = item.detail_text || (t.metrics?.heat ? `${t.metrics.heat} 万热度` : '') || '';
+    const answers = t.answer_count ?? 0;
+
+    return {
+        title,
+        heat,
+        answers,
+        url,
+    };
+}
+
+export function parseHotLimit(value) {
+    const limit = Number(value ?? 20);
+    if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_LIMIT) {
+        throw new ArgumentError(`zhihu hot --limit must be a positive integer no greater than ${MAX_LIMIT}`, `Example: opencli zhihu hot --limit 20`);
+    }
+    return limit;
+}
+
 cli({
     site: 'zhihu',
     name: 'hot',
     access: 'read',
     description: '知乎热榜',
     domain: 'www.zhihu.com',
+    strategy: Strategy.COOKIE,
     args: [
-        { name: 'limit', type: 'int', default: 20, help: 'Number of items to return' },
+        { name: 'limit', type: 'int', default: 20, help: 'Number of items to return (1-50)' },
     ],
-    columns: ['rank', 'title', 'heat', 'answers'],
-    pipeline: [
-        { navigate: 'https://www.zhihu.com' },
-        { evaluate: `(async () => {
-  const res = await fetch('https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=50', {
-    credentials: 'include'
-  });
-  const text = await res.text();
-  const d = JSON.parse(
-    text.replace(/("id"\\s*:\\s*)(\\d{16,})/g, '$1"$2"')
-  );
-  return (d?.data || []).map((item) => {
-    const t = item.target || {};
-    const questionId = t.id == null ? '' : String(t.id);
-    return {
-      title: t.title,
-      url: 'https://www.zhihu.com/question/' + questionId,
-      answer_count: t.answer_count,
-      follower_count: t.follower_count,
-      heat: item.detail_text || '',
-    };
-  });
-})()
-` },
-        { map: {
-                rank: '${{ index + 1 }}',
-                title: '${{ item.title }}',
-                heat: '${{ item.heat }}',
-                answers: '${{ item.answer_count }}',
-                url: '${{ item.url }}',
-            } },
-        { limit: '${{ args.limit }}' },
-    ],
+    columns: ['rank', 'title', 'heat', 'answers', 'url'],
+    func: async (page, kwargs) => {
+        const resultLimit = parseHotLimit(kwargs.limit);
+        await page.goto('https://www.zhihu.com');
+        const data = await page.evaluate(`
+            (async () => {
+                try {
+                    const res = await fetch('https://www.zhihu.com/api/v3/feed/topstory/hot-lists/total?limit=50', {
+                        credentials: 'include'
+                    });
+                    if (!res.ok) return { __httpError: res.status };
+                    const text = await res.text();
+                    return JSON.parse(
+                        text.replace(/("id"\\s*:\\s*)(\\d{16,})/g, '$1"$2"')
+                    );
+                } catch (err) {
+                    return { __fetchError: err?.message || String(err) };
+                }
+            })()
+        `);
+
+        if (!data || data.__httpError) {
+            const status = data?.__httpError;
+            if (status === 401 || status === 403) {
+                throw new AuthRequiredError('www.zhihu.com', 'Failed to fetch Zhihu hot list');
+            }
+            throw new CommandExecutionError(
+                status ? `Zhihu hot list request failed (HTTP ${status})` : 'Zhihu hot list request failed',
+                'Try again later or rerun with -v for more detail'
+            );
+        }
+
+        if (data.__fetchError) {
+            throw new CommandExecutionError('Zhihu hot list request failed', String(data.__fetchError));
+        }
+
+        const items = data.data || [];
+        const results = [];
+        for (const item of items) {
+            const normalized = normalizeHotItem(item);
+            if (!normalized) continue;
+            results.push(normalized);
+            if (results.length >= resultLimit) break;
+        }
+
+        if (results.length === 0) {
+            throw new EmptyResultError('zhihu hot', 'No items found in Zhihu hot list');
+        }
+
+        return results.map((row, i) => ({
+            rank: i + 1,
+            ...row,
+        }));
+    },
 });
+
+export const __test__ = {
+    normalizeHotItem,
+    parseHotLimit,
+};

--- a/clis/zhihu/hot.test.js
+++ b/clis/zhihu/hot.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import './hot.js';
+import { __test__ } from './hot.js';
+
+describe('zhihu hot', () => {
+    it('returns hot items from the Zhihu hot-lists API', async () => {
+        const cmd = getRegistry().get('zhihu/hot');
+        expect(cmd?.func).toBeTypeOf('function');
+        const goto = vi.fn().mockResolvedValue(undefined);
+        const evaluate = vi.fn().mockResolvedValue({
+            data: [
+                {
+                    card_id: 'Q_123456',
+                    detail_text: '100 万热度',
+                    target: {
+                        id: 123456,
+                        type: 'question',
+                        title: 'Test Question',
+                        answer_count: 50,
+                        url: 'https://api.zhihu.com/questions/123456',
+                    },
+                },
+                {
+                    card_id: 'A_789012',
+                    detail_text: '50 万热度',
+                    target: {
+                        id: 789012,
+                        type: 'article',
+                        title: 'Test Article',
+                        answer_count: 10,
+                    },
+                },
+            ],
+        });
+        const page = { goto, evaluate };
+        const res = await cmd.func(page, { limit: 5 });
+        expect(res).toEqual([
+            {
+                rank: 1,
+                title: 'Test Question',
+                heat: '100 万热度',
+                answers: 50,
+                url: 'https://www.zhihu.com/question/123456',
+            },
+            {
+                rank: 2,
+                title: 'Test Article',
+                heat: '50 万热度',
+                answers: 10,
+                url: 'https://zhuanlan.zhihu.com/p/789012',
+            },
+        ]);
+        expect(goto).toHaveBeenCalledWith('https://www.zhihu.com');
+    });
+
+    it('handles auth errors', async () => {
+        const cmd = getRegistry().get('zhihu/hot');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ __httpError: 401 }),
+        };
+        await expect(cmd.func(page, {})).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it('handles fetch errors', async () => {
+        const cmd = getRegistry().get('zhihu/hot');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ __fetchError: 'Network failure' }),
+        };
+        await expect(cmd.func(page, {})).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('handles empty results', async () => {
+        const cmd = getRegistry().get('zhihu/hot');
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue({ data: [] }),
+        };
+        await expect(cmd.func(page, {})).rejects.toBeInstanceOf(EmptyResultError);
+    });
+
+    it('validates limit range', () => {
+        expect(__test__.parseHotLimit(10)).toBe(10);
+        expect(() => __test__.parseHotLimit(0)).toThrow(ArgumentError);
+        expect(() => __test__.parseHotLimit(100)).toThrow(ArgumentError);
+    });
+});


### PR DESCRIPTION
### Summary

- **Modernize adapter**: Refactor `clis/zhihu/hot.js` from declarative pipeline to standard `Strategy.COOKIE` + `func: async (page, kwargs)` structure to align with other Zhihu adapters and prevent double-navigation conflicts.
- **Robust data normalization**:
  - Add 64-bit integer ID string replacement before `JSON.parse` to prevent int64 ID precision loss.
  - Support both question (`Q_`) and article (`A_`) billboard items.
  - Include `url` in output columns.
- **Proper error handling**:
  - Add explicit handling for HTTP errors (`AuthRequiredError` / `CommandExecutionError`).
  - Throw `EmptyResultError` when no items are returned instead of silently outputting empty arrays.
- **Tests**: Add unit tests in `clis/zhihu/hot.test.js` covering API parsing, auth errors, fetch errors, empty results, and limit bounds.