### PR TITLE
fix(weibo): persistent site session — stop re-opening the homepage on every command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -43213,7 +43213,8 @@
     "type": "js",
     "modulePath": "weibo/comments.js",
     "sourceFile": "weibo/comments.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43240,7 +43241,8 @@
     "type": "js",
     "modulePath": "weibo/delete.js",
     "sourceFile": "weibo/delete.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43272,7 +43274,8 @@
     "type": "js",
     "modulePath": "weibo/favorites.js",
     "sourceFile": "weibo/favorites.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43315,7 +43318,8 @@
     "type": "js",
     "modulePath": "weibo/feed.js",
     "sourceFile": "weibo/feed.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43345,7 +43349,8 @@
     "type": "js",
     "modulePath": "weibo/hot.js",
     "sourceFile": "weibo/hot.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43400,7 +43405,8 @@
     "type": "js",
     "modulePath": "weibo/me.js",
     "sourceFile": "weibo/me.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43426,7 +43432,8 @@
     "type": "js",
     "modulePath": "weibo/post.js",
     "sourceFile": "weibo/post.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43459,7 +43466,8 @@
     "type": "js",
     "modulePath": "weibo/publish.js",
     "sourceFile": "weibo/publish.js",
-    "navigateBefore": true
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43496,7 +43504,8 @@
     "type": "js",
     "modulePath": "weibo/search.js",
     "sourceFile": "weibo/search.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43529,7 +43538,8 @@
     "type": "js",
     "modulePath": "weibo/user.js",
     "sourceFile": "weibo/user.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",
@@ -43591,7 +43601,8 @@
     "type": "js",
     "modulePath": "weibo/user-posts.js",
     "sourceFile": "weibo/user-posts.js",
-    "navigateBefore": "https://weibo.com"
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "weibo",

--- a/clis/weibo/auth.test.js
+++ b/clis/weibo/auth.test.js
@@ -52,10 +52,14 @@ describe('weibo auth identity probe', () => {
         expect(page.evaluate.mock.calls[1][0]).toContain('/ajax/profile/info?uid=12345');
     });
 
-    it('typed-fails malformed uid payloads instead of probing /ajax/profile/info with garbage', async () => {
+    it('rejects malformed uid payloads instead of probing /ajax/profile/info with garbage', async () => {
+        // getSelfUid only accepts non-empty strings; a malformed store payload
+        // is treated as "uid unresolved" (one reload retry, then auth error).
         const page = makePage({ evalResults: [{ uid: '12345' }] });
-        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(CommandExecutionError);
-        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        await expect(__test__.verifyWeiboIdentity(page)).rejects.toBeInstanceOf(AuthRequiredError);
+        for (const [script] of page.evaluate.mock.calls) {
+            expect(String(script)).not.toContain('/ajax/profile/info');
+        }
     });
 
     it('typed-fails malformed probe payloads', async () => {

--- a/clis/weibo/comments.js
+++ b/clis/weibo/comments.js
@@ -2,7 +2,7 @@
  * Weibo comments — get comments on a post.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'comments',
@@ -10,6 +10,8 @@ cli({
     description: 'Get comments on a Weibo post',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Post ID (numeric idstr)' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of comments (max 50)' },
@@ -17,8 +19,7 @@ cli({
     columns: ['rank', 'author', 'text', 'likes', 'replies', 'time'],
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 20, 50);
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const id = String(kwargs.id);
         const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {

--- a/clis/weibo/delete.js
+++ b/clis/weibo/delete.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 
 const WEIBO_HOST_RE = /(^|\.)weibo\.(com|cn)$/i;
 const POST_ID_RE = /^[A-Za-z0-9]{4,32}$/;
@@ -47,6 +47,8 @@ cli({
     description: 'Delete one of my Weibo posts by id',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         {
             name: 'id',
@@ -62,8 +64,7 @@ cli({
         }
         const raw = String(kwargs.id ?? '').trim();
         const id = normalizePostId(raw);
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const result = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const input = ${JSON.stringify(id)};

--- a/clis/weibo/favorites.js
+++ b/clis/weibo/favorites.js
@@ -1,6 +1,6 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
@@ -101,6 +101,8 @@ cli({
   description: '我的微博收藏列表',
   domain: 'weibo.com',
   strategy: Strategy.COOKIE,
+  siteSession: 'persistent',
+  navigateBefore: false,
   args: [
     { name: 'limit', type: 'int', default: 20, help: '数量（最多50）' },
   ],
@@ -108,8 +110,7 @@ cli({
   func: async (page, kwargs) => {
     const limit = parsePositiveInt(kwargs.limit, 'limit', DEFAULT_LIMIT);
 
-    await page.goto('https://weibo.com');
-    await page.wait(2);
+    await ensureWeiboPage(page);
 
     const uid = await getSelfUid(page);
 

--- a/clis/weibo/feed.js
+++ b/clis/weibo/feed.js
@@ -2,7 +2,7 @@
  * Weibo feed — for-you or following timeline.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, getSelfUid, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 const TIMELINE_ENDPOINTS = {
     'for-you': 'unreadfriendstimeline',
     following: 'friendstimeline',
@@ -14,6 +14,8 @@ cli({
     description: 'Fetch Weibo timeline (for-you or following)',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         {
             name: 'type',
@@ -28,8 +30,7 @@ cli({
         const count = Math.min(kwargs.limit || 15, 50);
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';
         const endpoint = TIMELINE_ENDPOINTS[timelineType];
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const uid = await getSelfUid(page);
         const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {

--- a/clis/weibo/hot.js
+++ b/clis/weibo/hot.js
@@ -2,7 +2,7 @@
  * Weibo hot search — browser cookie API.
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, requireArrayEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'hot',
@@ -10,13 +10,15 @@ cli({
     description: '微博热搜',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'limit', type: 'int', default: 30, help: 'Number of items (max 50)' },
     ],
     columns: ['rank', 'word', 'hot_value', 'category', 'label', 'url'],
     func: async (page, kwargs) => {
         const count = Math.min(kwargs.limit || 30, 50);
-        await page.goto('https://weibo.com');
+        await ensureWeiboPage(page);
         const data = requireArrayEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {
         const resp = await fetch('/ajax/statuses/hot_band', {credentials: 'include'});

--- a/clis/weibo/me.js
+++ b/clis/weibo/me.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { getSelfUid, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, getSelfUid, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'me',
@@ -11,11 +11,12 @@ cli({
     description: 'My Weibo profile info',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [],
     columns: ['screen_name', 'uid', 'followers', 'following', 'statuses', 'verified', 'location'],
     func: async (page) => {
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const uid = await getSelfUid(page);
         const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {

--- a/clis/weibo/post.js
+++ b/clis/weibo/post.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'post',
@@ -11,13 +11,14 @@ cli({
     description: 'Get a single Weibo post',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'Post ID (numeric idstr or mblogid from URL)' },
     ],
     columns: ['field', 'value'],
     func: async (page, kwargs) => {
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const id = String(kwargs.id);
         const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {

--- a/clis/weibo/publish.js
+++ b/clis/weibo/publish.js
@@ -76,6 +76,8 @@ cli({
     domain: 'weibo.com',
     strategy: Strategy.UI,
     browser: true,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         {
             name: 'text',

--- a/clis/weibo/search.js
+++ b/clis/weibo/search.js
@@ -12,6 +12,8 @@ cli({
     domain: 'weibo.com',
     browser: true,
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'keyword', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 10, help: 'Number of results (max 50)' },

--- a/clis/weibo/site-session.test.js
+++ b/clis/weibo/site-session.test.js
@@ -1,0 +1,137 @@
+/**
+ * Weibo persistent site-session conventions.
+ *
+ * Every weibo command must reuse the stable `site:weibo` tab
+ * (siteSession: 'persistent') and own its navigation
+ * (navigateBefore: false) so a warm tab is never re-navigated to the
+ * homepage on every invocation. The ajax-based commands must go through
+ * the ensureWeiboPage URL guard: navigate only when the tab is not
+ * already on a weibo.com origin page (relative /ajax fetches break on
+ * s.weibo.com).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ensureWeiboPage } from './utils.js';
+import './search.js';
+import './post.js';
+import './comments.js';
+import './hot.js';
+import './feed.js';
+import './me.js';
+import './user.js';
+import './user-posts.js';
+import './favorites.js';
+import './delete.js';
+import './publish.js';
+
+const ALL_COMMANDS = [
+  'search',
+  'post',
+  'comments',
+  'hot',
+  'feed',
+  'me',
+  'user',
+  'user-posts',
+  'favorites',
+  'delete',
+  'publish',
+];
+
+// Commands whose func needs nothing but a weibo.com origin (relative
+// /ajax fetch or getSelfUid). favorites is included: its homepage goto
+// only exists to feed getSelfUid before the fav-page goto.
+const GUARDED_COMMANDS = [
+  { name: 'post', kwargs: { id: '1' } },
+  { name: 'comments', kwargs: { id: '1' } },
+  { name: 'hot', kwargs: {} },
+  { name: 'feed', kwargs: {} },
+  { name: 'me', kwargs: {} },
+  { name: 'user', kwargs: { id: '1' } },
+  { name: 'user-posts', kwargs: { id: '1' } },
+  { name: 'favorites', kwargs: {} },
+  { name: 'delete', kwargs: { id: '5188964593845467' } },
+];
+
+function makePage(currentUrl) {
+  return {
+    getCurrentUrl: vi.fn().mockResolvedValue(currentUrl),
+    goto: vi.fn().mockResolvedValue(undefined),
+    wait: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(null),
+    click: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('weibo siteSession conventions', () => {
+  it.each(ALL_COMMANDS)('weibo/%s declares persistent session and owns navigation', (name) => {
+    const command = getRegistry().get(`weibo/${name}`);
+    expect(command, `weibo/${name} not registered`).toBeTruthy();
+    expect(command.siteSession).toBe('persistent');
+    expect(command.navigateBefore).toBe(false);
+  });
+});
+
+describe('ensureWeiboPage', () => {
+  it('does not navigate when already on weibo.com', async () => {
+    const page = makePage('https://weibo.com/hot/weibo');
+    await ensureWeiboPage(page);
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.wait).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when already on www.weibo.com', async () => {
+    const page = makePage('https://www.weibo.com/u/12345');
+    await ensureWeiboPage(page);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+
+  it('navigates away from s.weibo.com (relative /ajax would hit the wrong origin)', async () => {
+    const page = makePage('https://s.weibo.com/weibo?q=x');
+    await ensureWeiboPage(page);
+    expect(page.goto).toHaveBeenCalledWith('https://weibo.com');
+    expect(page.wait).toHaveBeenCalledWith(2);
+  });
+
+  it('navigates from about:blank', async () => {
+    const page = makePage('about:blank');
+    await ensureWeiboPage(page);
+    expect(page.goto).toHaveBeenCalledWith('https://weibo.com');
+  });
+
+  it('navigates when getCurrentUrl is unavailable', async () => {
+    const page = makePage(null);
+    delete page.getCurrentUrl;
+    await ensureWeiboPage(page);
+    expect(page.goto).toHaveBeenCalledWith('https://weibo.com');
+  });
+
+  it('navigates when getCurrentUrl rejects', async () => {
+    const page = makePage(null);
+    page.getCurrentUrl = vi.fn().mockRejectedValue(new Error('detached'));
+    await ensureWeiboPage(page);
+    expect(page.goto).toHaveBeenCalledWith('https://weibo.com');
+  });
+});
+
+describe('warm-tab navigation guard in command funcs', () => {
+  it.each(GUARDED_COMMANDS)(
+    'weibo/$name skips the homepage goto when the tab is already on weibo.com',
+    async ({ name, kwargs }) => {
+      const command = getRegistry().get(`weibo/${name}`);
+      const page = makePage('https://weibo.com/');
+      await command.func(page, kwargs).catch(() => {});
+      expect(page.goto).not.toHaveBeenCalledWith('https://weibo.com');
+    },
+  );
+
+  it.each(GUARDED_COMMANDS)(
+    'weibo/$name still navigates when the tab is elsewhere',
+    async ({ name, kwargs }) => {
+      const command = getRegistry().get(`weibo/${name}`);
+      const page = makePage('about:blank');
+      await command.func(page, kwargs).catch(() => {});
+      expect(page.goto).toHaveBeenCalledWith('https://weibo.com');
+    },
+  );
+});

--- a/clis/weibo/site-session.test.js
+++ b/clis/weibo/site-session.test.js
@@ -41,24 +41,27 @@ const ALL_COMMANDS = [
 // Commands whose func needs nothing but a weibo.com origin (relative
 // /ajax fetch or getSelfUid). favorites is included: its homepage goto
 // only exists to feed getSelfUid before the fav-page goto.
+// feed/me/favorites resolve the logged-in uid first; feed them one valid
+// uid so getSelfUid succeeds without triggering its stale-tab reload.
 const GUARDED_COMMANDS = [
   { name: 'post', kwargs: { id: '1' } },
   { name: 'comments', kwargs: { id: '1' } },
   { name: 'hot', kwargs: {} },
-  { name: 'feed', kwargs: {} },
-  { name: 'me', kwargs: {} },
+  { name: 'feed', kwargs: {}, evalResults: ['1931632001'] },
+  { name: 'me', kwargs: {}, evalResults: ['1931632001'] },
   { name: 'user', kwargs: { id: '1' } },
   { name: 'user-posts', kwargs: { id: '1' } },
-  { name: 'favorites', kwargs: {} },
+  { name: 'favorites', kwargs: {}, evalResults: ['1931632001'] },
   { name: 'delete', kwargs: { id: '5188964593845467' } },
 ];
 
-function makePage(currentUrl) {
+function makePage(currentUrl, evalResults = []) {
+  const queue = [...evalResults];
   return {
     getCurrentUrl: vi.fn().mockResolvedValue(currentUrl),
     goto: vi.fn().mockResolvedValue(undefined),
     wait: vi.fn().mockResolvedValue(undefined),
-    evaluate: vi.fn().mockResolvedValue(null),
+    evaluate: vi.fn(async () => (queue.length ? queue.shift() : null)),
     click: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -117,9 +120,9 @@ describe('ensureWeiboPage', () => {
 describe('warm-tab navigation guard in command funcs', () => {
   it.each(GUARDED_COMMANDS)(
     'weibo/$name skips the homepage goto when the tab is already on weibo.com',
-    async ({ name, kwargs }) => {
+    async ({ name, kwargs, evalResults }) => {
       const command = getRegistry().get(`weibo/${name}`);
-      const page = makePage('https://weibo.com/');
+      const page = makePage('https://weibo.com/', evalResults);
       await command.func(page, kwargs).catch(() => {});
       expect(page.goto).not.toHaveBeenCalledWith('https://weibo.com');
     },

--- a/clis/weibo/user-posts.js
+++ b/clis/weibo/user-posts.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, unwrapEvaluateResult } from './utils.js';
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
@@ -84,6 +84,8 @@ cli({
     description: 'List Weibo posts from a user, optionally filtered by date range',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'id', positional: true, required: true, help: 'User ID (numeric uid) or screen name' },
         { name: 'start', help: 'Start date in Asia/Shanghai (YYYY-MM-DD)' },
@@ -102,8 +104,7 @@ cli({
         const starttime = start ? dateToTimestamp(start) : null;
         const endtime = end ? dateToTimestamp(end) + 24 * 60 * 60 - 1 : null;
 
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
 
         const evaluateResult = await page.evaluate(`
       (async () => {

--- a/clis/weibo/user.js
+++ b/clis/weibo/user.js
@@ -3,7 +3,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { ensureWeiboPage, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
 cli({
     site: 'weibo',
     name: 'user',
@@ -11,13 +11,14 @@ cli({
     description: 'Get Weibo user profile',
     domain: 'weibo.com',
     strategy: Strategy.COOKIE,
+    siteSession: 'persistent',
+    navigateBefore: false,
     args: [
         { name: 'id', required: true, positional: true, help: 'User ID (numeric uid) or screen name' },
     ],
     columns: ['screen_name', 'uid', 'followers', 'following', 'statuses', 'verified', 'description', 'location', 'url'],
     func: async (page, kwargs) => {
-        await page.goto('https://weibo.com');
-        await page.wait(2);
+        await ensureWeiboPage(page);
         const id = String(kwargs.id);
         const data = requireObjectEvaluateResult(unwrapEvaluateResult(await page.evaluate(`
       (async () => {

--- a/clis/weibo/utils.js
+++ b/clis/weibo/utils.js
@@ -49,8 +49,7 @@ export async function ensureWeiboPage(page) {
     await page.goto('https://weibo.com');
     await page.wait(2);
 }
-/** Get the currently logged-in user's uid from Vue store or config API. */
-export async function getSelfUid(page) {
+async function probeSelfUid(page) {
     const uid = unwrapEvaluateResult(await page.evaluate(`
     (() => {
       const app = document.querySelector('#app')?.__vue_app__;
@@ -60,7 +59,7 @@ export async function getSelfUid(page) {
       return null;
     })()
   `));
-    if (uid)
+    if (typeof uid === 'string' && uid)
         return uid;
     // Fallback: config API
     const config = unwrapEvaluateResult(await page.evaluate(`
@@ -71,7 +70,20 @@ export async function getSelfUid(page) {
       return data.ok && data.data?.uid ? String(data.data.uid) : null;
     })()
   `));
-    if (config)
-        return config;
+    return typeof config === 'string' && config ? config : null;
+}
+/** Get the currently logged-in user's uid from Vue store or config API. */
+export async function getSelfUid(page) {
+    const uid = await probeSelfUid(page);
+    if (uid)
+        return uid;
+    // A warm persistent tab may predate a login-state change: its page (and
+    // Vue store) still reflect the old session. Reload once so the probe runs
+    // against the current login state before concluding the user is logged out.
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+    const retried = await probeSelfUid(page);
+    if (retried)
+        return retried;
     throw new AuthRequiredError('weibo.com');
 }

--- a/clis/weibo/utils.js
+++ b/clis/weibo/utils.js
@@ -31,6 +31,24 @@ export function requireObjectEvaluateResult(payload, label) {
     }
     return payload;
 }
+// Origin check must be exact: cookies are shared across *.weibo.com, but the
+// relative /ajax fetches only work from weibo.com (not s.weibo.com).
+const WEIBO_ORIGIN_RE = /^https?:\/\/(?:www\.)?weibo\.com\//;
+/**
+ * Navigate to weibo.com only when the tab is not already there.
+ * Under a persistent site session the tab stays warm between commands,
+ * so consecutive invocations skip both the navigation and the settle wait.
+ */
+export async function ensureWeiboPage(page) {
+    const currentUrl = typeof page.getCurrentUrl === 'function'
+        ? await page.getCurrentUrl().catch(() => null)
+        : null;
+    if (typeof currentUrl === 'string' && WEIBO_ORIGIN_RE.test(currentUrl)) {
+        return;
+    }
+    await page.goto('https://weibo.com');
+    await page.wait(2);
+}
 /** Get the currently logged-in user's uid from Vue store or config API. */
 export async function getSelfUid(page) {
     const uid = unwrapEvaluateResult(await page.evaluate(`

--- a/clis/weibo/utils.test.js
+++ b/clis/weibo/utils.test.js
@@ -1,6 +1,38 @@
-import { describe, expect, it } from 'vitest';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
-import { requireArrayEvaluateResult, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { getSelfUid, requireArrayEvaluateResult, requireObjectEvaluateResult, unwrapEvaluateResult } from './utils.js';
+
+function makeUidPage(evalResults) {
+    let i = 0;
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(() => Promise.resolve(evalResults[i++])),
+    };
+}
+
+describe('getSelfUid (stale warm-tab recovery)', () => {
+    it('returns the uid without reloading when the store already knows it', async () => {
+        const page = makeUidPage(['1931632001']);
+        await expect(getSelfUid(page)).resolves.toBe('1931632001');
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('reloads once and retries when a warm tab predates the login (store and config both empty)', async () => {
+        // Persistent site session: the tab may still show the pre-login page,
+        // whose Vue store has no uid. A single reload must bring it current.
+        const page = makeUidPage([null, null, '1931632001']);
+        await expect(getSelfUid(page)).resolves.toBe('1931632001');
+        expect(page.goto).toHaveBeenCalledExactlyOnceWith('https://weibo.com');
+        expect(page.wait).toHaveBeenCalledWith(2);
+    });
+
+    it('throws AuthRequiredError only after the reload retry also fails', async () => {
+        const page = makeUidPage([null, null, null, null]);
+        await expect(getSelfUid(page)).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.goto).toHaveBeenCalledExactlyOnceWith('https://weibo.com');
+    });
+});
 
 describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
     it('returns the raw array unchanged when payload is already an array', () => {


### PR DESCRIPTION
## Problem

Every weibo data command was ephemeral: each invocation got a fresh `site:weibo:<uuid>` tab, ran `page.goto('https://weibo.com')`, slept a fixed 2s, and closed the tab afterwards. Only the shared `login`/`whoami` pair used the stable `site:weibo` session — so data commands didn't even run in the session that `login` had established.

For interactive use this is a mild tax (~3.5–4s per call, measured). For batch use it amplifies badly: a collection round of 16 searches + 80 post details + 20 comment fetches pays ~7 minutes of pure navigation overhead and opens/closes 100+ visible tabs in the user's Chrome. One connectivity hiccup mid-round turns into dozens of repeated homepage loads.

## What changed

**1. All 11 weibo commands declare `siteSession: 'persistent'` + `navigateBefore: false`** — the same two-field opt-in that `boss`, `gmail`, and the AI-chat adapters use. Consecutive commands now share one warm `site:weibo` tab.

**2. A new `ensureWeiboPage(page)` guard in `clis/weibo/utils.js`** replaces the unconditional `goto + wait(2)` in the nine ajax-based commands. It navigates only when the tab is not already on a `weibo.com` origin page.

Why adapter-owned navigation instead of relying on the framework's persistent-session pre-nav skip (`shouldRunPreNav`): the framework check matches at *domain* level, but weibo needs an *origin*-level distinction. `search` leaves the tab on `s.weibo.com`, where cookies still work but the relative `/ajax/...` fetches the other commands rely on would hit the wrong origin. The guard's regex (`^https?://(www\.)?weibo\.com/`) deliberately excludes `s.weibo.com` so the next ajax command navigates back.

Two deliberate exceptions:
- `search` always navigates — its target URL carries the query and lives on `s.weibo.com`.
- `publish` keeps its unconditional homepage goto — the UI composer flow depends on fresh home-feed state.

As a side effect, the write commands (`publish`/`delete`) now participate in session-lease arbitration: a concurrent duplicate write fails fast with `session_busy` instead of double-posting.

**3. Stale warm-tab recovery in `getSelfUid`** (second commit). Live testing surfaced an edge the ephemeral world never had: a warm tab that predates a login-state change still shows the pre-login page, so the Vue-store uid probe (and the in-page config fallback) report "logged out" even though the cookies are valid — and nothing ever refreshes the tab. `getSelfUid` now reloads weibo.com once and re-probes before throwing `AuthRequiredError`. A genuinely logged-out user pays one extra reload before the same error; a freshly logged-in user self-heals on their first command. It also only accepts non-empty strings as uids (the in-page scripts can only return `String(uid)` or `null`, so this is pure defense).

## Verification

Unit: 38 new tests (declaration conventions for all 11 commands, `ensureWeiboPage` URL matrix, warm-skip/cold-navigate behavior per command, stale-tab retry), written test-first. Full suite 7354 passed / 1 pre-existing skip; `tsc --noEmit` clean; silent-column-drop and typed-error gates report zero new violations.

Live, against real weibo.com with a logged-in session — all 11 commands returned correct data:

| scenario | timing |
|---|---|
| cold first command (navigates) | 5.7s |
| every warm command after (`hot`/`me`/`post`/`comments`/`user`) | 0.66–1.1s |
| old behavior on `main`, every single call | 3.6–4.1s |
| `comments` right after `search` (nav back from `s.weibo.com`) | 4.4s, then warm again at 0.67s |
| `publish` → verify → `delete` → verify-gone round-trip | 4.5s + 0.83s, delete's 404 postcondition passed |

## Caveat for callers

Persistent means same-site commands share one tab. Reads are not lease-arbitrated, so *parallel* weibo reads can race each other's navigation. Batch callers should keep per-site concurrency at 1 (sequential rounds — the common case — are exactly what this optimizes).

## Follow-ups

Same conversion applies to the other content adapters that still pay a domain-root pre-nav per command — `bilibili` (19 commands), `twitter` (18), `zhihu` (19), `linkedin` (16), `pixiv` (12), etc. Planning to do `bilibili` and `twitter` next as separate PRs, using this one as the template (two declaration fields + an `ensureXxxPage` origin guard + stale-login recovery where a command depends on page state rather than cookies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)