### PR TITLE
fix(xiaohongshu): give ask citation URLs that actually open

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -45528,6 +45528,7 @@
       "source_total_text",
       "sources_summary",
       "sources",
+      "share_url",
       "warning",
       "message_id",
       "conversation_id"

--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -18,6 +18,7 @@ const ASK_COLUMNS = [
     'source_total_text',
     'sources_summary',
     'sources',
+    'share_url',
     'warning',
     'message_id',
     'conversation_id',
@@ -143,11 +144,13 @@ function extractNoteId(source) {
 
 export function buildNoteUrl(noteId, xsecToken) {
     if (!/^[0-9a-f]{24}$/i.test(String(noteId || ''))) return '';
+    // No token, no URL. A bare /explore/<id> resolves for nobody — Xiaohongshu serves
+    // its "page not found" body under HTTP 200 — so returning one only launders a
+    // dead link into somewhere it looks trustworthy.
+    if (!xsecToken) return '';
     const url = new URL(`https://${XHS_WEB_HOST}/explore/${noteId}`);
-    if (xsecToken) {
-        url.searchParams.set('xsec_token', xsecToken);
-        url.searchParams.set('xsec_source', '');
-    }
+    url.searchParams.set('xsec_token', xsecToken);
+    url.searchParams.set('xsec_source', '');
     return url.toString();
 }
 
@@ -168,16 +171,25 @@ export function normalizeAskSource(source, index) {
         .map(parseTrustedSourceLink)
         .find(Boolean);
     const noteId = extractNoteId(source);
-    const xsecToken = trustedLink?.xsecToken || '';
+    // dqa/detail supplies the token as its own field; the older onebox/detail payload
+    // only ever carried one inside a link, and usually not at all.
+    const xsecToken = compactSingleLine(source?.xsecToken || source?.xsec_token)
+        || trustedLink?.xsecToken
+        || '';
+    const url = buildNoteUrl(noteId, xsecToken);
     const normalized = {
         rank: index + 1,
         type: 'note',
         title: firstNonEmpty(source?.title, source?.displayTitle, source?.name),
-        url: buildNoteUrl(noteId, xsecToken),
         note_id: noteId,
         xsec_token: xsecToken,
         author: firstNonEmpty(source?.nickName, source?.nickname, source?.author, source?.userName),
     };
+    // Emit `url` only when it works. Xiaohongshu answers a tokenless note URL with
+    // HTTP 200 and a "你访问的页面不见了" body, so shipping one hands the caller a
+    // link that every status-code check calls healthy and every human finds broken.
+    // #994 removed exactly this shape from note/comments; ask was missed.
+    if (url) normalized.url = url;
     const noteType = firstNonEmpty(source?.noteType);
     if (noteType) normalized.note_type = noteType;
     const likeCount = parseCount(source?.like);
@@ -216,6 +228,7 @@ export function buildAskResult(raw) {
         source_total_text: compactSingleLine(raw?.source_total_text),
         sources_summary: buildSourcesSummary(sources),
         sources,
+        share_url: compactSingleLine(raw?.share_url),
         warning,
         message_id: compactSingleLine(raw?.message_id),
         conversation_id: compactSingleLine(raw?.conversation_id),
@@ -235,6 +248,60 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
           const text = String(value || '');
           return text.length > max ? text.slice(0, max) : text;
         };
+        // Citation sources come from search/dqa/detail, not search/dqa/onebox/detail.
+        //
+        // Both answer for the same message, but only dqa/detail carries \`xsecToken\`,
+        // and Xiaohongshu requires that token on a note URL. Measured 2026-08-28 across
+        // one conversation, 10 sources each:
+        //   getResponseReferences (onebox/detail) -> 10 items,  0 with a token
+        //   dqa/detail                            -> 10 items, 10 with a token
+        //
+        // dqa/detail needs the site's signed transport: a bare same-origin fetch of the
+        // identical URL returns 406 {"code":-1,"success":false}. So borrow the page's own
+        // signed axios wrapper, located by shape rather than by module id for the same
+        // reason the conversation store is. Shape alone is not decisive — two modules
+        // match on a live page — so a candidate is accepted only once it answers.
+        const locateSignedClients = (req) => {
+          const clients = [];
+          for (const id of Object.keys(req.c || {})) {
+            let exports;
+            try { exports = req.c[id].exports; } catch { continue; }
+            if (!exports || typeof exports !== 'object') continue;
+            for (const key of Object.keys(exports)) {
+              let value;
+              try { value = exports[key]; } catch { continue; }
+              if (
+                value
+                && typeof value === 'object'
+                && typeof value.get === 'function'
+                && typeof value.post === 'function'
+                && typeof value.buildURL === 'function'
+                && value.interceptors
+              ) clients.push(value);
+            }
+          }
+          return clients;
+        };
+        const fetchTracedSources = async (clients, messageId, conversationId, size) => {
+          for (const client of clients) {
+            try {
+              const response = await client.get('/api/sns/web/v1/search/dqa/detail', {
+                params: {
+                  message_id: messageId,
+                  conversation_id: conversationId,
+                  query: '',
+                  scene: 'web_ask',
+                  type: 'inside',
+                  page_from: 0,
+                  size,
+                },
+              });
+              const body = response && response.data !== undefined ? response.data : response;
+              if (Array.isArray(body?.items) && body.items.length > 0) return body;
+            } catch { /* not the signed client, or this build moved the endpoint */ }
+          }
+          return null;
+        };
         const latestRound = (store, scenes, msgId) => {
           const rounds = typeof store.getSceneRounds === 'function'
             ? store.getSceneRounds(scenes.AiChat)
@@ -253,6 +320,9 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
           textLink: item?.textLink || '',
           link: item?.link || item?.imageList?.[0]?.link || '',
           url: item?.url || '',
+          // Required to build a URL that resolves. This projection is a whitelist:
+          // omitting a field here makes it unreachable no matter what the API returned.
+          xsecToken: item?.xsecToken || item?.xsec_token || '',
           like: item?.like ?? null,
           time: item?.time || '',
         });
@@ -346,17 +416,28 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
           let detail = null;
           let sourceError = '';
           try {
-            if (store.agent?.getResponseReferences) {
-              for (let attempt = 0; attempt < 5; attempt++) {
-              detail = await store.agent.getResponseReferences({
-                query: prompt,
-                message_id: msgId,
-                page: 0,
-                size: requestSourceSize,
-                version: 0,
-                result_version: 0,
-                id: '',
-              });
+            // Sources land a beat after the answer does, so this retries — but only
+            // when there is a client to retry against. Retrying an empty candidate list
+            // just delays the fallback by the length of the loop.
+            const signedClients = locateSignedClients(webpackRequire);
+            for (let attempt = 0; signedClients.length && attempt < 5 && !detail; attempt++) {
+              detail = await fetchTracedSources(signedClients, msgId, conversationId, requestSourceSize);
+              if (!detail) await sleep(1000);
+            }
+            // Fall back to the store's own reference call. Its rows carry no token, so
+            // their URLs are omitted rather than emitted dead — but a citation with
+            // note_id, title, author and quote is still worth returning.
+            if (!detail && store.agent?.getResponseReferences) {
+              for (let attempt = 0; attempt < 3; attempt++) {
+                detail = await store.agent.getResponseReferences({
+                  query: prompt,
+                  message_id: msgId,
+                  page: 0,
+                  size: requestSourceSize,
+                  version: 0,
+                  result_version: 0,
+                  id: '',
+                });
                 if (Array.isArray(detail?.items) && detail.items.length > 0) break;
                 await sleep(1000);
               }
@@ -364,6 +445,10 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
           } catch (err) {
             sourceError = String(err?.message || err || '');
           }
+          const shareEntries = Array.isArray(detail?.shareInfo?.functionEntries)
+            ? detail.shareInfo.functionEntries
+            : [];
+          const shareEntry = shareEntries.find((entry) => entry?.type === 'copy_link') || shareEntries[0];
 
           const rawSources = Array.isArray(detail?.items) ? detail.items.slice(0, sourceLimit).map(slimSource) : [];
           return {
@@ -372,6 +457,7 @@ export function buildAskEvaluateJs(query, timeoutSeconds, sourceLimit) {
             answer,
             source_total_text: detail?.baseInfo?.totalCnt || aiMessage?.querySource?.text || aiMessage?.querySource?.oneboxText || '',
             sources: rawSources,
+            share_url: shareEntry?.link || '',
             warning: sourceError,
             message_id: msgId,
             conversation_id: conversationId,

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -37,6 +37,7 @@ describe('xiaohongshu ask', () => {
             'source_total_text',
             'sources_summary',
             'sources',
+            'share_url',
             'warning',
             'message_id',
             'conversation_id',
@@ -117,10 +118,30 @@ describe('xiaohongshu ask', () => {
         expect(normalizeAskSource({ id: '69d6fc08000000001f007646', like: 1.5 }, 0)).not.toHaveProperty('like_count');
     });
 
-    it('builds a bare note URL when 点点 source data has no xsec token', () => {
-        expect(buildNoteUrl('69d6fc08000000001f007646', '')).toBe(
-            'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646',
+    it('refuses to build a note URL without an xsec token, because it would not resolve', () => {
+        // Xiaohongshu answers a tokenless note URL with HTTP 200 and a
+        // "你访问的页面不见了" body, so the dead link passes every status-code check
+        // a caller might run. Measured 2026-08-28, same note id, one variable:
+        //   /explore/<id>                  -> 200, 109746 bytes, title "你访问的页面不见了"
+        //   /explore/<id>?xsec_token=<tok> -> 200, 134011 bytes, title "香港小众玩法🔥…"
+        expect(buildNoteUrl('69d6fc08000000001f007646', '')).toBe('');
+        expect(buildNoteUrl('69d6fc08000000001f007646', 'tok')).toBe(
+            'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=tok&xsec_source=',
         );
+    });
+
+    it('takes the xsec token from the source field dqa/detail supplies', () => {
+        const source = normalizeAskSource({
+            id: '69d6fc08000000001f007646',
+            title: '来源标题',
+            xsecToken: 'ABLSQRovqo7q',
+        }, 0);
+
+        expect(source).toMatchObject({
+            note_id: '69d6fc08000000001f007646',
+            xsec_token: 'ABLSQRovqo7q',
+            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=ABLSQRovqo7q&xsec_source=',
+        });
     });
 
     it('does not project untrusted citation links into source URLs or deeplinks', () => {
@@ -133,10 +154,10 @@ describe('xiaohongshu ask', () => {
 
         expect(source).toMatchObject({
             note_id: '',
-            url: '',
             xsec_token: '',
             title: '来源标题',
         });
+        expect(source).not.toHaveProperty('url');
         expect(source).not.toHaveProperty('deeplink');
     });
 
@@ -149,9 +170,11 @@ describe('xiaohongshu ask', () => {
 
         expect(source).toMatchObject({
             note_id: '69d6fc08000000001f007646',
-            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646',
             xsec_token: '',
         });
+        // Identity survives an untrusted link; a URL built on a token we do not have
+        // would not resolve, so none is offered.
+        expect(source).not.toHaveProperty('url');
         expect(source).not.toHaveProperty('deeplink');
     });
 
@@ -273,7 +296,15 @@ describe('xiaohongshu ask', () => {
 // lookup is exercised for real rather than asserted as a substring. The point is the
 // module id: Xiaohongshu renumbers chunks on redeploys (6404 -> 32914 broke every ask),
 // so the lookup has to survive an id nobody has seen before.
-async function runAskScriptAgainstFakeRuntime({ moduleId, answer = '答案正文' }) {
+async function runAskScriptAgainstFakeRuntime({
+    moduleId,
+    answer = '答案正文',
+    // Each entry becomes one module in the require cache exporting an axios-shaped
+    // client. `respond` receives (path, config) and returns what .get resolves to.
+    signedClients = [],
+    referenceItems = [{ id: '69d6fc08000000001f007646', title: '来源标题', nickName: '作者A' }],
+    onGetResponseReferences = null,
+}) {
     const msgId = 'msg-1';
     const store = {
         switchScene: () => {},
@@ -282,10 +313,13 @@ async function runAskScriptAgainstFakeRuntime({ moduleId, answer = '答案正文
         sendMessage: async () => msgId,
         getSceneRounds: () => [{ aiMessage: { msgId, isFinished: true, text: answer } }],
         agent: {
-            getResponseReferences: async () => ({
-                baseInfo: { totalCnt: 'ai总结7篇笔记生成' },
-                items: [{ id: '69d6fc08000000001f007646', title: '来源标题', nickName: '作者A' }],
-            }),
+            getResponseReferences: async (params) => {
+                if (onGetResponseReferences) onGetResponseReferences(params);
+                return {
+                    baseInfo: { totalCnt: 'ai总结7篇笔记生成' },
+                    items: referenceItems,
+                };
+            },
         },
     };
     // toString() of this factory carries the fingerprint the scan looks for.
@@ -302,6 +336,21 @@ async function runAskScriptAgainstFakeRuntime({ moduleId, answer = '答案正文
     webpackRequire.m = moduleId === null
         ? { 4242: decoyFactory }
         : { 4242: decoyFactory, [moduleId]: conversationFactory };
+    // The module cache is where the signed HTTP client is found. A decoy that is an
+    // object but not axios-shaped keeps the shape test honest.
+    webpackRequire.c = { 777: { exports: { notAClient: { get: 'string, not a function' } } } };
+    signedClients.forEach((client, index) => {
+        webpackRequire.c[900 + index] = {
+            exports: {
+                [client.exportKey || 'dJ']: {
+                    get: (path, config) => client.respond(path, config),
+                    post: () => {},
+                    buildURL: () => {},
+                    interceptors: {},
+                },
+            },
+        };
+    });
 
     const priorWindow = globalThis.window;
     const priorLocation = globalThis.location;
@@ -333,5 +382,107 @@ describe('xiaohongshu ask conversation-store lookup', () => {
     it('reports conversation_store_missing when no module matches, instead of throwing', async () => {
         const result = await runAskScriptAgainstFakeRuntime({ moduleId: null });
         expect(result).toMatchObject({ ok: false, error: 'conversation_store_missing' });
+    });
+});
+
+describe('xiaohongshu ask citation sources', () => {
+    const TOKENED = [
+        { id: '699dd2250000000023038495', title: '香港小众玩法', nickName: 'Tim孟游记', xsecToken: 'ABLSQRovqo7q' },
+        { id: '6a87089d000000002702ef3c', title: '香港3天2晚', nickName: 'MorikawaMio', xsecToken: 'AB0BX-aB6nwD' },
+    ];
+
+    it('reads sources from dqa/detail and turns its token into a working URL', async () => {
+        const calls = [];
+        const result = await runAskScriptAgainstFakeRuntime({
+            moduleId: 32914,
+            signedClients: [{
+                respond: (path, config) => {
+                    calls.push({ path, params: config.params });
+                    return { data: { items: TOKENED, shareInfo: { functionEntries: [
+                        { type: 'generate_image', link: 'https://www.xiaohongshu.com/s/dqa?dqa_share_id=IMG' },
+                        { type: 'copy_link', link: 'https://www.xiaohongshu.com/s/dqa?dqa_share_id=LINK' },
+                    ] } } };
+                },
+            }],
+            // A trap, not a value: reaching the old endpoint at all is the bug.
+            onGetResponseReferences: () => { throw new Error('must not fall back when dqa/detail answered'); },
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].path).toBe('/api/sns/web/v1/search/dqa/detail');
+        expect(calls[0].params).toMatchObject({
+            message_id: 'msg-1',
+            conversation_id: expect.any(String),
+            scene: 'web_ask',
+            type: 'inside',
+            page_from: 0,
+        });
+        expect(result.sources[0]).toMatchObject({ id: '699dd2250000000023038495', xsecToken: 'ABLSQRovqo7q' });
+        expect(result.share_url).toBe('https://www.xiaohongshu.com/s/dqa?dqa_share_id=LINK');
+
+        const normalized = buildAskResult(result);
+        expect(normalized.sources.map((source) => source.url)).toEqual([
+            'https://www.xiaohongshu.com/explore/699dd2250000000023038495?xsec_token=ABLSQRovqo7q&xsec_source=',
+            'https://www.xiaohongshu.com/explore/6a87089d000000002702ef3c?xsec_token=AB0BX-aB6nwD&xsec_source=',
+        ]);
+    });
+
+    it('picks the client that answers when several match the shape', async () => {
+        // Measured on a live page: two loaded modules expose an axios-shaped client.
+        // Shape alone cannot choose between them, so the answer has to.
+        const reached = [];
+        const result = await runAskScriptAgainstFakeRuntime({
+            moduleId: 32914,
+            signedClients: [
+                { exportKey: 'ZP', respond: () => { reached.push('wrong'); return { data: { items: [] } }; } },
+                { exportKey: 'dJ', respond: () => { reached.push('right'); return { data: { items: TOKENED } }; } },
+            ],
+        });
+
+        expect(reached).toEqual(['wrong', 'right']);
+        expect(result.sources).toHaveLength(2);
+        expect(result.sources[0].xsecToken).toBe('ABLSQRovqo7q');
+    });
+
+    it('falls back to the store reference call when no signed client is present', async () => {
+        let fellBack = false;
+        const result = await runAskScriptAgainstFakeRuntime({
+            moduleId: 32914,
+            signedClients: [],
+            onGetResponseReferences: () => { fellBack = true; },
+        });
+
+        expect(fellBack).toBe(true);
+        expect(result.ok).toBe(true);
+        expect(result.sources).toHaveLength(1);
+    });
+
+    it('omits the URL rather than emitting a dead one when the fallback supplied no token', async () => {
+        const result = await runAskScriptAgainstFakeRuntime({ moduleId: 32914, signedClients: [] });
+        const normalized = buildAskResult(result);
+
+        expect(normalized.sources[0].note_id).toBe('69d6fc08000000001f007646');
+        expect(normalized.sources[0]).not.toHaveProperty('url');
+    });
+
+    it('survives a client whose get throws, instead of losing every source', async () => {
+        const result = await runAskScriptAgainstFakeRuntime({
+            moduleId: 32914,
+            signedClients: [
+                { exportKey: 'ZP', respond: () => { throw new Error('406 not signed'); } },
+                { exportKey: 'dJ', respond: () => ({ data: { items: TOKENED } }) },
+            ],
+        });
+
+        expect(result.sources).toHaveLength(2);
+    });
+
+    it('accepts a client that returns the body directly rather than under .data', async () => {
+        const result = await runAskScriptAgainstFakeRuntime({
+            moduleId: 32914,
+            signedClients: [{ respond: () => ({ items: TOKENED }) }],
+        });
+
+        expect(result.sources).toHaveLength(2);
     });
 });


### PR DESCRIPTION
> **Stacked on #2420.** The first two commits here are that PR; only
> `fix(xiaohongshu): give ask citation URLs that actually open` is new. The change
> conflicts on `main` alone because it builds on the module-lookup work in #2420,
> so this is easiest to review after (or together with) it.

## The bug

Every URL in `ask`'s `sources[]` is a dead link.

Each row comes back with `xsec_token: ""`, so the adapter emits a bare
`https://www.xiaohongshu.com/explore/<note_id>` — and Xiaohongshu answers that with
**HTTP 200** plus `<title>小红书 - 你访问的页面不见了</title>`. It is a soft 404, so
any check that reads the status code calls it healthy. Measured 50/50 empty tokens
across five separate asks.

#994 established this exact class and removed tokenless URLs from `note` /
`comments`. `ask` was never updated and still builds that shape.

## Why it happens

`ask` asks the wrong endpoint.

| caller | endpoint | items carry |
|---|---|---|
| `store.agent.getResponseReferences` (today) | `search/dqa/**onebox/**detail` | no token field at all |
| 点点's own reference panel | `search/**dqa/detail**` | the same fields **plus `video` and `xsecToken`** |

Measured side by side against a single conversation, 10 sources each:

```
getResponseReferences (onebox/detail) -> 10 items,  0 with a token
dqa/detail                            -> 10 items, 10 with a token
```

`dqa/detail` needs Xiaohongshu's signed transport — a bare same-origin `fetch` of the
identical URL returns `406 {"code":-1,"success":false}`. In the bundle it is
`R.dJ.get("/api/sns/web/v1/search/dqa/detail", {params:e})`, where `R.dJ` is the
site's signed axios wrapper.

## The change

- Fetch citation sources through the page's own signed client, located **by shape,
  never by module id** — the same reasoning as #2420. Shape alone is not decisive
  (two loaded modules match on a live page), so a candidate is accepted only once it
  answers with items.
- `buildNoteUrl` returns `''` without a token, and `normalizeAskSource` **omits**
  `url` rather than emitting one that cannot resolve. A citation keeps `note_id`,
  `title`, `author`, `like_count` and `quote`, which is what makes it checkable.
- `slimSource` carries `xsecToken`. That projection is a whitelist, so a field
  missing from it is invisible downstream however correct the rest of the chain is.
- New `share_url` column exposes `shareInfo.functionEntries[]` — an official share
  link for the whole answer that the payload already contained and the adapter threw
  away.

**It cannot regress into no citations.** If the signed client is absent or the
endpoint moves, the old `getResponseReferences` path still runs; output degrades to
citations without URLs, which is where `ask` is today.

## Verification

End to end against a live logged-in session, `--source-limit 8`:

```
sources    : 8
with token : 8
with url   : 8
share_url  : https://www.xiaohongshu.com/s/dqa?dqa_share_id=...
warning    : ''
```

Then every emitted URL was fetched. **8/8 returned the real note, and each `<title>`
matched the title the citation itself reported** — not merely "200", and not merely
"not the error page". Same note id, one variable:

| URL | status | bytes | `<title>` |
|---|---|---|---|
| `/explore/<id>` (before) | 200 | 109746 | 小红书 - 你访问的页面不见了 |
| `/explore/<id>?xsec_token=…` (after) | 200 | 134011 | 香港小众玩法🔥… - 小红书 |

Repo gates: `npm run typecheck`, `npm run check:silent-column-drop` (94 = baseline 94,
0 new), `npm run check:typed-error-lint` (130 = baseline 130, 0 new),
`node dist/src/main.js validate xiaohongshu` (PASS, 25 commands),
`npx vitest run --project adapter clis/xiaohongshu/` (338 passed).
`npm test` has 6 pre-existing failures in `src/cli.test.ts > browser tab targeting
commands`; they reproduce identically with this change stashed.

## Tests

The suite executes the generated page script against the fake webpack runtime, now
with a module cache. It asserts the endpoint and its params, reproduces the
two-candidate ambiguity seen on the live page, and covers a throwing client and a
client that returns the body directly rather than under `.data`. The fallback is
asserted with a **trap** rather than a value — reaching the old endpoint when
`dqa/detail` answered is itself the bug, and a stub returning a plausible value could
not observe that.

All five behaviours were mutation-checked so the assertions are known to be able to
fail:

| mutation | result |
|---|---|
| re-emit the tokenless URL | 3 failed |
| call `onebox/detail` instead | 1 failed |
| drop `xsecToken` from `slimSource` | 2 failed |
| take `clients[0]` blindly | 1 failed |
| remove the fallback | 3 failed |

Baseline green before and after each.