### PR TITLE
feat(twitter): allow post to attach a video

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -41574,7 +41574,7 @@
         "name": "images",
         "type": "string",
         "required": false,
-        "help": "Image paths, comma-separated, max 4 (jpg/png/gif/webp)"
+        "help": "Media paths, comma-separated: up to 4 images (jpg/png/gif/webp) or 1 video (mp4/mov)"
       }
     ],
     "columns": [

--- a/clis/twitter/post.js
+++ b/clis/twitter/post.js
@@ -7,25 +7,39 @@ import { isRecoverableFileInputError } from './utils.js';
 
 const MAX_IMAGES = 4;
 const UPLOAD_POLL_MS = 500;
-const UPLOAD_TIMEOUT_MS = 30_000;
+const IMAGE_UPLOAD_TIMEOUT_MS = 30_000;
+// X transcodes video server-side before the Post button re-enables, which takes
+// far longer than an image upload even for a small clip.
+const VIDEO_UPLOAD_TIMEOUT_MS = 180_000;
 const COMPOSER_POLL_MS = 250;
 const COMPOSER_TIMEOUT_MS = 10_000;
 const SUBMIT_POLL_MS = 500;
 const SUBMIT_TIMEOUT_MS = 15_000;
 const COMPOSE_URL = 'https://x.com/compose/post';
 const FILE_INPUT_SELECTOR = 'input[type="file"][data-testid="fileInput"]';
-const SUPPORTED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+const VIDEO_EXTENSIONS = new Set(['.mp4', '.m4v', '.mov']);
+const MIME_BY_EXTENSION = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.mp4': 'video/mp4',
+    '.m4v': 'video/mp4',
+    '.mov': 'video/quicktime',
+};
 
-function validateImagePaths(raw) {
+function validateMediaPaths(raw) {
     const paths = raw.split(',').map(s => s.trim()).filter(Boolean);
     if (paths.length > MAX_IMAGES) {
         throw new CommandExecutionError(`Too many images: ${paths.length} (max ${MAX_IMAGES})`);
     }
-    return paths.map(p => {
+    const absPaths = paths.map(p => {
         const absPath = path.resolve(p);
         const ext = path.extname(absPath).toLowerCase();
-        if (!SUPPORTED_EXTENSIONS.has(ext)) {
-            throw new CommandExecutionError(`Unsupported image format "${ext}". Supported: jpg, png, gif, webp`);
+        if (!IMAGE_EXTENSIONS.has(ext) && !VIDEO_EXTENSIONS.has(ext)) {
+            throw new CommandExecutionError(`Unsupported media format "${ext}". Supported: jpg, png, gif, webp, mp4, mov`);
         }
         const stat = fs.statSync(absPath, { throwIfNoEntry: false });
         if (!stat || !stat.isFile()) {
@@ -33,6 +47,20 @@ function validateImagePaths(raw) {
         }
         return absPath;
     });
+    // X accepts up to 4 images or a single video, never both in one post; the
+    // composer silently drops the extra attachments instead of reporting an error.
+    const videoCount = absPaths.filter(isVideoPath).length;
+    if (videoCount > 0 && videoCount !== absPaths.length) {
+        throw new CommandExecutionError('Cannot mix a video with images: X allows either up to 4 images or a single video.');
+    }
+    if (videoCount > 1) {
+        throw new CommandExecutionError(`Too many videos: ${videoCount} (max 1)`);
+    }
+    return absPaths;
+}
+
+function isVideoPath(absPath) {
+    return VIDEO_EXTENSIONS.has(path.extname(absPath).toLowerCase());
 }
 
 function isUnsupportedInsertTextError(err) {
@@ -158,8 +186,8 @@ async function insertComposerText(page, text) {
     })()`), 'Twitter composer DOM insertion');
 }
 
-async function waitForImageUpload(page, expectedCount) {
-    const iterations = Math.ceil(UPLOAD_TIMEOUT_MS / UPLOAD_POLL_MS);
+async function waitForMediaUpload(page, expectedCount, timeoutMs) {
+    const iterations = Math.ceil(timeoutMs / UPLOAD_POLL_MS);
     return requirePostActionResult(await page.evaluate(`(async () => {
         const expected = ${JSON.stringify(expectedCount)};
         const visible = (el) => !!el && (el.offsetParent !== null || el.getClientRects().length > 0);
@@ -178,20 +206,14 @@ async function waitForImageUpload(page, expectedCount) {
             const buttonReady = !!button && !button.disabled && button.getAttribute('aria-disabled') !== 'true';
             if (previewCount >= expected && buttonReady) return { ok: true, previewCount };
         }
-        return { ok: false, message: 'Image upload timed out (${UPLOAD_TIMEOUT_MS / 1000}s).' };
-    })()`), 'Twitter image upload verification');
+        return { ok: false, message: 'Media upload timed out (${timeoutMs / 1000}s).' };
+    })()`), 'Twitter media upload verification');
 }
 
-async function attachImagesViaDataTransfer(page, absPaths) {
+async function attachMediaViaDataTransfer(page, absPaths) {
     const files = absPaths.map((absPath) => {
         const ext = path.extname(absPath).toLowerCase();
-        const mime = ext === '.png'
-            ? 'image/png'
-            : ext === '.gif'
-                ? 'image/gif'
-                : ext === '.webp'
-                    ? 'image/webp'
-                    : 'image/jpeg';
+        const mime = MIME_BY_EXTENSION[ext] ?? 'application/octet-stream';
         return {
             name: path.basename(absPath),
             mime,
@@ -225,9 +247,9 @@ async function attachImagesViaDataTransfer(page, absPaths) {
         input.dispatchEvent(new Event('change', { bubbles: true }));
         input.dispatchEvent(new Event('input', { bubbles: true }));
         return { ok: true };
-    })()`), 'Twitter image upload fallback');
+    })()`), 'Twitter media upload fallback');
     if (!upload?.ok) {
-        throw new CommandExecutionError(`Image upload failed (base64 fallback): ${upload?.error ?? 'unknown error'}`);
+        throw new CommandExecutionError(`Media upload failed (base64 fallback): ${upload?.error ?? 'unknown error'}`);
     }
 }
 
@@ -298,15 +320,16 @@ cli({
     browser: true,
     args: [
         { name: 'text', type: 'string', required: true, positional: true, help: 'The text content of the tweet' },
-        { name: 'images', type: 'string', required: false, help: 'Image paths, comma-separated, max 4 (jpg/png/gif/webp)' },
+        { name: 'images', type: 'string', required: false, help: 'Media paths, comma-separated: up to 4 images (jpg/png/gif/webp) or 1 video (mp4/mov)' },
     ],
     columns: ['status', 'message', 'text', 'id', 'url'],
     func: async (page, kwargs) => {
         if (!page)
             throw new CommandExecutionError('Browser session required for twitter post');
 
-        // Validate images upfront before any browser interaction.
-        const absPaths = kwargs.images ? validateImagePaths(String(kwargs.images)) : [];
+        // Validate media upfront before any browser interaction.
+        const absPaths = kwargs.images ? validateMediaPaths(String(kwargs.images)) : [];
+        const uploadTimeoutMs = absPaths.some(isVideoPath) ? VIDEO_UPLOAD_TIMEOUT_MS : IMAGE_UPLOAD_TIMEOUT_MS;
         const text = String(kwargs.text ?? '');
 
         // The current X standalone composer is /compose/post. It keeps a single,
@@ -325,14 +348,14 @@ cli({
                     if (!isRecoverableFileInputError(err)) {
                         throw err;
                     }
-                    await attachImagesViaDataTransfer(page, absPaths);
+                    await attachMediaViaDataTransfer(page, absPaths);
                 }
             } else {
-                await attachImagesViaDataTransfer(page, absPaths);
+                await attachMediaViaDataTransfer(page, absPaths);
             }
-            const uploadState = await waitForImageUpload(page, absPaths.length);
+            const uploadState = await waitForMediaUpload(page, absPaths.length, uploadTimeoutMs);
             if (!uploadState?.ok) {
-                throw new TimeoutError('twitter image upload', UPLOAD_TIMEOUT_MS / 1000, 'Nothing was posted. Retry, or attach a smaller image.');
+                throw new TimeoutError('twitter media upload', uploadTimeoutMs / 1000, 'Nothing was posted. Retry, or attach a smaller file.');
             }
         }
 

--- a/clis/twitter/post.test.js
+++ b/clis/twitter/post.test.js
@@ -118,10 +118,60 @@ describe('twitter post command', () => {
         await expect(command.func(page, { text: 'hi', images: 'missing.png' })).rejects.toThrow('Not a valid file');
     });
 
-    it('throws on unsupported image format', async () => {
+    it('throws on unsupported media format', async () => {
         const command = getCommand();
         const page = makePage();
-        await expect(command.func(page, { text: 'hi', images: 'photo.bmp' })).rejects.toThrow('Unsupported image format');
+        await expect(command.func(page, { text: 'hi', images: 'photo.bmp' })).rejects.toThrow('Unsupported media format');
+    });
+
+    it('throws when a video is mixed with images', async () => {
+        const command = getCommand();
+        const page = makePage();
+        await expect(command.func(page, { text: 'hi', images: 'clip.mp4,a.png' })).rejects.toThrow('Cannot mix a video with images');
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('throws when more than one video is attached', async () => {
+        const command = getCommand();
+        const page = makePage();
+        await expect(command.func(page, { text: 'hi', images: 'a.mp4,b.mov' })).rejects.toThrow('Too many videos: 2 (max 1)');
+    });
+
+    it('uploads a video with a video mime type and waits out X transcoding', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true }, // DataTransfer fallback
+            { ok: true, previewCount: 1 }, // upload polling
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ], { setFileInput: undefined });
+
+        const result = await command.func(page, { text: 'with video', images: 'clip.mp4' });
+
+        expect(result).toEqual([{ status: 'success', message: 'Tweet posted successfully.', text: 'with video' }]);
+        const uploadScript = page.evaluate.mock.calls[0][0];
+        expect(uploadScript).toContain('video/mp4');
+        expect(uploadScript).not.toContain('image/jpeg');
+        // Video uploads must poll on the 180s budget, not the 30s image budget.
+        const pollScript = page.evaluate.mock.calls[1][0];
+        expect(pollScript).toContain('Media upload timed out (180s).');
+    });
+
+    it('keeps the 30s upload budget for image-only posts', async () => {
+        const command = getCommand();
+        const page = makePage([
+            { ok: true, previewCount: 1 }, // upload polling
+            { ok: true }, // focus composer
+            { ok: true }, // verify native insertText
+            { ok: true }, // click post
+            { ok: true, message: 'Tweet posted successfully.' },
+        ]);
+
+        await command.func(page, { text: 'with image', images: 'a.png' });
+
+        expect(page.evaluate.mock.calls[0][0]).toContain('Media upload timed out (30s).');
     });
 
     it('falls back to DataTransfer upload when page.setFileInput is not available', async () => {
@@ -410,10 +460,10 @@ describe('twitter post command', () => {
         expect(submitScript).toContain('data-opencli-before-submit-toast');
     });
 
-    it('typed-fails when image upload times out', async () => {
+    it('typed-fails when media upload times out', async () => {
         const command = getCommand();
         const page = makePage([
-            { ok: false, message: 'Image upload timed out (30s).' },
+            { ok: false, message: 'Media upload timed out (30s).' },
         ]);
 
         await expect(command.func(page, { text: 'timeout', images: 'a.png' })).rejects.toMatchObject({


### PR DESCRIPTION
## Description

`twitter post --images` rejects every video before it ever reaches the browser:

```
$ opencli twitter post "..." --images clip.mp4
Unsupported image format ".mp4". Supported: jpg, png, gif, webp
```

That gate is narrower than the implementation behind it. X's composer file input
(`[data-testid="fileInput"]`) accepts video, and the existing DataTransfer upload path already
builds a `File` from raw bytes — so the allowlist plus an image-shaped MIME guess were the only
things standing between the command and a working video post.

This PR lifts the gate and makes the surrounding code honest about carrying video:

- accept `mp4` / `m4v` / `mov`, and resolve the MIME from a lookup table instead of the previous
  image-only ternary (a video used to arrive tagged `image/jpeg`)
- enforce X's actual media rules: up to 4 images **or** exactly 1 video, never mixed. The composer
  silently drops the extras rather than erroring, so validating up front is the only way the user
  finds out
- give video uploads a 180s budget instead of 30s. X transcodes server-side before the Post button
  re-enables; even a small clip can outlast the image budget on a slow link. Image-only posts keep
  the 30s budget
- rename the image-only helpers and messages to `media-*` now that they carry both

Related issue: —

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Checks run: `npx tsc --noEmit`, `npx vitest run --project adapter clis/twitter/post.test.js`
(33 passed, 5 of them new), `npm run check:typed-error-lint`, `npm run check:silent-column-drop`
(both gates unchanged at baseline), `npm run build` (regenerates `cli-manifest.json`).

New tests cover: video mime + 180s poll budget, images keeping the 30s budget, mixing a video with
images, and more than one video.

## Screenshots / Output

Verified end-to-end against a real Chrome over remote CDP (`OPENCLI_CDP_ENDPOINT`), posting an
842KB / 7s h264+aac clip in one shot:

```
$ opencli twitter post "…" --images clip.mp4 -f json
[
  {
    "status": "success",
    "message": "Tweet posted successfully.",
    "text": "…",
    "id": "…",
    "url": "https://x.com/…/status/…"
  }
]
```

Reading the posted status back confirms the attachment is a real video rather than a dropped
upload:

```
$ opencli twitter thread <url> -f json
    "has_media": true,
    "media_urls": ["https://video.twimg.com/amplify_video/…/vid/avc1/320x568/….mp4?tag=14"],
    "media_posters": ["https://pbs.twimg.com/amplify_video_thumb/…/img/….jpg"]
```

The upload went through the base64 + `DataTransfer` fallback (`page.setFileInput` is not
implemented on that page type), which is the path this PR fixes the MIME for.
