### PR TITLE
fix(errors): stop suggesting --timeout, which adapter commands do not accept

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -51,7 +51,21 @@ describe('Error type hierarchy', () => {
     const err = new TimeoutError('bilibili/hot', 60);
     expect(err.code).toBe('TIMEOUT');
     expect(err.message).toBe('bilibili/hot timed out after 60s');
-    expect(err.hint).toContain('timeout');
+    expect(err.hint).toContain('OPENCLI_BROWSER_COMMAND_TIMEOUT');
+  });
+
+  // Adapter commands do not declare a --timeout flag: only `browser wait`
+  // (--timeout <ms>) and `antigravity serve` (--timeout <seconds>) do. The
+  // default hint reaches adapter timeouts via runWithTimeout(), so suggesting
+  // the flag there sends users into `error: unknown option '--timeout'`.
+  it('TimeoutError default hint does not suggest the unsupported --timeout flag', () => {
+    const err = new TimeoutError('xiaohongshu/search', 1);
+    expect(err.hint).not.toContain('--timeout');
+  });
+
+  it('TimeoutError keeps a caller-supplied hint verbatim', () => {
+    const err = new TimeoutError('twitter post', 30, 'Nothing was posted. Retry with a smaller image.');
+    expect(err.hint).toBe('Nothing was posted. Retry with a smaller image.');
   });
 
   it('ArgumentError has correct code', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -119,7 +119,7 @@ export class TimeoutError extends CliError {
     super(
       'TIMEOUT',
       `${label} timed out after ${seconds}s`,
-      hint ?? 'Try again, or increase timeout with --timeout <seconds> (or OPENCLI_BROWSER_COMMAND_TIMEOUT for the global default)',
+      hint ?? 'Try again, or raise the global default with OPENCLI_BROWSER_COMMAND_TIMEOUT=<seconds>',
       EXIT_CODES.TEMPFAIL,
     );
   }


### PR DESCRIPTION
## Description

The default `TimeoutError` hint tells users to retry with `--timeout <seconds>`, but adapter commands do not declare that flag — following the advice fails with a different error.

Only two commands in the repo accept `--timeout`, and neither is an adapter command: `browser wait` (`--timeout <ms>`, `src/cli.ts:2412`) and `antigravity serve` (`--timeout <seconds>`, `src/cli.ts:3612`). The default hint is reached from the generic `runWithTimeout()` wrapper (`src/runtime.ts:24-31`) used by adapter execution, plus a handful of adapters that omit the third constructor argument.

Before:

```console
$ OPENCLI_BROWSER_COMMAND_TIMEOUT=1 opencli xiaohongshu search "opencli" --limit 3
ok: false
error:
  code: TIMEOUT
  message: xiaohongshu/search timed out after 1s
  help: Try again, or increase timeout with --timeout <seconds> (or OPENCLI_BROWSER_COMMAND_TIMEOUT for the global default)
  exitCode: 75

$ opencli xiaohongshu search "opencli" --limit 3 --timeout 90
error: unknown option '--timeout'          # exit 1
```

This matters most for agents driving OpenCLI programmatically: the natural recovery is to retry with the flag the error text named, which converts a retryable `TIMEOUT` (exit 75) into an opaque usage error (exit 1).

The fix points the default hint at `OPENCLI_BROWSER_COMMAND_TIMEOUT`, which is the knob that actually applies to adapter commands. The 49 call sites that pass an explicit `hint` are unaffected.

Related issue: Fixes #2415

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Tests

The existing assertion was `expect(err.hint).toContain('timeout')`, which matches the broken text as well as the fixed one — it could not catch this. Tightened it to assert the env var, and added two cases:

- default hint must not contain `--timeout` (fails on the old wording — verified by reverting the source and re-running: `AssertionError: expected 'Try again, or increase timeout with -…' not to contain '--timeout'`)
- a caller-supplied hint is still preserved verbatim

```console
$ npx tsc --noEmit                    # clean
$ npm test
 Test Files  628 passed (628)
      Tests  7288 passed | 1 skipped (7289)
```

Baseline on `main` before the change was 7286 passing; the +2 are the new cases.

## Note

While this is being touched, there is an adjacent inconsistency worth flagging separately: `browser wait` takes `--timeout` in **milliseconds** while `antigravity serve` takes **seconds**, so a user who does find a working `--timeout` may still pass the wrong magnitude. I left that alone here to keep the change minimal — happy to open a follow-up if you'd like it unified.
