### PR TITLE
docs: list opencli-plugin-multcloud in the community plugin lists

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -210,6 +210,7 @@ On startup, if both `my-command.ts` and `my-command.js` exist, the `.js` version
 | [opencli-plugin-juejin](https://github.com/Astro-Han/opencli-plugin-juejin) | TS | 稀土掘金 (Juejin) hot articles, categories, and article feed |
 | [opencli-plugin-rubysec](https://github.com/nullptrKey/opencli-plugin-rubysec) | TS | RubySec advisory archive and advisory article reader |
 | [opencli-plugin-x-article-publisher](https://github.com/genoooool/opencli-plugin-x-article-publisher) | JS | Publish Markdown with local images as X long-form Articles via OpenCLI and xPoster |
+| [opencli-plugin-multcloud](https://github.com/vecyang1/opencli-plugin-multcloud) | JS | MultCloud cloud-to-cloud transfer, sync, backup, offline remote upload (HTTP/magnet) and Cloud Explorer |
 
 ## Troubleshooting
 

--- a/docs/zh/guide/plugins.md
+++ b/docs/zh/guide/plugins.md
@@ -178,6 +178,7 @@ cli({
 - `opencli-plugin-juejin`：稀土掘金热榜、分类和文章流
 - `opencli-plugin-rubysec`：RubySec 漏洞归档与单篇漏洞文章读取
 - [`opencli-plugin-x-article-publisher`](https://github.com/genoooool/opencli-plugin-x-article-publisher)：通过 OpenCLI 与 xPoster 将带本地图片的 Markdown 发布为 X 长文
+- [`opencli-plugin-multcloud`](https://github.com/vecyang1/opencli-plugin-multcloud)：MultCloud 云盘互传、同步、备份、离线下载（HTTP/磁力）与云端文件管理
 
 ## 排查问题
 


### PR DESCRIPTION
Adds one row to the community plugin lists in `docs/guide/plugins.md` and `docs/zh/guide/plugins.md`. Docs only — no code changes.

**[opencli-plugin-multcloud](https://github.com/vecyang1/opencli-plugin-multcloud)** drives [MultCloud](https://app.multcloud.com) through the OpenCLI browser bridge: cloud-to-cloud transfer, sync, backup, offline remote upload (HTTP/magnet), Cloud Explorer and task observability, across Google Drive, OneDrive, Baidu Netdisk, Google Photos, Gmail and the rest. MultCloud has no public API — payloads are AES-encrypted client-side and posted to `/action.php` with a session cookie — so it drives the real app in an authenticated tab.

```bash
opencli plugin install github:vecyang1/opencli-plugin-multcloud
opencli multcloud doctor
```

Twelve commands: `account`, `stats`, `doctor`, `clouds`, `explorer`, `tasks`, `transfer`, `sync`, `backup`, `remote-upload`, `flow`, `shares`.

A few things it does that might be useful precedent for other adapters against stateful web apps:

- **Writes are verified by read-back.** A create confirms a new task id appeared; a delete confirms the id is gone. The page reporting success is not treated as evidence.
- **Unreadable values are `null`, never `0`.** Aggregates carry a `warnings` array on stderr, so `-f json` stays clean while a human still learns a total is a floor.
- **118 hermetic tests** — no browser, no network, no account — behind a transport seam, plus an opt-in read-only live suite.

Licensing, since it matters for a docs listing: the plugin lives in its own repository under AGPL-3.0-or-later and depends on `@jackwener/opencli` as a **peer** dependency. Nothing AGPL is proposed for this repo — this PR is a one-line-per-file docs addition, contributed under Apache-2.0 per CONTRIBUTING.md, exactly like the other entries in those lists.

Happy to adjust the wording or drop the zh entry if you would rather keep that list shorter.