### PR TITLE
fix(doubao-app): support current desktop renderer

### DIFF
--- a/clis/doubao-app/ask.js
+++ b/clis/doubao-app/ask.js
@@ -1,5 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { SEL, injectTextScript, clickSendScript, pollResponseScript } from './utils.js';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { cleanupSubmissionScript, normalizeTimeout, responseAfterPromptScript, sendDoubaoMessage } from './utils.js';
 export const askCommand = cli({
     site: 'doubao-app',
     name: 'ask',
@@ -15,40 +16,36 @@ export const askCommand = cli({
     columns: ['Role', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const timeout = kwargs.timeout || 30;
-        // Count existing messages before sending
-        const beforeCount = await page.evaluate(`document.querySelectorAll('${SEL.MESSAGE}').length`);
-        // Inject text + send
-        const injected = await page.evaluate(injectTextScript(text));
-        if (!injected?.ok)
-            throw new Error('Could not find chat input.');
-        await page.wait(0.5);
-        const clicked = await page.evaluate(clickSendScript());
-        if (!clicked)
-            await page.pressKey('Enter');
-        // Poll for response
-        const pollInterval = 1;
-        const maxPolls = Math.ceil(timeout / pollInterval);
-        let response = '';
-        for (let i = 0; i < maxPolls; i++) {
-            await page.wait(pollInterval);
-            const result = await page.evaluate(pollResponseScript(beforeCount));
-            if (!result)
-                continue;
-            if (result.phase === 'done' && result.text) {
-                response = result.text;
-                break;
+        const timeout = normalizeTimeout(kwargs.timeout, 30);
+        const submission = await sendDoubaoMessage(page, text, {
+            timeoutMs: Math.min(timeout * 1000, 10_000),
+            retainSubmission: true,
+        });
+
+        try {
+            const deadline = Date.now() + timeout * 1000;
+            let response = '';
+            let stablePolls = 0;
+            while (Date.now() < deadline) {
+                await page.wait(0.5);
+                const result = await page.evaluate(responseAfterPromptScript(text, submission.token));
+                const candidate = result?.text || '';
+                if (result?.phase === 'candidate' && candidate && candidate === response) stablePolls += 1;
+                else stablePolls = 0;
+                response = candidate;
+                if (stablePolls >= 2) {
+                    return [
+                        { Role: 'User', Text: text },
+                        { Role: 'Assistant', Text: response },
+                    ];
+                }
             }
+            throw new CommandExecutionError(
+                `Doubao prompt was sent, but reply completion is unknown after ${timeout}s`,
+                'Run "opencli doubao-app read" before retrying; retrying ask may send the prompt twice.',
+            );
+        } finally {
+            await page.evaluate(cleanupSubmissionScript(submission.token)).catch(() => {});
         }
-        if (!response) {
-            return [
-                { Role: 'User', Text: text },
-                { Role: 'System', Text: `No response received within ${timeout}s.` },
-            ];
-        }
-        return [
-            { Role: 'User', Text: text },
-            { Role: 'Assistant', Text: response },
-        ];
     },
 });

--- a/clis/doubao-app/doubao-app.test.js
+++ b/clis/doubao-app/doubao-app.test.js
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { statusCommand } from './status.js';
+import {
+  cleanupSubmissionScript,
+  clickSendScript,
+  injectTextScript,
+  inspectSurfaceScript,
+  isDoubaoChatUrl,
+  prepareSubmissionScript,
+  readMessagesScript,
+  responseAfterPromptScript,
+  submittedMessageScript,
+} from './utils.js';
+
+function evaluateInDom(html, script, url = 'chrome://doubao-chat/chat/123') {
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url });
+  return dom.window.eval(script);
+}
+
+describe('doubao-app renderer helpers', () => {
+  it('recognizes both current and legacy Doubao chat renderer URLs', () => {
+    expect(isDoubaoChatUrl('chrome://doubao-chat/chat/123')).toBe(true);
+    expect(isDoubaoChatUrl('doubao://doubao-chat/chat')).toBe(true);
+    expect(isDoubaoChatUrl('doubao://doubao-background/')).toBe(false);
+    expect(isDoubaoChatUrl('doubao://doubao-chat/cross-site-support/')).toBe(false);
+  });
+
+  it('finds the nested contenteditable composer on the current renderer', () => {
+    const surface = evaluateInDom(`
+      <div data-testid="chat_input_input"><div contenteditable="true"></div></div>
+      <div data-testid="union_message"></div>
+    `, inspectSurfaceScript());
+
+    expect(surface).toMatchObject({ composerReady: true, messageSurfaceReady: true });
+    expect(surface.url).toBe('chrome://doubao-chat/chat/123');
+  });
+
+  it('injects exact text into the nested contenteditable instead of treating the root as a textarea', () => {
+    const result = evaluateInDom(`
+      <div data-testid="chat_input_input"><div contenteditable="true"></div></div>
+    `, injectTextScript('hello from OpenCLI'));
+
+    expect(result).toEqual({ ok: true, text: 'hello from OpenCLI' });
+  });
+
+  it('keeps the legacy textarea composer compatible', () => {
+    const html = '<textarea data-testid="chat_input_input"></textarea>';
+    expect(evaluateInDom(html, inspectSurfaceScript())).toMatchObject({ composerReady: true });
+    expect(evaluateInDom(html, injectTextScript('legacy message'))).toEqual({
+      ok: true,
+      text: 'legacy message',
+    });
+  });
+
+  it('rejects a disabled send button', () => {
+    const result = evaluateInDom('<button data-testid="chat_input_send_button" disabled></button>', clickSendScript());
+    expect(result).toEqual({ ok: false, error: 'Send button is disabled' });
+  });
+
+  it('reads roles from explicit union-message markers', () => {
+    const messages = evaluateInDom(`
+      <section data-testid="union_message">
+        <div data-testid="send_message"></div>
+        <div data-testid="message_text_content">same prompt</div>
+      </section>
+      <section data-testid="union_message">
+        <div data-testid="receive_message"></div>
+        <div data-testid="message_text_content">current reply</div>
+      </section>
+    `, readMessagesScript());
+
+    expect(messages).toEqual([
+      { role: 'User', text: 'same prompt' },
+      { role: 'Assistant', text: 'current reply' },
+    ]);
+  });
+
+  it('confirms a replacement user-turn identity when a virtualized list keeps the same count', () => {
+    const dom = new JSDOM(`
+      <section data-testid="union_message">
+        <div data-testid="send_message"></div>
+        <div data-testid="message_text_content">repeatable prompt</div>
+      </section>
+    `, { runScripts: 'dangerously', url: 'chrome://doubao-chat/chat/123' });
+    const token = 'virtualized-replacement';
+    dom.window.eval(prepareSubmissionScript(token));
+    dom.window.document.querySelector('[data-testid="union_message"]').remove();
+    dom.window.document.body.insertAdjacentHTML('beforeend', `
+      <section data-testid="union_message">
+        <div data-testid="send_message"></div>
+        <div data-testid="message_text_content">repeatable prompt</div>
+      </section>
+    `);
+
+    expect(dom.window.document.querySelectorAll('[data-testid="union_message"]')).toHaveLength(1);
+    expect(dom.window.eval(submittedMessageScript('repeatable prompt ', token))).toBe(true);
+    expect(dom.window.eval(cleanupSubmissionScript(token))).toBe(true);
+  });
+
+  it('binds a repeated prompt to its new turn and waits for authoritative completion', () => {
+    const dom = new JSDOM(`
+      <section data-testid="union_message">
+        <div data-testid="send_message"></div>
+        <div data-testid="message_text_content">repeatable prompt</div>
+      </section>
+      <section data-testid="union_message">
+        <div data-testid="receive_message"></div>
+        <div data-testid="message_text_content">older reply</div>
+        <div data-testid="message_action_bar"></div>
+      </section>
+    `, { runScripts: 'dangerously', url: 'chrome://doubao-chat/chat/123' });
+    const token = 'repeated-prompt';
+    dom.window.eval(prepareSubmissionScript(token));
+    dom.window.document.body.insertAdjacentHTML('beforeend', `
+      <section data-testid="union_message">
+        <div data-testid="send_message"></div>
+        <div data-testid="message_text_content">repeatable prompt</div>
+      </section>
+      <section data-testid="union_message" id="current-reply">
+        <div data-testid="receive_message"></div>
+        <div data-testid="message_text_content">current reply</div>
+      </section>
+    `);
+
+    expect(dom.window.eval(submittedMessageScript('repeatable prompt', token))).toBe(true);
+    expect(dom.window.eval(responseAfterPromptScript('repeatable prompt', token))).toEqual({
+      phase: 'streaming',
+      text: 'current reply',
+    });
+
+    dom.window.document.querySelector('#current-reply')
+      .insertAdjacentHTML('beforeend', '<div data-testid="message_action_bar"></div>');
+    const stop = dom.window.document.createElement('button');
+    stop.setAttribute('data-testid', 'chat_input_end_button');
+    stop.getBoundingClientRect = () => ({ width: 20, height: 20 });
+    dom.window.document.body.append(stop);
+    expect(dom.window.eval(responseAfterPromptScript('repeatable prompt', token))).toEqual({
+      phase: 'streaming',
+      text: 'current reply',
+    });
+
+    stop.remove();
+    expect(dom.window.eval(responseAfterPromptScript('repeatable prompt', token))).toEqual({
+      phase: 'candidate',
+      text: 'current reply',
+    });
+    expect(dom.window.eval(cleanupSubmissionScript(token))).toBe(true);
+  });
+});
+
+describe('doubao-app status', () => {
+  it('rejects a background renderer even when CDP is connected', async () => {
+    const page = {
+      evaluate: async () => ({
+        url: 'chrome://doubao-background/',
+        title: 'doubao://doubao-background',
+        composerReady: false,
+      }),
+    };
+
+    await expect(statusCommand.func(page, {})).rejects.toBeInstanceOf(CommandExecutionError);
+  });
+
+  it('reports connected only for a ready chat renderer', async () => {
+    const page = {
+      evaluate: async () => ({
+        url: 'chrome://doubao-chat/chat/123',
+        title: '对话主题 - 豆包工作',
+        composerReady: true,
+      }),
+    };
+
+    await expect(statusCommand.func(page, {})).resolves.toEqual([{
+      Status: 'Connected',
+      Url: 'chrome://doubao-chat/chat/123',
+      Title: '对话主题 - 豆包工作',
+    }]);
+  });
+});

--- a/clis/doubao-app/send.js
+++ b/clis/doubao-app/send.js
@@ -1,5 +1,5 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { injectTextScript, clickSendScript } from './utils.js';
+import { sendDoubaoMessage } from './utils.js';
 export const sendCommand = cli({
     site: 'doubao-app',
     name: 'send',
@@ -14,15 +14,7 @@ export const sendCommand = cli({
     columns: ['Status', 'Text'],
     func: async (page, kwargs) => {
         const text = kwargs.text;
-        const injected = await page.evaluate(injectTextScript(text));
-        if (!injected || !injected.ok) {
-            throw new Error('Could not find chat input: ' + (injected?.error || 'unknown'));
-        }
-        await page.wait(0.5);
-        const clicked = await page.evaluate(clickSendScript());
-        if (!clicked)
-            await page.pressKey('Enter');
-        await page.wait(1);
+        await sendDoubaoMessage(page, text);
         return [{ Status: 'Sent', Text: text }];
     },
 });

--- a/clis/doubao-app/status.js
+++ b/clis/doubao-app/status.js
@@ -1,4 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { inspectSurfaceScript, isDoubaoChatUrl } from './utils.js';
 export const statusCommand = cli({
     site: 'doubao-app',
     name: 'status',
@@ -10,8 +12,13 @@ export const statusCommand = cli({
     args: [],
     columns: ['Status', 'Url', 'Title'],
     func: async (page) => {
-        const url = await page.evaluate('window.location.href');
-        const title = await page.evaluate('document.title');
-        return [{ Status: 'Connected', Url: url, Title: title }];
+        const surface = await page.evaluate(inspectSurfaceScript());
+        if (!isDoubaoChatUrl(surface?.url) || !surface?.composerReady) {
+            throw new CommandExecutionError(
+                `Connected to a non-chat Doubao surface: ${surface?.url || 'unknown URL'}`,
+                'Open a Doubao conversation. If OPENCLI_CDP_TARGET is set, remove it or point it at "doubao-chat/chat".',
+            );
+        }
+        return [{ Status: 'Connected', Url: surface.url, Title: surface.title }];
     },
 });

--- a/clis/doubao-app/utils.js
+++ b/clis/doubao-app/utils.js
@@ -1,110 +1,254 @@
-/**
- * Shared constants and helpers for Doubao desktop app (Electron + CDP).
- *
- * Requires: Doubao launched with --remote-debugging-port=9226
- */
-/** Selectors discovered via data-testid attributes */
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+
+/** Shared selectors for current and legacy Doubao desktop renderers. */
 export const SEL = {
-    INPUT: '[data-testid="chat_input_input"]',
-    SEND_BTN: '[data-testid="chat_input_send_button"]',
-    MESSAGE: '[data-testid="message_content"]',
-    MESSAGE_TEXT: '[data-testid="message_text_content"]',
-    INDICATOR: '[data-testid="indicator"]',
-    NEW_CHAT: '[data-testid="new_chat_button"]',
-    NEW_CHAT_SIDEBAR: '[data-testid="app-open-newChat"]',
+  INPUT_ROOT: '[data-testid="chat_input_input"]',
+  INPUT: 'textarea[data-testid="chat_input_input"], input[data-testid="chat_input_input"], [data-testid="chat_input_input"][contenteditable="true"], [data-testid="chat_input_input"] [contenteditable="true"]',
+  SEND_BTN: '[data-testid="chat_input_send_button"]',
+  MESSAGE: '[data-testid="message_content"]',
+  MESSAGE_TEXT: '[data-testid="message_text_content"]',
+  MESSAGE_ROOT: '[data-testid="union_message"]',
+  USER_MESSAGE: '[data-testid="send_message"]',
+  ASSISTANT_MESSAGE: '[data-testid="receive_message"]',
+  MESSAGE_ACTIONS: '[data-testid="message_action_bar"]',
+  INDICATOR: '[data-testid="indicator"]',
+  GENERATING: '[data-testid="chat_input_local_break_button"], [data-testid="chat_input_end_button"]',
+  NEW_CHAT: '[data-testid="new_chat_button"]',
+  NEW_CHAT_SIDEBAR: '[data-testid="app-open-newChat"]',
 };
-/**
- * Inject text into the Doubao chat textarea via React-compatible value setter.
- * Returns an evaluate script string.
- */
+
+export function ensureMessageText(value) {
+  const text = typeof value === 'string' ? value : '';
+  if (!text.trim()) throw new ArgumentError('text must not be empty');
+  if (text.length > 100_000) throw new ArgumentError('text must not exceed 100000 characters');
+  return text;
+}
+
+export function normalizeTimeout(value, fallback = 30) {
+  const timeout = value === undefined || value === null ? fallback : Number(value);
+  if (!Number.isInteger(timeout) || timeout < 1) {
+    throw new ArgumentError('--timeout must be a positive integer (seconds)');
+  }
+  return timeout;
+}
+
+export function isDoubaoChatUrl(url) {
+  return /^(?:chrome|doubao):\/\/doubao-chat\/chat(?:[/?#]|$)/i.test(String(url || ''));
+}
+
+export function inspectSurfaceScript() {
+  return `(function() {
+    return {
+      url: window.location.href,
+      title: document.title,
+      composerReady: Boolean(document.querySelector('${SEL.INPUT}')),
+      messageSurfaceReady: Boolean(document.querySelector('${SEL.MESSAGE_ROOT}, ${SEL.MESSAGE}'))
+    };
+  })()`;
+}
+
+/** Inject text and verify the exact draft in textarea and contenteditable renderers. */
 export function injectTextScript(text) {
-    return `(function(t) {
-    const textarea = document.querySelector('${SEL.INPUT}');
-    if (!textarea) return { ok: false, error: 'No textarea found' };
-    textarea.focus();
-    const setter = Object.getOwnPropertyDescriptor(
-      window.HTMLTextAreaElement.prototype, 'value'
-    )?.set;
-    if (setter) setter.call(textarea, t);
-    else textarea.value = t;
-    textarea.dispatchEvent(new Event('input', { bubbles: true }));
-    textarea.dispatchEvent(new Event('change', { bubbles: true }));
-    return { ok: true };
+  return `(function(t) {
+    const editor = document.querySelector('${SEL.INPUT}');
+    if (!editor) return { ok: false, error: 'Message editor was not found' };
+    editor.focus();
+    const isTextControl = editor instanceof HTMLTextAreaElement || editor instanceof HTMLInputElement;
+    if (isTextControl) {
+      const prototype = editor instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+      if (setter) setter.call(editor, t);
+      else editor.value = t;
+      editor.dispatchEvent(new Event('input', { bubbles: true }));
+      editor.dispatchEvent(new Event('change', { bubbles: true }));
+    } else {
+      let inserted = false;
+      if (typeof document.execCommand === 'function') {
+        document.execCommand('selectAll', false, null);
+        inserted = document.execCommand('insertText', false, t);
+      }
+      if (!inserted) {
+        editor.textContent = t;
+        const event = typeof InputEvent === 'function'
+          ? new InputEvent('input', { bubbles: true, inputType: 'insertText', data: t })
+          : new Event('input', { bubbles: true });
+        editor.dispatchEvent(event);
+      }
+    }
+    const draft = isTextControl
+      ? editor.value
+      : String(editor.innerText ?? editor.textContent ?? '').replace(/\\n$/, '');
+    return draft === t
+      ? { ok: true, text: draft }
+      : { ok: false, error: 'Message editor did not accept the complete text', text: draft };
   })(${JSON.stringify(text)})`;
 }
-/**
- * Click the send button. Returns an evaluate script string.
- */
+
+/** Click the enabled send button. */
 export function clickSendScript() {
-    return `(function() {
-    const btn = document.querySelector('${SEL.SEND_BTN}');
-    if (!btn) return false;
-    btn.click();
-    return true;
-  })()`;
-}
-/**
- * Read all chat messages from the DOM. Returns an evaluate script string.
- */
-export function readMessagesScript() {
-    return `(function() {
-    const results = [];
-    const containers = document.querySelectorAll('${SEL.MESSAGE}');
-    for (const container of containers) {
-      const textEl = container.querySelector('${SEL.MESSAGE_TEXT}');
-      if (!textEl) continue;
-      // Skip streaming messages
-      if (textEl.querySelector('${SEL.INDICATOR}') ||
-          textEl.getAttribute('data-show-indicator') === 'true') continue;
-      const isUser = container.classList.contains('justify-end');
-      let text = '';
-      const children = textEl.querySelectorAll('div[dir]');
-      if (children.length > 0) {
-        text = Array.from(children).map(c => c.innerText || c.textContent || '').join('');
-      } else {
-        text = textEl.innerText?.trim() || textEl.textContent?.trim() || '';
-      }
-      if (!text) continue;
-      results.push({ role: isUser ? 'User' : 'Assistant', text: text.substring(0, 2000) });
+  return `(function() {
+    const button = document.querySelector('${SEL.SEND_BTN}');
+    if (!button) return { ok: false, error: 'Send button was not found' };
+    if (button.disabled || button.getAttribute('aria-disabled') === 'true') {
+      return { ok: false, error: 'Send button is disabled' };
     }
-    return results;
+    button.click();
+    return { ok: true };
   })()`;
 }
-/**
- * Click the new-chat button. Returns an evaluate script string.
- */
+
+/** Read the currently rendered turns, using explicit role markers where available. */
+export function readMessagesScript() {
+  return `(function() {
+    const textOf = (root) => {
+      const parts = Array.from(root.querySelectorAll('${SEL.MESSAGE_TEXT}'))
+        .filter((part) => !part.querySelector('${SEL.INDICATOR}') && part.getAttribute('data-show-indicator') !== 'true')
+        .map((part) => String(part.innerText || part.textContent || '').trim())
+        .filter(Boolean);
+      return parts.join('\\n');
+    };
+    const roots = Array.from(document.querySelectorAll('${SEL.MESSAGE_ROOT}'));
+    if (roots.length > 0) {
+      return roots.map((root) => {
+        const role = root.querySelector('${SEL.USER_MESSAGE}')
+          ? 'User'
+          : root.querySelector('${SEL.ASSISTANT_MESSAGE}') ? 'Assistant' : null;
+        const text = textOf(root);
+        return role && text ? { role, text: text.substring(0, 2000) } : null;
+      }).filter(Boolean);
+    }
+    return Array.from(document.querySelectorAll('${SEL.MESSAGE}')).map((container) => {
+      const role = container.classList.contains('justify-end') ? 'User' : 'Assistant';
+      const text = textOf(container);
+      return text ? { role, text: text.substring(0, 2000) } : null;
+    }).filter(Boolean);
+  })()`;
+}
+
+/** Capture the identity of all currently mounted turns before clicking Send. */
+export function prepareSubmissionScript(token) {
+  return `(function(token) {
+    const roots = Array.from(document.querySelectorAll('${SEL.MESSAGE_ROOT}'));
+    const store = globalThis.__opencliDoubaoSubmissions ||= new Map();
+    store.set(token, { initialRoots: new WeakSet(roots), promptRoot: null });
+    return roots.length;
+  })(${JSON.stringify(token)})`;
+}
+
+/** Confirm a newly mounted user turn and retain its DOM identity for ask. */
+export function submittedMessageScript(text, token) {
+  return `(function(expected, token) {
+    const textOf = (root) => Array.from(root.querySelectorAll('${SEL.MESSAGE_TEXT}'))
+      .map((part) => String(part.innerText || part.textContent || '').trim())
+      .filter(Boolean)
+      .join('\\n');
+    const state = globalThis.__opencliDoubaoSubmissions?.get(token);
+    if (!state) return false;
+    const normalizedExpected = String(expected).trim();
+    const messages = Array.from(document.querySelectorAll('${SEL.MESSAGE_ROOT}'));
+    const candidates = messages.filter((root) =>
+      !state.initialRoots.has(root)
+      && root.querySelector('${SEL.USER_MESSAGE}')
+      && textOf(root) === normalizedExpected
+    );
+    const promptRoot = candidates[candidates.length - 1];
+    if (!promptRoot) return false;
+    state.promptRoot = promptRoot;
+    return true;
+  })(${JSON.stringify(text)}, ${JSON.stringify(token)})`;
+}
+
+export function cleanupSubmissionScript(token) {
+  return `(function(token) {
+    const store = globalThis.__opencliDoubaoSubmissions;
+    if (!store) return false;
+    const deleted = store.delete(token);
+    if (store.size === 0) delete globalThis.__opencliDoubaoSubmissions;
+    return deleted;
+  })(${JSON.stringify(token)})`;
+}
+
+/** Find the completed assistant turn following the confirmed user-turn identity. */
+export function responseAfterPromptScript(text, token) {
+  return `(function(expected, token) {
+    const isVisible = (element) => {
+      if (!element) return false;
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== 'none' && style.visibility !== 'hidden'
+        && Number(style.opacity) !== 0 && rect.width > 0 && rect.height > 0;
+    };
+    const textOf = (root) => Array.from(root.querySelectorAll('${SEL.MESSAGE_TEXT}'))
+      .filter((part) => !part.querySelector('${SEL.INDICATOR}') && part.getAttribute('data-show-indicator') !== 'true')
+      .map((part) => String(part.innerText || part.textContent || '').trim())
+      .filter(Boolean)
+      .join('\\n');
+    const state = globalThis.__opencliDoubaoSubmissions?.get(token);
+    const promptRoot = state?.promptRoot;
+    if (!promptRoot || textOf(promptRoot) !== String(expected).trim()) {
+      return { phase: 'waiting', text: '', reason: 'prompt_not_confirmed' };
+    }
+    const messages = Array.from(document.querySelectorAll('${SEL.MESSAGE_ROOT}'));
+    const promptIndex = messages.indexOf(promptRoot);
+    if (promptIndex < 0) return { phase: 'waiting', text: '', reason: 'prompt_unmounted' };
+    const reply = messages.slice(promptIndex + 1)
+      .find((root) => root.querySelector('${SEL.ASSISTANT_MESSAGE}') && textOf(root));
+    const generating = Array.from(document.querySelectorAll('${SEL.GENERATING}')).some(isVisible);
+    const replyText = reply ? textOf(reply) : '';
+    if (!replyText) return { phase: generating ? 'streaming' : 'waiting', text: '' };
+    const completed = Boolean(reply.querySelector('${SEL.MESSAGE_ACTIONS}'));
+    return { phase: generating || !completed ? 'streaming' : 'candidate', text: replyText };
+  })(${JSON.stringify(text)}, ${JSON.stringify(token)})`;
+}
+
+export async function sendDoubaoMessage(page, value, options = {}) {
+  const text = ensureMessageText(value);
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const token = `opencli-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await page.evaluate(prepareSubmissionScript(token));
+  const injected = await page.evaluate(injectTextScript(text));
+  if (!injected?.ok) {
+    await page.evaluate(cleanupSubmissionScript(token)).catch(() => {});
+    throw new CommandExecutionError(
+      injected?.error || 'Could not fill the Doubao message editor',
+      'Open a Doubao chat and check that its composer is visible.',
+    );
+  }
+  const clicked = await page.evaluate(clickSendScript());
+  if (!clicked?.ok) {
+    await page.evaluate(cleanupSubmissionScript(token)).catch(() => {});
+    throw new CommandExecutionError(
+      clicked?.error || 'Could not submit the Doubao message',
+      'Wait for the current response to finish, then retry.',
+    );
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await page.wait(0.25);
+    if (await page.evaluate(submittedMessageScript(text, token))) {
+      if (!options.retainSubmission) {
+        await page.evaluate(cleanupSubmissionScript(token)).catch(() => {});
+      }
+      return { text, token };
+    }
+  }
+  await page.evaluate(cleanupSubmissionScript(token)).catch(() => {});
+  throw new CommandExecutionError(
+    `Doubao send outcome is unknown after ${Math.ceil(timeoutMs / 1000)}s`,
+    'Check the current conversation before retrying; the message may already have been sent.',
+  );
+}
+
+/** Click the new-chat button. */
 export function clickNewChatScript() {
-    return `(function() {
+  return `(function() {
     let btn = document.querySelector('${SEL.NEW_CHAT}');
     if (btn) { btn.click(); return true; }
     btn = document.querySelector('${SEL.NEW_CHAT_SIDEBAR}');
     if (btn) { btn.click(); return true; }
     return false;
   })()`;
-}
-/**
- * Poll for a new assistant response after sending.
- * Returns evaluate script that checks message count vs baseline.
- */
-export function pollResponseScript(beforeCount) {
-    return `(function(prevCount) {
-    const msgs = document.querySelectorAll('${SEL.MESSAGE}');
-    if (msgs.length <= prevCount) return { phase: 'waiting', text: null };
-    const lastMsg = msgs[msgs.length - 1];
-    if (lastMsg.classList.contains('justify-end')) return { phase: 'waiting', text: null };
-    const textEl = lastMsg.querySelector('${SEL.MESSAGE_TEXT}');
-    if (!textEl) return { phase: 'waiting', text: null };
-    if (textEl.querySelector('${SEL.INDICATOR}') ||
-        textEl.getAttribute('data-show-indicator') === 'true') {
-      return { phase: 'streaming', text: null };
-    }
-    let text = '';
-    const children = textEl.querySelectorAll('div[dir]');
-    if (children.length > 0) {
-      text = Array.from(children).map(c => c.innerText || c.textContent || '').join('');
-    } else {
-      text = textEl.innerText?.trim() || textEl.textContent?.trim() || '';
-    }
-    return { phase: 'done', text };
-  })(${beforeCount})`;
 }

--- a/docs/adapters/desktop/doubao-app.md
+++ b/docs/adapters/desktop/doubao-app.md
@@ -13,6 +13,8 @@ Control the **Doubao AI Desktop App** via Chrome DevTools Protocol (CDP).
    export OPENCLI_CDP_ENDPOINT="http://127.0.0.1:9225"
    ```
 
+OpenCLI automatically selects the `doubao-chat/chat` renderer when Doubao exposes multiple CDP targets. `OPENCLI_CDP_TARGET` is only needed to override that default for diagnostics.
+
 ## Commands
 
 | Command | Description |
@@ -20,7 +22,7 @@ Control the **Doubao AI Desktop App** via Chrome DevTools Protocol (CDP).
 | `opencli doubao-app status` | Check CDP connection status |
 | `opencli doubao-app new` | Start a new conversation |
 | `opencli doubao-app send "message"` | Send a message to the current chat |
-| `opencli doubao-app read` | Read the latest assistant reply |
+| `opencli doubao-app read` | Read the currently rendered conversation turns |
 | `opencli doubao-app ask "message"` | Send a prompt and wait for the reply |
 | `opencli doubao-app screenshot` | Capture a screenshot of the app window |
 | `opencli doubao-app dump` | Export DOM and snapshot debug info |
@@ -29,7 +31,12 @@ Control the **Doubao AI Desktop App** via Chrome DevTools Protocol (CDP).
 
 Connects to the Doubao Electron app via CDP, injecting JavaScript into the renderer process to control the chat UI — sending messages, reading replies, and capturing screenshots.
 
+`send` confirms that the new user turn appeared. `ask` then follows the reply after that exact prompt and waits for the text to stabilize, so long chats with a virtualized message list do not depend on the total DOM message count increasing.
+
+If submission or reply completion cannot be confirmed, inspect the conversation with `read` before retrying. The prompt may already have been sent.
+
 ## Limitations
 
 - Requires Doubao Desktop to be launched with `--remote-debugging-port`
 - macOS / Linux / Windows (Electron-based, platform independent)
+- `read` returns only turns currently mounted by Doubao's virtualized renderer

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -78,6 +78,73 @@ describe('browser helpers', () => {
     expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9226/codex');
   });
 
+  it('uses an app target filter when Electron exposes background and chat pages', () => {
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'doubao://doubao-background',
+        url: 'doubao://doubao-background/',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/background',
+      },
+      {
+        type: 'other',
+        title: 'doubao://doubao-chat/cross-site-support/',
+        url: 'doubao://doubao-chat/cross-site-support/',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/cross-site-support',
+      },
+      {
+        type: 'page',
+        title: '对话主题 - 豆包工作',
+        url: 'doubao://doubao-chat/chat/38439138239851266',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/chat',
+      },
+    ], 'doubao-chat/chat');
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9225/chat');
+  });
+
+  it('lets OPENCLI_CDP_TARGET override an app target filter', () => {
+    vi.stubEnv('OPENCLI_CDP_TARGET', 'doubao-background');
+
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'doubao://doubao-background',
+        url: 'doubao://doubao-background/',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/background',
+      },
+      {
+        type: 'page',
+        title: '对话主题 - 豆包工作',
+        url: 'doubao://doubao-chat/chat/38439138239851266',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/chat',
+      },
+    ], 'doubao-chat/chat');
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9225/background');
+  });
+
+  it('ignores a blank OPENCLI_CDP_TARGET and keeps the app target filter', () => {
+    vi.stubEnv('OPENCLI_CDP_TARGET', '   ');
+
+    const target = cdpTest.selectCDPTarget([
+      {
+        type: 'page',
+        title: 'doubao://doubao-background',
+        url: 'doubao://doubao-background/',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/background',
+      },
+      {
+        type: 'page',
+        title: '对话主题 - 豆包工作',
+        url: 'doubao://doubao-chat/chat',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9225/chat',
+      },
+    ], 'doubao-chat/chat');
+
+    expect(target?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9225/chat');
+  });
+
   it('prefers the main Electron window over a routed auxiliary window on the same document', () => {
     const target = cdpTest.selectCDPTarget([
       {

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -54,7 +54,7 @@ export class CDPBridge implements IBrowserFactory {
   private _pending = new Map<number, { resolve: (val: unknown) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }>();
   private _eventListeners = new Map<string, Set<(params: unknown) => void>>();
 
-  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage> {
+  async connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; cdpTargetFilter?: string; contextId?: string; idleTimeout?: number; windowMode?: 'foreground' | 'background'; surface?: 'browser' | 'adapter'; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage> {
     if (this._ws) throw new Error('CDPBridge is already connected. Call close() before reconnecting.');
 
     const endpoint = opts?.cdpEndpoint ?? process.env.OPENCLI_CDP_ENDPOINT;
@@ -63,7 +63,7 @@ export class CDPBridge implements IBrowserFactory {
     let wsUrl = endpoint;
     if (endpoint.startsWith('http')) {
       const targets = await fetchJsonDirect(`${endpoint.replace(/\/$/, '')}/json`) as CDPTarget[];
-      const target = selectCDPTarget(targets);
+      const target = selectCDPTarget(targets, opts?.cdpTargetFilter);
       if (!target || !target.webSocketDebuggerUrl) {
         throw new Error('No inspectable targets found at CDP endpoint');
       }
@@ -476,8 +476,9 @@ function matchesCookieDomain(cookieDomain: string, targetDomain: string): boolea
     || normalizedTargetDomain.endsWith(`.${normalizedCookieDomain}`);
 }
 
-function selectCDPTarget(targets: CDPTarget[]): CDPTarget | undefined {
-  const preferredPattern = compilePreferredPattern(process.env.OPENCLI_CDP_TARGET);
+function selectCDPTarget(targets: CDPTarget[], appTargetFilter?: string): CDPTarget | undefined {
+  const envTarget = process.env.OPENCLI_CDP_TARGET?.trim();
+  const preferredPattern = compilePreferredPattern(envTarget || appTargetFilter);
 
   const candidates = targets
     .map((target, index) => ({ target, index, score: scoreCDPTarget(target, preferredPattern) }))

--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -16,6 +16,10 @@ describe('electron-apps registry', () => {
     expect(app!.executableNames).toEqual(['ChatGPT', 'Codex']);
   });
 
+  it('prefers the Doubao chat renderer CDP target', () => {
+    expect(getElectronApp('doubao-app')?.targetFilter).toBe('doubao-chat/chat');
+  });
+
   it('keeps builtin Electron app CDP ports unique and off the browser-bridge port', () => {
     const ports = Object.values(builtinApps).map((app) => app.port);
 

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -23,6 +23,8 @@ export interface ElectronAppEntry {
   displayName?: string;
   /** Additional launch args beyond --remote-debugging-port */
   extraArgs?: string[];
+  /** Preferred CDP target title/URL substring when the app exposes multiple surfaces */
+  targetFilter?: string;
 }
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
@@ -36,7 +38,13 @@ export const builtinApps: Record<string, ElectronAppEntry> = {
   },
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
-  'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },
+  'doubao-app':  {
+    port: 9225,
+    processName: 'Doubao',
+    bundleId: 'com.volcengine.doubao',
+    displayName: 'Doubao',
+    targetFilter: 'doubao-chat/chat',
+  },
   antigravity:   {
     port: 9234,
     processName: 'Antigravity',

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -190,6 +190,32 @@ describe('executeCommand — non-browser timeout', () => {
     vi.restoreAllMocks();
   });
 
+  it('passes a registered Electron app target filter to the browser session', async () => {
+    const closeWindow = vi.fn().mockResolvedValue(undefined);
+    const mockPage = { closeWindow } as any;
+    const launcher = await import('./launcher.js');
+    vi.spyOn(launcher, 'resolveElectronEndpoint').mockResolvedValue('http://127.0.0.1:9225');
+    vi.spyOn(capRouting, 'shouldUseBrowserSession').mockReturnValue(true);
+    const sessionSpy = vi.spyOn(runtime, 'browserSession').mockImplementation(async (_Factory, fn) => fn(mockPage));
+
+    const cmd = cli({
+      site: 'doubao-app',
+      name: 'target-filter-test', access: 'read',
+      description: 'test Electron target filter routing',
+      browser: true,
+      strategy: Strategy.UI,
+      func: async () => [{ ok: true }],
+    });
+
+    await executeCommand(cmd, {});
+
+    expect(launcher.resolveElectronEndpoint).toHaveBeenCalledWith('doubao-app');
+    expect(sessionSpy.mock.calls[0]?.[2]).toMatchObject({
+      cdpEndpoint: 'http://127.0.0.1:9225',
+      cdpTargetFilter: 'doubao-chat/chat',
+    });
+  });
+
   it('reuses a persistent site browser session and keeps the tab lease open', async () => {
     const closeWindow = vi.fn().mockResolvedValue(undefined);
     const mockPage = { closeWindow } as any;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -33,7 +33,7 @@ import { profileRouteParams, resolveProfileSelection } from './browser/profile.j
 import { clearDaemonRunContext, generateRunId, isUnknownOutcomeError, releaseSiteSessionLease, setDaemonCommandTimeoutSeconds, setDaemonRunContext } from './browser/daemon-client.js';
 import { emitHook, type HookContext } from './hooks.js';
 import { log } from './logger.js';
-import { isElectronApp } from './electron-apps.js';
+import { getElectronApp, isElectronApp } from './electron-apps.js';
 import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
@@ -246,8 +246,10 @@ export async function executeCommand(
     if (siteSession !== null) {
       const electron = isElectronApp(cmd.site);
       let cdpEndpoint: string | undefined;
+      let cdpTargetFilter: string | undefined;
 
       if (electron) {
+        cdpTargetFilter = getElectronApp(cmd.site)?.targetFilter;
         // Electron apps: respect manual endpoint override, then try auto-detect
         const manualEndpoint = process.env.OPENCLI_CDP_ENDPOINT;
         if (manualEndpoint) {
@@ -420,7 +422,7 @@ export async function executeCommand(
           if (!keepTab) await page.closeWindow?.().catch(() => {});
           throw err;
         }
-      }, { session, cdpEndpoint, ...profileRouting, windowMode, surface: 'adapter', siteSession });
+      }, { session, cdpEndpoint, cdpTargetFilter, ...profileRouting, windowMode, surface: 'adapter', siteSession });
       } catch (err) {
         browserRunError = err;
         throw err;

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { browserSession, type IBrowserFactory } from './runtime.js';
+import type { IPage } from './types.js';
+
+describe('browserSession', () => {
+  it('forwards the app CDP target filter to the browser factory', async () => {
+    let connectOptions: Parameters<IBrowserFactory['connect']>[0];
+    class TestBrowser implements IBrowserFactory {
+      async connect(options?: Parameters<IBrowserFactory['connect']>[0]) {
+        connectOptions = options;
+        return {} as IPage;
+      }
+
+      async close() {}
+    }
+
+    await browserSession(TestBrowser, async () => true, {
+      cdpEndpoint: 'http://127.0.0.1:9225',
+      cdpTargetFilter: 'doubao-chat/chat',
+    });
+
+    expect(connectOptions).toMatchObject({
+      cdpEndpoint: 'http://127.0.0.1:9225',
+      cdpTargetFilter: 'doubao-chat/chat',
+    });
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -54,14 +54,14 @@ export function withTimeoutMs<T>(
 
 /** Interface for browser factory (BrowserBridge or test mocks) */
 export interface IBrowserFactory {
-  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
+  connect(opts?: { timeout?: number; session?: string; cdpEndpoint?: string; cdpTargetFilter?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' }): Promise<IPage>;
   close(): Promise<void>;
 }
 
 export async function browserSession<T>(
   BrowserFactory: new () => IBrowserFactory,
   fn: (page: IPage) => Promise<T>,
-  opts: { session?: string; cdpEndpoint?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
+  opts: { session?: string; cdpEndpoint?: string; cdpTargetFilter?: string; contextId?: string; preferredContextId?: string; idleTimeout?: number; windowMode?: BrowserWindowMode; surface?: BrowserSurface; siteSession?: 'ephemeral' | 'persistent' } = {},
 ): Promise<T> {
   const browser = new BrowserFactory();
   try {
@@ -69,6 +69,7 @@ export async function browserSession<T>(
       timeout: DEFAULT_BROWSER_CONNECT_TIMEOUT,
       session: opts.session,
       cdpEndpoint: opts.cdpEndpoint,
+      cdpTargetFilter: opts.cdpTargetFilter,
       contextId: opts.contextId,
       preferredContextId: opts.preferredContextId,
       idleTimeout: opts.idleTimeout,


### PR DESCRIPTION
## Description

Fix the Doubao desktop adapter against Doubao 2.27.6 and current CDP target payloads. This is a regression follow-up to #674: the background renderer is now exposed as `type: page`, so filtering only `background_page` no longer selects the chat surface reliably.

- add an app-level CDP target preference for `doubao-chat/chat`, while preserving explicit `OPENCLI_CDP_TARGET` overrides
- make `status` reject background and auxiliary renderers instead of reporting a false connection
- support the current nested contenteditable composer while retaining the legacy textarea path
- confirm a newly submitted user turn by DOM identity rather than total mounted-message count
- bind `ask` to that exact user turn and wait for the assistant action bar with no active generation control
- report unknown submission/reply outcomes as non-retryable errors to avoid duplicate prompts
- document current virtual-list and retry behavior

Related issue: #634

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [x] Updated the existing doc page under `docs/adapters/desktop/`
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`
- [x] No command-discovery or argument-shape changes require index/sidebar/README updates

## Verification

- `npm run typecheck`
- `npm test` — 630 files passed; 7302 tests passed, 1 skipped
- `opencli validate` — 1366 commands checked, 0 errors
- focused target-selection, renderer, legacy textarea, repeated-prompt, virtualization, and runtime-plumbing tests

Real E2E on Doubao Desktop 2.27.6, CDP port 9225, with no `OPENCLI_CDP_TARGET`:

```console
$ opencli doubao-app ask '这是 OpenCLI PR1 最终代码的端到端测试。请只回复：OPENCLI_PR1_FINAL_OK' --timeout 120 -f json
[
  { "Role": "User", "Text": "这是 OpenCLI PR1 最终代码的端到端测试。请只回复：OPENCLI_PR1_FINAL_OK" },
  { "Role": "Assistant", "Text": "OPENCLI_PR1_FINAL_OK" }
]
```
