### PR TITLE
chore(pack): prune @mixmark-io/domino's vendored test suite on install

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -15,9 +15,10 @@
  * the main source tree) so that it can run without a build step.
  */
 
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { createRequire } from 'node:module';
 
 
 // ── Completion script content ──────────────────────────────────────────────
@@ -71,9 +72,28 @@ function ensureDir(dir) {
   }
 }
 
+// ── Prune vendored test suites ─────────────────────────────────────────────
+
+function pruneVendoredTests() {
+  // @mixmark-io/domino (pulled in via turndown) publishes its entire test
+  // suite to npm: 959 files / 7 MB, ~94% of the package. Upstream is
+  // unmaintained (mixmark-io/domino#2 has been open since 2024), so remove
+  // the dead weight here. Nothing at runtime touches domino/test.
+  try {
+    const require = createRequire(import.meta.url);
+    const dominoDir = dirname(require.resolve('@mixmark-io/domino/package.json'));
+    rmSync(join(dominoDir, 'test'), { recursive: true, force: true });
+  } catch {
+    // Best-effort; never fail the install.
+  }
+}
+
 // ── Main ───────────────────────────────────────────────────────────────────
 
 function main() {
+  // Prune runs everywhere, including CI, so packaged app bundles shrink too.
+  pruneVendoredTests();
+
   // Skip in CI environments
   if (process.env.CI || process.env.CONTINUOUS_INTEGRATION) {
     return;


### PR DESCRIPTION
## Problem

`turndown` depends on `@mixmark-io/domino`, and the domino npm package ships its **entire test suite**: `test/` is 959 files / 7 MB — ~94% of the package's file count (1023 files total). Every `npm install @jackwener/opencli` extracts those files, and they also end up inside the OpenCLIApp macOS bundle at `Resources/node_modules/@mixmark-io/domino/test/`, which makes installation noticeably slow.

Upstream is effectively unmaintained: mixmark-io/domino#2 (adding `.npmignore` for exactly this) has been open since May 2024 with no maintainer response, and the repo has had no pushes since.

## Fix

`scripts/postinstall.js` now removes `@mixmark-io/domino/test/` after install:

- resolves domino via `createRequire`, so both hoisted and nested layouts work
- runs before the existing CI early-return, so CI/app-bundle builds that stage `node_modules` get pruned too
- best-effort `try/catch` + `rmSync(..., { force: true })` — a missing dir or failed resolution never breaks the install

Nothing at runtime references `domino/test` (it's only reachable via domino's own vitest-style test entry points, which are not exported or required by `lib/`).

## Verification

Tested against a real `npm install turndown` tree with the script placed at `node_modules/@jackwener/opencli/scripts/postinstall.js` (hoisted layout, `CI=true`): the 7 MB `test/` dir is removed, all other domino files untouched. Also verified the script exits 0 when domino is absent.

Related: #2410 removes our own test files from the published tarball; together they cut a fresh install by roughly 12 MB and ~1600 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)