### PR TITLE
fix(windows): make path handling and tests portable

### DIFF
--- a/clis/instagram/download.test.js
+++ b/clis/instagram/download.test.js
@@ -253,8 +253,8 @@ describe('instagram download command', () => {
         });
         expect(result).toBeNull();
         expect(page.goto.mock.calls[0]?.[0]).toBe('https://www.instagram.com/p/DWUR_azCWbN/');
-        expect(mockHttpDownload).toHaveBeenNthCalledWith(1, 'https://cdn.example.com/photo.webp?foo=1', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_01.webp'), expect.objectContaining({ timeout: 60000 }));
-        expect(mockHttpDownload).toHaveBeenNthCalledWith(2, 'https://cdn.example.com/video.mp4?bar=2', expect.stringContaining('instagram-test/DWUR_azCWbN/DWUR_azCWbN_02.mp4'), expect.objectContaining({ timeout: 120000 }));
+        expect(mockHttpDownload).toHaveBeenNthCalledWith(1, 'https://cdn.example.com/photo.webp?foo=1', expect.stringContaining(path.join('instagram-test', 'DWUR_azCWbN', 'DWUR_azCWbN_01.webp')), expect.objectContaining({ timeout: 60000 }));
+        expect(mockHttpDownload).toHaveBeenNthCalledWith(2, 'https://cdn.example.com/video.mp4?bar=2', expect.stringContaining(path.join('instagram-test', 'DWUR_azCWbN', 'DWUR_azCWbN_02.mp4')), expect.objectContaining({ timeout: 120000 }));
         const savedDir = path.join(path.resolve('instagram-test'), 'DWUR_azCWbN');
         const displayed = savedDir.startsWith(os.homedir()) ? `~${savedDir.slice(os.homedir().length)}` : savedDir;
         expect(logSpy).toHaveBeenCalledWith(`📁 saved: ${displayed}`);
@@ -269,6 +269,6 @@ describe('instagram download command', () => {
             ],
         });
         await cmd.func(page, { url: 'https://www.instagram.com/p/DWUR_azCWbN/', path: '~/Downloads/Instagram' });
-        expect(mockHttpDownload).toHaveBeenCalledWith('https://cdn.example.com/photo.webp?foo=1', expect.stringContaining(`${os.homedir()}/Downloads/Instagram/DWUR_azCWbN/DWUR_azCWbN_01.webp`), expect.objectContaining({ timeout: 60000 }));
+        expect(mockHttpDownload).toHaveBeenCalledWith('https://cdn.example.com/photo.webp?foo=1', expect.stringContaining(path.join(os.homedir(), 'Downloads', 'Instagram', 'DWUR_azCWbN', 'DWUR_azCWbN_01.webp')), expect.objectContaining({ timeout: 60000 }));
     });
 });

--- a/clis/instagram/reel.test.js
+++ b/clis/instagram/reel.test.js
@@ -9,7 +9,7 @@ const tempDirs = [];
 function createTempVideo(name = 'demo.mp4', bytes = Buffer.from('video')) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-instagram-reel-'));
     tempDirs.push(dir);
-    const filePath = path.join(dir, name);
+    const filePath = path.join(dir, process.platform === 'win32' ? name.replaceAll('?', '_') : name);
     fs.writeFileSync(filePath, bytes);
     return filePath;
 }

--- a/clis/suno/utils.js
+++ b/clis/suno/utils.js
@@ -16,6 +16,7 @@
  *   - device-id: <uuid> (persistent per browser, found in `suno_device_id` cookie)
  */
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
 
@@ -49,9 +50,10 @@ export function parseFormats(value) {
 
 export function resolveSunoOutputDir(value) {
     const raw = String(value || '').trim();
-    if (!raw) return path.join(process.env.HOME || '~', 'Music', 'suno');
-    if (raw === '~') return process.env.HOME || '~';
-    if (raw.startsWith('~/')) return path.join(process.env.HOME || '~', raw.slice(2));
+    const home = os.homedir();
+    if (!raw) return path.join(home, 'Music', 'suno');
+    if (raw === '~') return home;
+    if (raw.startsWith('~/')) return path.join(home, raw.slice(2));
     return path.resolve(raw);
 }
 

--- a/clis/suno/utils.test.js
+++ b/clis/suno/utils.test.js
@@ -63,7 +63,7 @@ describe('suno utils — resolveSunoOutputDir', () => {
     });
 
     it('absolute paths are returned as-is (resolved)', () => {
-        expect(resolveSunoOutputDir('/tmp/suno')).toBe('/tmp/suno');
+        expect(resolveSunoOutputDir('/tmp/suno')).toBe(path.resolve('/tmp/suno'));
     });
 });
 

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { __test__ } from './bookmarks.js';
@@ -258,8 +260,8 @@ function bookmarksPayload(withBottomCursor = false) {
 describe('twitter bookmarks command', () => {
     it('keeps resume state and reports complete=false when --max-pages stops early', async () => {
         const command = getRegistry().get('twitter/bookmarks');
-        const resumeFile = `/tmp/opencli-bookmarks-resume-${process.pid}-${Date.now()}.json`;
-        const outputFile = `/tmp/opencli-bookmarks-out-${process.pid}-${Date.now()}.jsonl`;
+        const resumeFile = path.join(os.tmpdir(), `opencli-bookmarks-resume-${process.pid}-${Date.now()}.json`);
+        const outputFile = path.join(os.tmpdir(), `opencli-bookmarks-out-${process.pid}-${Date.now()}.jsonl`);
         const page = {
             getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
             evaluate: vi.fn(async (script) => {
@@ -306,8 +308,8 @@ describe('twitter bookmarks command', () => {
 
     it('removes resume file only after the bookmarks timeline is exhausted', async () => {
         const command = getRegistry().get('twitter/bookmarks');
-        const resumeFile = `/tmp/opencli-bookmarks-resume-done-${process.pid}-${Date.now()}.json`;
-        const outputFile = `/tmp/opencli-bookmarks-out-done-${process.pid}-${Date.now()}.jsonl`;
+        const resumeFile = path.join(os.tmpdir(), `opencli-bookmarks-resume-done-${process.pid}-${Date.now()}.json`);
+        const outputFile = path.join(os.tmpdir(), `opencli-bookmarks-out-done-${process.pid}-${Date.now()}.jsonl`);
         const page = {
             getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
             evaluate: vi.fn(async (script) => {

--- a/clis/twitter/likes.test.js
+++ b/clis/twitter/likes.test.js
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, EmptyResultError } from '@jackwener/opencli/errors';
@@ -355,8 +357,8 @@ describe('twitter likes command', () => {
 
     it('keeps resume state and reports complete=false when --max-pages stops early', async () => {
         const command = getRegistry().get('twitter/likes');
-        const resumeFile = `/tmp/opencli-likes-resume-${process.pid}-${Date.now()}.json`;
-        const outputFile = `/tmp/opencli-likes-out-${process.pid}-${Date.now()}.jsonl`;
+        const resumeFile = path.join(os.tmpdir(), `opencli-likes-resume-${process.pid}-${Date.now()}.json`);
+        const outputFile = path.join(os.tmpdir(), `opencli-likes-out-${process.pid}-${Date.now()}.jsonl`);
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),
@@ -425,8 +427,8 @@ describe('twitter likes command', () => {
 
     it('removes resume file only after the likes timeline is exhausted', async () => {
         const command = getRegistry().get('twitter/likes');
-        const resumeFile = `/tmp/opencli-likes-resume-done-${process.pid}-${Date.now()}.json`;
-        const outputFile = `/tmp/opencli-likes-out-done-${process.pid}-${Date.now()}.jsonl`;
+        const resumeFile = path.join(os.tmpdir(), `opencli-likes-resume-done-${process.pid}-${Date.now()}.json`);
+        const outputFile = path.join(os.tmpdir(), `opencli-likes-out-done-${process.pid}-${Date.now()}.jsonl`);
         const page = {
             goto: vi.fn().mockResolvedValue(undefined),
             wait: vi.fn().mockResolvedValue(undefined),

--- a/clis/twitter/quote.test.js
+++ b/clis/twitter/quote.test.js
@@ -127,7 +127,7 @@ describe('twitter quote command', () => {
         expect(fetchMock).toHaveBeenCalledWith('https://example.com/banner');
         expect(setFileInput).toHaveBeenCalledTimes(1);
         const uploadedPath = setFileInput.mock.calls[0][0][0];
-        expect(uploadedPath).toMatch(/opencli-twitter-.*\/image\.png$/);
+        expect(uploadedPath.replaceAll(path.sep, '/')).toMatch(/opencli-twitter-.*\/image\.png$/);
         // Per-call tmp dir is removed in the adapter's finally block.
         expect(fs.existsSync(uploadedPath)).toBe(false);
         expect(result).toEqual([

--- a/clis/twitter/reply.test.js
+++ b/clis/twitter/reply.test.js
@@ -134,7 +134,7 @@ describe('twitter reply command', () => {
         const uploadedPath = setFileInput.mock.calls[0][0][0];
         // Tmp dir is created by utils.downloadRemoteImage with the
         // 'opencli-twitter-' prefix; final extension comes from Content-Type.
-        expect(uploadedPath).toMatch(/opencli-twitter-.*\/image\.png$/);
+        expect(uploadedPath.replaceAll(path.sep, '/')).toMatch(/opencli-twitter-.*\/image\.png$/);
         // Per-call tmp dir is removed in the adapter's finally block, so the
         // downloaded file no longer exists once the command returns.
         expect(fs.existsSync(uploadedPath)).toBe(false);

--- a/clis/xiaoyuzhou/auth.test.js
+++ b/clis/xiaoyuzhou/auth.test.js
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockExistsSync, mockReadFileSync, mockMkdirSync, mockWriteFileSync, mockHomedir } = vi.hoisted(() => ({
@@ -68,8 +69,9 @@ describe('xiaoyuzhou auth helpers', () => {
         expect(refreshed.access_token).toBe('new-access');
         expect(refreshed.refresh_token).toBe('new-refresh');
         expect(refreshed.expires_at).toBe(Date.now() + XIAOYUZHOU_TOKEN_TTL_MS);
-        expect(mockMkdirSync).toHaveBeenCalledWith('/Users/tester/.opencli', { recursive: true });
-        expect(mockWriteFileSync).toHaveBeenCalledWith('/Users/tester/.opencli/xiaoyuzhou.json', expect.stringContaining('"access_token": "new-access"'), 'utf-8');
+        const credentialFile = getXiaoyuzhouCredentialFile();
+        expect(mockMkdirSync).toHaveBeenCalledWith(path.dirname(credentialFile), { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(credentialFile, expect.stringContaining('"access_token": "new-access"'), 'utf-8');
     });
 
     it('retries once on 401 using refreshed credentials', async () => {

--- a/clis/xiaoyuzhou/download.test.js
+++ b/clis/xiaoyuzhou/download.test.js
@@ -79,7 +79,7 @@ describe('xiaoyuzhou download', () => {
         });
         expect(toPosixPath(mockMkdirSync.mock.calls[0][0])).toBe('/tmp/xiaoyuzhou-test/ep123');
         expect(mockMkdirSync.mock.calls[0][1]).toEqual({ recursive: true });
-        expect(mockHttpDownload).toHaveBeenCalledWith('https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc', expect.stringContaining('/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3'), {
+        expect(mockHttpDownload).toHaveBeenCalledWith('https://media.xyzcdn.net/audio/hello-world.mp3?sign=abc', expect.stringContaining(path.join('/tmp/xiaoyuzhou-test', 'ep123', 'ep123_Hello_World.mp3')), {
             timeout: 60000,
         });
         expect(result).toEqual([{
@@ -87,7 +87,7 @@ describe('xiaoyuzhou download', () => {
                 podcast: 'OpenCLI FM',
                 status: 'success',
                 size: '1234 B',
-                file: '/tmp/xiaoyuzhou-test/ep123/ep123_Hello_World.mp3',
+                file: path.join('/tmp/xiaoyuzhou-test', 'ep123', 'ep123_Hello_World.mp3'),
             }]);
     });
 
@@ -112,7 +112,7 @@ describe('xiaoyuzhou download', () => {
         });
 
         expect(mockHttpDownload.mock.calls[0][1]).toContain('ep456_Lossless_Episode.m4a');
-        expect(result[0].file).toBe('/tmp/xiaoyuzhou-test/ep456/ep456_Lossless_Episode.m4a');
+        expect(result[0].file).toBe(path.join('/tmp/xiaoyuzhou-test', 'ep456', 'ep456_Lossless_Episode.m4a'));
     });
 
     it('throws when media.source.url is missing', async () => {

--- a/clis/xiaoyuzhou/transcript.test.js
+++ b/clis/xiaoyuzhou/transcript.test.js
@@ -82,16 +82,16 @@ describe('xiaoyuzhou transcript', () => {
             body: { eid: 'ep123', mediaId: 'media-123' },
             credentials: { access_token: 'access-1', refresh_token: 'refresh-1' },
         });
-        expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep123', { recursive: true });
-        expect(mockWriteFileSync).toHaveBeenNthCalledWith(1, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json', expect.any(String), 'utf-8');
-        expect(mockWriteFileSync).toHaveBeenNthCalledWith(2, '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt', 'hello\nworld', 'utf-8');
+        expect(mockMkdirSync).toHaveBeenCalledWith(path.join('/tmp/xiaoyuzhou-transcripts', 'ep123'), { recursive: true });
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(1, path.join('/tmp/xiaoyuzhou-transcripts', 'ep123', 'transcript.json'), expect.any(String), 'utf-8');
+        expect(mockWriteFileSync).toHaveBeenNthCalledWith(2, path.join('/tmp/xiaoyuzhou-transcripts', 'ep123', 'transcript.txt'), 'hello\nworld', 'utf-8');
         expect(result).toEqual([{
                 title: 'Transcript Episode',
                 podcast: 'OpenCLI FM',
                 status: 'success',
                 segments: '2',
-                json_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.json',
-                text_file: '/tmp/xiaoyuzhou-transcripts/ep123/transcript.txt',
+                json_file: path.join('/tmp/xiaoyuzhou-transcripts', 'ep123', 'transcript.json'),
+                text_file: path.join('/tmp/xiaoyuzhou-transcripts', 'ep123', 'transcript.txt'),
             }]);
     });
 
@@ -120,7 +120,7 @@ describe('xiaoyuzhou transcript', () => {
         });
         expect(mockRequestJson.mock.calls[1][1].body.mediaId).toBe('media-456');
         expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-        expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/xiaoyuzhou-transcripts/ep456/transcript.txt', 'hello', 'utf-8');
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.join('/tmp/xiaoyuzhou-transcripts', 'ep456', 'transcript.txt'), 'hello', 'utf-8');
     });
 
     it('throws when transcript url is missing', async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -1159,6 +1159,9 @@ describe('profile list', () => {
 describe('browser tab targeting commands', () => {
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  const originalCacheDir = process.env.OPENCLI_CACHE_DIR;
+  const originalConfigDir = process.env.OPENCLI_CONFIG_DIR;
+  const originalProfile = process.env.OPENCLI_PROFILE;
 
   function getBrowserStateFile(cacheDir: string, session: string = 'test'): string {
     return path.join(cacheDir, 'browser-state', `${session}.json`);
@@ -1166,7 +1169,10 @@ describe('browser tab targeting commands', () => {
 
   beforeEach(() => {
     process.exitCode = undefined;
-    process.env.OPENCLI_CACHE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tab-state-'));
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-browser-tab-state-'));
+    process.env.OPENCLI_CACHE_DIR = cacheDir;
+    process.env.OPENCLI_CONFIG_DIR = path.join(cacheDir, 'config');
+    delete process.env.OPENCLI_PROFILE;
     consoleLogSpy.mockClear();
     stderrSpy.mockClear();
     mockBrowserConnect.mockClear();
@@ -1215,6 +1221,15 @@ describe('browser tab targeting commands', () => {
       }),
       session: 'test',
     } as unknown as IPage;
+  });
+
+  afterEach(() => {
+    if (originalCacheDir === undefined) delete process.env.OPENCLI_CACHE_DIR;
+    else process.env.OPENCLI_CACHE_DIR = originalCacheDir;
+    if (originalConfigDir === undefined) delete process.env.OPENCLI_CONFIG_DIR;
+    else process.env.OPENCLI_CONFIG_DIR = originalConfigDir;
+    if (originalProfile === undefined) delete process.env.OPENCLI_PROFILE;
+    else process.env.OPENCLI_PROFILE = originalProfile;
   });
 
   function lastJsonLog(): any {


### PR DESCRIPTION
## Description

Fix Windows portability failures in path handling and test isolation.

- Resolve Suno output directories with `os.homedir()` instead of relying on `HOME`.
- Use platform-native paths and temporary directories in adapter tests, including Windows-safe fixture filenames.
- Isolate browser tab-targeting tests from the user's OpenCLI config/profile and restore environment variables after each test.

Related issue: N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

N/A — no adapter command or documentation surface changed.

## Screenshots / Output

Windows verification:

- `node_modules/.bin/tsc.cmd --noEmit` — passed
- `node_modules/.bin/vitest.cmd run --project unit --project extension --project adapter` — 631 files passed; 7,303 tests passed; 14 skipped; 0 failed
- Baseline `main` run before the fix — 7,282 passed; 21 failed; 14 skipped