### PR TITLE
feat(safety): add opt-in read-only adapter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ When the site you need is not yet covered, use the `opencli-adapter-author` skil
 | `OPENCLI_PROFILE` | — | Browser Bridge profile alias/contextId to use when multiple Chrome profiles are connected |
 | `OPENCLI_WINDOW` | command default | Set to `foreground` or `background` to override Browser Bridge window placement. Browser-backed commands also accept `--window <foreground\|background>`. |
 | `OPENCLI_SITE_SESSION` | adapter default | Set to `ephemeral` or `persistent` to override `siteSession` metadata for browser-backed adapter commands. `ephemeral` closes the one-shot automation window when the command finishes; `persistent` reuses the site's session. Per-command `--site-session` takes precedence. |
+| `OPENCLI_READ_ONLY` | `false` | Set to `1` or `true` to allow only registered adapter commands declared `access: read`. Adapter commands also accept `--read-only`. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `45` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
@@ -180,6 +181,8 @@ When the site you need is not yet covered, use the `opencli-adapter-author` skil
 | `DEBUG_SNAPSHOT` | — | Set to `1` for DOM snapshot debug output |
 
 `opencli browser *` requires an explicit `<session>` positional, uses a foreground browser window by default, and keeps that session's tab lease until `opencli browser <session> close` or idle cleanup. Browser-backed adapters use a background adapter window and release one-shot tab leases by default. Interactive adapters can declare `siteSession: 'persistent'` to keep a stable site tab for continuity; pass `--site-session ephemeral` for a one-shot tab.
+
+For safer agent delegation, pass `--read-only` to an adapter command or set `OPENCLI_READ_ONLY=1`. Commands declared `access: write` are rejected before adapter-defined validation, command execution hooks, browser setup, pre-navigation, or adapter code runs. This first policy gate covers registered adapters; direct `opencli browser ...` primitives and external CLI passthroughs do not carry adapter access metadata and are not classified by it.
 
 ## Built-in Commands
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,6 +157,7 @@ Agent 在内部自动处理所有 `opencli browser` 命令——你只需用自�
 |------|--------|------|
 | `OPENCLI_WINDOW` | 命令默认值 | 设为 `foreground` 或 `background` 来覆盖 Browser Bridge 窗口位置。浏览器型命令也支持 `--window <foreground\|background>` |
 | `OPENCLI_SITE_SESSION` | adapter 默认值 | 设为 `ephemeral` 或 `persistent`，覆盖浏览器型 adapter 命令的 `siteSession` 元数据。`ephemeral` 会在命令结束时关闭一次性自动化窗口；`persistent` 会复用该站点的 session。命令级 `--site-session` 优先。 |
+| `OPENCLI_READ_ONLY` | `false` | 设为 `1` 或 `true` 后，只允许执行声明为 `access: read` 的已注册 adapter 命令。adapter 命令也支持 `--read-only`。 |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `45` | 浏览器连接超时（秒） |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
@@ -167,6 +168,8 @@ Agent 在内部自动处理所有 `opencli browser` 命令——你只需用自�
 Browser Bridge daemon 与扩展的通信端口固定为 `localhost:19825`，不再支持通过 `OPENCLI_DAEMON_PORT` 配置自定义端口。
 
 `opencli browser *` 必须紧跟一个 `<session>` 位置参数，默认使用前台窗口，并保留该 session 的 tab lease，直到你手动执行 `opencli browser <session> close` 或等空闲超时。浏览器型 adapter 默认使用后台 adapter 窗口并在命令结束后释放一次性 tab lease；如果需要调试最终页面，可以传 `--window foreground --keep-tab true`。
+
+为了更安全地把 adapter 命令交给 AI Agent，可以传入 `--read-only`，或设置 `OPENCLI_READ_ONLY=1`。声明为 `access: write` 的命令会在 adapter 自定义校验、命令执行 hook、浏览器连接、预导航或 adapter 代码运行之前被拒绝。首版策略只覆盖已注册 adapter；直接使用的 `opencli browser ...` 原语和外部 CLI 透传没有 adapter access 元数据，不在该策略的分类范围内。
 
 ## 内置命令
 

--- a/src/access-policy.test.ts
+++ b/src/access-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { enforceAdapterReadOnlyPolicy } from './access-policy.js';
+import { ArgumentError, EXIT_CODES, ReadOnlyPolicyError, toEnvelope } from './errors.js';
+import type { CliCommand } from './registry.js';
+
+function command(access: 'read' | 'write'): CliCommand {
+  return {
+    site: 'test-policy',
+    name: access,
+    access,
+    description: `${access} policy fixture`,
+    browser: false,
+    args: [],
+    func: async () => [],
+  };
+}
+
+describe('adapter read-only policy', () => {
+  it('keeps default adapter execution unchanged', () => {
+    expect(() => enforceAdapterReadOnlyPolicy(command('write'), false, undefined)).not.toThrow();
+    expect(() => enforceAdapterReadOnlyPolicy(command('write'), false, '0')).not.toThrow();
+    expect(() => enforceAdapterReadOnlyPolicy(command('write'), false, 'false')).not.toThrow();
+  });
+
+  it('allows commands declared access: read', () => {
+    expect(() => enforceAdapterReadOnlyPolicy(command('read'), true, undefined)).not.toThrow();
+    expect(() => enforceAdapterReadOnlyPolicy(command('read'), false, '1')).not.toThrow();
+    expect(() => enforceAdapterReadOnlyPolicy(command('read'), false, 'TRUE')).not.toThrow();
+  });
+
+  it('returns a typed permission error for commands declared access: write', () => {
+    const error = (() => {
+      try {
+        enforceAdapterReadOnlyPolicy(command('write'), true, undefined);
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(ReadOnlyPolicyError);
+    expect(error).toMatchObject({ code: 'READ_ONLY_POLICY', exitCode: EXIT_CODES.NOPERM });
+    expect(toEnvelope(error)).toMatchObject({
+      ok: false,
+      error: {
+        code: 'READ_ONLY_POLICY',
+        exitCode: EXIT_CODES.NOPERM,
+      },
+    });
+  });
+
+  it('enables the policy from OPENCLI_READ_ONLY', () => {
+    expect(() => enforceAdapterReadOnlyPolicy(command('write'), false, '1')).toThrow(ReadOnlyPolicyError);
+    expect(() => enforceAdapterReadOnlyPolicy(command('write'), false, 'true')).toThrow(ReadOnlyPolicyError);
+  });
+
+  it('rejects ambiguous OPENCLI_READ_ONLY values', () => {
+    expect(() => enforceAdapterReadOnlyPolicy(command('read'), false, 'yes')).toThrow(ArgumentError);
+  });
+});

--- a/src/access-policy.ts
+++ b/src/access-policy.ts
@@ -1,0 +1,34 @@
+import { ArgumentError, ReadOnlyPolicyError } from './errors.js';
+import { fullName, type CliCommand } from './registry.js';
+
+const READ_ONLY_ENV = 'OPENCLI_READ_ONLY';
+
+function parseReadOnlyEnv(raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === '') return false;
+
+  switch (raw.trim().toLowerCase()) {
+    case '1':
+    case 'true':
+      return true;
+    case '0':
+    case 'false':
+      return false;
+    default:
+      throw new ArgumentError(`${READ_ONLY_ENV} must be one of: 1, 0, true, false. Received: "${raw}"`);
+  }
+}
+
+/**
+ * Enforce the opt-in adapter read-only policy before command preparation or
+ * lifecycle work can run. Direct browser primitives and external CLI
+ * passthroughs do not carry adapter access metadata and are outside this gate.
+ */
+export function enforceAdapterReadOnlyPolicy(
+  cmd: CliCommand,
+  explicitReadOnly: boolean = false,
+  envValue: string | undefined = process.env.OPENCLI_READ_ONLY,
+): void {
+  if (!explicitReadOnly && !parseReadOnlyEnv(envValue)) return;
+  if (cmd.access === 'read') return;
+  throw new ReadOnlyPolicyError(fullName(cmd));
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -500,7 +500,7 @@ describe('createProgram root help descriptions', () => {
       expect(data.domain).toBe('www.bilibili.com');
       expect(data.positionals).toMatchObject([{ name: 'bvid', positional: true, required: true }]);
       expect(data.command_options).toMatchObject([{ name: 'with-comments', default: false }]);
-      expect(data.common_options.map((option: any) => option.name)).toEqual(['format', 'trace', 'verbose', 'help']);
+      expect(data.common_options.map((option: any) => option.name)).toEqual(['format', 'trace', 'read-only', 'verbose', 'help']);
       expect(data.columns).toEqual(['title', 'url']);
       expect(data).not.toHaveProperty('args');
     } finally {

--- a/src/commanderAdapter.test.ts
+++ b/src/commanderAdapter.test.ts
@@ -99,6 +99,44 @@ describe('commanderAdapter arg passing', () => {
     );
   });
 
+  it('passes explicit read-only mode to executeCommand', async () => {
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, cmd);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'submit', './paper.pdf', '--read-only']);
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ site: 'paperreview', name: 'submit' }),
+      expect.objectContaining({ pdf: './paper.pdf' }),
+      false,
+      { prepared: true, readOnly: true },
+    );
+  });
+
+  it('blocks write commands before adapter validation or execution', async () => {
+    const validateArgs = vi.fn();
+    const writeCommand: CliCommand = {
+      site: 'paperreview',
+      name: 'publish',
+      access: 'write',
+      description: 'Publish a paper',
+      browser: false,
+      args: [],
+      validateArgs,
+      func: vi.fn(),
+    };
+    const program = new Command();
+    const siteCmd = program.command('paperreview');
+    registerCommandToProgram(siteCmd, writeCommand);
+
+    await program.parseAsync(['node', 'opencli', 'paperreview', 'publish', '--read-only']);
+
+    expect(validateArgs).not.toHaveBeenCalled();
+    expect(mockExecuteCommand).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(77);
+  });
+
   it('rejects invalid bool values before calling executeCommand', async () => {
     const program = new Command();
     const siteCmd = program.command('paperreview');

--- a/src/commanderAdapter.ts
+++ b/src/commanderAdapter.ts
@@ -31,6 +31,7 @@ import {
   EXIT_CODES,
   toEnvelope,
 } from './errors.js';
+import { enforceAdapterReadOnlyPolicy } from './access-policy.js';
 
 /**
  * Register a single CliCommand as a Commander subcommand.
@@ -59,6 +60,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
   subCmd
     .option('-f, --format <fmt>', 'Output format: table, plain, json, yaml, md, csv', 'table')
     .option('--trace <mode>', 'Trace capture: off, on, retain-on-failure', 'off')
+    .option('--read-only', 'Only run adapters declared access: read', false)
     .option('-v, --verbose', 'Debug output', false);
   if (cmd.browser) {
     subCmd
@@ -84,6 +86,8 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
 
     // ── Execute + render ────────────────────────────────────────────────
     try {
+      enforceAdapterReadOnlyPolicy(cmd, optionsRecord.readOnly === true);
+
       // ── Collect kwargs ────────────────────────────────────────────────
       const rawKwargs: Record<string, unknown> = {};
       for (let i = 0; i < positionalArgs.length; i++) {
@@ -120,6 +124,7 @@ export function registerCommandToProgram(siteCmd: Command, cmd: CliCommand): voi
         ...(cmd.browser && typeof optionsRecord.window === 'string' ? { windowMode: optionsRecord.window } : {}),
         ...(cmd.browser && typeof optionsRecord.siteSession === 'string' ? { siteSession: optionsRecord.siteSession } : {}),
         ...(cmd.browser && typeof optionsRecord.keepTab === 'string' ? { keepTab: optionsRecord.keepTab } : {}),
+        ...(optionsRecord.readOnly === true ? { readOnly: true } : {}),
       });
       if (result === null || result === undefined) {
         return;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -101,6 +101,17 @@ export class ConfigError extends CliError {
   }
 }
 
+export class ReadOnlyPolicyError extends CliError {
+  constructor(command: string) {
+    super(
+      'READ_ONLY_POLICY',
+      `${command} is marked access: write and cannot run in read-only mode.`,
+      'Run without --read-only or unset OPENCLI_READ_ONLY only after explicitly approving this write command.',
+      EXIT_CODES.NOPERM,
+    );
+  }
+}
+
 export class AuthRequiredError extends CliError {
   readonly domain: string;
   constructor(domain: string, message?: string) {

--- a/src/execution.test.ts
+++ b/src/execution.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CliCommand } from './registry.js';
 import { coerceAndValidateArgs, executeCommand, prepareCommandArgs } from './execution.js';
-import { ArgumentError, TimeoutError, toEnvelope } from './errors.js';
+import { ArgumentError, ReadOnlyPolicyError, TimeoutError, toEnvelope } from './errors.js';
 import { cli, Strategy } from './registry.js';
 import { withTimeoutMs } from './runtime.js';
 import * as runtime from './runtime.js';
@@ -32,6 +32,67 @@ describe('coerceAndValidateArgs', () => {
 
     expect(() => coerceAndValidateArgs(integerArgs, { limit: 'Infinity' })).toThrow(ArgumentError);
     expect(() => coerceAndValidateArgs(numberArgs, { threshold: '-Infinity' })).toThrow(ArgumentError);
+  });
+});
+
+describe('executeCommand — read-only policy ordering', () => {
+  it('allows read adapters when the policy is enabled', async () => {
+    const func = vi.fn().mockResolvedValue([{ ok: true }]);
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'read-only-allowed',
+      access: 'read',
+      description: 'read-only allow fixture',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      func,
+    });
+
+    await expect(executeCommand(cmd, {}, false, { readOnly: true })).resolves.toEqual([{ ok: true }]);
+    expect(func).toHaveBeenCalledOnce();
+  });
+
+  it('blocks write adapters before validation, hooks, browser setup, or adapter code', async () => {
+    const validateArgs = vi.fn();
+    const func = vi.fn().mockResolvedValue([{ ok: true }]);
+    const beforeHook = vi.fn();
+    onBeforeExecute(beforeHook);
+    const browserSessionSpy = vi.spyOn(runtime, 'browserSession');
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'read-only-blocked',
+      access: 'write',
+      description: 'read-only block fixture',
+      browser: true,
+      strategy: Strategy.COOKIE,
+      domain: 'example.com',
+      args: [{ name: 'required-value', required: true }],
+      validateArgs,
+      func,
+    });
+
+    await expect(executeCommand(cmd, {}, false, { readOnly: true })).rejects.toBeInstanceOf(ReadOnlyPolicyError);
+    expect(validateArgs).not.toHaveBeenCalled();
+    expect(beforeHook).not.toHaveBeenCalled();
+    expect(browserSessionSpy).not.toHaveBeenCalled();
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it('honors OPENCLI_READ_ONLY without a command option', async () => {
+    vi.stubEnv('OPENCLI_READ_ONLY', '1');
+    const func = vi.fn().mockResolvedValue([{ ok: true }]);
+    const cmd = cli({
+      site: 'test-execution',
+      name: 'read-only-env-blocked',
+      access: 'write',
+      description: 'read-only environment fixture',
+      browser: false,
+      strategy: Strategy.PUBLIC,
+      func,
+    });
+
+    await expect(executeCommand(cmd, {})).rejects.toBeInstanceOf(ReadOnlyPolicyError);
+    expect(func).not.toHaveBeenCalled();
   });
 });
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -37,6 +37,7 @@ import { isElectronApp } from './electron-apps.js';
 import { probeCDP, resolveElectronEndpoint } from './launcher.js';
 import { ObservationSession, exportObservationSession, type ObservationExportResult, type ObservationExportStatus } from './observation/index.js';
 import { resolveAdapterSourcePath } from './adapter-source.js';
+import { enforceAdapterReadOnlyPolicy } from './access-policy.js';
 
 const _loadedModules = new Map<string, Promise<void>>();
 /** Track mtime of loaded user adapter files for hot-reload in daemon mode. */
@@ -208,9 +209,12 @@ export async function executeCommand(
     keepTab?: string;
     windowMode?: string;
     siteSession?: string;
+    readOnly?: boolean;
     onTraceExport?: (trace: ObservationExportResult) => void;
   } = {},
 ): Promise<unknown> {
+  enforceAdapterReadOnlyPolicy(cmd, opts.readOnly);
+
   // Resolve browser-only configuration before argument hooks or any browser
   // lifecycle setup. Non-browser commands must not be affected by browser
   // environment defaults, even when those defaults are invalid.

--- a/src/help.ts
+++ b/src/help.ts
@@ -42,6 +42,12 @@ const COMMON_OPTIONS = [
     choices: ['off', 'on', 'retain-on-failure'],
   },
   {
+    flags: '--read-only',
+    name: 'read-only',
+    help: 'Only run adapters declared access: read',
+    default: false,
+  },
+  {
     flags: '-v, --verbose',
     name: 'verbose',
     help: 'Debug output',


### PR DESCRIPTION
## Summary

This PR adds a narrow, opt-in read-only execution mode for registered adapter commands:

- `--read-only` for a single adapter invocation
- `OPENCLI_READ_ONLY=1|true` for process-level enforcement
- commands declared `access: read` continue to run
- commands declared `access: write` fail with `READ_ONLY_POLICY` and exit code `77`
- default behavior remains unchanged when read-only mode is not enabled

This is intended as a small first safety boundary for delegating OpenCLI adapter reads to AI agents without relying on prompt discipline alone.

## Enforcement order

The policy is checked at two layers:

1. The Commander adapter entry point rejects writes before adapter argument collection/validation and command lifecycle work.
2. `executeCommand` enforces the same policy for programmatic callers that bypass Commander.

A rejected write therefore does not reach adapter-defined validation, command hooks, Browser Bridge/CDP setup, pre-navigation, or adapter code.

## Scope

This first slice intentionally applies only to registered adapters because they carry `access: read|write` metadata.

It does **not** classify or gate:

- direct `opencli browser ...` primitives
- external CLI passthroughs
- domain-level access
- daemon authentication
- confirmation prompts or adapter dry-run behavior

Those can be considered separately without broadening this PR's policy boundary.

## Examples

```bash
# Allowed when the adapter is declared access: read
opencli hackernews top --read-only

# Rejected before browser or adapter work when declared access: write
opencli boss greet --job-id 123 --read-only

# Apply to all registered adapter commands in the process
OPENCLI_READ_ONLY=1 opencli hackernews top
```

Invalid non-empty environment values fail as argument errors; accepted false values are `0` and `false`.

## Tests

Passed:

- focused tests: 4 files, 236 tests
- `npm run typecheck`
- `npm run build`
- real CLI smoke tests for flag-based rejection, environment-based rejection, and an allowed read command

The complete suite on Windows reports 7,288 passed, 14 skipped, and 25 failed. The same 25 failures reproduce on an unmodified `8271afc` checkout and are pre-existing Windows path / non-admin symlink failures; this branch adds no new full-suite failures.

Related to #1595.