### PR TITLE
fix(douyin): make fast_detect retries independent of error wording

### DIFF
--- a/clis/douyin/_shared/browser-fetch.js
+++ b/clis/douyin/_shared/browser-fetch.js
@@ -1,9 +1,57 @@
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { unwrapEvaluateResult } from './evaluate-result.js';
 
+const BROWSER_FETCH_ERROR_MARKER = '__opencli_douyin_error';
+const BROWSER_FETCH_HTTP_STATUS = '__opencli_douyin_http_status';
+const BROWSER_FETCH_PAYLOAD = '__opencli_douyin_payload';
+const REQUEST_ERROR_CODES = {
+    EMPTY_RESPONSE: 'DOUYIN_EMPTY_RESPONSE',
+    HTTP: 'DOUYIN_HTTP_ERROR',
+    NETWORK: 'DOUYIN_NETWORK_ERROR',
+    TIMEOUT: 'DOUYIN_TIMEOUT',
+    PARSE: 'DOUYIN_PARSE_ERROR',
+    API: 'DOUYIN_API_ERROR',
+    MALFORMED: 'DOUYIN_MALFORMED_RESPONSE',
+    EVALUATE: 'DOUYIN_EVALUATE_ERROR',
+};
+
+export class DouyinRequestError extends CommandExecutionError {
+    constructor(errorCode, message, { hint, phase, httpStatus, apiCode, url } = {}) {
+        super(message, hint);
+        // Keep COMMAND_EXEC as the public envelope code. Consumers can use the
+        // request-specific code without depending on error-message wording.
+        this.errorCode = errorCode;
+        if (phase) this.phase = phase;
+        if (httpStatus !== undefined) this.httpStatus = httpStatus;
+        if (apiCode !== undefined) this.apiCode = apiCode;
+        if (url) this.url = url;
+    }
+}
+
 function isAuthLikeError(code, message) {
     const text = String(message ?? '');
     return code === 401 || code === 403 || /login|cookie|auth|captcha|verify|forbidden|permission|登录|登陆|权限|验证|验证码/i.test(text);
+}
+
+function requestError(code, message, options) {
+    return new DouyinRequestError(code, message, options);
+}
+
+function getRequestErrorCode(marker, statusCode) {
+    switch (marker) {
+        case 'HTTP':
+            return REQUEST_ERROR_CODES.HTTP;
+        case 'NETWORK':
+            return REQUEST_ERROR_CODES.NETWORK;
+        case 'TIMEOUT':
+            return REQUEST_ERROR_CODES.TIMEOUT;
+        case 'PARSE':
+            return REQUEST_ERROR_CODES.PARSE;
+        default:
+            if (statusCode === -1) return REQUEST_ERROR_CODES.NETWORK;
+            if (statusCode === -2) return REQUEST_ERROR_CODES.PARSE;
+            return REQUEST_ERROR_CODES.API;
+    }
 }
 
 /**
@@ -14,7 +62,11 @@ export async function browserFetch(page, method, url, options = {}) {
     const js = `
     (async () => {
       const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), ${Number(options.timeoutMs ?? 30000)});
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, ${Number(options.timeoutMs ?? 30000)});
       try {
         const res = await fetch(${JSON.stringify(url)}, {
           method: ${JSON.stringify(method)},
@@ -30,14 +82,38 @@ export async function browserFetch(page, method, url, options = {}) {
         // A retired or gated endpoint answers 200 with no body. Reporting that
         // as a parse failure sends readers after the JSON instead of the
         // endpoint (issue #1405 fixed it, #1587 dropped it again).
-        if (!text.trim()) return res.ok ? null : { status_code: res.status, status_msg: 'Empty response body' };
+        if (!text.trim()) {
+          return res.ok ? null : {
+            ${JSON.stringify(BROWSER_FETCH_ERROR_MARKER)}: 'HTTP',
+            ${JSON.stringify(BROWSER_FETCH_HTTP_STATUS)}: res.status,
+            ${JSON.stringify(BROWSER_FETCH_PAYLOAD)}: { status_msg: 'Empty response body' },
+          };
+        }
         try {
-          return JSON.parse(text);
+          const payload = JSON.parse(text);
+          return res.ok ? payload : {
+            ${JSON.stringify(BROWSER_FETCH_ERROR_MARKER)}: 'HTTP',
+            ${JSON.stringify(BROWSER_FETCH_HTTP_STATUS)}: res.status,
+            ${JSON.stringify(BROWSER_FETCH_PAYLOAD)}: payload,
+          };
         } catch (error) {
-          return { status_code: res.ok ? -2 : res.status, status_msg: \`JSON parse failed: \${text.slice(0, 500) || String(error && error.message || error)}\` };
+          return {
+            ${JSON.stringify(BROWSER_FETCH_ERROR_MARKER)}: res.ok ? 'PARSE' : 'HTTP',
+            ${JSON.stringify(BROWSER_FETCH_HTTP_STATUS)}: res.ok ? undefined : res.status,
+            ${JSON.stringify(BROWSER_FETCH_PAYLOAD)}: {
+              status_code: res.ok ? -2 : undefined,
+              status_msg: \`JSON parse failed: \${text.slice(0, 500) || String(error && error.message || error)}\`,
+            },
+          };
         }
       } catch (error) {
-        return { status_code: -1, status_msg: String(error && error.message || error) };
+        return {
+          ${JSON.stringify(BROWSER_FETCH_ERROR_MARKER)}: timedOut ? 'TIMEOUT' : 'NETWORK',
+          ${JSON.stringify(BROWSER_FETCH_PAYLOAD)}: {
+            status_code: -1,
+            status_msg: String(error && error.message || error),
+          },
+        };
       } finally {
         clearTimeout(timer);
       }
@@ -48,25 +124,77 @@ export async function browserFetch(page, method, url, options = {}) {
         result = unwrapEvaluateResult(await page.evaluate(js));
     }
     catch (error) {
-        throw new CommandExecutionError(`Douyin API request failed (${method} ${url}): ${error instanceof Error ? error.message : String(error)}`);
+        const code = error?.code === 'TIMEOUT' || error?.name === 'TimeoutError'
+            ? REQUEST_ERROR_CODES.TIMEOUT
+            : REQUEST_ERROR_CODES.EVALUATE;
+        throw requestError(
+            code,
+            `Douyin API request failed (${method} ${url}): ${error instanceof Error ? error.message : String(error)}`,
+            { phase: options.phase, url },
+        );
+    }
+    const markedResult = result && typeof result === 'object' && !Array.isArray(result)
+        ? result[BROWSER_FETCH_ERROR_MARKER]
+        : undefined;
+    if (markedResult) {
+        const httpStatus = result[BROWSER_FETCH_HTTP_STATUS];
+        const payload = result[BROWSER_FETCH_PAYLOAD] ?? result;
+        const apiCode = payload && typeof payload === 'object' && !Array.isArray(payload)
+            ? payload.status_code
+            : undefined;
+        const msg = payload && typeof payload === 'object' && !Array.isArray(payload)
+            ? payload.status_msg ?? payload.message ?? `HTTP ${httpStatus}`
+            : `HTTP ${httpStatus}`;
+        if (markedResult === 'HTTP' && (isAuthLikeError(httpStatus, msg) || isAuthLikeError(apiCode, msg))) {
+            const error = new AuthRequiredError('creator.douyin.com', `Douyin API auth/permission error ${apiCode ?? httpStatus} at ${method} ${url}: ${msg}`);
+            if (options.phase) error.phase = options.phase;
+            if (httpStatus !== undefined) error.httpStatus = httpStatus;
+            if (apiCode !== undefined) error.apiCode = apiCode;
+            error.url = url;
+            throw error;
+        }
+        const errorCode = getRequestErrorCode(markedResult, apiCode);
+        throw requestError(
+            errorCode,
+            `Douyin API error ${apiCode ?? httpStatus} at ${method} ${url}: ${msg}`,
+            { phase: options.phase, httpStatus, apiCode, url },
+        );
     }
     if (result == null) {
-        throw new CommandExecutionError(
+        throw requestError(
+            REQUEST_ERROR_CODES.EMPTY_RESPONSE,
             `Empty response from Douyin API (${method} ${url})`,
-            'The endpoint may have been retired or may now require signed parameters.',
+            {
+                hint: 'The endpoint may have been retired or may now require signed parameters.',
+                phase: options.phase,
+                url,
+            },
         );
     }
     if (Array.isArray(result) || typeof result !== 'object') {
-        throw new CommandExecutionError(`Malformed response from Douyin API (${method} ${url})`);
+        throw requestError(
+            REQUEST_ERROR_CODES.MALFORMED,
+            `Malformed response from Douyin API (${method} ${url})`,
+            { phase: options.phase, url },
+        );
     }
     if (result && typeof result === 'object' && 'status_code' in result) {
         const code = result.status_code;
         if (code !== 0) {
             const msg = result.status_msg ?? result.message ?? 'unknown error';
+            const marker = result[BROWSER_FETCH_ERROR_MARKER];
             if (isAuthLikeError(code, msg)) {
-                throw new AuthRequiredError('creator.douyin.com', `Douyin API auth/permission error ${code} at ${method} ${url}: ${msg}`);
+                const error = new AuthRequiredError('creator.douyin.com', `Douyin API auth/permission error ${code} at ${method} ${url}: ${msg}`);
+                if (options.phase) error.phase = options.phase;
+                error.apiCode = code;
+                error.url = url;
+                throw error;
             }
-            throw new CommandExecutionError(`Douyin API error ${code} at ${method} ${url}: ${msg}`);
+            throw requestError(
+                getRequestErrorCode(marker, code),
+                `Douyin API error ${code} at ${method} ${url}: ${msg}`,
+                { phase: options.phase, apiCode: code, url },
+            );
         }
     }
     return result;

--- a/clis/douyin/_shared/browser-fetch.test.js
+++ b/clis/douyin/_shared/browser-fetch.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
-import { browserFetch } from './browser-fetch.js';
+import { browserFetch, DouyinRequestError } from './browser-fetch.js';
 function makePage(result) {
     return {
         goto: vi.fn(), evaluate: vi.fn().mockResolvedValue(result),
@@ -13,10 +13,18 @@ function makePage(result) {
         screenshot: vi.fn(),
     };
 }
-function makeScriptPage(body, { ok = true, status = 200, envelope = false } = {}) {
+function makeScriptPage(body, { ok = true, status = 200, envelope = false, fetchError, hang = false } = {}) {
     const page = makePage(null);
     page.evaluate = vi.fn(async (script) => {
-        const stubFetch = async () => ({ ok, status, text: async () => body });
+        const stubFetch = async (_url, requestOptions) => {
+            if (fetchError) throw new Error(fetchError);
+            if (hang) {
+                return new Promise((_, reject) => {
+                    requestOptions.signal.addEventListener('abort', () => reject(new Error('This operation was aborted')), { once: true });
+                });
+            }
+            return { ok, status, text: async () => body };
+        };
         const value = await new Function('fetch', `return (${script});`)(stubFetch);
         return envelope ? { session: 'site:douyin:test', data: value } : value;
     });
@@ -35,7 +43,8 @@ describe('browserFetch', () => {
     });
     it('throws when status_code is non-zero', async () => {
         const page = makePage({ status_code: 8, message: 'fail' });
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API error 8');
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_API_ERROR', apiCode: 8 });
     });
     it('maps auth-like API errors to AuthRequiredError', async () => {
         const page = makePage({ status_code: 401, status_msg: 'login required' });
@@ -50,22 +59,22 @@ describe('browserFetch', () => {
     it('reports an empty body as an empty response, not a parse failure', async () => {
         const page = makeScriptPage('');
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('Empty response from Douyin API');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EMPTY_RESPONSE' });
     });
     it('treats a whitespace-only body the same way', async () => {
         const page = makeScriptPage('  \n  ');
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('Empty response from Douyin API');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EMPTY_RESPONSE' });
     });
     it('reports an empty body through a Browser Bridge {session,data} envelope', async () => {
         const page = makeScriptPage('', { envelope: true });
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('Empty response from Douyin API');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EMPTY_RESPONSE' });
     });
     it('still reports a non-JSON body as a parse failure', async () => {
         const page = makeScriptPage('<html>gateway</html>');
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('JSON parse failed: <html>gateway</html>');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_PARSE_ERROR', apiCode: -2 });
     });
     it('parses a JSON body from the generated script', async () => {
         const page = makeScriptPage('{"status_code":0,"challenge_list":[]}');
@@ -74,35 +83,92 @@ describe('browserFetch', () => {
     });
     it('keeps the auth classification when an empty body comes with 403', async () => {
         const page = makeScriptPage('', { ok: false, status: 403 });
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toBeInstanceOf(AuthRequiredError);
+        const error = await browserFetch(page, 'GET', 'https://creator.douyin.com/api/test').catch((caught) => caught);
+        expect(error).toBeInstanceOf(AuthRequiredError);
+        expect(error).toMatchObject({ httpStatus: 403 });
     });
     it('keeps the status when an empty body comes with 404', async () => {
         const page = makeScriptPage('', { ok: false, status: 404 });
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('Douyin API error 404');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_HTTP_ERROR', httpStatus: 404 });
+    });
+    it('uses the HTTP status when a non-2xx response has a successful API body', async () => {
+        const page = makeScriptPage('{"status_code":0,"data":{"ok":true}}', { ok: false, status: 404 });
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                errorCode: 'DOUYIN_HTTP_ERROR',
+                httpStatus: 404,
+                apiCode: 0,
+            });
+    });
+    it('does not treat an API 404 as an HTTP 404', async () => {
+        const page = makePage({ status_code: 404, status_msg: 'business record not found' });
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toMatchObject({
+                code: 'COMMAND_EXEC',
+                errorCode: 'DOUYIN_API_ERROR',
+                apiCode: 404,
+            });
     });
     it('throws on empty response body (null from evaluate)', async () => {
         const page = makePage(null);
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EMPTY_RESPONSE' });
     });
     it('throws on undefined response body', async () => {
         const page = makePage(undefined);
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Empty response from Douyin API');
+        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EMPTY_RESPONSE' });
     });
     it('throws typed on malformed primitive response body', async () => {
         const page = makePage('not-json-object');
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toBeInstanceOf(CommandExecutionError);
+        const error = await browserFetch(page, 'GET', 'https://creator.douyin.com/api/test').catch((caught) => caught);
+        expect(error).toBeInstanceOf(DouyinRequestError);
+        expect(error).toBeInstanceOf(CommandExecutionError);
+        expect(error).toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_MALFORMED_RESPONSE' });
     });
     it('throws typed when browser fetch returns a non-JSON body', async () => {
         const page = makePage({ status_code: -2, status_msg: 'JSON parse failed: <html>not-json</html>' });
         await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test'))
-            .rejects.toThrow('Douyin API error -2');
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_PARSE_ERROR', apiCode: -2 });
     });
-    it('wraps browser-side fetch or JSON parse failures', async () => {
+    it('wraps evaluator failures with a stable error code', async () => {
         const page = makePage(null);
         page.evaluate.mockRejectedValueOnce(new SyntaxError('Unexpected token < in JSON'));
-        await expect(browserFetch(page, 'GET', 'https://creator.douyin.com/api/test')).rejects.toThrow('Douyin API request failed (GET https://creator.douyin.com/api/test): Unexpected token < in JSON');
+        const error = await browserFetch(page, 'GET', 'https://creator.douyin.com/api/test').catch((caught) => caught);
+        expect(error).toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_EVALUATE_ERROR' });
+        expect(error.message).toBe('Douyin API request failed (GET https://creator.douyin.com/api/test): Unexpected token < in JSON');
+    });
+    it('preserves the fast-detect phase on transient request errors', async () => {
+        const page = makeScriptPage('');
+        await expect(browserFetch(page, 'POST', 'https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/pre_check', {
+            phase: 'fast_detect/pre_check',
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            errorCode: 'DOUYIN_EMPTY_RESPONSE',
+            phase: 'fast_detect/pre_check',
+        });
+    });
+    it('classifies network failures without inspecting their message', async () => {
+        const page = makeScriptPage('', { fetchError: 'transport wording changed' });
+        await expect(browserFetch(page, 'POST', 'https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/poll', {
+            phase: 'fast_detect/poll',
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            errorCode: 'DOUYIN_NETWORK_ERROR',
+            phase: 'fast_detect/poll',
+        });
+    });
+    it('classifies an aborted request as a timeout', async () => {
+        const page = makeScriptPage('', { hang: true });
+        await expect(browserFetch(page, 'POST', 'https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/poll', {
+            timeoutMs: 1,
+            phase: 'fast_detect/poll',
+        })).rejects.toMatchObject({
+            code: 'COMMAND_EXEC',
+            errorCode: 'DOUYIN_TIMEOUT',
+            phase: 'fast_detect/poll',
+        });
     });
 });

--- a/clis/douyin/publish-upload-id.test.js
+++ b/clis/douyin/publish-upload-id.test.js
@@ -110,7 +110,10 @@ describe('douyin publish upload identifier handling', () => {
     fs.writeFileSync(video, Buffer.from('fake-video'));
     mocks.browserFetch.mockImplementation(async (_page, method, url) => {
       if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
-        throw new Error('Empty response from Douyin API (POST https://creator.douyin.com/aweme/v1/post_assistant/fast_detect/pre_check)');
+        const error = Object.assign(new Error('transport wording changed'), { code: 'COMMAND_EXEC' });
+        error.errorCode = 'DOUYIN_EMPTY_RESPONSE';
+        error.phase = 'fast_detect/pre_check';
+        throw error;
       }
       if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/poll')) return { status: -1, has_done: true, detect_result: { reason_code: 0 }, detect_list: [] };
       if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { item_id: 'item-1' };
@@ -133,7 +136,160 @@ describe('douyin publish upload identifier handling', () => {
     });
 
     expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toBe(true);
+    expect(mocks.browserFetch.mock.calls.filter((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toHaveLength(3);
     expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/aweme/create_v2/'))).toBe(true);
+  });
+
+  it('retries fast detect from typed errors even when the message wording changes', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-retry-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    let preCheckCalls = 0;
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
+        preCheckCalls += 1;
+        if (preCheckCalls === 1) {
+          const error = Object.assign(new Error('transport wording changed'), { code: 'COMMAND_EXEC' });
+          error.errorCode = 'DOUYIN_NETWORK_ERROR';
+          error.phase = 'fast_detect/pre_check';
+          throw error;
+        }
+        return { status_code: 0 };
+      }
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/poll')) return { status: 0 };
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { aweme_id: 'aweme-retried' };
+      return { status_code: 0 };
+    });
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      visibility: 'public',
+      caption: 'caption',
+      no_safety_check: false,
+    });
+
+    expect(preCheckCalls).toBe(2);
+    expect(mocks.browserFetch.mock.calls.filter((call) => String(call[2]).includes('/aweme/create_v2/'))).toHaveLength(1);
+  });
+
+  it('does not retry a non-transient typed error because its message contains a retry token', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-no-retry-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
+        const error = Object.assign(new Error('Empty response wording from parser'), { code: 'COMMAND_EXEC' });
+        error.errorCode = 'DOUYIN_PARSE_ERROR';
+        error.phase = 'fast_detect/pre_check';
+        throw error;
+      }
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { aweme_id: 'should-not-publish' };
+      return { status_code: 0 };
+    });
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await expect(cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      visibility: 'public',
+      caption: 'caption',
+      no_safety_check: false,
+    })).rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_PARSE_ERROR', phase: 'fast_detect/pre_check' });
+
+    expect(mocks.browserFetch.mock.calls.filter((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toHaveLength(1);
+    expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/aweme/create_v2/'))).toBe(false);
+  });
+
+  it('retries an actual HTTP 404', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-http-404-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    let preCheckCalls = 0;
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
+        preCheckCalls += 1;
+        if (preCheckCalls === 1) {
+          throw Object.assign(new Error('business response changed'), {
+            code: 'COMMAND_EXEC',
+            errorCode: 'DOUYIN_HTTP_ERROR',
+            httpStatus: 404,
+            apiCode: 0,
+            phase: 'fast_detect/pre_check',
+          });
+        }
+        return { status_code: 0 };
+      }
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/poll')) return { status: 0 };
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { aweme_id: 'aweme-http-retried' };
+      return { status_code: 0 };
+    });
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      visibility: 'public',
+      caption: 'caption',
+      no_safety_check: false,
+    });
+
+    expect(preCheckCalls).toBe(2);
+  });
+
+  it('does not retry an API-level 404', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'douyin-publish-api-404-'));
+    const video = path.join(tmpDir, 'video.mp4');
+    fs.writeFileSync(video, Buffer.from('fake-video'));
+    mocks.browserFetch.mockImplementation(async (_page, method, url) => {
+      if (method === 'POST' && String(url).includes('/post_assistant/fast_detect/pre_check')) {
+        throw Object.assign(new Error('record not found'), {
+          code: 'COMMAND_EXEC',
+          errorCode: 'DOUYIN_API_ERROR',
+          apiCode: 404,
+          phase: 'fast_detect/pre_check',
+        });
+      }
+      if (method === 'POST' && String(url).includes('/aweme/create_v2/')) return { aweme_id: 'should-not-publish' };
+      return { status_code: 0 };
+    });
+
+    const { getRegistry } = await import('@jackwener/opencli/registry');
+    getRegistry().delete('douyin/publish');
+    await import('./publish.js');
+    const cmd = getRegistry().get('douyin/publish');
+    if (!cmd) throw new Error('douyin publish command not registered');
+
+    await expect(cmd.func({}, {
+      video,
+      title: 'OpenCLI自测',
+      schedule: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      visibility: 'public',
+      caption: 'caption',
+      no_safety_check: false,
+    })).rejects.toMatchObject({ code: 'COMMAND_EXEC', errorCode: 'DOUYIN_API_ERROR', apiCode: 404 });
+
+    expect(mocks.browserFetch.mock.calls.filter((call) => String(call[2]).includes('/post_assistant/fast_detect/pre_check'))).toHaveLength(1);
+    expect(mocks.browserFetch.mock.calls.some((call) => String(call[2]).includes('/aweme/create_v2/'))).toBe(false);
   });
 
   it('unwraps Browser Bridge envelopes around cover ImageX evaluate results', async () => {

--- a/clis/douyin/publish.js
+++ b/clis/douyin/publish.js
@@ -54,9 +54,16 @@ const DEFAULT_COVER_TOOLS_INFO = JSON.stringify({
     initial_cover_uri: '',
     cut_coordinate: '',
 });
-function isFastDetectRetryable(error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return message.includes('post_assistant/fast_detect') && (message.includes('Empty response') || message.includes('404') || message.includes('Not Found') || message.includes('Timeout') || message.includes('timed out') || message.includes('Failed to fetch'));
+function isFastDetectRetryable(error, phase) {
+    if (!error || error.phase !== phase) {
+        return false;
+    }
+    // Preserve retry behavior for transport-level 404s; an API-level 404 is a
+    // service result and should be surfaced unchanged.
+    return error.errorCode === 'DOUYIN_EMPTY_RESPONSE'
+        || error.errorCode === 'DOUYIN_NETWORK_ERROR'
+        || error.errorCode === 'DOUYIN_TIMEOUT'
+        || (error.errorCode === 'DOUYIN_HTTP_ERROR' && error.httpStatus === 404);
 }
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -67,13 +74,13 @@ function throwIfImagexError(action, payload) {
         throw new CommandExecutionError(`${action}失败: ${JSON.stringify(error)}`);
     }
 }
-async function tryFastDetectFetch(page, method, url, options) {
+async function tryFastDetectFetch(page, phase, method, url, options) {
     let lastError;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
         try {
-            return { ok: true, value: await browserFetch(page, method, url, options) };
+            return { ok: true, value: await browserFetch(page, method, url, { ...options, phase }) };
         } catch (error) {
-            if (!isFastDetectRetryable(error)) {
+            if (!isFastDetectRetryable(error, phase)) {
                 throw error;
             }
             lastError = error;
@@ -207,7 +214,7 @@ cli({
                 title,
                 desc: caption,
             };
-            const preCheck = await tryFastDetectFetch(page, 'POST', safetyUrl, { body: safetyBody });
+            const preCheck = await tryFastDetectFetch(page, 'fast_detect/pre_check', 'POST', safetyUrl, { body: safetyBody });
             if (!preCheck.ok) {
                 process.stderr.write('  内容安全预检接口无响应，继续轮询检测结果。\n');
             }
@@ -216,7 +223,7 @@ cli({
             let safetyPassed = false;
             let pollUnavailableCount = 0;
             while (Date.now() < deadline) {
-                const poll = await tryFastDetectFetch(page, 'POST', pollUrl, { body: safetyBody });
+                const poll = await tryFastDetectFetch(page, 'fast_detect/poll', 'POST', pollUrl, { body: safetyBody });
                 if (!poll.ok) {
                     pollUnavailableCount += 1;
                     if (!preCheck.ok && pollUnavailableCount >= 3) {


### PR DESCRIPTION
## Description

`fast_detect` currently decides whether to retry by searching error-message text. This makes retry behavior depend on wording and can silently stop working when the upstream response or wrapper changes.

This patch gives Douyin browser requests stable typed error metadata (`errorCode`, `phase`, HTTP/API status) while keeping the existing public `COMMAND_EXEC` envelope. `publish` now retries only transient failures from the `fast_detect` phase: empty responses, network failures, timeouts, and transport-level HTTP 404s. API-level 404s, parse failures, malformed responses, and other non-transient errors are surfaced without retrying.

The scope is intentionally limited to request classification and the `fast_detect` retry decision. Uploading, polling, `create_v2`, CLI arguments, and other adapters remain unchanged. Keeping the change focused preserves existing behavior, reduces regression and review cost, and makes verification of #2319 straightforward.

Related issue: Fixes #2319

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

Focused regression tests:

```text
Test Files  2 passed (2)
Tests       31 passed (31)
```

Full Douyin adapter suite:

```text
Test Files  25 passed (25)
Tests       210 passed (210)
```

Additional checks passed:

- `npm run typecheck`
- `npm run build`
- `npm run check:typed-error-lint`
- `npm run check:silent-column-drop`
- `node dist/src/main.js validate douyin`
- `npm audit --registry=https://registry.npmjs.org/ --omit=dev --audit-level=high`
- `git diff --check`

The typed-error lint remained at `current=130, baseline=130, new=0`, and the silent-column-drop check remained at `current=94, baseline=94, new=0`.

Manual verification with a logged-in Douyin creator session confirmed that an empty `fast_detect/pre_check` response entered the retry path and allowed the pipeline to continue into polling. A later empty `create_v2` response was observed separately; this PR does not claim to fix that downstream issue.

