### PR TITLE
fix(xiaohongshu): stop ask breaking on webpack chunk renumbering, and stop it spending a note search per call

### DIFF
--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -440,8 +440,25 @@ export const command = cli({
         const query = requirePrompt(kwargs?.query);
         const timeout = parseAskTimeout(kwargs?.timeout);
         const sourceLimit = parseAskLimit(kwargs?.['source-limit']);
-        const keyword = encodeURIComponent(query);
-        await page.goto(`https://${XHS_WEB_HOST}/search_result?keyword=${keyword}&source=web_search_result_notes`);
+        // Enter through 点点's own page, not search_result?keyword=<query>.
+        //
+        // Two reasons, both measured 2026-08-28 on a live logged-in session:
+        //
+        // 1. Cost. Loading search_result?keyword=... fires a real note search
+        //    (so.xiaohongshu.com/api/sns/web/v2/search/notes) before any chat happens —
+        //    a search request spent purely as a side effect of the URL chosen to reach
+        //    a chat store. /ai_chat serves the same conversation store and fires zero
+        //    search/notes for the whole page lifetime.
+        // 2. Risk control. #1224 documented that direct navigation to
+        //    search_result?keyword=... triggers Xiaohongshu's security verification in
+        //    the automation browser; xiaohongshu/search was reworked away from that
+        //    exact pattern. ask still used it.
+        //
+        // Controlled A/B, identical query ("清迈 咖啡馆 推荐"), same session, minutes apart:
+        //    search_result -> 1238 chars, 5 sources, 1x search/notes
+        //    /ai_chat      -> 1195 chars, 5 sources, 0x search/notes
+        // The navigation contributes nothing to answer quality or citation count.
+        await page.goto(`https://${XHS_WEB_HOST}/ai_chat`);
         await page.wait?.(1);
         const raw = unwrapEvaluateResult(await page.evaluate(buildAskEvaluateJs(query, timeout, sourceLimit)));
         if (!raw || typeof raw !== 'object') {

--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -263,7 +263,41 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
           let webpackRequire;
           window.webpackChunkxhs_pc_web.push([[Date.now()], {}, (req) => { webpackRequire = req; }]);
           if (!webpackRequire) return { ok: false, error: 'webpack_require_unavailable', page_url: location.href };
-          const mod = webpackRequire(6404);
+          // Locate the conversation store module.
+          //
+          // A hardcoded webpack module id has no contract with the site: Xiaohongshu
+          // renumbers chunks on redeploys, and when it does, webpackRequire(<stale id>)
+          // throws "Cannot read properties of undefined (reading 'call')" from webpack's
+          // own runtime and every ask fails. That already happened once (6404 -> 32914).
+          //
+          // So: try known ids first (zero scan cost in the common case), then fall back
+          // to locating the module by what it *is* rather than by its number. The scan
+          // only calls .toString() on factory functions, which has no side effects; a
+          // candidate is executed only after its source matches the fingerprint.
+          const looksLikeConversationModule = (candidate) => (
+            candidate
+            && typeof candidate.t === 'function'
+            && candidate.G
+            && typeof candidate.G.AiChat === 'string'
+          );
+          let mod = null;
+          for (const knownId of [32914, 6404]) {
+            try {
+              const candidate = webpackRequire(knownId);
+              if (looksLikeConversationModule(candidate)) { mod = candidate; break; }
+            } catch { /* id absent from this build */ }
+          }
+          if (!mod) {
+            for (const id of Object.keys(webpackRequire.m || {})) {
+              let source = '';
+              try { source = webpackRequire.m[id].toString(); } catch { continue; }
+              if (!source.includes('createConversation') || !source.includes('sendMessage')) continue;
+              try {
+                const candidate = webpackRequire(id);
+                if (looksLikeConversationModule(candidate)) { mod = candidate; break; }
+              } catch { /* not loadable, keep looking */ }
+            }
+          }
           const useConversationStore = mod?.t;
           const scenes = mod?.G || { AiChat: 'aiChat' };
           if (typeof useConversationStore !== 'function') {

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -197,7 +197,10 @@ describe('xiaohongshu ask', () => {
 
         const result = await cmd.func(page, { query: '上海露营需要注意什么？', timeout: 30, 'source-limit': 10 });
 
-        expect(page.goto).toHaveBeenCalledWith(expect.stringContaining('https://www.xiaohongshu.com/search_result?keyword='));
+        // 点点's own page, never search_result?keyword=... — that URL costs a real
+        // note search on load and is the pattern #1224 tied to security verification.
+        expect(page.goto).toHaveBeenCalledWith('https://www.xiaohongshu.com/ai_chat');
+        expect(page.goto).not.toHaveBeenCalledWith(expect.stringContaining('search_result'));
         expect(page.evaluate.mock.calls[0][0]).toContain('window.webpackChunkxhs_pc_web');
         expect(result).toMatchObject({
             answer: '答案正文',

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -265,3 +265,70 @@ describe('xiaohongshu ask', () => {
         expect(script).not.toContain('rounds[rounds.length - 1]');
     });
 });
+
+// Executes the generated page script against a fake webpack runtime, so the module
+// lookup is exercised for real rather than asserted as a substring. The point is the
+// module id: Xiaohongshu renumbers chunks on redeploys (6404 -> 32914 broke every ask),
+// so the lookup has to survive an id nobody has seen before.
+async function runAskScriptAgainstFakeRuntime({ moduleId, answer = '答案正文' }) {
+    const msgId = 'msg-1';
+    const store = {
+        switchScene: () => {},
+        clearConversation: () => {},
+        createConversation: () => {},
+        sendMessage: async () => msgId,
+        getSceneRounds: () => [{ aiMessage: { msgId, isFinished: true, text: answer } }],
+        agent: {
+            getResponseReferences: async () => ({
+                baseInfo: { totalCnt: 'ai总结7篇笔记生成' },
+                items: [{ id: '69d6fc08000000001f007646', title: '来源标题', nickName: '作者A' }],
+            }),
+        },
+    };
+    // toString() of this factory carries the fingerprint the scan looks for.
+    const conversationFactory = () => ({ marker: 'createConversation sendMessage' });
+    const decoyFactory = () => ({ marker: 'unrelated module' });
+    // moduleId === null models a build where the store is simply not present at all.
+    const exportsById = moduleId === null
+        ? {}
+        : { [moduleId]: { t: () => store, G: { AiChat: 'aiChat', Onebox: 'onebox' } } };
+    const webpackRequire = (id) => {
+        if (!(id in exportsById)) throw new TypeError("Cannot read properties of undefined (reading 'call')");
+        return exportsById[id];
+    };
+    webpackRequire.m = moduleId === null
+        ? { 4242: decoyFactory }
+        : { 4242: decoyFactory, [moduleId]: conversationFactory };
+
+    const priorWindow = globalThis.window;
+    const priorLocation = globalThis.location;
+    globalThis.window = {
+        webpackChunkxhs_pc_web: { push: ([, , cb]) => cb(webpackRequire) },
+    };
+    globalThis.location = { href: 'https://www.xiaohongshu.com/ai_chat' };
+    try {
+        return await (0, eval)(buildAskEvaluateJs('测试问题', 5, 5));
+    } finally {
+        globalThis.window = priorWindow;
+        globalThis.location = priorLocation;
+    }
+}
+
+describe('xiaohongshu ask conversation-store lookup', () => {
+    it('uses the known module id when the build still has it', async () => {
+        const result = await runAskScriptAgainstFakeRuntime({ moduleId: 32914 });
+        expect(result).toMatchObject({ ok: true, answer: '答案正文' });
+        expect(result.sources).toHaveLength(1);
+    });
+
+    it('still finds the store after Xiaohongshu renumbers the chunk', async () => {
+        // An id in neither the known list nor any previous build.
+        const result = await runAskScriptAgainstFakeRuntime({ moduleId: 778899 });
+        expect(result).toMatchObject({ ok: true, answer: '答案正文' });
+    });
+
+    it('reports conversation_store_missing when no module matches, instead of throwing', async () => {
+        const result = await runAskScriptAgainstFakeRuntime({ moduleId: null });
+        expect(result).toMatchObject({ ok: false, error: 'conversation_store_missing' });
+    });
+});


### PR DESCRIPTION
Two independent fixes to `xiaohongshu/ask`, one commit each so they can be taken separately.

## 1. Locate the 点点 store by fingerprint, not a hardcoded module id — fixes #2408

`ask` reaches 点点's conversation store with `webpackRequire(6404)`. Xiaohongshu renumbered its chunks, `modules[6404]` became `undefined`, and webpack's own runtime now throws `Cannot read properties of undefined (reading 'call')` — so **every `ask` call currently fails**, in about 4s, before any chat happens. Reported in #2408 (`6404` → `32914`).

Patching in `32914` fixes it until the next redeploy. A hardcoded numeric module id has no contract with the site — that is the actual defect, and the id is only its symptom.

This tries the known ids first (zero scan cost in the common case), then falls back to locating the module by **what it is**: scan `webpackRequire.m` for a factory whose source mentions both `createConversation` and `sendMessage`. On a live page that is **1 candidate out of ~1600 modules**. The scan only calls `.toString()` on factories, which has no side effects; a candidate is executed only after its source matches, so no unrelated module is ever run.

`conversation_store_missing` also becomes meaningful again — it now means the store is genuinely gone (点点 retired or reimplemented), rather than being drowned out by an integer that moved.

## 2. Enter through `/ai_chat` instead of `search_result?keyword=`

`ask` navigated to `search_result?keyword=<query>` to reach the chat store. That entry point costs something and buys nothing.

Measured on a live logged-in session, using in-page `fetch`/XHR/WebSocket hooks plus `performance.getEntriesByType("resource")` to catch what loaded before the hooks went in:

**Cost** — loading `search_result?keyword=...` fires a real note search (`so.xiaohongshu.com/api/sns/web/v2/search/notes`) before any chat happens. That is a search request spent purely as a side effect of the URL chosen to reach a chat store. `/ai_chat` serves the same conversation store and fires **zero** `search/notes` for the whole page lifetime.

**Risk control** — #1224 documented that direct navigation to `search_result?keyword=...` triggers Xiaohongshu's security verification in the automation browser, and `xiaohongshu/search` was reworked away from exactly that pattern. `ask` still used it.

Controlled A/B, identical query (`清迈 咖啡馆 推荐`), same session, minutes apart:

| entry page | answer | sources | `search/notes` |
|---|---|---|---|
| `search_result?keyword=` | 1238 chars | 5 | **1×** |
| `/ai_chat` | 1195 chars | 5 | **0×** |

The navigation contributes nothing to answer quality or citation count; 3.5% is ordinary model variance.

> A first pass compared two *different* queries and saw 16131 vs 1195 chars, which reads as though the entry page matters enormously. It was query variance. Only the same-query control settled it — noting it in case anyone re-runs this and sees the same misleading spread.

For context on what 点点 actually calls, since it is not obvious from the adapter:

| leg | endpoint |
|---|---|
| answer | `so.xiaohongshu.com/api/sns/web/search/send/ai` |
| citations | `edith.xiaohongshu.com/api/sns/web/v1/search/dqa/onebox/detail` |

Neither is `/v1/search/notes`, so the only note search `ask` was performing was the one this commit removes.

## Tests

The new tests **execute** the generated page script against a fake webpack runtime rather than asserting substrings, so the module lookup is genuinely exercised:

- store at the known id → resolves
- **store at an id in neither the known list nor any previous build** → still resolves (this is the case the whole change exists for)
- no matching module anywhere → returns `conversation_store_missing` instead of throwing

The entry-page assertion pins `/ai_chat` and additionally asserts `goto` is **never** called with a `search_result` URL, so a regression back to a search-spending entry point fails loudly rather than silently costing a request per call.

Verified the new guard can actually go red, not just green: breaking the fingerprint string turns exactly the renumbered-chunk test red and nothing else, and restoring it returns all 17 to green.

```
npx vitest run --project adapter clis/xiaohongshu/   →  21 files, 331 tests passed
npm run typecheck                                    →  clean
npm run check:typed-error-lint                       →  current=130, baseline=130, new=0
npm run check:silent-column-drop                     →  current=94,  baseline=94,  new=0
npx tsx src/main.ts convention-audit xiaohongshu     →  no new findings
npm run build && node dist/src/main.js validate xiaohongshu → PASS, 25 commands, 0 errors 0 warnings
```

`npm test` also reports 6 pre-existing failures in `src/cli.test.ts` ("browser tab targeting commands"). Those reproduce on a clean checkout of `main` at `90d5070` with this branch stashed — unrelated to this change, flagging them rather than leaving them to look like fallout.

Also re-verified end-to-end against the live site through the real command after both changes: full answer, 5 sources, no warning, valid `explore` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
