### PR TITLE
fix(dribbble): distinguish empty states from selector drift

### DIFF
--- a/clis/dribbble/dribbble.test.js
+++ b/clis/dribbble/dribbble.test.js
@@ -245,6 +245,114 @@ describe('dribbble production DOM extractors', () => {
             'https://dribbble.com/shots/999999999')).toMatchObject({ ok: true, empty: true });
     });
 
+    it('distinguishes an explicit empty shot page from shot-card selector drift', async () => {
+        const emptyPage = pageFor('<div class="no-results">No results found</div><main id="content"></main>',
+            'https://dribbble.com/search/shots/popular?q=missing');
+        await expect(command('shot').func(emptyPage, {
+            query: 'missing', sort: 'popular', limit: 1,
+        })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+
+        const driftPage = pageFor('<main id="content"></main>',
+            'https://dribbble.com/search/shots/popular?q=mobile');
+        await expect(command('shot').func(driftPage, {
+            query: 'mobile', sort: 'popular', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('distinguishes completed empty designer results from card selector drift', async () => {
+        const emptyPage = pageFor(`
+          <div class="designer-search-results">
+            <drb-infinite-scroll data-designer-search-infinite-scroll disabled></drb-infinite-scroll>
+          </div>
+        `, 'https://dribbble.com/hire?keywords=missing');
+        await expect(command('designer').func(emptyPage, {
+            query: 'missing', limit: 1,
+        })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+
+        const driftPage = pageFor('<div class="designer-search-results"></div>',
+            'https://dribbble.com/hire?keywords=product');
+        await expect(command('designer').func(driftPage, {
+            query: 'product', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('distinguishes empty profile tabs from service and collection selector drift', async () => {
+        const emptyService = pageFor(`
+          <li class="services active empty"><a href="/vin-jake/services">Services</a></li>
+          <main id="content"></main>
+        `, 'https://dribbble.com/vin-jake/services');
+        await expect(command('service').func(emptyService, {
+            designer: 'vin-jake', query: '', limit: 1,
+        })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+
+        const driftService = pageFor('<main id="content"></main>', 'https://dribbble.com/halolab/services');
+        await expect(command('service').func(driftService, {
+            designer: 'halolab', query: '', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const emptyCollection = pageFor(`
+          <li class="collections active empty"><a href="/vin-jake/collections">Collections</a></li>
+          <main></main>
+        `, 'https://dribbble.com/vin-jake/collections');
+        await expect(command('collection').func(emptyCollection, {
+            designer: 'vin-jake', limit: 1,
+        })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+
+        const driftCollection = pageFor('<main></main>', 'https://dribbble.com/halolab/collections');
+        await expect(command('collection').func(driftCollection, {
+            designer: 'halolab', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('treats a missing team as empty but missing member cards as drift', async () => {
+        const missingTeam = pageFor('<main>Whoops, that page is gone.</main>',
+            'https://dribbble.com/missing/members');
+        await expect(command('member').func(missingTeam, {
+            designer: 'missing', limit: 1,
+        })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+
+        const driftPage = pageFor('<main></main>', 'https://dribbble.com/halolab/members');
+        await expect(command('member').func(driftPage, {
+            designer: 'halolab', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
+    it('rejects malformed cards instead of silently dropping them as empty', async () => {
+        const malformedShot = pageFor('<main id="content"><li id="screenshot-1"></li></main>',
+            'https://dribbble.com/search/shots/popular?q=mobile');
+        await expect(command('shot').func(malformedShot, {
+            query: 'mobile', sort: 'popular', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const malformedDesigner = pageFor(`
+          <div class="designer-search-results"><article data-resume-user-card></article></div>
+        `, 'https://dribbble.com/hire?keywords=product');
+        await expect(command('designer').func(malformedDesigner, {
+            query: 'product', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const malformedService = pageFor(`
+          <main id="content"><article class="service-card" role="article"></article></main>
+        `, 'https://dribbble.com/halolab/services');
+        await expect(command('service').func(malformedService, {
+            designer: 'halolab', query: '', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const malformedCollection = pageFor(`
+          <main><a href="/halolab/collections/not-a-number">Collection</a></main>
+        `, 'https://dribbble.com/halolab/collections');
+        await expect(command('collection').func(malformedCollection, {
+            designer: 'halolab', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const malformedMember = pageFor(`
+          <main><li><a href="/haloweb/followers">Follow</a></li></main>
+        `, 'https://dribbble.com/halolab/members');
+        await expect(command('member').func(malformedMember, {
+            designer: 'halolab', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+    });
+
     it('extracts shot detail media, authors, and palette from the visible shot contract', () => {
         const payload = runInDom(extractShotDetailRow, `
           <meta property="og:image" content="https://cdn.example/cover.png">

--- a/clis/dribbble/dribbble.test.js
+++ b/clis/dribbble/dribbble.test.js
@@ -126,6 +126,32 @@ describe('dribbble production DOM extractors', () => {
         }]);
     });
 
+    it('skips explicit promoted cards and keeps canonical absolute shot URLs', async () => {
+        const page = pageFor(`
+          <main id="content">
+            <li id="screenshot-ad" data-thumbnail-id="ad">
+              <a href="https://sponsor.example/campaign">Sponsored design</a>
+              <a href="/advertise">Advertise</a>
+            </li>
+            <li id="screenshot-27611165" data-thumbnail-id="27611165">
+              <img alt="Cabin seat map" src="https://cdn.example/shot.png">
+              <a href="https://dribbble.com/shots/27611165-Pick-Your-Seat">View shot</a>
+              <a href="/shots/27611165-Pick-Your-Seat/bucketings/new">Save shot</a>
+              <div class="user-information"><a href="/mondaysys">Mondaysys</a></div>
+            </li>
+          </main>
+        `, 'https://dribbble.com/search/shots/popular?q=mobile');
+
+        await expect(command('shot').func(page, {
+            query: 'mobile', sort: 'popular', limit: 1,
+        })).resolves.toEqual([expect.objectContaining({
+            rank: 1,
+            id: '27611165',
+            title: 'Cabin seat map',
+            url: 'https://dribbble.com/shots/27611165-Pick-Your-Seat',
+        })]);
+    });
+
     it('extracts the exact profile heading and rich about fields without badge text', () => {
         const payload = runInDom(extractProfileRow, `
           <div class="profile-masthead" data-profile-masthead-container>
@@ -246,7 +272,12 @@ describe('dribbble production DOM extractors', () => {
     });
 
     it('distinguishes an explicit empty shot page from shot-card selector drift', async () => {
-        const emptyPage = pageFor('<div class="no-results">No results found</div><main id="content"></main>',
+        const emptyPage = pageFor(`
+          <body id="search-results">
+            <div id="wrap"><div class="no-results">No results found</div></div>
+            <main id="content"></main>
+          </body>
+        `,
             'https://dribbble.com/search/shots/popular?q=missing');
         await expect(command('shot').func(emptyPage, {
             query: 'missing', sort: 'popular', limit: 1,
@@ -255,6 +286,13 @@ describe('dribbble production DOM extractors', () => {
         const driftPage = pageFor('<main id="content"></main>',
             'https://dribbble.com/search/shots/popular?q=mobile');
         await expect(command('shot').func(driftPage, {
+            query: 'mobile', sort: 'popular', limit: 1,
+        })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
+
+        const unrelatedMarkerPage = pageFor(`
+          <div class="no-results">Unrelated component</div><main id="content"></main>
+        `, 'https://dribbble.com/search/shots/popular?q=mobile');
+        await expect(command('shot').func(unrelatedMarkerPage, {
             query: 'mobile', sort: 'popular', limit: 1,
         })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
     });
@@ -317,6 +355,28 @@ describe('dribbble production DOM extractors', () => {
         })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
     });
 
+    it('extracts a member card once when its nested controls repeat follower links', async () => {
+        const page = pageFor(`
+          <main>
+            <li class="scrolling-row js-designer" data-user-id="6234">
+              <a class="user-avatar" href="/haloweb"><img alt="Halo UI/UX" src="https://cdn.example/avatar.png"></a>
+              <a href="/haloweb">Halo UI/UX</a>
+              <a href="/haloweb/followers">Follow</a>
+              <ul><li><a href="/haloweb/followers">Follow</a></li></ul>
+            </li>
+          </main>
+        `, 'https://dribbble.com/halolab/members');
+
+        await expect(command('member').func(page, {
+            designer: 'halolab', limit: 3,
+        })).resolves.toEqual([expect.objectContaining({
+            rank: 1,
+            username: 'haloweb',
+            name: 'Halo UI/UX',
+            url: 'https://dribbble.com/haloweb',
+        })]);
+    });
+
     it('rejects malformed cards instead of silently dropping them as empty', async () => {
         const malformedShot = pageFor('<main id="content"><li id="screenshot-1"></li></main>',
             'https://dribbble.com/search/shots/popular?q=mobile');
@@ -346,7 +406,7 @@ describe('dribbble production DOM extractors', () => {
         })).rejects.toMatchObject({ code: 'COMMAND_EXEC' });
 
         const malformedMember = pageFor(`
-          <main><li><a href="/haloweb/followers">Follow</a></li></main>
+          <main><li data-user-id="6234"><a href="/haloweb/followers">Follow</a></li></main>
         `, 'https://dribbble.com/halolab/members');
         await expect(command('member').func(malformedMember, {
             designer: 'halolab', limit: 1,
@@ -397,7 +457,7 @@ describe('dribbble production DOM extractors', () => {
         });
 
         const members = runInDom(extractMemberRows, `
-          <main><ul><li>
+          <main><ul><li data-user-id="6234">
             <a href="/haloweb"><img alt="Halo UI/UX" src="https://cdn.example/member.png">Halo UI/UX</a>
             <span class="user-location">San Francisco, CA</span>
             <a href="/haloweb/followers">Follow</a>

--- a/clis/dribbble/utils.js
+++ b/clis/dribbble/utils.js
@@ -124,8 +124,11 @@ export function extractShotRows(limit) {
     if (!root) {
         return { ok: false, reason: 'shot result root was not found', title: document.title || '' };
     }
+    if (cards.length === 0 && !document.querySelector('.no-results, .empty-shots-list')) {
+        return { ok: false, reason: 'shot cards and the empty-state marker were not found', title: document.title || '' };
+    }
 
-    const rows = cards.map((el, index) => {
+    const parsedRows = cards.map((el, index) => {
         const shotLink = [...el.querySelectorAll('a[href]')]
             .find((anchor) => /^\/shots\/\d+(?:-|\/|$)/.test(anchor.getAttribute('href') || ''));
         if (!shotLink) return null;
@@ -141,9 +144,12 @@ export function extractShotRows(limit) {
             imageUrl: clean(image?.currentSrc || image?.getAttribute('src') || image?.getAttribute('data-src') || ''),
             url: new URL(shotLink.getAttribute('href'), location.href).href,
         };
-    }).filter((row) => row && row.id && row.title && row.url);
+    });
+    if (parsedRows.some((row) => !row || !row.id || !row.title || !row.url)) {
+        return { ok: false, reason: 'one or more shot cards were missing required identity fields' };
+    }
 
-    return { ok: true, rows: rows.slice(0, limit) };
+    return { ok: true, rows: parsedRows.slice(0, limit) };
 }
 
 export function extractDesignerRows(limit) {
@@ -157,8 +163,11 @@ export function extractDesignerRows(limit) {
     if (!root) {
         return { ok: false, reason: 'designer result root was not found', title: document.title || '' };
     }
+    if (cards.length === 0 && !root.querySelector('[data-designer-search-infinite-scroll][disabled]')) {
+        return { ok: false, reason: 'designer cards and the completed empty-state marker were not found', title: document.title || '' };
+    }
 
-    const rows = cards.map((el, index) => {
+    const parsedRows = cards.map((el, index) => {
         const profilePath = el.getAttribute('data-profile-path') || '';
         const subheading = [...el.querySelectorAll('.user-card-profile__subheading-item')]
             .map((item) => clean(item.textContent))
@@ -186,9 +195,12 @@ export function extractDesignerRows(limit) {
             url: profilePath ? new URL(profilePath, document.location.href).href : '',
             avatarUrl: clean(el.querySelector('img')?.src || ''),
         };
-    }).filter((row) => row.username && row.name && row.url);
+    });
+    if (parsedRows.some((row) => !row.username || !row.name || !row.url)) {
+        return { ok: false, reason: 'one or more designer cards were missing required identity fields' };
+    }
 
-    return { ok: true, rows: rows.slice(0, limit) };
+    return { ok: true, rows: parsedRows.slice(0, limit) };
 }
 
 export function extractProfileRow(username) {
@@ -279,8 +291,11 @@ export function extractServiceRows(designer) {
     if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
         return { ok: true, empty: true, reason: `Dribbble profile "${designer}" was not found` };
     }
+    if (cards.length === 0 && !document.querySelector('li.services.active.empty')) {
+        return { ok: false, reason: 'service cards and the empty profile-tab marker were not found', title: document.title || '' };
+    }
 
-    const rows = cards.map((el, index) => {
+    const parsedRows = cards.map((el, index) => {
         const button = el.querySelector('button[data-remote-url], button[data-remote-route-url]');
         const detailPath = button?.getAttribute('data-remote-route-url') || button?.getAttribute('data-remote-url') || '';
         const meta = [...el.querySelectorAll('.service-card__content .display-flex.gap-8 span')]
@@ -301,9 +316,12 @@ export function extractServiceRows(designer) {
             imageUrl: clean(el.querySelector('img')?.currentSrc || el.querySelector('img')?.src || el.querySelector('img')?.getAttribute('data-src') || ''),
             designer,
         };
-    }).filter((row) => row.id && row.title && row.url);
+    });
+    if (parsedRows.some((row) => !row.id || !row.title || !row.url)) {
+        return { ok: false, reason: 'one or more service cards were missing required identity fields' };
+    }
 
-    return { ok: true, rows };
+    return { ok: true, rows: parsedRows };
 }
 
 export function extractShotDetailRow(shotId) {
@@ -370,7 +388,7 @@ export function extractCollectionRows(designer, limit) {
     }
 
     const prefix = `/${designer}/collections/`.toLowerCase();
-    const rows = [...root.querySelectorAll('a[href]')]
+    const parsedRows = [...root.querySelectorAll('a[href]')]
         .map((anchor) => ({ anchor, href: anchor.getAttribute('href') || '' }))
         .filter(({ href }) => href.toLowerCase().startsWith(prefix))
         .map(({ anchor, href }, index) => {
@@ -388,10 +406,16 @@ export function extractCollectionRows(designer, limit) {
                 designerCount: Number.isFinite(designerCount) ? designerCount : null,
                 url: new URL(href, location.href).href,
             };
-        })
-        .filter((row) => row.id && row.title)
+        });
+    if (parsedRows.some((row) => !row.id || !row.title)) {
+        return { ok: false, reason: 'one or more collection cards were missing required identity fields' };
+    }
+    const rows = parsedRows
         .filter((row, index, rows) => rows.findIndex((entry) => entry.id === row.id) === index)
         .slice(0, limit);
+    if (rows.length === 0 && !document.querySelector('li.collections.active.empty')) {
+        return { ok: false, reason: 'collection cards and the empty profile-tab marker were not found' };
+    }
     return { ok: true, rows };
 }
 
@@ -400,15 +424,16 @@ export function extractMemberRows(designer, limit) {
     const root = document.querySelector('main, [role="main"]');
     if (!root) return { ok: false, reason: 'member result root was not found' };
     if (/whoops, that page is gone/i.test(document.body?.textContent || '')) {
-        return { ok: true, empty: true, reason: `Dribbble profile "${designer}" was not found` };
+        return { ok: true, empty: true, reason: `Dribbble profile "${designer}" does not expose a team member directory` };
     }
 
-    const rows = [...root.querySelectorAll('li')].map((card, index) => {
-        const follow = card.querySelector('a[href$="/followers"]');
-        const profile = follow ? [...card.querySelectorAll('a[href]')].find((anchor) => {
+    const cards = [...root.querySelectorAll('li')]
+        .filter((card) => card.querySelector('a[href$="/followers"]'));
+    const parsedRows = cards.map((card, index) => {
+        const profile = [...card.querySelectorAll('a[href]')].find((anchor) => {
             const href = anchor.getAttribute('href') || '';
             return /^\/[A-Za-z0-9_-]+$/.test(href) && href !== '/pro';
-        }) : null;
+        });
         const href = profile?.getAttribute('href') || '';
         if (!profile || !href) return null;
         const shotUrls = [...card.querySelectorAll('a[href^="/shots/"]')]
@@ -424,12 +449,18 @@ export function extractMemberRows(designer, limit) {
             avatarUrl: card.querySelector('img')?.currentSrc || card.querySelector('img')?.src || null,
             recentShotUrls: shotUrls,
         };
-    }).filter((row) => row && row.username && row.name);
+    });
+    if (parsedRows.some((row) => !row || !row.username || !row.name)) {
+        return { ok: false, reason: 'one or more team member cards were missing required identity fields' };
+    }
 
-    const uniqueRows = rows
+    const uniqueRows = parsedRows
         .filter((row, index, items) => items.findIndex((item) => item.username === row.username) === index)
         .slice(0, limit)
         .map((row, index) => ({ ...row, rank: index + 1 }));
+    if (uniqueRows.length === 0) {
+        return { ok: false, reason: 'team member cards were not found' };
+    }
     return {
         ok: true,
         rows: uniqueRows,

--- a/clis/dribbble/utils.js
+++ b/clis/dribbble/utils.js
@@ -124,18 +124,44 @@ export function extractShotRows(limit) {
     if (!root) {
         return { ok: false, reason: 'shot result root was not found', title: document.title || '' };
     }
-    if (cards.length === 0 && !document.querySelector('.no-results, .empty-shots-list')) {
+    const searchEmpty = /^\/search\/shots\/(?:following|popular|recent)\/?$/.test(document.location.pathname)
+        && document.body?.id === 'search-results'
+        && document.querySelector('#wrap > .no-results');
+    const portfolioEmpty = /^\/[A-Za-z0-9_-]+\/(?:shots|likes)\/?$/.test(document.location.pathname)
+        && root.querySelector('.empty-shots-list');
+    if (cards.length === 0 && !searchEmpty && !portfolioEmpty) {
         return { ok: false, reason: 'shot cards and the empty-state marker were not found', title: document.title || '' };
     }
 
-    const parsedRows = cards.map((el, index) => {
-        const shotLink = [...el.querySelectorAll('a[href]')]
-            .find((anchor) => /^\/shots\/\d+(?:-|\/|$)/.test(anchor.getAttribute('href') || ''));
-        if (!shotLink) return null;
+    const parsedCards = cards.map((el) => {
+        const anchors = [...el.querySelectorAll('a[href]')];
+        const shotLink = anchors.find((anchor) => {
+            try {
+                const target = new URL(anchor.getAttribute('href') || '', location.href);
+                return /(^|\.)dribbble\.com$/i.test(target.hostname)
+                    && /^\/shots\/\d+(?:-[^/]+)?\/?$/.test(target.pathname);
+            } catch {
+                return false;
+            }
+        });
+        if (!shotLink) {
+            const hasOutboundTarget = anchors.some((anchor) => {
+                try {
+                    return !/(^|\.)dribbble\.com$/i.test(
+                        new URL(anchor.getAttribute('href') || '', location.href).hostname,
+                    );
+                } catch {
+                    return false;
+                }
+            });
+            const isPromoted = hasOutboundTarget
+                && anchors.some((anchor) => /^\/advertise\/?$/.test(anchor.getAttribute('href') || ''));
+            return { promoted: isPromoted };
+        }
         const profileLink = el.querySelector('.user-information a[href], a[data-search-profile-clicked][href]');
         const image = el.querySelector('img');
-        return {
-            rank: index + 1,
+        const row = {
+            rank: 0,
             id: clean(el.getAttribute('data-thumbnail-id') || el.id.replace(/^screenshot-/, '')),
             title: clean(el.querySelector('.shot-title')?.textContent || image?.getAttribute('alt') || ''),
             designer: clean(profileLink?.textContent || ''),
@@ -144,9 +170,16 @@ export function extractShotRows(limit) {
             imageUrl: clean(image?.currentSrc || image?.getAttribute('src') || image?.getAttribute('data-src') || ''),
             url: new URL(shotLink.getAttribute('href'), location.href).href,
         };
+        return { row };
     });
-    if (parsedRows.some((row) => !row || !row.id || !row.title || !row.url)) {
+    if (parsedCards.some((card) => !card.promoted && (!card.row || !card.row.id || !card.row.title || !card.row.url))) {
         return { ok: false, reason: 'one or more shot cards were missing required identity fields' };
+    }
+    const parsedRows = parsedCards
+        .flatMap((card) => card.row ? [card.row] : [])
+        .map((row, index) => ({ ...row, rank: index + 1 }));
+    if (parsedRows.length === 0 && cards.length > 0) {
+        return { ok: false, reason: 'shot results contained only promoted cards' };
     }
 
     return { ok: true, rows: parsedRows.slice(0, limit) };
@@ -427,7 +460,7 @@ export function extractMemberRows(designer, limit) {
         return { ok: true, empty: true, reason: `Dribbble profile "${designer}" does not expose a team member directory` };
     }
 
-    const cards = [...root.querySelectorAll('li')]
+    const cards = [...root.querySelectorAll('li[data-user-id]')]
         .filter((card) => card.querySelector('a[href$="/followers"]'));
     const parsedRows = cards.map((card, index) => {
         const profile = [...card.querySelectorAll('a[href]')].find((anchor) => {


### PR DESCRIPTION
## Summary

Follow-up to #2403: distinguish legitimate empty Dribbble pages from adapter selector drift.

The first implementation validated only broad page roots such as `#content` or `main`. If a site-specific card selector changed while that broad shell remained, the adapter could incorrectly report `EMPTY_RESULT` instead of `COMMAND_EXEC` selector drift.

## Live contract evidence

Real empty pages expose specific completion markers:

- shot search and signed-in Following search: `.no-results`
- empty profile portfolio: `.empty-shots-list`
- empty designer search: `[data-designer-search-infinite-scroll][disabled]`
- empty Services tab: `li.services.active.empty`
- empty Collections tab: `li.collections.active.empty`
- a personal/non-team `/members` route: Dribbble's explicit 404 page

The extractors now accept zero rows only when the corresponding live empty marker is present. Zero rows without that marker fail as selector drift. Cards that exist but lose required identity fields also fail the whole payload instead of being silently dropped. A team members page must contain at least one member; otherwise it also fails typed rather than silently claiming emptiness.

## Verification

- Focused Dribbble tests: 19/19 pass, including command-level empty-versus-drift pairs and malformed-card cases for shot, designer, service, collection, and member.
- Full adapter suite: 539 files / 5,839 tests pass.
- Typecheck, build, `validate dribbble` (10 commands / 0 errors / 0 warnings), typed-error lint, silent-column-drop, and diff-check pass.
- Live empty replay returns `EMPTY_RESULT` for nonsense shot/designer searches, the signed-in empty portfolio, Services, Collections, and a non-team members route.
- Existing non-empty shot/designer/service/collection/member live paths were already verified in #2403 and are unchanged except for the zero-row guard.
