### PR TITLE
chore: release v1.8.8

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCLI",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Browser automation bridge for the OpenCLI CLI tool. Executes commands in Chrome tab leases via a local daemon.",
   "permissions": [
     "debugger",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencli-extension",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencli-extension",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "private": true,
   "opencli": {
     "compatRange": ">=1.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jackwener/opencli",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jackwener/opencli",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- bump `@jackwener/opencli` from 1.8.7 to 1.8.8
- bump the bundled Chrome extension from 1.0.23 to 1.0.24
- keep package lockfiles and extension manifest in sync

The extension bump is required because changes merged after v1.8.7 updated `extension/src/background.ts` and the tracked bundle.

## Verification

- `npm run build`
- `npm run typecheck`
- `OPENCLI_CONFIG_DIR=<clean temp dir> npm test` (631 files, 7,316 passed, 1 skipped)
- `npm run check:silent-column-drop`
- `npm run check:typed-error-lint`
- `cd extension && npm ci && npm run build`
- `git diff --exit-code -- extension/dist`
- `cd extension && npm run package:release -- --out <temp dir>`
- packaged extension manifest reports 1.0.24
- `npm pack --dry-run --json` reports `@jackwener/opencli@1.8.8`
- `git diff --check`
