### PR TITLE
fix(twitter): stop bookmarks/likes archives failing on X's terminal repeated cursor

### DIFF
--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -73,6 +73,7 @@ export function extractBookmarkTweet(result, seen) {
 export function parseBookmarks(data, seen) {
     const tweets = [];
     let nextCursor = null;
+    let entryCount = 0;
     const instructions = data?.data?.bookmark_timeline_v2?.timeline?.instructions
         || data?.data?.bookmark_timeline?.timeline?.instructions
         || [];
@@ -88,19 +89,25 @@ export function parseBookmarks(data, seen) {
                 nextCursor = content?.value || content?.itemContent?.value || nextCursor;
                 continue;
             }
-            const direct = extractBookmarkTweet(content?.itemContent?.tweet_results?.result, seen);
+            const directResult = content?.itemContent?.tweet_results?.result;
+            if (directResult)
+                entryCount += 1;
+            const direct = extractBookmarkTweet(directResult, seen);
             if (direct) {
                 tweets.push(direct);
                 continue;
             }
             for (const item of content?.items || []) {
-                const nested = extractBookmarkTweet(item.item?.itemContent?.tweet_results?.result, seen);
+                const nestedResult = item.item?.itemContent?.tweet_results?.result;
+                if (nestedResult)
+                    entryCount += 1;
+                const nested = extractBookmarkTweet(nestedResult, seen);
                 if (nested)
                     tweets.push(nested);
             }
         }
     }
-    return { tweets, nextCursor };
+    return { tweets, nextCursor, entryCount };
 }
 function readResumeFile(filePath, expected = null) {
     if (!filePath || !fs.existsSync(filePath))
@@ -255,7 +262,7 @@ cli({
             if (!hasInstructions) {
                 throw new CommandExecutionError('twitter_bookmarks_protocol_error: missing Bookmarks timeline instructions');
             }
-            const { tweets, nextCursor } = parseBookmarks(data, seen);
+            const { tweets, nextCursor, entryCount } = parseBookmarks(data, seen);
             if (useOutputFile) {
                 appendJsonlRows(outputFile, tweets);
                 outputCount += tweets.length;
@@ -278,6 +285,14 @@ cli({
                 break;
             }
             if (nextCursor === cursor) {
+                // X keeps returning the same bottom cursor on the final page rather than
+                // dropping it, so a repeat that carries no timeline items means the
+                // archive is exhausted. A repeat that still carries items is a real
+                // stall and must keep failing loudly so resume state survives.
+                if (entryCount === 0) {
+                    exhausted = true;
+                    break;
+                }
                 throw new CommandExecutionError('twitter_bookmarks_repeated_cursor: archive completion cannot be proven; resume state was retained');
             }
             cursor = nextCursor;

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -203,7 +203,7 @@ describe('twitter bookmarks parser', () => {
     });
 
     it('returns empty tweets + null cursor for unknown envelope', () => {
-        expect(parseBookmarks({}, new Set())).toEqual({ tweets: [], nextCursor: null });
+        expect(parseBookmarks({}, new Set())).toEqual({ tweets: [], nextCursor: null, entryCount: 0 });
     });
 });
 
@@ -249,6 +249,27 @@ function bookmarksPayload(withBottomCursor = false) {
             bookmark_timeline_v2: {
                 timeline: {
                     instructions: [{ entries }],
+                },
+            },
+        },
+    };
+}
+
+function bookmarksTerminalPayload(cursorValue = 'NEXT_CURSOR') {
+    return {
+        data: {
+            bookmark_timeline_v2: {
+                timeline: {
+                    instructions: [{
+                        entries: [{
+                            entryId: `cursor-bottom-${cursorValue}`,
+                            content: {
+                                entryType: 'TimelineTimelineCursor',
+                                cursorType: 'Bottom',
+                                value: cursorValue,
+                            },
+                        }],
+                    }],
                 },
             },
         },
@@ -336,6 +357,76 @@ describe('twitter bookmarks command', () => {
             expect(result.cursor).toBeUndefined();
             expect(fs.existsSync(resumeFile)).toBe(false);
             expect(fs.existsSync(outputFile)).toBe(true);
+        }
+        finally {
+            fs.rmSync(resumeFile, { force: true });
+            fs.rmSync(outputFile, { force: true });
+        }
+    });
+
+    it('treats a repeated bottom cursor with no timeline items as an exhausted archive', async () => {
+        const command = getRegistry().get('twitter/bookmarks');
+        const resumeFile = `/tmp/opencli-bookmarks-resume-terminal-${process.pid}-${Date.now()}.json`;
+        const outputFile = `/tmp/opencli-bookmarks-out-terminal-${process.pid}-${Date.now()}.jsonl`;
+        let bookmarkPages = 0;
+        const page = {
+            getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn(async (script) => {
+                const text = String(script);
+                if (text.includes('Bookmarks') && text.includes('queryId')) return null;
+                if (text.includes('/Bookmarks')) {
+                    bookmarkPages += 1;
+                    return bookmarkPages === 1 ? bookmarksPayload(true) : bookmarksTerminalPayload();
+                }
+                throw new Error(`Unexpected evaluate: ${text.slice(0, 80)}`);
+            }),
+        };
+
+        try {
+            const result = await command.func(page, {
+                all: true,
+                'resume-file': resumeFile,
+                'output-file': outputFile,
+            });
+
+            expect(result).toMatchObject({
+                outputFile,
+                count: 1,
+                source: 'bookmarks',
+                complete: true,
+                pages: 2,
+            });
+            expect(result.cursor).toBeUndefined();
+            expect(fs.existsSync(resumeFile)).toBe(false);
+            expect(fs.readFileSync(outputFile, 'utf8').trim().split('\n')).toHaveLength(1);
+        }
+        finally {
+            fs.rmSync(resumeFile, { force: true });
+            fs.rmSync(outputFile, { force: true });
+        }
+    });
+
+    it('keeps failing when a repeated cursor still carries timeline items', async () => {
+        const command = getRegistry().get('twitter/bookmarks');
+        const resumeFile = `/tmp/opencli-bookmarks-resume-stall-${process.pid}-${Date.now()}.json`;
+        const outputFile = `/tmp/opencli-bookmarks-out-stall-${process.pid}-${Date.now()}.jsonl`;
+        const page = {
+            getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
+            evaluate: vi.fn(async (script) => {
+                const text = String(script);
+                if (text.includes('Bookmarks') && text.includes('queryId')) return null;
+                if (text.includes('/Bookmarks')) return bookmarksPayload(true);
+                throw new Error(`Unexpected evaluate: ${text.slice(0, 80)}`);
+            }),
+        };
+
+        try {
+            await expect(command.func(page, {
+                all: true,
+                'resume-file': resumeFile,
+                'output-file': outputFile,
+            })).rejects.toThrow(/twitter_bookmarks_repeated_cursor/);
+            expect(fs.existsSync(resumeFile)).toBe(true);
         }
         finally {
             fs.rmSync(resumeFile, { force: true });

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -88,6 +88,7 @@ function extractLikedTweet(result, seen) {
 function parseLikes(data, seen) {
     const tweets = [];
     let nextCursor = null;
+    let entryCount = 0;
     const instructions = data?.data?.user?.result?.timeline_v2?.timeline?.instructions
         || data?.data?.user?.result?.timeline?.timeline?.instructions
         || [];
@@ -103,19 +104,25 @@ function parseLikes(data, seen) {
                 nextCursor = content?.value || content?.itemContent?.value || nextCursor;
                 continue;
             }
-            const direct = extractLikedTweet(content?.itemContent?.tweet_results?.result, seen);
+            const directResult = content?.itemContent?.tweet_results?.result;
+            if (directResult)
+                entryCount += 1;
+            const direct = extractLikedTweet(directResult, seen);
             if (direct) {
                 tweets.push(direct);
                 continue;
             }
             for (const item of content?.items || []) {
-                const nested = extractLikedTweet(item.item?.itemContent?.tweet_results?.result, seen);
+                const nestedResult = item.item?.itemContent?.tweet_results?.result;
+                if (nestedResult)
+                    entryCount += 1;
+                const nested = extractLikedTweet(nestedResult, seen);
                 if (nested)
                     tweets.push(nested);
             }
         }
     }
-    return { tweets, nextCursor };
+    return { tweets, nextCursor, entryCount };
 }
 function readResumeFile(filePath, expected = null) {
     if (!filePath || !fs.existsSync(filePath))
@@ -317,7 +324,7 @@ cli({
                 }
                 throw new CommandExecutionError('twitter_likes_protocol_error: missing Likes timeline instructions');
             }
-            const { tweets, nextCursor } = parseLikes(data, seen);
+            const { tweets, nextCursor, entryCount } = parseLikes(data, seen);
             if (useOutputFile) {
                 appendJsonlRows(outputFile, tweets);
                 outputCount += tweets.length;
@@ -341,6 +348,14 @@ cli({
                 break;
             }
             if (nextCursor === cursor) {
+                // X keeps returning the same bottom cursor on the final page rather than
+                // dropping it, so a repeat that carries no timeline items means the
+                // archive is exhausted. A repeat that still carries items is a real
+                // stall and must keep failing loudly so resume state survives.
+                if (entryCount === 0) {
+                    exhausted = true;
+                    break;
+                }
                 throw new CommandExecutionError('twitter_likes_repeated_cursor: archive completion cannot be proven; resume state was retained');
             }
             cursor = nextCursor;

--- a/clis/twitter/likes.test.js
+++ b/clis/twitter/likes.test.js
@@ -46,6 +46,66 @@ function likesPayload() {
     };
 }
 
+function likesTerminalPayload(cursorValue = 'NEXT_CURSOR') {
+    return {
+        data: {
+            user: {
+                result: {
+                    timeline_v2: {
+                        timeline: {
+                            instructions: [{
+                                entries: [{
+                                    entryId: `cursor-bottom-${cursorValue}`,
+                                    content: {
+                                        entryType: 'TimelineTimelineCursor',
+                                        cursorType: 'Bottom',
+                                        value: cursorValue,
+                                    },
+                                }],
+                            }],
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+
+function likesPayloadWithCursor(cursorValue = 'NEXT_CURSOR') {
+    const payload = likesPayload();
+    payload.data.user.result.timeline_v2.timeline.instructions[0].entries.push({
+        entryId: `cursor-bottom-${cursorValue}`,
+        content: {
+            entryType: 'TimelineTimelineCursor',
+            cursorType: 'Bottom',
+            value: cursorValue,
+        },
+    });
+    return payload;
+}
+
+function likesArchivePage(respond) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        getCookies: vi.fn(async () => [{ name: 'ct0', value: 'token' }]),
+        evaluate: vi.fn(async (script) => {
+            const text = String(script);
+            if (text.includes('AppTabBar_Profile_Link')) {
+                return { session: 'site:twitter', data: '/viewer' };
+            }
+            if (text.includes('operationName')) return null;
+            if (text.includes('/UserByScreenName')) {
+                return { session: 'site:twitter', data: '42' };
+            }
+            if (text.includes('/Likes')) {
+                return { session: 'site:twitter', data: respond() };
+            }
+            throw new Error(`Unexpected evaluate: ${text.slice(0, 80)}`);
+        }),
+    };
+}
+
 describe('twitter likes helpers', () => {
     it('falls back when queryId contains unsafe characters', () => {
         expect(__test__.sanitizeQueryId('safe_Query-123', 'fallback')).toBe('safe_Query-123');
@@ -466,6 +526,61 @@ describe('twitter likes command', () => {
             expect(result.cursor).toBeUndefined();
             expect(fs.existsSync(resumeFile)).toBe(false);
             expect(fs.existsSync(outputFile)).toBe(true);
+        }
+        finally {
+            fs.rmSync(resumeFile, { force: true });
+            fs.rmSync(outputFile, { force: true });
+        }
+    });
+
+    it('treats a repeated bottom cursor with no timeline items as an exhausted archive', async () => {
+        const command = getRegistry().get('twitter/likes');
+        const resumeFile = `/tmp/opencli-likes-resume-terminal-${process.pid}-${Date.now()}.json`;
+        const outputFile = `/tmp/opencli-likes-out-terminal-${process.pid}-${Date.now()}.jsonl`;
+        let likePages = 0;
+        const page = likesArchivePage(() => {
+            likePages += 1;
+            return likePages === 1 ? likesPayloadWithCursor() : likesTerminalPayload();
+        });
+
+        try {
+            const result = await command.func(page, {
+                all: true,
+                'resume-file': resumeFile,
+                'output-file': outputFile,
+            });
+
+            expect(result).toMatchObject({
+                outputFile,
+                count: 1,
+                source: 'likes',
+                username: 'viewer',
+                complete: true,
+                pages: 2,
+            });
+            expect(result.cursor).toBeUndefined();
+            expect(fs.existsSync(resumeFile)).toBe(false);
+            expect(fs.readFileSync(outputFile, 'utf8').trim().split('\n')).toHaveLength(1);
+        }
+        finally {
+            fs.rmSync(resumeFile, { force: true });
+            fs.rmSync(outputFile, { force: true });
+        }
+    });
+
+    it('keeps failing when a repeated cursor still carries timeline items', async () => {
+        const command = getRegistry().get('twitter/likes');
+        const resumeFile = `/tmp/opencli-likes-resume-stall-${process.pid}-${Date.now()}.json`;
+        const outputFile = `/tmp/opencli-likes-out-stall-${process.pid}-${Date.now()}.jsonl`;
+        const page = likesArchivePage(() => likesPayloadWithCursor());
+
+        try {
+            await expect(command.func(page, {
+                all: true,
+                'resume-file': resumeFile,
+                'output-file': outputFile,
+            })).rejects.toThrow(/twitter_likes_repeated_cursor/);
+            expect(fs.existsSync(resumeFile)).toBe(true);
         }
         finally {
             fs.rmSync(resumeFile, { force: true });


### PR DESCRIPTION
## Description

`twitter bookmarks` and `twitter likes` cannot finish a full archive run today. X does not drop the bottom cursor on the last page of the timeline — it keeps serving the same cursor value next to an entry list that carries no timeline items. The pagination loop reads that as a stalled cursor and throws `twitter_bookmarks_repeated_cursor` / `twitter_likes_repeated_cursor`, so a fully drained timeline is reported as "completion cannot be proven" and the resume state is retained.

Reproduced directly against the Bookmarks GraphQL endpoint with `count=10` on a 19-bookmark account:

~~~
page 1  sent=null                  items=10  bottom=HBayyrLV5e+fhDQAAA==
page 2  sent=HBayyrLV5e+fhDQAAA==  items=9   bottom=HBaAg/DHsNz7+DMAAA==
page 3  sent=HBaAg/DHsNz7+DMAAA==  items=0   bottom=HBaAg/DHsNz7+DMAAA==
~~~

Pagination itself advances correctly. Only the terminal page repeats its cursor, and it repeats it forever. The existing tests missed this because their final-page fixture omits the bottom cursor entirely, which is not the shape X actually sends.

### The fix

A repeated cursor now counts as exhaustion only when the page carried no timeline items at all.

`parseBookmarks` / `parseLikes` additionally report `entryCount` — the number of raw timeline items seen **before** dedupe. Using the post-dedupe row count here would be wrong: a genuinely stalled cursor that keeps replaying rows already in `seen` would produce zero new rows, get accepted as complete, and delete the resume file for a truncated archive. That case still throws and still retains resume state.

`twitter collection` carries the same cursor predicate but has its own bounded-completion-receipt semantics and a test that asserts the throw, so it is deliberately left alone here.

Related issue: none filed — reporting and fixing together.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Four regression tests added, two per adapter: a repeated terminal cursor with no items must complete and clear resume state; a repeated cursor that still carries items must keep throwing and keep resume state.

Reverting only the implementation while keeping the new tests fails exactly the cases the fix targets:

~~~
× returns empty tweets + null cursor for unknown envelope
× treats a repeated bottom cursor with no timeline items as an exhausted archive   (bookmarks)
× treats a repeated bottom cursor with no timeline items as an exhausted archive   (likes)
Tests  3 failed | 33 passed (36)
~~~

With the fix in place:

~~~
npx vitest run --project adapter clis/twitter/
Test Files  45 passed (45)
     Tests  558 passed (558)

npx tsc --noEmit    # clean
~~~

Full `npm test` on this branch leaves 9 failures across `xiaohongshu/search`, `browser/article-extract.e2e`, `src/cli.test.ts` and `src/package-exports.test.ts`. All of them reproduce on an unmodified checkout of `main` in the same environment (10 failures there, same four files — the delta is a flaky `slock` canary), and none are twitter-related.

Live verification against a real account, after the fix:

~~~
opencli twitter bookmarks --all --resume-file bm.resume --output-file bm.jsonl
{ "count": 19, "source": "bookmarks", "complete": true, "pages": 2 }
# resume file removed, 19 rows written

opencli twitter likes --all --resume-file lk.resume --output-file lk.jsonl
{ "count": 1, "source": "likes", "complete": true, "pages": 2 }
~~~
