### PR TITLE
fix(codex): add the ChatGPT executable for Codex.app

### DIFF
--- a/src/electron-apps.test.ts
+++ b/src/electron-apps.test.ts
@@ -13,6 +13,7 @@ describe('electron-apps registry', () => {
     const app = getElectronApp('codex');
     expect(app).toBeDefined();
     expect(app!.port).toBe(9238);
+    expect(app!.executableNames).toEqual(['ChatGPT', 'Codex']);
   });
 
   it('keeps builtin Electron app CDP ports unique and off the browser-bridge port', () => {

--- a/src/electron-apps.ts
+++ b/src/electron-apps.ts
@@ -27,7 +27,7 @@ export interface ElectronAppEntry {
 
 export const builtinApps: Record<string, ElectronAppEntry> = {
   cursor:        { port: 9226, processName: 'Cursor',      bundleId: 'com.todesktop.runtime.Cursor',   displayName: 'Cursor' },
-  codex:         { port: 9238, processName: 'Codex',        bundleId: 'com.openai.codex',               displayName: 'Codex' },
+  codex:         { port: 9238, processName: 'Codex',        executableNames: ['ChatGPT', 'Codex'], bundleId: 'com.openai.codex',               displayName: 'Codex' },
   chatwise:      { port: 9228, processName: 'ChatWise',     bundleId: 'com.chatwise.app',               displayName: 'ChatWise' },
   'discord-app': { port: 9232, processName: 'Discord',      bundleId: 'com.discord.app',                 displayName: 'Discord' },
   'doubao-app':  { port: 9225, processName: 'Doubao',       bundleId: 'com.volcengine.doubao',          displayName: 'Doubao' },


### PR DESCRIPTION
## Summary
Codex.app can expose `ChatGPT` as the actual bundle executable, so the builtin Codex registry now advertises both `ChatGPT` and `Codex`.

## Verification
- `npx vitest run --project unit src/electron-apps.test.ts`
- `npx vitest run --project unit src/launcher.test.ts`
- `npm run typecheck`
- `npm test`

Fixes #2231