### PR TITLE
fix(update-check): stop a failed extension lookup from silencing the update notice

### DIFF
--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   _extractLatestExtensionVersionFromReleases as extractLatestExtensionVersionFromReleases,
   _buildUpdateNotices as buildUpdateNotices,
+  _computeDueChecks as computeDueChecks,
   _EXTENSION_STALE_MS as EXTENSION_STALE_MS,
+  _CHECK_INTERVAL_MS as CHECK_INTERVAL_MS,
+  _EXTENSION_RETRY_INTERVAL_MS as EXTENSION_RETRY_INTERVAL_MS,
 } from './update-check.js';
 
 describe('extractLatestExtensionVersionFromReleases', () => {
@@ -133,5 +136,51 @@ describe('buildUpdateNotices', () => {
     });
     expect(lines.cli).toContain('v1.0.0 → v1.1.0');
     expect(lines.extension).toContain('v2.0.0 → v2.1.0');
+  });
+});
+
+describe('computeDueChecks', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('runs both lookups when the cache is empty', () => {
+    expect(computeDueChecks(null, NOW)).toEqual({ cli: true, extension: true });
+  });
+
+  it('skips both while each cooldown is still fresh', () => {
+    const cache = { lastCheck: NOW - 1000, extLastCheck: NOW - 1000, extLastFetchOk: true };
+    expect(computeDueChecks(cache, NOW)).toEqual({ cli: false, extension: false });
+  });
+
+  // The regression this file exists to guard: a failed extension lookup used to
+  // stamp the shared `lastCheck`, so the next run returned early and the lookup
+  // never retried. A failure must now come back within the retry window.
+  it('retries the extension lookup within the hour after a failure', () => {
+    const failed = { lastCheck: NOW, extLastCheck: NOW, extLastFetchOk: false };
+    expect(computeDueChecks(failed, NOW + EXTENSION_RETRY_INTERVAL_MS - 1).extension).toBe(false);
+    expect(computeDueChecks(failed, NOW + EXTENSION_RETRY_INTERVAL_MS).extension).toBe(true);
+  });
+
+  it('waits the full interval after a successful extension lookup', () => {
+    const ok = { lastCheck: NOW, extLastCheck: NOW, extLastFetchOk: true };
+    expect(computeDueChecks(ok, NOW + EXTENSION_RETRY_INTERVAL_MS).extension).toBe(false);
+    expect(computeDueChecks(ok, NOW + CHECK_INTERVAL_MS).extension).toBe(true);
+  });
+
+  // A fresh npm check must not suppress the extension lookup, and vice versa —
+  // that coupling was the root cause.
+  it('gates the two lookups independently', () => {
+    const cliFresh = { lastCheck: NOW, extLastCheck: NOW - CHECK_INTERVAL_MS, extLastFetchOk: true };
+    expect(computeDueChecks(cliFresh, NOW)).toEqual({ cli: false, extension: true });
+
+    const extFresh = { lastCheck: NOW - CHECK_INTERVAL_MS, extLastCheck: NOW, extLastFetchOk: true };
+    expect(computeDueChecks(extFresh, NOW)).toEqual({ cli: true, extension: false });
+  });
+
+  // Caches written before this field existed (or by the daemon, which only
+  // writes currentExtensionVersion/extensionLastSeenAt) must still trigger a
+  // lookup rather than being treated as fresh.
+  it('treats a legacy cache without extLastCheck as due', () => {
+    const legacy = { lastCheck: NOW, latestVersion: '1.8.7', currentExtensionVersion: '1.0.23' };
+    expect(computeDueChecks(legacy, NOW)).toEqual({ cli: false, extension: true });
   });
 });

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -22,6 +22,7 @@ import { PKG_VERSION } from './version.js';
 const CACHE_DIR = path.join(os.homedir(), '.opencli');
 const CACHE_FILE = path.join(CACHE_DIR, 'update-check.json');
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const EXTENSION_RETRY_INTERVAL_MS = 60 * 60 * 1000; // 1h — backoff after a failed extension lookup
 const EXTENSION_STALE_MS = 7 * 24 * 60 * 60 * 1000; // 7d
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@jackwener/opencli/latest';
 const GITHUB_RELEASES_URL = 'https://api.github.com/repos/jackwener/OpenCLI/releases?per_page=20';
@@ -32,6 +33,11 @@ interface UpdateCache {
   lastCheck?: number;
   latestVersion?: string;
   latestExtensionVersion?: string;
+  // Extension lookup bookkeeping, tracked independently of `lastCheck` because
+  // the GitHub endpoint is rate-limited per IP and fails on its own schedule.
+  extLastCheck?: number;
+  extLastFetchOk?: boolean;
+  extEtag?: string;
   // Daemon hello fields.
   currentExtensionVersion?: string;
   extensionLastSeenAt?: number;
@@ -159,22 +165,74 @@ function extractLatestExtensionVersionFromReleases(releases: GitHubRelease[]): s
   return undefined;
 }
 
+interface ExtensionFetchResult {
+  /** Whether the lookup reached a usable answer (2xx or 304). */
+  ok: boolean;
+  version?: string;
+  etag?: string;
+}
+
+/**
+ * How long to wait before retrying the extension lookup. A successful lookup
+ * waits the normal 24h; a failed one retries within the hour so a transient
+ * rate-limit or outage heals itself instead of silencing the notice until the
+ * next day.
+ */
+function extensionRecheckDelay(cache: UpdateCache | null): number {
+  return cache?.extLastFetchOk === false ? EXTENSION_RETRY_INTERVAL_MS : CHECK_INTERVAL_MS;
+}
+
 /** Fetch the latest extension version from GitHub Releases. */
-async function fetchLatestExtensionVersion(): Promise<string | undefined> {
+async function fetchLatestExtensionVersion(etag?: string): Promise<ExtensionFetchResult> {
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(GITHUB_RELEASES_URL, {
-      signal: controller.signal,
-      headers: { 'User-Agent': `opencli/${PKG_VERSION}`, Accept: 'application/vnd.github+json' },
-    });
+    const headers: Record<string, string> = {
+      'User-Agent': `opencli/${PKG_VERSION}`,
+      Accept: 'application/vnd.github+json',
+    };
+    // Send the previous ETag so an unchanged release list comes back as a 304
+    // with no body to parse. Note this still consumes unauthenticated
+    // rate-limit budget (GitHub only exempts 304s for authenticated requests),
+    // so the retry backoff above is what actually keeps this lookup alive under
+    // a 403 — the ETag just avoids re-downloading 20 release objects.
+    if (etag) headers['If-None-Match'] = etag;
+    const res = await fetch(GITHUB_RELEASES_URL, { signal: controller.signal, headers });
     clearTimeout(timer);
-    if (!res.ok) return undefined;
+    // 304: nothing changed, so the cached version is still current.
+    if (res.status === 304) return { ok: true, etag };
+    if (!res.ok) return { ok: false };
     const releases = await res.json() as GitHubRelease[];
-    return extractLatestExtensionVersionFromReleases(releases);
+    return {
+      ok: true,
+      version: extractLatestExtensionVersionFromReleases(releases),
+      etag: res.headers.get('etag') ?? undefined,
+    };
   } catch {
-    return undefined;
+    return { ok: false };
   }
+}
+
+interface DueChecks {
+  /** npm registry lookup for the CLI version. */
+  cli: boolean;
+  /** GitHub Releases lookup for the extension version. */
+  extension: boolean;
+}
+
+/**
+ * Pure function: decide which lookups are due. Exported for tests.
+ *
+ * The two lookups are gated independently. They previously shared `lastCheck`,
+ * which meant a failed GitHub call still stamped the 24h cooldown without
+ * recording an extension version — the next run then returned early, so the
+ * lookup never retried and the extension notice stayed silent indefinitely.
+ */
+function computeDueChecks(cache: UpdateCache | null, now: number): DueChecks {
+  return {
+    cli: !cache?.lastCheck || now - cache.lastCheck >= CHECK_INTERVAL_MS,
+    extension: !cache?.extLastCheck || now - cache.extLastCheck >= extensionRecheckDelay(cache),
+  };
 }
 
 /**
@@ -183,27 +241,40 @@ async function fetchLatestExtensionVersion(): Promise<string | undefined> {
  */
 export function checkForUpdateBackground(): void {
   if (isCI()) return;
-  if (_cache?.lastCheck && Date.now() - _cache.lastCheck < CHECK_INTERVAL_MS) return;
+  const { cli: cliDue, extension: extDue } = computeDueChecks(_cache, Date.now());
+  if (!cliDue && !extDue) return;
 
   void (async () => {
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 3000);
-      const res = await fetch(NPM_REGISTRY_URL, {
-        signal: controller.signal,
-        headers: { 'User-Agent': `opencli/${PKG_VERSION}` },
-      });
-      clearTimeout(timer);
-      if (!res.ok) return;
-      const data = await res.json() as { version?: string };
-      if (typeof data.version === 'string') {
-        const extVersion = await fetchLatestExtensionVersion();
-        const updates: Partial<UpdateCache> = { lastCheck: Date.now(), latestVersion: data.version };
-        if (extVersion) updates.latestExtensionVersion = extVersion;
-        writeCacheMerge(updates);
+    if (cliDue) {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 3000);
+        const res = await fetch(NPM_REGISTRY_URL, {
+          signal: controller.signal,
+          headers: { 'User-Agent': `opencli/${PKG_VERSION}` },
+        });
+        clearTimeout(timer);
+        if (res.ok) {
+          const data = await res.json() as { version?: string };
+          if (typeof data.version === 'string') {
+            writeCacheMerge({ lastCheck: Date.now(), latestVersion: data.version });
+          }
+        }
+      } catch {
+        // Network error: silently skip, try again next run.
       }
-    } catch {
-      // Network error: silently skip, try again next run
+    }
+
+    if (extDue) {
+      const result = await fetchLatestExtensionVersion(_cache?.extEtag);
+      // Stamp extLastCheck on every outcome so a hard-down endpoint cannot spin
+      // on each invocation, but use a short backoff on failure (see
+      // extensionRecheckDelay) so the lookup recovers on its own.
+      const updates: Partial<UpdateCache> = { extLastCheck: Date.now() };
+      if (result.version) updates.latestExtensionVersion = result.version;
+      if (result.etag) updates.extEtag = result.etag;
+      updates.extLastFetchOk = result.ok;
+      writeCacheMerge(updates);
     }
   })();
 }
@@ -232,5 +303,8 @@ export function getCachedLatestExtensionVersion(): string | undefined {
 export {
   extractLatestExtensionVersionFromReleases as _extractLatestExtensionVersionFromReleases,
   buildUpdateNotices as _buildUpdateNotices,
+  computeDueChecks as _computeDueChecks,
   EXTENSION_STALE_MS as _EXTENSION_STALE_MS,
+  CHECK_INTERVAL_MS as _CHECK_INTERVAL_MS,
+  EXTENSION_RETRY_INTERVAL_MS as _EXTENSION_RETRY_INTERVAL_MS,
 };


### PR DESCRIPTION
## Description

`checkForUpdateBackground()` wrote `lastCheck` unconditionally but `latestExtensionVersion` only on success. Because `lastCheck` also gates the 24h re-check, a single failed GitHub Releases fetch stamped the cooldown *without* recording an extension version — and every later run returned early at the gate before it could retry. The extension update notice then stayed silent indefinitely.

Before (`src/update-check.ts:199-204`):

```js
if (typeof data.version === 'string') {
  const extVersion = await fetchLatestExtensionVersion();   // undefined on any non-2xx
  const updates: Partial<UpdateCache> = { lastCheck: Date.now(), latestVersion: data.version };
  if (extVersion) updates.latestExtensionVersion = extVersion;   // conditional
  writeCacheMerge(updates);                                      // lastCheck: unconditional
}
```

The two lookups have very different reliability. `NPM_REGISTRY_URL` is a global CDN; `GITHUB_RELEASES_URL` is unauthenticated `api.github.com`, capped at 60 requests/hour **per IP** and shared with any other tooling on the machine. On my machine the quota was already exhausted:

```console
$ curl -s https://api.github.com/rate_limit -H 'User-Agent: opencli/1.8.7' | jq '.resources.core|.limit,.remaining'
60
0
$ curl -s -o /dev/null -w '%{http_code}\n' -H 'Accept: application/vnd.github+json' \
    -H 'User-Agent: opencli/1.8.7' 'https://api.github.com/repos/jackwener/OpenCLI/releases?per_page=20'
403
```

`fetchLatestExtensionVersion()` hit `if (!res.ok) return undefined`, so the key was skipped while the cooldown was refreshed anyway. Resulting cache after months of daily use:

```json
{
  "currentExtensionVersion": "1.0.23",
  "extensionLastSeenAt": 1787847804948,
  "lastCheck": 1787815161355,
  "latestVersion": "1.8.7"
}
```

`latestVersion` (npm) present; `latestExtensionVersion` (GitHub) never written. Both consumers were therefore unreachable — doctor's "Extension update available" issue (`src/doctor.ts:209`) and the exit-time notice from `buildUpdateNotices` (`src/update-check.ts:108-118`). The user-visible outcome was an extension pinned at **v1.0.21 against CLI v1.8.7 for roughly two months** with neither surface ever mentioning an update; it only surfaced via manual `shasum` comparison of `dist/background.js`.

The release-asset parser itself is fine — verified against the live API, it correctly resolves `opencli-extension-v1.0.23.zip`. The defect was purely cache bookkeeping.

## Fix

- Gate the two lookups independently via a new `extLastCheck`, so a failing GitHub call can no longer suppress itself or be suppressed by a fresh npm check.
- Stamp `extLastCheck` on every outcome (so a hard-down endpoint cannot spin on each invocation) but retry within the hour on failure via `extLastFetchOk`, instead of waiting the full day.
- Send the previous ETag so an unchanged release list returns 304 with no body to parse.

I deliberately did **not** implement "only advance `lastCheck` when both succeed": that would re-hit the network on every single invocation while the endpoint is rate-limited, which is worse than the bug. The bounded backoff self-heals without hammering.

One correction worth stating explicitly, since it shaped the comment in the code: I measured whether a 304 avoids rate-limit cost, and **it does not** for unauthenticated requests (`remaining` went 59 → 58). GitHub only exempts conditional requests for authenticated calls. So the ETag is a bandwidth optimization, not a quota fix — the retry backoff is what actually keeps this lookup alive under a 403. The comment says so rather than implying otherwise.

Related issue: Fixes #2414

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Tests

The gating decision is extracted into a pure `computeDueChecks(cache, now)` — matching the existing `buildUpdateNotices` pattern in this file — and exported for tests. Six cases cover: empty cache, both fresh, retry-after-failure boundary, full interval after success, independent gating in both directions, and legacy caches written before `extLastCheck` existed (including daemon-only caches).

Verified the tests fail against the old shared-timestamp logic rather than merely passing against the new code:

```
× retries the extension lookup within the hour after a failure
    AssertionError: expected false to be true
× gates the two lookups independently
    AssertionError: expected { cli: false, extension: false } to deeply equal { cli: false, extension: true }
× treats a legacy cache without extLastCheck as due
    AssertionError: expected { cli: false, extension: false } to deeply equal { cli: false, extension: true }
```

With the fix:

```console
$ npx tsc --noEmit                    # clean
$ npm test
 Test Files  628 passed (628)
      Tests  7292 passed | 1 skipped (7293)
```

Baseline on `main` was 7286 passing; +6 are the new cases.

### Backward compatibility

`writeCacheMerge` already read-merge-writes, and the new fields are optional. An existing cache without `extLastCheck` is treated as due, so the first run after upgrading performs the extension lookup that has been skipped until now — which is the desired healing behavior for anyone currently stuck.
