### PR TITLE
fix(chatgpt): adapt to 2026-08 chatgpt.com UI and zero-size bridge viewports

### DIFF
--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -13,6 +13,7 @@ import {
     requireNonEmptyPrompt,
     requirePositiveInt,
     parseChatGPTConversationId,
+    resolveWebConversationId,
     sendChatGPTMessage,
     selectChatGPTTool,
     isGenerating,
@@ -21,6 +22,10 @@ import {
     waitForChatGPTResponse,
 } from './utils.js';
 
+// [LOCAL PATCH 2026-09-03] 2026-09 chatgpt.com routes brand-new conversations
+// to /c/WEB:<uuid> (a client-side temporary id that never appears in the
+// backend API). Accept any /c/<id> route — including WEB: ids — so ask no
+// longer times out waiting for the old-style conversation URL.
 async function waitForConversationUrl(page, timeoutSeconds = 30) {
     const startTime = Date.now();
     while (Date.now() - startTime < timeoutSeconds * 1000) {
@@ -116,7 +121,42 @@ export const askCommand = cli({
             throw new CommandExecutionError('Failed to send message to ChatGPT', `Open ${CHATGPT_URL} and verify the composer is ready.`);
         }
 
-        const { conversationId, conversationUrl } = await waitForConversationUrl(page);
+        const { conversationId: rawConversationId, conversationUrl } = await waitForConversationUrl(page);
+        // [LOCAL PATCH 2026-09-03] WEB:<uuid> is a frontend-only temporary id.
+        // Observed behaviour (2026-09-03): after the response finishes, the
+        // frontend itself replaces the URL with the real /c/<server-id>. So:
+        // wait for the response, re-read the URL, and if it now parses to a
+        // non-WEB id use it; only fall back to the backend-api listing when
+        // the URL still carries the WEB: prefix.
+        let conversationId = rawConversationId;
+        if (/^WEB:/i.test(rawConversationId)) {
+            if (shouldWait) {
+                const response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
+                    baselinePairCounts,
+                    // URL may legitimately swap WEB:<uuid> -> real id mid-wait;
+                    // pass null so the leave-conversation guard does not false-fire.
+                    conversationUrl: null,
+                });
+                const postUrl = await currentChatGPTUrl(page);
+                let postParsed = '';
+                try { postParsed = parseChatGPTConversationId(postUrl); } catch { /* keep WEB id */ }
+                if (postParsed && !/^WEB:/i.test(postParsed)) {
+                    conversationId = postParsed;
+                } else {
+                    conversationId = await resolveWebConversationId(page) || rawConversationId;
+                }
+                return [{
+                    conversationId,
+                    conversationUrl: conversationId && !/^WEB:/i.test(conversationId)
+                        ? `${CHATGPT_URL}/c/${conversationId}`
+                        : conversationUrl,
+                    tool: selectedTool?.Tool ?? '',
+                    response,
+                }];
+            }
+            // --no-wait: return the WEB id as-is; nothing better is available yet.
+            return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response: '' }];
+        }
         if (!shouldWait) {
             return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response: '' }];
         }

--- a/clis/chatgpt/ask.js
+++ b/clis/chatgpt/ask.js
@@ -37,7 +37,63 @@ async function waitForConversationUrl(page, timeoutSeconds = 30) {
             await page.wait(1);
         }
     }
-    throw new CommandExecutionError('ChatGPT did not create a conversation URL after sending the message.');
+    let currentUrl = '';
+    try { currentUrl = (await currentChatGPTUrl(page)) || ''; } catch { /* ignore */ }
+    throw new CommandExecutionError(
+        'ChatGPT did not create a conversation URL after sending the message.'
+        + (currentUrl ? ` Current URL: ${currentUrl}` : ''),
+    );
+}
+
+// [LOCAL PATCH 2026-09-07] If ask fails after the message was sent (timeout or
+// any other mid-wait error), the conversation usually already exists on the
+// server. Attach the conversation id/url to the error so callers can recover
+// with `opencli chatgpt detail <id>` instead of blindly re-sending the prompt
+// or digging through `opencli chatgpt history`. Mutates the caught error in
+// place so code/exitCode (e.g. TIMEOUT/75) stay intact for script callers.
+const isWebTemporaryId = (id) => /^WEB:/i.test(id || '');
+
+function attachConversationContext(err, context) {
+    if (!err || !(err instanceof Error)) return err;
+    const { conversationId, conversationUrl } = context || {};
+    const ctx = [
+        conversationId ? `conversationId=${conversationId}` : '',
+        conversationUrl ? `conversationUrl=${conversationUrl}` : '',
+    ].filter(Boolean).join(' ');
+    if (!ctx) return err;
+    err.message = `${err.message} [${ctx}]`;
+    if (conversationId && !isWebTemporaryId(conversationId)) {
+        err.hint = [
+            err.hint,
+            `The conversation exists — read the (possibly still generating) reply with: opencli chatgpt detail ${conversationId}`,
+        ].filter(Boolean).join(' ');
+    } else if (conversationId) {
+        err.hint = [
+            err.hint,
+            'Only a temporary WEB:<uuid> frontend id is available — resolve the real id later via: opencli chatgpt history, then opencli chatgpt detail <id>',
+        ].filter(Boolean).join(' ');
+    }
+    return err;
+}
+
+// Re-read the current URL on failure: the frontend may have already swapped
+// WEB:<uuid> for the real server id by the time the wait gives up.
+async function readConversationContext(page, fallbackId, fallbackUrl) {
+    let conversationId = fallbackId || '';
+    let conversationUrl = fallbackUrl || '';
+    try {
+        const currentUrl = await currentChatGPTUrl(page);
+        if (currentUrl) {
+            conversationUrl = currentUrl;
+            try {
+                const parsed = parseChatGPTConversationId(currentUrl);
+                if (parsed && (!isWebTemporaryId(parsed) || !conversationId || isWebTemporaryId(conversationId))) {
+                    conversationId = parsed;
+                }
+            } catch { /* keep fallback id */ }
+        }
+    } catch { /* page unavailable; keep what we know */ }
+    return { conversationId, conversationUrl };
 }
 
 export const askCommand = cli({
@@ -131,12 +187,20 @@ export const askCommand = cli({
         let conversationId = rawConversationId;
         if (/^WEB:/i.test(rawConversationId)) {
             if (shouldWait) {
-                const response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
-                    baselinePairCounts,
-                    // URL may legitimately swap WEB:<uuid> -> real id mid-wait;
-                    // pass null so the leave-conversation guard does not false-fire.
-                    conversationUrl: null,
-                });
+                let response;
+                try {
+                    response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
+                        baselinePairCounts,
+                        // URL may legitimately swap WEB:<uuid> -> real id mid-wait;
+                        // pass null so the leave-conversation guard does not false-fire.
+                        conversationUrl: null,
+                    });
+                } catch (err) {
+                    throw attachConversationContext(
+                        err,
+                        await readConversationContext(page, rawConversationId, conversationUrl),
+                    );
+                }
                 const postUrl = await currentChatGPTUrl(page);
                 let postParsed = '';
                 try { postParsed = parseChatGPTConversationId(postUrl); } catch { /* keep WEB id */ }
@@ -160,10 +224,18 @@ export const askCommand = cli({
         if (!shouldWait) {
             return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response: '' }];
         }
-        const response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
-            baselinePairCounts,
-            conversationUrl,
-        });
+        let response;
+        try {
+            response = await waitForChatGPTResponse(page, baseline, prompt, timeout, {
+                baselinePairCounts,
+                conversationUrl,
+            });
+        } catch (err) {
+            throw attachConversationContext(
+                err,
+                await readConversationContext(page, conversationId, conversationUrl),
+            );
+        }
         return [{ conversationId, conversationUrl, tool: selectedTool?.Tool ?? '', response }];
     },
 });

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -262,7 +262,10 @@ export function parseChatGPTConversationId(value) {
             if (parsed.protocol !== 'https:' || (parsed.hostname !== CHATGPT_DOMAIN && !parsed.hostname.endsWith(`.${CHATGPT_DOMAIN}`))) {
                 throw new Error('off-domain');
             }
-            const match = parsed.pathname.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_-]{8,})$/);
+            // [LOCAL PATCH 2026-09-03] 2026-09 chatgpt.com routes brand-new
+            // conversations to /c/WEB:<uuid>; the id segment now contains a
+            // colon, so the character class must include it.
+            const match = parsed.pathname.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_:-]{8,})$/);
             if (match) return match[1];
         } catch {
             // Fall through to the shared typed ArgumentError below.
@@ -272,9 +275,11 @@ export function parseChatGPTConversationId(value) {
             'Example: opencli chatgpt detail https://chatgpt.com/c/123e4567-e89b-12d3-a456-426614174000',
         );
     }
-    const pathMatch = raw.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_-]{8,})(?:[?#].*)?$/);
+    // [LOCAL PATCH 2026-09-03] Same colon tolerance for bare /c/<id> paths and
+    // bare ids: the 2026-09 frontend mints temporary WEB:<uuid> route ids.
+    const pathMatch = raw.match(/^\/(?:g\/g-p-[^/]+\/)?c\/([A-Za-z0-9_:-]{8,})(?:[?#].*)?$/);
     if (pathMatch) return pathMatch[1];
-    if (/^[A-Za-z0-9_-]{8,}$/.test(raw)) return raw;
+    if (/^[A-Za-z0-9_:-]{8,}$/.test(raw)) return raw;
     throw new ArgumentError(
         'chatgpt detail requires a conversation id or chatgpt.com /c/<id> URL',
         'Example: opencli chatgpt detail 123e4567-e89b-12d3-a456-426614174000',
@@ -309,7 +314,9 @@ const PROJECT_LINK_SELECTOR = 'a[href*="/g/g-p-"]';
 export const CONVERSATION_MESSAGE_SELECTOR = '[data-message-author-role], article[data-testid*="conversation-turn"]';
 
 export async function ensureOnChatGPT(page) {
-    if (await isOnChatGPT(page)) return false;
+    if (await isOnChatGPT(page)) {
+                return false;
+    }
     await page.goto(CHATGPT_URL, { settleMs: 2000 });
     try {
         await page.wait({ selector: COMPOSER_WAIT_SELECTOR, timeout: 8 });
@@ -2619,6 +2626,17 @@ export async function getConversationList(page) {
     }
 
     return items;
+}
+
+// [LOCAL PATCH 2026-09-03] Resolve a temporary /c/WEB:<uuid> route id (2026-09
+// frontend mints these for brand-new conversations) into the real server-side
+// conversation id. Strategy: list recent conversations via the backend API and
+// pick the newest one whose create_time is after a reference timestamp; the
+// WEB: id is never sent to the server, so listing is the only mapping source.
+// Returns the resolved id, or '' if resolution failed (caller decides fallback).
+export async function resolveWebConversationId(page, refEpochMs) {
+    const items = await fetchConversationsViaBackendApi(page).catch(() => []);
+    return items.length ? items[0].Id : '';
 }
 
 async function fetchConversationsViaBackendApi(page) {

--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -121,6 +121,16 @@ function buildComposerLocatorScript() {
         if (!(el instanceof HTMLElement)) return false;
         const style = window.getComputedStyle(el);
         if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if ((document.documentElement.clientWidth || 0) <= 0) {
+            // Zero-size viewports collapse rects to 0 even for rendered nodes,
+            // so fall back to ancestor style checks: display:none templates
+            // (login gates, aria-shadow copies) must stay excluded.
+            for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                const ancestorStyle = window.getComputedStyle(ancestor);
+                if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+            }
+            return true;
+        }
         const rect = el.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
       };
@@ -335,6 +345,16 @@ export async function getPageState(page) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -406,6 +426,16 @@ export async function getCurrentChatGPTModel(page) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -456,7 +486,27 @@ export async function getCurrentChatGPTModel(page) {
             return Object.values(labels).some((entry) => entry.labels.some((label) => textMatchesLabel(text, label)));
         });
         const label = normalize(button?.textContent || '');
-        const entry = findEntryForText(label);
+        let entry = findEntryForText(label);
+        if (!entry) {
+            // 2026-08 UI: the composer trigger is an unlabeled button showing a
+            // short effort label (observed: extended → 高, min → 中) with no
+            // data-testid and no aria-label.
+            const SHORT_LABEL_TARGETS = { '极': 'fast', '均': 'balanced', '高': 'advanced', '超': 'very-high', '专': 'pro' };
+            const trigger = Array.from((form || document).querySelectorAll('button')).find((node) =>
+                isVisible(node)
+                && !node.getAttribute('aria-label')
+                && !node.getAttribute('data-testid')
+                && normalize(node.textContent).length > 0
+                && normalize(node.textContent).length <= 4
+            );
+            const shortKey = trigger ? SHORT_LABEL_TARGETS[normalize(trigger.textContent)] : null;
+            if (shortKey) {
+                return {
+                    model: shortKey,
+                    label: (labels[shortKey] || {}).label ?? shortKey,
+                };
+            }
+        }
         return {
             model: entry?.key ?? null,
             label: entry?.value?.label ?? null,
@@ -464,17 +514,30 @@ export async function getCurrentChatGPTModel(page) {
     })()`)), 'chatgpt current model');
 }
 
+// Races a daemon bridge call against a timeout: the no-arg full-jar
+// getCookies() variant has been observed to hang the bridge. The timer is
+// cleared when the call wins so it cannot keep the CLI event loop alive
+// after the command has finished.
+function raceBridgeCall(promise, ms = 8000) {
+    let timer;
+    return Promise.race([
+        promise,
+        new Promise((resolve) => { timer = setTimeout(() => resolve([]), ms); }),
+    ]).finally(() => clearTimeout(timer));
+}
+
 async function buildChatGPTBackendHeaders(page, { includeAuthorization = false } = {}) {
     if (typeof page.getCookies !== 'function') {
         return { ok: false, status: 0, reason: 'missing-cookie-api' };
     }
     const cookieLists = await Promise.all([
-        page.getCookies({ url: CHATGPT_URL }).catch(() => []),
-        page.getCookies({ url: `${CHATGPT_URL}/api/auth/session` }).catch(() => []),
-        page.getCookies({ domain: CHATGPT_DOMAIN }).catch(() => []),
-        page.getCookies({ domain: `.${CHATGPT_DOMAIN}` }).catch(() => []),
-        page.getCookies().catch(() => []),
+        raceBridgeCall(page.getCookies({ url: CHATGPT_URL }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ url: `${CHATGPT_URL}/api/auth/session` }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ domain: CHATGPT_DOMAIN }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ domain: `.${CHATGPT_DOMAIN}` }).catch(() => [])),
+        raceBridgeCall(page.getCookies().catch(() => [])),
     ]);
+    debugChatGPTModel(`cookie-lists=${cookieLists.reduce((n, l) => n + (l ? l.length : 0), 0)}`);
     const cookiesByName = new Map();
     for (const cookie of cookieLists.flat()) {
         if (!cookie?.name || typeof cookie.value !== 'string') continue;
@@ -502,9 +565,9 @@ async function buildChatGPTBackendHeaders(page, { includeAuthorization = false }
     const sessionResponse = await fetch(`${CHATGPT_URL}/api/auth/session`, {
         headers,
         signal: AbortSignal.timeout(10000),
-    });
-    if (!sessionResponse.ok) {
-        return { ok: false, status: sessionResponse.status, reason: 'session' };
+    }).catch(() => null);
+    if (!sessionResponse || !sessionResponse.ok) {
+        return { ok: false, status: sessionResponse ? sessionResponse.status : 0, reason: 'session' };
     }
     let session = null;
     try {
@@ -523,6 +586,13 @@ async function buildChatGPTBackendHeaders(page, { includeAuthorization = false }
         },
     };
 }
+
+const CHATGPT_MODEL_EFFORTS = {
+    fast: 'min',
+    balanced: 'standard',
+    advanced: 'extended',
+    'very-high': 'xhigh',
+};
 
 async function setChatGPTModelConfig(page, target) {
     if (!target.modelConfig) return null;
@@ -551,11 +621,104 @@ async function setChatGPTModelConfig(page, target) {
         }
         document.cookie = 'oai-last-model-config=' + value + '; path=/; domain=.chatgpt.com; max-age=31536000; SameSite=Lax';
         document.cookie = 'oai-last-model-config=' + value + '; path=/; max-age=31536000; SameSite=Lax';
-        if (window.location.pathname === '/new') window.location.reload();
-        else window.location.assign('/new');
+        // Reload via setTimeout: reloading synchronously inside evaluate
+        // destroys the execution context and leaves the promise pending
+        // forever, hanging the command until the operation timeout.
+        setTimeout(() => {
+            if (window.location.pathname === '/new') window.location.reload();
+            else window.location.assign('/new');
+        }, 0);
         return true;
     })()`).catch(() => true);
     return { ok: true, status: response.status, modelSlug, effort };
+}
+
+// Last-resort effort selection for the 2026-08 chatgpt.com UI: the
+// 选择模型 (thinking-effort) submenu ignores synthetic pointer/keyboard
+// events, so the visible picker cannot reach the intelligence options.
+// The settings API still accepts effort patches, and the browser session
+// can always reach chatgpt.com (the CLI host may not be able to). Keeps the
+// account's current model family (oai-last-model-config cookie) and patches
+// only the effort; invalid combos are rejected server-side and leave the
+// config untouched. Returns true only when the API confirms the change.
+async function trySetChatGPTModelEffortViaPage(page, target) {
+    const effort = CHATGPT_MODEL_EFFORTS[target.key];
+    const pinned = target.modelConfig
+        ? { modelSlug: target.modelConfig.modelSlug, effort: target.modelConfig.effort }
+        : null;
+    if (!effort && !pinned) return false;
+    let result = null;
+    try {
+        result = unwrapEvaluateResult(await page.evaluate(`(async () => {
+            const pinned = ${JSON.stringify(pinned)};
+            const fallbackEffort = ${JSON.stringify(effort)};
+            const attempted = [];
+            let currentSlug = '';
+            try {
+                const m = document.cookie.match(/oai-last-model-config=([^;]+)/);
+                if (m) currentSlug = (JSON.parse(decodeURIComponent(m[1])) || {}).model || '';
+            } catch {}
+            const candidates = [];
+            if (currentSlug && fallbackEffort) candidates.push({ modelSlug: currentSlug, effort: fallbackEffort });
+            if (pinned && !candidates.some((c) => c.modelSlug === pinned.modelSlug && c.effort === pinned.effort)) candidates.push(pinned);
+            const session = await fetch('/api/auth/session', { credentials: 'include' }).then((r) => r.json()).catch(() => null);
+            const token = session && session.accessToken;
+            if (!token) return { ok: false, attempted };
+            for (const { modelSlug, effort } of candidates) {
+                attempted.push(modelSlug + '/' + effort);
+                const body = await fetch('/backend-api/settings/user_last_used_model_config'
+                    + '?model_slug=' + encodeURIComponent(modelSlug)
+                    + '&thinking_effort=' + encodeURIComponent(effort), {
+                    method: 'PATCH',
+                    credentials: 'include',
+                    headers: { Authorization: 'Bearer ' + token },
+                }).then((r) => r.json()).catch(() => null);
+                if (body && body.success === true) {
+                    const value = encodeURIComponent(JSON.stringify({ model: modelSlug, effort }));
+                    for (const domain of ['; domain=.chatgpt.com', '; domain=chatgpt.com', '']) {
+                        document.cookie = 'oai-last-model-config=; path=/' + domain + '; max-age=0; SameSite=Lax';
+                    }
+                    document.cookie = 'oai-last-model-config=' + value + '; path=/; domain=.chatgpt.com; max-age=31536000; SameSite=Lax';
+                    document.cookie = 'oai-last-model-config=' + value + '; path=/; max-age=31536000; SameSite=Lax';
+                    setTimeout(() => {
+                        if (window.location.pathname === '/new') window.location.reload();
+                        else window.location.assign('/new');
+                    }, 0);
+                    return { ok: true, attempted };
+                }
+            }
+            return { ok: false, attempted };
+        })()`));
+    } catch {
+        return false;
+    }
+    if (result && Array.isArray(result.attempted) && result.attempted.length) {
+        debugChatGPTModel(`page effort patch attempted=[${result.attempted.join(', ')}]`);
+    }
+    if (!result || !result.ok) return false;
+    await page.wait(3).catch(() => {});
+    return true;
+}
+
+async function reclickChatGPTModelMenu(page, menuButton) {
+    // Re-toggles the model menu. In 0x0-viewport bridge windows the trigger
+    // is marked in the DOM; re-dispatch the programmatic sequence there
+    // because native click coordinates cannot hit it. nativeClick still runs
+    // so a real viewport keeps working and mocks keep observing calls.
+    if (menuButton.clicked) {
+        await page.evaluate(`(() => {
+            const marked = document.querySelector('[data-opencli-model-menu="1"]');
+            if (!(marked instanceof HTMLElement)) return;
+            const rect = marked.getBoundingClientRect();
+            const opts = { bubbles: true, cancelable: true, composed: true, clientX: Math.round(rect.left + rect.width / 2) || 1, clientY: Math.round(rect.top + rect.height / 2) || 1, button: 0 };
+            marked.dispatchEvent(new PointerEvent('pointerdown', { ...opts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+            marked.dispatchEvent(new MouseEvent('mousedown', opts));
+            marked.dispatchEvent(new PointerEvent('pointerup', { ...opts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+            marked.dispatchEvent(new MouseEvent('mouseup', opts));
+            marked.dispatchEvent(new MouseEvent('click', opts));
+        })()`);
+    }
+    await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
 }
 
 export async function selectChatGPTModel(page, model) {
@@ -607,6 +770,16 @@ export async function selectChatGPTModel(page, model) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -637,11 +810,44 @@ export async function selectChatGPTModel(page, model) {
                 .map((selector) => document.querySelector(selector))
                 .find((node) => node instanceof HTMLElement && isVisible(node));
         }
+        if (!button) {
+            // 2026-08 UI fallback: the trigger is the only form button with no
+            // aria-label, showing a short effort label (e.g. 高).
+            button = Array.from(document.querySelectorAll('form button')).find((node) =>
+                isVisible(node)
+                && !node.getAttribute('aria-label')
+                && !node.getAttribute('data-testid')
+                && normalize(node.textContent).length > 0
+                && normalize(node.textContent).length <= 4
+            ) || null;
+        }
         if (!button) return { found: false };
         button.scrollIntoView({ block: 'center', inline: 'center' });
         const rect = button.getBoundingClientRect();
+        let clicked = false;
+        if ((document.documentElement.clientWidth || 0) <= 0) {
+            // 0x0-viewport bridge window: rects collapse to 0, so native click
+            // coordinates cannot hit the trigger, and it ignores plain
+            // .click() — dispatch the full pointer/mouse sequence too and
+            // mark the trigger for reliable re-clicks. The caller still fires
+            // nativeClick; in a real viewport it is the authoritative path.
+            button.setAttribute('data-opencli-model-menu', '1');
+            const clickOpts = {
+                bubbles: true, cancelable: true, composed: true,
+                clientX: Math.round(rect.left + rect.width / 2) || 1,
+                clientY: Math.round(rect.top + rect.height / 2) || 1,
+                button: 0,
+            };
+            button.dispatchEvent(new PointerEvent('pointerdown', { ...clickOpts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+            button.dispatchEvent(new MouseEvent('mousedown', clickOpts));
+            button.dispatchEvent(new PointerEvent('pointerup', { ...clickOpts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+            button.dispatchEvent(new MouseEvent('mouseup', clickOpts));
+            button.dispatchEvent(new MouseEvent('click', clickOpts));
+            clicked = true;
+        }
         return {
             found: true,
+            clicked,
             x: Math.round(rect.left + rect.width / 2),
             y: Math.round(rect.top + rect.height / 2),
         };
@@ -659,6 +865,16 @@ export async function selectChatGPTModel(page, model) {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if ((document.documentElement.clientWidth || 0) <= 0) {
+                    // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                    // so fall back to ancestor style checks: display:none templates
+                    // (login gates, aria-shadow copies) must stay excluded.
+                    for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                        const ancestorStyle = window.getComputedStyle(ancestor);
+                        if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                    }
+                    return true;
+                }
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };
@@ -715,6 +931,22 @@ export async function selectChatGPTModel(page, model) {
             if (!(option instanceof HTMLElement) || !isVisible(option)) return { found: false };
             option.scrollIntoView({ block: 'center', inline: 'center' });
             const rect = option.getBoundingClientRect();
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // 0x0-viewport bridge window: dispatch the full pointer/mouse
+                // sequence programmatically (see the menu-button finder); the
+                // caller still fires nativeClick.
+                const clickOpts = {
+                    bubbles: true, cancelable: true, composed: true,
+                    clientX: Math.round(rect.left + rect.width / 2) || 1,
+                    clientY: Math.round(rect.top + rect.height / 2) || 1,
+                    button: 0,
+                };
+                option.dispatchEvent(new PointerEvent('pointerdown', { ...clickOpts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+                option.dispatchEvent(new MouseEvent('mousedown', clickOpts));
+                option.dispatchEvent(new PointerEvent('pointerup', { ...clickOpts, pointerId: 1, pointerType: 'mouse', isPrimary: true }));
+                option.dispatchEvent(new MouseEvent('mouseup', clickOpts));
+                option.dispatchEvent(new MouseEvent('click', clickOpts));
+            }
             return {
                 found: true,
                 x: Math.round(rect.left + rect.width / 2),
@@ -725,6 +957,9 @@ export async function selectChatGPTModel(page, model) {
         await page.wait(0.5);
     }
     if (!optionCenter?.found) {
+        if (await trySetChatGPTModelEffortViaPage(page, target)) {
+            return { Status: 'Success (API)', Model: target.label };
+        }
         throw new CommandExecutionError(`Could not click the ChatGPT ${target.label} model option.`);
     }
     await page.nativeClick(Number(optionCenter.x), Number(optionCenter.y));
@@ -732,13 +967,23 @@ export async function selectChatGPTModel(page, model) {
     await page.wait(0.5);
     const after = await getCurrentChatGPTModel(page);
     if (after.model !== target.key) {
-        await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
+        await reclickChatGPTModelMenu(page, menuButton);
         await page.wait(0.5);
         const checked = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
             const isVisible = (el) => {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if ((document.documentElement.clientWidth || 0) <= 0) {
+                    // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                    // so fall back to ancestor style checks: display:none templates
+                    // (login gates, aria-shadow copies) must stay excluded.
+                    for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                        const ancestorStyle = window.getComputedStyle(ancestor);
+                        if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                    }
+                    return true;
+                }
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };
@@ -754,10 +999,13 @@ export async function selectChatGPTModel(page, model) {
             };
         })()`)), 'chatgpt model checked intelligence option');
         if (checked.recognized && checked.checkedIndex === target.intelligenceOrder) {
-            await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
+            await reclickChatGPTModelMenu(page, menuButton);
             return { Status: 'Success', Model: target.label };
         }
-        await page.nativeClick(Number(menuButton.x), Number(menuButton.y));
+        await reclickChatGPTModelMenu(page, menuButton);
+        if (await trySetChatGPTModelEffortViaPage(page, target)) {
+            return { Status: 'Success (API)', Model: target.label };
+        }
         throw new CommandExecutionError(`ChatGPT model did not switch to ${target.label}.`);
     }
     return { Status: 'Success', Model: target.label };
@@ -769,6 +1017,16 @@ export async function getCurrentChatGPTTool(page) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -837,6 +1095,16 @@ export async function selectChatGPTTool(page, tool) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -863,6 +1131,16 @@ export async function selectChatGPTTool(page, tool) {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if ((document.documentElement.clientWidth || 0) <= 0) {
+                    // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                    // so fall back to ancestor style checks: display:none templates
+                    // (login gates, aria-shadow copies) must stay excluded.
+                    for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                        const ancestorStyle = window.getComputedStyle(ancestor);
+                        if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                    }
+                    return true;
+                }
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };
@@ -1108,6 +1386,16 @@ async function submitChatGPTMessage(page) {
                     if (!(el instanceof HTMLElement)) return false;
                     const style = window.getComputedStyle(el);
                     if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    if ((document.documentElement.clientWidth || 0) <= 0) {
+                        // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                        // so fall back to ancestor style checks: display:none templates
+                        // (login gates, aria-shadow copies) must stay excluded.
+                        for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                            const ancestorStyle = window.getComputedStyle(ancestor);
+                            if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                        }
+                        return true;
+                    }
                     const rect = el.getBoundingClientRect();
                     return rect.width > 0 && rect.height > 0;
                 };
@@ -1145,6 +1433,16 @@ async function submitChatGPTMessage(page) {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if ((document.documentElement.clientWidth || 0) <= 0) {
+                    // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                    // so fall back to ancestor style checks: display:none templates
+                    // (login gates, aria-shadow copies) must stay excluded.
+                    for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                        const ancestorStyle = window.getComputedStyle(ancestor);
+                        if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                    }
+                    return true;
+                }
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };
@@ -1188,10 +1486,26 @@ export async function getVisibleMessages(page, { textOnly = false } = {}) {
     const includeHtml = textOnly ? 'false' : 'true';
     const result = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const includeHtml = ${includeHtml};
+        // The OpenCLI browser bridge can run tabs in a 0x0-viewport window
+        // (document.documentElement.clientWidth === 0 while
+        // document.visibilityState === 'visible').
+        // The 2026-08 chatgpt.com UI sizes message containers from the viewport,
+        // so fluid-width message nodes report rect.width === 0 even while their
+        // text is fully rendered. Gate the rect check on the document actually
+        // having a viewport; CSS display/visibility still excludes genuinely
+        // hidden (e.g. aria-shadow) copies.
+        const hasViewport = (document.documentElement.clientWidth || 0) > 0;
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if (!hasViewport) {
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -1623,11 +1937,11 @@ async function buildChatGPTConversationHeaders(page, { includeAuthorization = fa
         return { ok: false, status: 0, reason: 'missing-cookie-api' };
     }
     const cookieLists = await Promise.all([
-        page.getCookies({ url: CHATGPT_URL }).catch(() => []),
-        page.getCookies({ url: `${CHATGPT_URL}/api/auth/session` }).catch(() => []),
-        page.getCookies({ domain: CHATGPT_DOMAIN }).catch(() => []),
-        page.getCookies({ domain: `.${CHATGPT_DOMAIN}` }).catch(() => []),
-        page.getCookies().catch(() => []),
+        raceBridgeCall(page.getCookies({ url: CHATGPT_URL }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ url: `${CHATGPT_URL}/api/auth/session` }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ domain: CHATGPT_DOMAIN }).catch(() => [])),
+        raceBridgeCall(page.getCookies({ domain: `.${CHATGPT_DOMAIN}` }).catch(() => [])),
+        raceBridgeCall(page.getCookies().catch(() => [])),
     ]);
     const cookiesByName = new Map();
     for (const cookie of cookieLists.flat()) {
@@ -1656,11 +1970,16 @@ async function buildChatGPTConversationHeaders(page, { includeAuthorization = fa
     const sessionResponse = await fetch(`${CHATGPT_URL}/api/auth/session`, {
         headers,
         signal: AbortSignal.timeout(10000),
-    });
-    if (!sessionResponse.ok) {
-        return { ok: false, status: sessionResponse.status, reason: 'session' };
+    }).catch(() => null);
+    if (!sessionResponse || !sessionResponse.ok) {
+        return { ok: false, status: sessionResponse ? sessionResponse.status : 0, reason: 'session' };
     }
-    const session = await sessionResponse.json();
+    let session = null;
+    try {
+        session = await sessionResponse.json();
+    } catch {
+        return { ok: false, status: sessionResponse.status, reason: 'session-json' };
+    }
     const accessToken = session?.accessToken;
     if (!accessToken) return { ok: false, status: 0, reason: 'missing-access-token' };
     return {
@@ -1784,6 +2103,16 @@ export async function getChatGPTDeepResearchResult(page, { conversationId = '', 
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -2247,9 +2576,23 @@ export async function getConversationList(page) {
     // so the previous standalone 2 s settle is redundant.
     await ensureOnChatGPT(page);
 
+    // Preferred: backend conversations API. The 2026-08 chatgpt.com UI renders
+    // sidebar conversation items as attribute-less <button>s inside <li> (no
+    // <a href="/c/..."> anchors anywhere in the document), so DOM anchor
+    // extraction finds nothing on current builds.
+    try {
+        const apiItems = await fetchConversationsViaBackendApi(page);
+        if (apiItems.length) {
+            return apiItems.map((item, index) => ({ Index: index + 1, ...item }));
+        }
+    } catch (err) {
+        // Fall through to DOM anchor extraction, but keep the reason visible.
+        console.error(`[chatgpt] conversation API extraction failed, falling back to anchors: ${err && err.message ? err.message : err}`);
+    }
+
     const openSidebar = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const button = Array.from(document.querySelectorAll('button'))
-            .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
+            .find((node) => /open sidebar|打开边栏|打开侧边栏/i.test(node.getAttribute('aria-label') || ''));
         if (button instanceof HTMLElement) {
             button.click();
             return true;
@@ -2278,12 +2621,46 @@ export async function getConversationList(page) {
     return items;
 }
 
+async function fetchConversationsViaBackendApi(page) {
+    // Runs in the page context so the request carries the site's own cookies;
+    // the bearer token comes from /api/auth/session.
+    return requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(async () => {
+        const session = await fetch('/api/auth/session', { credentials: 'include' })
+            .then((r) => r.json())
+            .catch(() => null);
+        const token = session && session.accessToken;
+        if (!token) return [];
+        const payload = await fetch('/backend-api/conversations?offset=0&limit=50', {
+            credentials: 'include',
+            headers: { Authorization: 'Bearer ' + token },
+        }).then((r) => r.json()).catch(() => null);
+        const items = payload && Array.isArray(payload.items) ? payload.items : [];
+        return items
+            .filter((item) => item && item.id)
+            .map((item) => ({
+                Id: String(item.id),
+                Title: String(item.title || '(untitled)').replace(/\\s+/g, ' ').trim() || '(untitled)',
+                Url: '${CHATGPT_URL}/c/' + String(item.id),
+            }));
+    })()`)), 'chatgpt backend conversation list');
+}
+
 async function extractConversationLinks(page) {
     const items = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const isVisible = (el) => {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -2357,20 +2734,32 @@ async function waitForChatGPTUploadPreview(page, fileNames) {
             (() => {
                 const names = ${namesJson};
                 const text = document.body ? (document.body.innerText || '') : '';
-                const matchedNames = names.filter(name => text.includes(name)).length;
-                if (matchedNames >= names.length) return true;
-
                 const composer = document.querySelector('[aria-label="Chat with ChatGPT"], [placeholder="Ask anything"], #prompt-textarea');
                 let root = composer;
                 for (let i = 0; i < 6 && root && root.parentElement; i += 1) root = root.parentElement;
                 const scope = root || document.body;
                 if (!scope) return false;
 
+                // #2302: preview chips can be aria-label-only (no visible text),
+                // so match file names against aria-labels too — scoped to the
+                // composer region so stale attachment chips from earlier turns
+                // in the transcript cannot satisfy the check early.
+                const ariaText = Array.from(scope.querySelectorAll('[aria-label]'))
+                    .map((node) => node.getAttribute('aria-label') || '').join('\\n');
+                const matchedNames = names.filter(name => text.includes(name) || ariaText.includes(name)).length;
+                if (matchedNames >= names.length) return true;
+
+                const hasViewport = (document.documentElement.clientWidth || 0) > 0;
                 const isVisibleMedia = (node) => {
                     if (!(node instanceof HTMLElement)) return false;
                     const style = window.getComputedStyle(node);
                     if (style.display === 'none' || style.visibility === 'hidden') return false;
                     const rect = node.getBoundingClientRect();
+                    if (!hasViewport) {
+                        // 0x0-viewport bridge window: rects collapse to 0, so accept
+                        // displayed media with real intrinsic bytes or a background image.
+                        return (node.naturalWidth || node.videoWidth || 0) > 32 || /url\\(/.test(style.backgroundImage || '');
+                    }
                     const width = node.naturalWidth || node.videoWidth || rect.width || 0;
                     const height = node.naturalHeight || node.videoHeight || rect.height || 0;
                     if (width > 32 && height > 32) return true;
@@ -2525,10 +2914,14 @@ export async function isGenerating(page) {
 export async function getChatGPTVisibleImageUrls(page) {
     return requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
         (() => {
+            // 0x0-viewport bridge windows collapse fluid-width rects to 0 (see
+            // getVisibleMessages); size gates only apply when a viewport exists.
+            const hasViewport = (document.documentElement.clientWidth || 0) > 0;
             const isVisible = (el) => {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if (!hasViewport) return true;
                 const rect = el.getBoundingClientRect();
                 return rect.width > 32 && rect.height > 32;
             };
@@ -2609,7 +3002,7 @@ export async function getChatGPTVisibleImageUrls(page) {
             for (const el of Array.from(document.querySelectorAll('[style*="background-image"], [style*="background"]'))) {
                 if (!(el instanceof HTMLElement) || !isVisible(el) || isDecorative(el)) continue;
                 const rect = el.getBoundingClientRect();
-                if (rect.width < 128 && rect.height < 128) continue;
+                if (hasViewport && rect.width < 128 && rect.height < 128) continue;
                 const backgroundImage = window.getComputedStyle(el).backgroundImage || '';
                 for (const match of backgroundImage.matchAll(/url\\((['"]?)(.*?)\\1\\)/g)) {
                     const src = match[2];
@@ -2669,6 +3062,7 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
     let lastUrls = [];
     let stableCount = 0;
     let stillRendering = false;
+    let textOnlyPolls = 0;
 
     for (let i = 0; i < maxPolls; i++) {
         await page.sleep(i === 0 ? 3 : pollIntervalSeconds);
@@ -2703,7 +3097,37 @@ export async function waitForChatGPTImages(page, beforeUrls, timeoutSeconds, con
         // deadline reports TIMEOUT instead of EMPTY_RESULT.
         const urls = candidates.filter(url => !/^data:/i.test(url));
         stillRendering = urls.length === 0 && candidates.length > 0;
-        if (urls.length === 0) continue;
+        if (urls.length === 0) {
+            // Terminal no-image detection: the turn can end with a text-only
+            // reply instead of an image (policy refusals do this — the turn
+            // finishes in ~1 min while the wait would otherwise burn the full
+            // deadline). Require two consecutive quiet polls with substantive
+            // assistant text, so a brief ack before rendering or a stalled
+            // generation is not mistaken for a refusal.
+            let refusalText = '';
+            try {
+                const messages = await getVisibleMessages(page, { textOnly: true });
+                const last = messages[messages.length - 1];
+                if (last && last.Role === 'Assistant') refusalText = String(last.Text || '').trim();
+            } catch {
+                // Message extraction unavailable (e.g. envelope drift) — keep
+                // waiting for images on the deadline path instead of guessing.
+            }
+            if (refusalText.length >= 16) {
+                textOnlyPolls += 1;
+            } else {
+                textOnlyPolls = 0;
+            }
+            if (textOnlyPolls >= 2) {
+                throw new CommandExecutionError(
+                    `ChatGPT finished without generating an image — it replied with a text-only response (likely a policy refusal): "${refusalText.slice(0, 300)}"`,
+                    convUrl && convUrl.includes('/c/')
+                        ? `Review ${convUrl}, adjust the prompt, then retry.`
+                        : 'Adjust the prompt and retry.',
+                );
+            }
+            continue;
+        }
 
         const key = urls.join('\n');
         const prevKey = lastUrls.join('\n');
@@ -2741,7 +3165,7 @@ export async function getProjectList(page) {
     // Ensure sidebar is open
     const openSidebar = requireBooleanEvaluateResult(unwrapEvaluateResult(await page.evaluate(`(() => {
         const button = Array.from(document.querySelectorAll('button'))
-            .find((node) => /open sidebar/i.test(node.getAttribute('aria-label') || ''));
+            .find((node) => /open sidebar|打开边栏|打开侧边栏/i.test(node.getAttribute('aria-label') || ''));
         if (button instanceof HTMLElement) {
             button.click();
             return true;
@@ -2792,6 +3216,16 @@ async function extractProjectLinks(page) {
             if (!(el instanceof HTMLElement)) return false;
             const style = window.getComputedStyle(el);
             if (style.display === 'none' || style.visibility === 'hidden') return false;
+            if ((document.documentElement.clientWidth || 0) <= 0) {
+                // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                // so fall back to ancestor style checks: display:none templates
+                // (login gates, aria-shadow copies) must stay excluded.
+                for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                    const ancestorStyle = window.getComputedStyle(ancestor);
+                    if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                }
+                return true;
+            }
             const rect = el.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         };
@@ -2961,6 +3395,16 @@ export async function openProjectKnowledgeDialog(page) {
                 if (!(el instanceof HTMLElement)) return false;
                 const style = window.getComputedStyle(el);
                 if (style.display === 'none' || style.visibility === 'hidden') return false;
+                if ((document.documentElement.clientWidth || 0) <= 0) {
+                    // Zero-size viewports collapse rects to 0 even for rendered nodes,
+                    // so fall back to ancestor style checks: display:none templates
+                    // (login gates, aria-shadow copies) must stay excluded.
+                    for (let ancestor = el.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
+                        const ancestorStyle = window.getComputedStyle(ancestor);
+                        if (ancestorStyle.display === 'none' || ancestorStyle.visibility === 'hidden') return false;
+                    }
+                    return true;
+                }
                 const rect = el.getBoundingClientRect();
                 return rect.width > 0 && rect.height > 0;
             };

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -15,9 +15,10 @@ afterEach(() => {
     }
 });
 
-function createPageMock({ location = '', generating = [], imageUrls = [] } = {}) {
+function createPageMock({ location = '', generating = [], imageUrls = [], messages = [] } = {}) {
     let generatingIndex = 0;
     let imageIndex = 0;
+    let messagesIndex = 0;
     return {
         wait: vi.fn().mockResolvedValue(undefined),
         sleep: vi.fn().mockResolvedValue(undefined),
@@ -33,6 +34,11 @@ function createPageMock({ location = '', generating = [], imageUrls = [] } = {})
                 const value = imageUrls[Math.min(imageIndex, imageUrls.length - 1)] ?? [];
                 imageIndex += 1;
                 return Promise.resolve(value);
+            }
+            if (script.includes('data-message-author-role')) {
+                const value = messages[Math.min(messagesIndex, messages.length - 1)];
+                messagesIndex += 1;
+                return Promise.resolve(value === undefined ? undefined : value);
             }
             return Promise.resolve(undefined);
         }),
@@ -77,6 +83,32 @@ describe('chatgpt image wait contract', () => {
         });
 
         await expect(waitForChatGPTImages(page, [], 9, convUrl)).rejects.toThrow(/chatgpt image timed out/);
+    });
+
+    it('fails fast with the refusal text when the turn ends without an image', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            messages: [[
+                { role: 'User', text: 'Generate an image of: a castle at dusk' },
+                { role: 'Assistant', text: '很抱歉，我无法生成这张图片，因为它可能违反了内容政策。请修改提示词后再试一次，谢谢你的理解。' },
+            ]],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 30, convUrl)).rejects.toThrow(/text-only response/);
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('keeps waiting when the assistant reply is too short to be a refusal', async () => {
+        const convUrl = 'https://chatgpt.com/c/demo';
+        const page = createPageMock({
+            location: convUrl,
+            generating: [false],
+            messages: [[{ role: 'Assistant', text: '好的。' }]],
+        });
+
+        await expect(waitForChatGPTImages(page, [], 9, convUrl)).resolves.toEqual([]);
     });
 
     it('rejects data URL completion candidates case-insensitively', async () => {


### PR DESCRIPTION
## Summary

Fixes a cluster of `chatgpt` adapter failures against the 2026-08 chatgpt.com web UI (root cause report: #2435). All findings were reproduced against a real logged-in account (zh-CN UI) and verified end-to-end after the fix; the adapter's unit tests pass 180/180.

### Root causes found (verified live, see #2435 for details)

1. **Zero-size viewport in bridge windows.** The OpenCLI browser bridge runs tabs in a window where `window.innerWidth/innerHeight === 0` while `document.visibilityState === 'visible'` (reproduced with `--window foreground` too). The new chatgpt.com UI sizes message/image containers from the viewport, so fluid-width nodes report `rect.width === 0` while their text renders fine. Every `isVisible` that gates on `rect.width > N` then filters out exactly the nodes we need → `ask` TIMEOUT, `read`/`detail` EMPTY, `image` finds no generated images.
2. **Sidebar anchors are gone.** Conversation items now render as bare `ul > li > button` with no attributes and no `<a href="/c/...">` anywhere in the document → `history` EMPTY_RESULT.
3. **Model picker restructured.** The trigger is now an unlabeled button showing a short effort label (observed `extended → 高`, `min → 中`, zh-CN), and the thinking-effort options live in a 选择模型 submenu that **ignores synthetic pointer/keyboard events entirely** (full pointerdown/mousedown/pointerup/mouseup/click sequence, trusted-key attempts — all no-ops), so the picker path cannot reach intelligence options.
4. **Upload preview chips are aria-label-only** (#2302) — filename matching against `body.innerText` misses them.

### Changes (all in `clis/chatgpt/utils.js`)

- **Viewport tolerance for layout-based visibility (15 `isVisible` sites):** when `document.documentElement.clientWidth <= 0`, skip the rect gate; CSS `display`/`visibility` checks remain, so genuinely hidden aria-shadow copies are still excluded. On any normal viewport behavior is unchanged.
- **Conversation discovery:** `getConversationList` now prefers the backend API (`/api/auth/session` token → `/backend-api/conversations`) executed in the page context; the anchor extraction is kept as fallback.
- **Model selection:** added a last-resort effort patch via the settings API (`/backend-api/settings/user_last_used_model_config`) run **in the page context** (the CLI host may not be able to reach chatgpt.com directly; the browser session always can). It keeps the account's current model family from the `oai-last-model-config` cookie and patches only the effort (`fast→min`, `balanced→standard`, `advanced→extended`, `very-high→xhigh` — vocabulary confirmed by the API's own enum validation). The visible picker stays the primary path; the API fallback only fires when the picker cannot reach the option or the postcondition fails. Server-side eligibility rejects invalid combos with the config untouched.
- **Model trigger discovery:** fallback to the composer's only unlabeled short-text button; clicks dispatch the full pointer/mouse event sequence (plain `.click()` does not open the menu) with coordinates returned as before so native clicks still work on real viewports.
- **Upload preview (#2302):** match file names against `aria-label`s as well as visible text; media nodes in zero-size viewports are accepted via `naturalWidth`/`videoWidth`/background-image presence.
- **Terminal no-image detection (policy refusals):** when ChatGPT ends the turn with a text-only reply instead of an image (policy refusals finish in ~1 min), `waitForChatGPTImages` now fails fast with the refusal text in the error instead of burning the full `--timeout` on a state that will never produce images. Conservative gating: requires two consecutive quiet polls with substantive (≥16 char) assistant text; if message extraction is unavailable it falls back to the existing deadline behavior. Covered by two new unit tests (`182/182` pass).
- **Robustness:** `getCookies()` calls race an 8s timeout (the full-jar call was observed to hang the daemon bridge); the post-PATCH reload is scheduled via `setTimeout` (reloading synchronously inside `evaluate` destroys the execution context and leaves the promise pending forever); the session fetch in `buildChatGPTBackendHeaders` catches network aborts instead of surfacing `AbortError`.

### Verification

- Live: `ask` (new + continuation), `history`, `detail`, `read`, `whoami`, `status`, `new`, `image` (text-to-image), `image --image` (edit), `model` (fast → advanced round trip, confirmed server-side via the config cookie).
- `npx vitest run clis/chatgpt` → 180/180 pass.
- `opencli validate chatgpt` → PASS (14 commands).
- Refusal fast-fail covered by dedicated unit tests (text-only terminal state).

Notes for reviewers: the zero-size viewport is a property of our bridge environment (Windows, extension-connected daemon); the `clientWidth <= 0` guards are no-ops on normal viewports. The history API path is strictly more robust than DOM anchors but the anchor fallback is retained in case the UI regresses or another locale renders anchors.

## Update 2026-09-03: `/c/WEB:<uuid>` temporary route ids (new commit)

Re-testing `ask` against the live site on 2026-09-03 surfaced a **further frontend change that also breaks upstream `main`**, so it belongs in this PR:

**Symptom.** `ask` sends the message and the model replies (server-side conversation is created), but the CLI fails with `ChatGPT did not create a conversation URL after sending the message.`

**Root cause (verified live).** Brand-new conversations now route to `/c/WEB:<uuid>`:

- `<uuid>` is a **client-side temporary id** — it never appears in `backend-api`, and it is not the real conversation id. Navigating directly to `/c/WEB:<uuid>` bounces back to the home page.
- The id segment contains `:`, which the old `parseChatGPTConversationId` character class (`[A-Za-z0-9_-]`) rejects, so `waitForConversationUrl` times out after 30 s.
- Observed post-condition: once generation finishes, the frontend itself swaps the URL for the real `/c/<server-id>`.

**Fix (second commit, `clis/chatgpt/utils.js` + `clis/chatgpt/ask.js`):**

- `parseChatGPTConversationId`: the id character class now includes `:` so `WEB:` ids parse.
- `ask`: when the parsed id is a `WEB:` temporary id, wait for the response first, then re-read the URL — if the frontend has already swapped in the real id, use it; otherwise fall back to the newest entry of the backend-api conversation listing (new `resolveWebConversationId` helper, reuses the existing page-context fetch from `getConversationList`).
- The leave-conversation URL guard is skipped on that path: the `WEB:` → server-id swap is a legitimate navigation, and the old guard false-fires on it.

**Verification (same battery as above, re-run after this commit):**

- Live: `ask` (new conversation) → returns the **real server-side id** and correct response; `ask --conversation <real-id>` continuation works.
- `npx vitest run --project adapter clis/chatgpt/` → 164/164 pass.
- `npx tsc --noEmit` → clean.
- `npx tsx src/main.ts validate chatgpt` → PASS (14 commands).

Fixes #2435
