### PR TITLE
feat(doctor): add --strict exit code and -f json output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3091,11 +3091,19 @@ cli({
     .command('doctor')
     .description('Diagnose opencli browser bridge connectivity')
     .option('-v, --verbose', 'Debug output')
+    .option('-f, --format <fmt>', 'Output format: text, json, yaml', 'text')
+    .option('--strict', 'Exit non-zero when the bridge is not healthy', false)
     .action(async (opts) => {
       applyVerbose(opts);
       const { runBrowserDoctor, renderBrowserDoctorReport } = await import('./doctor.js');
       const report = await runBrowserDoctor({ cliVersion: PKG_VERSION });
-      console.log(renderBrowserDoctorReport(report));
+      const fmt = String(opts.format ?? 'text').toLowerCase();
+      if (fmt === 'json' || fmt === 'yaml' || fmt === 'yml') {
+        renderOutput(report, { fmt });
+      } else {
+        console.log(renderBrowserDoctorReport(report));
+      }
+      if (opts.strict && !report.ok) process.exitCode = EXIT_CODES.GENERIC_ERROR;
     });
 
   program

--- a/src/doctor-cli.test.ts
+++ b/src/doctor-cli.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+// `doctor` is mocked at module scope, so these cases live in their own file
+// rather than in cli.test.ts, where the mock would apply to every other suite.
+const { mockRunBrowserDoctor } = vi.hoisted(() => ({ mockRunBrowserDoctor: vi.fn() }));
+
+vi.mock('./doctor.js', () => ({
+  runBrowserDoctor: mockRunBrowserDoctor,
+  renderBrowserDoctorReport: () => 'doctor text report',
+}));
+
+import { createProgram } from './cli.js';
+
+const healthy = { ok: true, daemonRunning: true, extensionConnected: true, issues: [] };
+const unhealthy = {
+  ok: false,
+  daemonRunning: false,
+  extensionConnected: false,
+  issues: ['Daemon is not running.'],
+};
+
+describe('doctor --strict / -f', () => {
+  let stdout: string[];
+  let logSpy: MockInstance;
+  let writeSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    stdout = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      stdout.push(args.join(' '));
+    });
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+  });
+
+  async function runDoctor(argv: string[]): Promise<{ exitCode: number; out: string }> {
+    const program = createProgram('', '');
+    await program.parseAsync(['node', 'opencli', 'doctor', ...argv]);
+    // process.exitCode is `number | string | undefined` in Node's types.
+    const exitCode = Number(process.exitCode ?? 0);
+    logSpy.mockRestore();
+    writeSpy.mockRestore();
+    return { exitCode, out: stdout.join('\n') };
+  }
+
+  it('exits non-zero with --strict when the bridge is unhealthy', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(unhealthy);
+
+    const { exitCode } = await runDoctor(['--strict']);
+
+    expect(exitCode).toBe(1);
+  });
+
+  // Default behavior must stay exit 0 even when unhealthy: scripts and
+  // interactive users running under `set -e` predate --strict.
+  it('exits zero without --strict even when the bridge is unhealthy', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(unhealthy);
+
+    const { exitCode } = await runDoctor([]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('exits zero with --strict when the bridge is healthy', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(healthy);
+
+    const { exitCode } = await runDoctor(['--strict']);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('renders the text report by default', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(healthy);
+
+    const { out } = await runDoctor([]);
+
+    expect(out).toContain('doctor text report');
+  });
+
+  it('emits the report as JSON with -f json', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(unhealthy);
+
+    const { out } = await runDoctor(['-f', 'json']);
+
+    expect(out).not.toContain('doctor text report');
+    expect(JSON.parse(out)).toMatchObject({ ok: false, issues: ['Daemon is not running.'] });
+  });
+
+  it('combines -f json with a non-zero --strict exit', async () => {
+    mockRunBrowserDoctor.mockResolvedValue(unhealthy);
+
+    const { exitCode, out } = await runDoctor(['--strict', '-f', 'json']);
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(out).ok).toBe(false);
+  });
+});

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -52,6 +52,7 @@ describe('doctor report rendering', () => {
 
   it('renders OK-style report when daemon and extension connected', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: true,
       cliVersion: '1.7.9',
       daemonRunning: true,
       daemonVersion: '1.7.9',
@@ -69,6 +70,7 @@ describe('doctor report rendering', () => {
 
   it('renders a warning when daemon version is stale', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       cliVersion: '1.7.9',
       daemonRunning: true,
       daemonVersion: '1.7.6',
@@ -85,6 +87,7 @@ describe('doctor report rendering', () => {
 
   it('renders MISSING when daemon not running', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       daemonRunning: false,
       extensionConnected: false,
       issues: ['Daemon is not running.'],
@@ -97,6 +100,7 @@ describe('doctor report rendering', () => {
 
   it('renders extension not connected when daemon is running', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       daemonRunning: true,
       extensionConnected: false,
       issues: ['Daemon is running but the Chrome extension is not connected.'],
@@ -108,6 +112,7 @@ describe('doctor report rendering', () => {
 
   it('renders a warning when the extension version is unknown', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       daemonRunning: true,
       extensionConnected: true,
       issues: ['Extension is connected but did not report a version.'],
@@ -120,6 +125,7 @@ describe('doctor report rendering', () => {
 
   it('renders connectivity OK when live test succeeds', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: true,
       daemonRunning: true,
       extensionConnected: true,
       connectivity: { ok: true, durationMs: 1234 },
@@ -131,6 +137,7 @@ describe('doctor report rendering', () => {
 
   it('renders connected profiles when multiple are present', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: true,
       daemonRunning: true,
       extensionConnected: false,
       profiles: [
@@ -147,6 +154,7 @@ describe('doctor report rendering', () => {
 
   it('renders unstable extension state when live connectivity and status disagree', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       daemonRunning: true,
       extensionConnected: true,
       extensionFlaky: true,
@@ -160,6 +168,7 @@ describe('doctor report rendering', () => {
 
   it('renders unstable daemon state when live connectivity and status disagree', () => {
     const text = strip(renderBrowserDoctorReport({
+      ok: false,
       daemonRunning: false,
       daemonFlaky: true,
       extensionConnected: false,
@@ -183,6 +192,30 @@ describe('doctor report rendering', () => {
     expect(report.issues).toEqual(expect.arrayContaining([
       expect.stringContaining('Daemon is not running'),
     ]));
+  });
+
+  // `ok` is what `doctor --strict` turns into an exit code, so it must track the
+  // same condition the text renderer uses for "Everything looks good!".
+  it('reports ok: false when the report carries issues', async () => {
+    mockSendCommand.mockRejectedValueOnce(new Error('Could not start daemon'));
+    mockGetDaemonHealth.mockResolvedValueOnce({ state: 'stopped', status: null });
+
+    const report = await runBrowserDoctor();
+
+    expect(report.issues.length).toBeGreaterThan(0);
+    expect(report.ok).toBe(false);
+  });
+
+  it('reports ok: true when the bridge is healthy', async () => {
+    mockGetDaemonHealth.mockResolvedValueOnce({
+      state: 'ready',
+      status: { extensionConnected: true, extensionVersion: '1.0.23', daemonVersion: '1.8.7' },
+    });
+
+    const report = await runBrowserDoctor({ cliVersion: '1.8.7' });
+
+    expect(report.issues).toEqual([]);
+    expect(report.ok).toBe(true);
   });
 
   it('reports a stale default profile when it is not among the connected profiles', async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -59,6 +59,12 @@ export type ConnectivityResult = {
 
 
 export type DoctorReport = {
+  /**
+   * Overall health, derived from `issues`. Mirrors what the text renderer
+   * treats as healthy when it prints "Everything looks good!", so the exit
+   * code and the human output can never disagree.
+   */
+  ok: boolean;
   cliVersion?: string;
   daemonRunning: boolean;
   daemonFlaky?: boolean;
@@ -217,6 +223,7 @@ export async function runBrowserDoctor(opts: DoctorOptions = {}): Promise<Doctor
   }
 
   return {
+    ok: issues.length === 0,
     cliVersion: opts.cliVersion,
     daemonRunning,
     daemonFlaky,


### PR DESCRIPTION
## Description

`opencli doctor` had no machine-readable result. The action only logged (`src/cli.ts:3094-3099`) and never set `process.exitCode`, so a health gate could not distinguish a working bridge from a missing extension:

```console
$ opencli doctor >/dev/null 2>&1; echo $?
0        # bridge healthy
$ # ... and with the extension disconnected, printing [MISSING] plus Issues:
$ opencli doctor >/dev/null 2>&1; echo $?
0        # indistinguishable
```

`--json` did not exist either, so the only options were parsing the human-readable text — coupling callers to `[OK]`/`[WARN]`/`[MISSING]` presentation details that have changed before — or bypassing `doctor` entirely. I ended up doing the latter in a wrapper script, grepping the `Extension:` line out of `opencli daemon status`, which answers a strictly weaker question: it reports connection state but does not run the live connectivity probe, the compat-range check, or stale-default-profile detection.

This follows the pattern `convention-audit` already establishes in this repo (`src/cli.ts:962-983`), rather than inventing a new convention:

```js
.option('-f, --format <fmt>', 'Output format: text, json, yaml', 'text')
.option('--strict', 'Exit non-zero when the bridge is not healthy', false)
// ...
if (opts.strict && !report.ok) process.exitCode = EXIT_CODES.GENERIC_ERROR;
```

`DoctorReport` gains a derived `ok`, computed as `issues.length === 0` — the same condition `renderBrowserDoctorReport()` already uses to decide whether to print "Everything looks good!" (`src/doctor.ts:297-299`). Deriving it from the existing signal means the exit code cannot drift from what the human-readable output claims. This matches `ConventionAuditReport`, which also has a required `ok`.

Related issue: Fixes #2417

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Backward compatibility

Default behavior is unchanged in both dimensions — still text, still exit 0 even when unhealthy. `--strict` is opt-in precisely because making non-zero the default would break existing scripts and anyone running `doctor` interactively under `set -e`. If you'd prefer non-zero-by-default (arguably cleaner semantically), I'm happy to switch it; that's your call on the breaking change.

## Verification

Smoke tested against a real bridge with the built CLI:

```console
$ node dist/src/main.js doctor                      # unchanged default
[OK] Daemon: running on port 19825 (v1.8.7)
[OK] Extension: connected (v1.0.23)
[OK] Connectivity: connected in 2.8s
  exit=0

$ node dist/src/main.js doctor --strict; echo $?     # healthy → still 0
0

$ node dist/src/main.js doctor -f json | head -c 60
{"ok":true,"cliVersion":"1.8.7","daemonRunning":true,...

$ node dist/src/main.js doctor --help | grep -E 'strict|format'
  -f, --format <fmt>  Output format: text, json, yaml (default: "text")
  --strict            Exit non-zero when the bridge is not healthy
```

The unhealthy path is covered by tests rather than by a live broken bridge: `OPENCLI_DAEMON_PORT` is explicitly rejected by the CLI now, so there is no supported way to point `doctor` at a dead daemon from the outside.

New `src/doctor-cli.test.ts` drives the real `createProgram()` command wiring with `doctor` mocked, and asserts the actual `process.exitCode` across all four flag/health combinations plus both output formats. It lives in its own file because mocking `./doctor.js` at module scope inside `cli.test.ts` would apply to that file's other ~3600 lines of suites. Two cases in `doctor.test.ts` pin the `ok`-vs-`issues` invariant.

```console
$ npx tsc --noEmit                    # clean
$ npm test
 Test Files  629 passed (629)
      Tests  7294 passed | 1 skipped (7295)
```

Baseline on `main` was 628 files / 7286 tests.

## Note on the existing fixtures

Making `ok` required updated 9 `renderBrowserDoctorReport({...})` fixtures in `doctor.test.ts`. Each was given the value matching its own `issues` array (6 `true`, 6 `false` including the new cases) rather than a blanket `true`, so no fixture encodes a state the production code could never produce.
