### PR TITLE
fix(xiaohongshu): accept overlapping duplicate filter options

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -361,6 +361,9 @@ function buildApplySearchFiltersJs(requestedFilters) {
         const requestedFilters = ${JSON.stringify(requestedFilters)};
         const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
         const text = (element) => (element?.textContent || '').replace(/\\s+/g, '').trim();
+        const sameBoundingBox = (left, right) =>
+          left.left === right.left && left.top === right.top &&
+          left.width === right.width && left.height === right.height;
         const visible = (element) => {
           if (!element) return false;
           const rect = element.getBoundingClientRect();
@@ -405,7 +408,16 @@ function buildApplySearchFiltersJs(requestedFilters) {
           const options = visibleMatches(groups[0], '.tag-container > .tags')
             .filter((option) => text(option) === request.option);
           if (options.length !== 1) {
-            return { status: 'layout', detail: options.length ? 'ambiguous_option' : 'option_not_found' };
+            const firstOption = options[0];
+            const firstRect = firstOption?.getBoundingClientRect();
+            const firstActive = firstOption?.classList.contains('active');
+            const sameRenderedOption = firstRect && options.every((option) =>
+              sameBoundingBox(option.getBoundingClientRect(), firstRect) &&
+              option.classList.contains('active') === firstActive
+            );
+            if (!sameRenderedOption) {
+              return { status: 'layout', detail: options.length ? 'ambiguous_option' : 'option_not_found' };
+            }
           }
           return { status: 'ok', option: options[0] };
         };

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -15,7 +15,7 @@ import {
 } from './search.js';
 
 function markVisible(el) {
-    el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0 });
+    el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0, left: 0 });
 }
 function createPageMock(evaluateResults) {
     const queuedResults = [...evaluateResults];
@@ -145,7 +145,8 @@ function createFilterBehaviorPage(options = {}) {
             container.className = 'tag-container';
             for (const choice of choices) {
                 if (options.missing === `${groupLabel}/${choice}`) continue;
-                const copies = options.ambiguous === `${groupLabel}/${choice}` ? 2 : 1;
+                const copies = options.ambiguous === `${groupLabel}/${choice}` ||
+                    options.stacked === `${groupLabel}/${choice}` ? 2 : 1;
                 for (let copy = 0; copy < copies; copy++) {
                     const option = document.createElement('div');
                     option.className = `tags${state[groupLabel] === choice ? ' active' : ''}`;
@@ -173,7 +174,12 @@ function createFilterBehaviorPage(options = {}) {
                         }, 300);
                     });
                     container.append(option);
-                    markVisible(option);
+                    if (options.ambiguous === `${groupLabel}/${choice}` && copy > 0) {
+                        option.getBoundingClientRect = () => ({ width: 100, height: 100, top: 120, left: 0 });
+                    }
+                    else {
+                        markVisible(option);
+                    }
                     markVisible(optionLabel);
                 }
             }
@@ -678,6 +684,19 @@ describe('xiaohongshu search filter behavior', () => {
             const page = createFilterBehaviorPage({ initial: { '排序依据': '最新' } });
             const result = await runFilterCommand(page, { sort: 'latest' });
             expect(result[0].title).toBe('最新');
+            expect(page.filterClicks).toEqual([]);
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('accepts overlapping duplicate nodes for the same active filter option', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ stacked: '排序依据/综合' });
+            const result = await runFilterCommand(page, {});
+            expect(result[0].title).toBe('综合');
             expect(page.filterClicks).toEqual([]);
         }
         finally {


### PR DESCRIPTION
## Description

Xiaohongshu can render two overlapping DOM elements for one visible search filter option. OpenCLI currently treats any duplicate text match as ambiguous, so a search can stop with `ambiguous_option` even when both elements represent the same rendered option.

This change accepts multiple same-text matches only when every match has the same bounding box and active state. Matches at different positions or sizes, or with different active states, continue to fail closed with `ambiguous_option`.

The regression fixture reproduces the observed default `排序依据/综合` state with two overlapping active elements and verifies that no unnecessary filter click is issued. The existing distinct-position case continues to cover the genuinely ambiguous path.

Related issue: Fixes #2445

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

Not applicable: this fixes existing adapter behavior without changing commands, arguments, documentation surfaces, or failure types.

## Screenshots / Output

```text
npx vitest run --project adapter clis/xiaohongshu/search.test.js
Test Files  1 passed (1)
Tests       65 passed (65)

npm test
Test Files  631 passed (631)
Tests       7317 passed | 1 skipped (7318)

npm run typecheck
tsc --noEmit
```
