### PR TITLE
chore(pack): exclude test files and fixtures from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "cli-manifest.json",
     "scripts/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "!**/*.test.*",
+    "!**/__fixtures__/"
   ],
   "scripts": {
     "dev": "tsx src/main.ts",


### PR DESCRIPTION
## Problem

Installing `@jackwener/opencli` is noticeably slow because the published tarball ships a lot of test artifacts that are never used at runtime:

- 601 compiled `*.test.js` files (in `dist/src/` and `clis/`)
- ~100 `*.test.d.ts` typings
- a couple of stray `*.test.ts` sources (e.g. `clis/grok/image.test.ts`, `clis/jd/item.test.ts`)
- `clis/**/__fixtures__/` HTML snapshots

That's ~700 of the 2340 files in the package (~30%), and the many small files make extraction slow on install.

## Fix

Add negation patterns to the `files` whitelist in `package.json`:

```json
"!**/*.test.*",
"!**/__fixtures__/"
```

## Verification

Ran `npm pack --dry-run` against the extracted v1.8.7 tarball contents with the updated `files` field:

| | before | after |
|---|---|---|
| total files | 2340 | 1638 (−30%) |
| unpacked size | 14.0 MB | 9.2 MB (−34%) |
| tarball size | 3.1 MB | 2.2 MB (−29%) |

No `.test.*` or `__fixtures__` entries remain in the pack list. Nothing in `src/`, `scripts/`, `cli-manifest.json`, or the shipped skills references these files at runtime (the vitest configs and `tests/` were already excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)