### PR TITLE
feat(gutenberg): add book browsing commands

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -17224,6 +17224,297 @@
     "sourceFile": "guazi/car.js"
   },
   {
+    "site": "gutenberg",
+    "name": "author",
+    "description": "List all books by a Project Gutenberg author",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Author number, for example 69"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "downloads",
+        "required": false,
+        "help": "Sort by title, downloads, or release_date",
+        "choices": [
+          "title",
+          "downloads",
+          "release_date"
+        ]
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "author",
+      "url",
+      "downloads"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/author.js",
+    "sourceFile": "gutenberg/author.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "categories",
+    "description": "List Project Gutenberg Reading List categories, optionally filtered by initial",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "initial",
+        "type": "str",
+        "required": false,
+        "help": "Initial letter A-Z; returns all categories by default"
+      }
+    ],
+    "columns": [
+      "id",
+      "initial",
+      "name",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/categories.js",
+    "sourceFile": "gutenberg/categories.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "category-search",
+    "description": "Search Project Gutenberg bookshelf categories",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Category search query"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "downloads",
+        "required": false,
+        "help": "Sort by title, downloads, quantity, or release_date",
+        "choices": [
+          "title",
+          "downloads",
+          "quantity",
+          "release_date"
+        ]
+      }
+    ],
+    "columns": [
+      "name",
+      "downloads",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/category-search.js",
+    "sourceFile": "gutenberg/category-search.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "collections",
+    "description": "List the top Collections from Project Gutenberg Reading Lists",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "name",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/collections.js",
+    "sourceFile": "gutenberg/collections.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "ebooks",
+    "description": "Get Project Gutenberg ebook metadata and download URLs for all formats",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "id",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Gutenberg ebook number, for example 30849"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "author",
+      "summary",
+      "language",
+      "subjects",
+      "releaseDate",
+      "lastUpdate",
+      "copyright",
+      "downloads",
+      "readOnlineUrl",
+      "url",
+      "formats"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/ebooks.js",
+    "sourceFile": "gutenberg/ebooks.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "hot-author",
+    "description": "List the Project Gutenberg top author rankings",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of results (1-100)"
+      },
+      {
+        "name": "period",
+        "type": "str",
+        "default": "yesterday",
+        "required": false,
+        "help": "Period: yesterday, 7days, or 30days"
+      }
+    ],
+    "columns": [
+      "id",
+      "name",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/hot-author.js",
+    "sourceFile": "gutenberg/hot-author.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "hot-books",
+    "description": "List the Project Gutenberg top book rankings",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of results (1-100)"
+      },
+      {
+        "name": "period",
+        "type": "str",
+        "default": "yesterday",
+        "required": false,
+        "help": "Period: yesterday, 7days, or 30days"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/hot-books.js",
+    "sourceFile": "gutenberg/hot-books.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "main-categories",
+    "description": "List Project Gutenberg main book categories and parent categories",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [],
+    "columns": [
+      "id",
+      "name",
+      "parentName",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/main-categories.js",
+    "sourceFile": "gutenberg/main-categories.js"
+  },
+  {
+    "site": "gutenberg",
+    "name": "search",
+    "description": "Search Project Gutenberg books, returning 10 results by default",
+    "access": "read",
+    "domain": "www.gutenberg.org",
+    "strategy": "public",
+    "browser": false,
+    "args": [
+      {
+        "name": "title",
+        "type": "str",
+        "default": "",
+        "required": false,
+        "positional": true,
+        "help": "Optional book title or keyword"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "downloads",
+        "required": false,
+        "help": "Sort by title, downloads, or release_date",
+        "choices": [
+          "title",
+          "downloads",
+          "release_date"
+        ]
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 10,
+        "required": false,
+        "help": "Number of results (1-100)"
+      }
+    ],
+    "columns": [
+      "id",
+      "title",
+      "author",
+      "url",
+      "downloads"
+    ],
+    "type": "js",
+    "modulePath": "gutenberg/search.js",
+    "sourceFile": "gutenberg/search.js"
+  },
+  {
     "site": "hackernews",
     "name": "ask",
     "description": "Hacker News Ask HN posts",

--- a/clis/gutenberg/author.js
+++ b/clis/gutenberg/author.js
@@ -1,0 +1,25 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { fetchAllAuthorBooks, requireChoice, requireId } from './utils.js';
+
+const SORTS = ['title', 'downloads', 'release_date'];
+
+cli({
+    site: 'gutenberg',
+    name: 'author',
+    access: 'read',
+    description: 'List all books by a Project Gutenberg author',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'id', positional: true, required: true, help: 'Author number, for example 69' },
+        { name: 'sort', default: 'downloads', choices: SORTS, help: 'Sort by title, downloads, or release_date' },
+    ],
+    columns: ['id', 'title', 'author', 'url', 'downloads'],
+    func: async (args) => {
+        const id = requireId(args.id, 'author id');
+        const sort = requireChoice(args.sort, 'downloads', SORTS, 'author sort');
+        const rows = await fetchAllAuthorBooks(id, sort);
+        return rows.map((row) => ({ id: row.id, title: row.title, author: row.author, url: row.url, downloads: row.downloads }));
+    },
+});

--- a/clis/gutenberg/author.test.js
+++ b/clis/gutenberg/author.test.js
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './author.js';
+
+function book(id, extra = `${id} downloads`) {
+    return `<li class="booklink"><a href="/ebooks/${id}"><span class="title">Book ${id}</span><span class="subtitle">Author Name</span><span class="extra">${extra}</span></a></li>`;
+}
+
+describe('gutenberg author', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('follows author pagination and returns all books', async () => {
+        const firstPage = Array.from({ length: 25 }, (_, index) => book(index + 1)).join('');
+        const firstTitlePage = Array.from({ length: 25 }, (_, index) => book(index + 1, 'Jan 1, 2020')).join('');
+        const secondTitlePage = book(26, 'Jan 2, 2020');
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => firstTitlePage })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => secondTitlePage })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => firstPage })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => book(26) });
+
+        const rows = await getRegistry().get('gutenberg/author').func({ id: '69', sort: 'title' });
+
+        expect(rows).toHaveLength(26);
+        expect(rows[0]).toMatchObject({ id: '1', title: 'Book 1', author: 'Author Name', downloads: 1 });
+        expect(rows[25].id).toBe('26');
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('/ebooks/author/69?sort_order=title');
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('/ebooks/author/69?sort_order=title&start_index=26');
+        expect(globalThis.fetch.mock.calls[2][0]).toContain('/ebooks/author/69?sort_order=downloads');
+        expect(globalThis.fetch.mock.calls[3][0]).toContain('/ebooks/author/69?sort_order=downloads&start_index=26');
+    });
+
+    it('distinguishes an author with no books from book-list selector drift', async () => {
+        const command = getRegistry().get('gutenberg/author');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<meta content="0" name="totalResults"><span class="title">No records found.</span>' });
+        await expect(command.func({ id: '999999999', sort: 'downloads' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<main><ul class="results"></ul></main>' });
+        await expect(command.func({ id: '69', sort: 'downloads' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails when a non-download sort cannot be joined to download counts', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => book(1, 'Jan 1, 2020') })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => book(1, 'not available') });
+
+        await expect(getRegistry().get('gutenberg/author').func({ id: '69', sort: 'title' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/categories.js
+++ b/clis/gutenberg/categories.js
@@ -1,0 +1,21 @@
+import { EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, normalizeInitial, parseCategories } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'categories',
+    access: 'read',
+    description: 'List Project Gutenberg Reading List categories, optionally filtered by initial',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [{ name: 'initial', help: 'Initial letter A-Z; returns all categories by default' }],
+    columns: ['id', 'initial', 'name', 'url'],
+    func: async (args) => {
+        const initial = normalizeInitial(args.initial);
+        const rows = parseCategories(await fetchText(buildUrl('/ebooks/bookshelf/'), 'gutenberg categories'), initial);
+        if (!rows.length) throw new EmptyResultError('gutenberg categories', initial ? `No categories found for ${initial}` : 'No categories found');
+        return rows;
+    },
+});

--- a/clis/gutenberg/categories.test.js
+++ b/clis/gutenberg/categories.test.js
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './categories.js';
+
+describe('gutenberg categories', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('filters reading-list categories by initial', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => `
+            <h2> All Reading Lists </h2><div class="bookshelves">
+              <div class="book-list"><h2>A</h2><ul><li><a href="/ebooks/bookshelf/82">Adventure</a></li><li><a href="/ebooks/bookshelf/5">Africa</a></li></ul></div>
+              <div class="book-list"><h2>B</h2><ul><li><a href="/ebooks/bookshelf/13">Best Books</a></li></ul></div>
+            </div>` });
+        const rows = await getRegistry().get('gutenberg/categories').func({ initial: 'a' });
+
+        expect(rows).toEqual([
+            { id: '82', initial: 'A', name: 'Adventure', url: 'https://www.gutenberg.org/ebooks/bookshelf/82' },
+            { id: '5', initial: 'A', name: 'Africa', url: 'https://www.gutenberg.org/ebooks/bookshelf/5' },
+        ]);
+    });
+
+    it('rejects a non-letter initial', async () => {
+        await expect(getRegistry().get('gutenberg/categories').func({ initial: 'AA' })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('keeps an absent initial as empty but treats a missing category contract as drift', async () => {
+        const command = getRegistry().get('gutenberg/categories');
+        const validPage = '<h2>All Reading Lists</h2><div class="book-list"><h2>A</h2><ul><li><a href="/ebooks/bookshelf/82">Adventure</a></li></ul></div>';
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => validPage });
+        await expect(command.func({ initial: 'Z' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2>All Reading Lists</h2><div class="bookshelves"></div>' });
+        await expect(command.func({ initial: 'A' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects a malformed category row instead of silently dropping it', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2>All Reading Lists</h2><div class="book-list"><h2>A</h2><ul><li><a href="/ebooks/bookshelf/">Broken</a></li></ul></div>' });
+        await expect(getRegistry().get('gutenberg/categories').func({ initial: 'A' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/category-search.js
+++ b/clis/gutenberg/category-search.js
@@ -1,0 +1,25 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchCategorySearchPages, requireChoice, requireString } from './utils.js';
+
+const SORTS = ['title', 'downloads', 'quantity', 'release_date'];
+
+cli({
+    site: 'gutenberg',
+    name: 'category-search',
+    access: 'read',
+    description: 'Search Project Gutenberg bookshelf categories',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'query', positional: true, required: true, help: 'Category search query' },
+        { name: 'sort', default: 'downloads', choices: SORTS, help: 'Sort by title, downloads, quantity, or release_date' },
+    ],
+    columns: ['name', 'downloads', 'url'],
+    func: async (args) => {
+        const query = requireString(args.query, 'category search query');
+        const sort = requireChoice(args.sort, 'downloads', SORTS, 'category search sort');
+        const rows = await fetchCategorySearchPages(query, sort);
+        return rows.map(({ name, downloads, url }) => ({ name, downloads, url }));
+    },
+});

--- a/clis/gutenberg/category-search.test.js
+++ b/clis/gutenberg/category-search.test.js
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './category-search.js';
+
+const HTML = `
+<meta name="totalResults" content="2">
+<ul class="results">
+  <li class="navlink"><a class="link" href="/ebooks/bookshelf/646"><span class="cell content"><span class="title">Category: Mythology, Legends &amp; Folklore</span><span class="extra">3,948,846 downloads</span></span></a></li>
+  <li class="navlink"><a class="link" href="/ebooks/bookshelf/119"><span class="cell content"><span class="title">Christianity</span><span class="extra">227,041 downloads</span></span></a></li>
+</ul>`;
+
+const TITLE_HTML = `
+<meta name="totalResults" content="2">
+<ul class="results">
+  <li class="navlink"><a class="link" href="/ebooks/bookshelf/646"><span class="cell content"><span class="title">Category: Mythology, Legends &amp; Folklore</span></span></a></li>
+  <li class="navlink"><a class="link" href="/ebooks/bookshelf/119"><span class="cell content"><span class="title">Christianity</span></span></a></li>
+</ul>`;
+
+describe('gutenberg category-search', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('maps category search rows and translates title sorting to alpha', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => TITLE_HTML })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML });
+
+        const rows = await getRegistry().get('gutenberg/category-search').func({ query: 'faith', sort: 'title' });
+
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('sort_order=alpha');
+        expect(rows).toEqual([
+            { name: 'Category: Mythology, Legends & Folklore', downloads: 3948846, url: 'https://www.gutenberg.org/ebooks/bookshelf/646' },
+            { name: 'Christianity', downloads: 227041, url: 'https://www.gutenberg.org/ebooks/bookshelf/119' },
+        ]);
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('sort_order=downloads');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the downloads-sorted page directly when downloads are requested', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML });
+        const rows = await getRegistry().get('gutenberg/category-search').func({ query: 'faith', sort: 'downloads' });
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(rows[0].downloads).toBe(3948846);
+    });
+
+    it.each([
+        ['quantity', 'quantity'],
+        ['release_date', 'release_date'],
+    ])('passes %s to Gutenberg and merges download counts', async (sort, sortOrder) => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML });
+
+        const rows = await getRegistry().get('gutenberg/category-search').func({ query: 'faith', sort });
+
+        expect(globalThis.fetch.mock.calls[0][0]).toContain(`sort_order=${sortOrder}`);
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('sort_order=downloads');
+        expect(rows[0].downloads).toBe(3948846);
+    });
+
+    it('rejects an empty query before fetching', async () => {
+        await expect(getRegistry().get('gutenberg/category-search').func({ query: ' ' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('distinguishes explicit empty results from selector drift', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<meta name="totalResults" content="0"><ul class="results"><li><span class="title">No records found.</span></li></ul>' });
+        await expect(getRegistry().get('gutenberg/category-search').func({ query: 'missing' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<ul class="results"></ul>' });
+        await expect(getRegistry().get('gutenberg/category-search').func({ query: 'missing' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/collections.js
+++ b/clis/gutenberg/collections.js
@@ -1,0 +1,18 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, parseCollections } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'collections',
+    access: 'read',
+    description: 'List the top Collections from Project Gutenberg Reading Lists',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [],
+    columns: ['name', 'url'],
+    func: async () => {
+        const rows = parseCollections(await fetchText(buildUrl('/ebooks/bookshelf/'), 'gutenberg collections'));
+        return rows.map(({ name, url }) => ({ name, url }));
+    },
+});

--- a/clis/gutenberg/collections.test.js
+++ b/clis/gutenberg/collections.test.js
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './collections.js';
+
+describe('gutenberg collections', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('reads only the top Collections block in page order', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => `
+            <h2> Collections </h2><div class="bookshelves"><ul>
+              <li><a href="/ebooks/bookshelves/search/?query=animal">&quot;Animals&quot; Reading Lists</a></li>
+              <li><a href="/ebooks/bookshelf/emmys">&quot;Emmy's Picks&quot;</a></li>
+            </ul></div>
+            <h2> All Reading Lists </h2><div class="book-list"><h2>A</h2></div>` });
+        const command = getRegistry().get('gutenberg/collections');
+        expect(command.args).toEqual([]);
+        const rows = await command.func();
+
+        expect(rows).toEqual([
+            { name: '"Animals" Reading Lists', url: 'https://www.gutenberg.org/ebooks/bookshelves/search/?query=animal' },
+            { name: '"Emmy\'s Picks"', url: 'https://www.gutenberg.org/ebooks/bookshelf/emmys' },
+        ]);
+    });
+
+    it('rejects missing section boundaries and malformed collection rows', async () => {
+        const command = getRegistry().get('gutenberg/collections');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2>Collections</h2><div class="bookshelves"></div>' });
+        await expect(command.func()).rejects.toBeInstanceOf(CommandExecutionError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2>Collections</h2><li><a href="/ebooks/broken">Broken</a></li><h2>All Reading Lists</h2>' });
+        await expect(command.func()).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/ebooks.js
+++ b/clis/gutenberg/ebooks.js
@@ -1,0 +1,19 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, parseBookDetails, requireId } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'ebooks',
+    access: 'read',
+    description: 'Get Project Gutenberg ebook metadata and download URLs for all formats',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [{ name: 'id', positional: true, required: true, help: 'Gutenberg ebook number, for example 30849' }],
+    columns: ['id', 'title', 'author', 'summary', 'language', 'subjects', 'releaseDate', 'lastUpdate', 'copyright', 'downloads', 'readOnlineUrl', 'url', 'formats'],
+    func: async (args) => {
+        const id = requireId(args.id, 'ebook id');
+        const book = parseBookDetails(await fetchText(buildUrl(`/ebooks/${id}`), `gutenberg ebook ${id}`), id);
+        return [{ id: book.id, title: book.title, author: book.author, summary: book.summary, language: book.language, subjects: book.subjects, releaseDate: book.releaseDate, lastUpdate: book.lastUpdate, copyright: book.copyright, downloads: book.downloads, readOnlineUrl: book.readOnlineUrl, url: book.url, formats: book.formats }];
+    },
+});

--- a/clis/gutenberg/ebooks.test.js
+++ b/clis/gutenberg/ebooks.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './ebooks.js';
+
+const HTML = `
+<div class="summary-text-container">A short summary.</div>
+<a class="read-online-button" href="/cache/epub/30849/pg30849-images.html">Read online now</a>
+<a class="featured-format-link" href="/ebooks/30849.epub3.images" title="Download EPUB3"><span class="featured-format-name">EPUB3</span></a>
+<span class="featured-format-size">448 kB</span>
+<a class="other-format-link" href="/ebooks/30849.txt.utf-8" type="text/plain; charset=utf-8" title="Download (Plain Text (accessible))">Plain Text</a>
+<span class="other-format-size">744 kB</span>
+<table id="about_book_table">
+<tr><th>Author</th><td> Austen, Jane </td></tr>
+<tr><th>Title</th><td>Pride and Prejudice</td></tr>
+<tr><th>Language</th><td>English</td></tr>
+<tr><th>Subject</th><td property="dcterms:subject">Love stories</td></tr>
+<tr><th>Release Date</th><td>Jan 28, 2006</td></tr>
+<tr><th>Copyright</th><td>Public domain</td></tr>
+<tr><th>Downloads</th><td>12,345 downloads in the last 30 days.</td></tr>
+<tr><th>eBook-No.</th><td>1342</td></tr>
+</table>`;
+
+describe('gutenberg ebooks', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('registers and maps book metadata plus format URLs', async () => {
+        const command = getRegistry().get('gutenberg/ebooks');
+        expect(command?.columns).toContain('formats');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML });
+
+        const rows = await command.func({ id: '1342' });
+
+        expect(rows[0]).toMatchObject({ id: '1342', title: 'Pride and Prejudice', author: 'Austen, Jane', downloads: 12345 });
+        expect(rows[0].readOnlineUrl).toBe('https://www.gutenberg.org/cache/epub/30849/pg30849-images.html');
+        expect(rows[0].formats).toHaveLength(2);
+        expect(rows[0].formats[0].url).toBe('https://www.gutenberg.org/ebooks/30849.epub3.images');
+        expect(rows[0].formats[1].mediaType).toBe('text/plain; charset=utf-8');
+    });
+
+    it('rejects malformed IDs before fetching', async () => {
+        const command = getRegistry().get('gutenberg/ebooks');
+        await expect(command.func({ id: 'abc' })).rejects.toBeInstanceOf(ArgumentError);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('reports missing download-format selectors as page-shape drift', async () => {
+        const command = getRegistry().get('gutenberg/ebooks');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace(/<a class="(?:featured|other)-format-link"[\s\S]*?<\/a>/g, '') });
+        await expect(command.func({ id: '1342' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects a malformed download-format row instead of dropping it', async () => {
+        const command = getRegistry().get('gutenberg/ebooks');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace('href="/ebooks/30849.epub3.images"', '') });
+        await expect(command.func({ id: '1342' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects a detail page for a different ebook id', async () => {
+        const command = getRegistry().get('gutenberg/ebooks');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace('<td>1342</td>', '<td>9999</td>') });
+        await expect(command.func({ id: '1342' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/hot-author.js
+++ b/clis/gutenberg/hot-author.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, normalizePeriod, parseHotAuthors, requireBoundedInt } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'hot-author',
+    access: 'read',
+    description: 'List the Project Gutenberg top author rankings',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 10, help: 'Number of results (1-100)' },
+        { name: 'period', default: 'yesterday', help: 'Period: yesterday, 7days, or 30days' },
+    ],
+    columns: ['id', 'name', 'url'],
+    func: async (args) => {
+        const period = normalizePeriod(args.period);
+        const limit = requireBoundedInt(args.limit, 10, 100, 'hot-author limit');
+        const rows = parseHotAuthors(await fetchText(buildUrl('/browse/scores/top'), 'gutenberg hot authors'), period);
+        return rows.slice(0, limit);
+    },
+});

--- a/clis/gutenberg/hot-author.test.js
+++ b/clis/gutenberg/hot-author.test.js
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot-author.js';
+
+describe('gutenberg hot-author', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('selects the requested author period and limits rows', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => `
+            <h2 id="authors-last1">Top 100 Authors yesterday</h2><ol><li><a href="/browse/authors/d#a69">Doyle, Arthur Conan (42894)</a></li></ol>
+            <h2 id="authors-last7">Top 100 Authors last 7 days</h2><ol><li><a href="/browse/authors/s#a65">Shakespeare, William (33506)</a></li><li><a href="/browse/authors/c#a451">Christie, Agatha (33463)</a></li></ol>` });
+        const rows = await getRegistry().get('gutenberg/hot-author').func({ period: '7days', limit: 1 });
+
+        expect(rows).toEqual([{ id: '65', name: 'Shakespeare, William', url: 'https://www.gutenberg.org/browse/authors/s#a65' }]);
+    });
+
+    it('rejects missing ranking sections and malformed ranking rows', async () => {
+        const command = getRegistry().get('gutenberg/hot-author');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<main></main>' });
+        await expect(command.func({ period: 'yesterday' })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2 id="authors-last1">Top authors</h2><ol><li><a href="/browse/authors/d">Broken author</a></li></ol>' });
+        await expect(command.func({ period: 'yesterday' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/hot-books.js
+++ b/clis/gutenberg/hot-books.js
@@ -1,0 +1,23 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, normalizePeriod, parseHotBooks, requireBoundedInt } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'hot-books',
+    access: 'read',
+    description: 'List the Project Gutenberg top book rankings',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'limit', type: 'int', default: 10, help: 'Number of results (1-100)' },
+        { name: 'period', default: 'yesterday', help: 'Period: yesterday, 7days, or 30days' },
+    ],
+    columns: ['id', 'title', 'url'],
+    func: async (args) => {
+        const period = normalizePeriod(args.period);
+        const limit = requireBoundedInt(args.limit, 10, 100, 'hot-books limit');
+        const rows = parseHotBooks(await fetchText(buildUrl('/browse/scores/top'), 'gutenberg hot books'), period);
+        return rows.slice(0, limit);
+    },
+});

--- a/clis/gutenberg/hot-books.test.js
+++ b/clis/gutenberg/hot-books.test.js
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './hot-books.js';
+
+describe('gutenberg hot-books', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('extracts titles and IDs from the requested top-book section', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => `
+            <h2 id="books-last30">Top 100 EBooks last 30 days</h2><ol>
+              <li><a href="/ebooks/2701">Moby Dick; Or, The Whale by Herman Melville (7134)</a></li>
+              <li><a href="/ebooks/1342">Pride and Prejudice by Jane Austen (7123)</a></li>
+            </ol>` });
+        const rows = await getRegistry().get('gutenberg/hot-books').func({ period: '30days', limit: 2 });
+
+        expect(rows).toEqual([
+            { id: '2701', title: 'Moby Dick; Or, The Whale', url: 'https://www.gutenberg.org/ebooks/2701' },
+            { id: '1342', title: 'Pride and Prejudice', url: 'https://www.gutenberg.org/ebooks/1342' },
+        ]);
+    });
+
+    it('rejects missing ranking sections and malformed ranking rows', async () => {
+        const command = getRegistry().get('gutenberg/hot-books');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<main></main>' });
+        await expect(command.func({ period: 'yesterday' })).rejects.toBeInstanceOf(CommandExecutionError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<h2 id="books-last1">Top books</h2><ol><li><a href="/ebooks/broken">Broken book</a></li></ol>' });
+        await expect(command.func({ period: 'yesterday' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/main-categories.js
+++ b/clis/gutenberg/main-categories.js
@@ -1,0 +1,17 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { buildUrl, fetchText, parseMainCategories } from './utils.js';
+
+cli({
+    site: 'gutenberg',
+    name: 'main-categories',
+    access: 'read',
+    description: 'List Project Gutenberg main book categories and parent categories',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [],
+    columns: ['id', 'name', 'parentName', 'url'],
+    func: async () => {
+        return parseMainCategories(await fetchText(buildUrl('/ebooks/categories'), 'gutenberg main categories'));
+    },
+});

--- a/clis/gutenberg/main-categories.test.js
+++ b/clis/gutenberg/main-categories.test.js
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './main-categories.js';
+
+describe('gutenberg main-categories', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('returns every category with its parent category', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => `
+            <div class="bookshelves">
+              <div class="book-list"><h2>Literature</h2><ul>
+                <li><a href="/ebooks/bookshelf/645">Novels</a></li>
+                <li><a href="/ebooks/bookshelf/637">Poetry &amp; Drama</a></li>
+              </ul></div>
+              <div class="book-list"><h2>Science &amp; Technology</h2><ul>
+                <li><a href="/ebooks/bookshelf/672">Mathematics</a></li>
+              </ul></div>
+            </div>` });
+
+        const rows = await getRegistry().get('gutenberg/main-categories').func();
+
+        expect(rows).toEqual([
+            { id: '645', name: 'Novels', parentName: 'Literature', url: 'https://www.gutenberg.org/ebooks/bookshelf/645' },
+            { id: '637', name: 'Poetry & Drama', parentName: 'Literature', url: 'https://www.gutenberg.org/ebooks/bookshelf/637' },
+            { id: '672', name: 'Mathematics', parentName: 'Science & Technology', url: 'https://www.gutenberg.org/ebooks/bookshelf/672' },
+        ]);
+    });
+
+    it('rejects missing category groups and malformed category rows', async () => {
+        const command = getRegistry().get('gutenberg/main-categories');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<div class="bookshelves"></div>' });
+        await expect(command.func()).rejects.toBeInstanceOf(CommandExecutionError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<div class="book-list"><h2>Literature</h2><ul><li><a href="/ebooks/bookshelf/broken">Broken</a></li></ul></div>' });
+        await expect(command.func()).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/search.js
+++ b/clis/gutenberg/search.js
@@ -1,0 +1,42 @@
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import { fetchBookPages, fetchBookPagesForIds, requireBoundedInt, requireChoice } from './utils.js';
+
+const SORTS = ['title', 'downloads', 'release_date'];
+
+cli({
+    site: 'gutenberg',
+    name: 'search',
+    access: 'read',
+    description: 'Search Project Gutenberg books, returning 10 results by default',
+    domain: 'www.gutenberg.org',
+    strategy: Strategy.PUBLIC,
+    browser: false,
+    args: [
+        { name: 'title', positional: true, default: '', help: 'Optional book title or keyword' },
+        { name: 'sort', default: 'downloads', choices: SORTS, help: 'Sort by title, downloads, or release_date' },
+        { name: 'limit', type: 'int', default: 10, help: 'Number of results (1-100)' },
+    ],
+    columns: ['id', 'title', 'author', 'url', 'downloads'],
+    func: async (args) => {
+        const sort = requireChoice(args.sort, 'downloads', SORTS, 'search sort');
+        const limit = requireBoundedInt(args.limit, 10, 100, 'search limit');
+        const rows = await fetchBookPages('/ebooks/search/', { query: String(args.title ?? '').trim(), sort_order: sort }, limit, 'gutenberg search');
+        if (sort !== 'downloads') {
+            const query = String(args.title ?? '').trim();
+            const downloadRows = await fetchBookPagesForIds('/ebooks/search/', { query, sort_order: 'downloads' }, new Set(rows.map((row) => row.id)), 'gutenberg search downloads');
+            const downloadsById = new Map(downloadRows.map((row) => [row.id, row.downloads]));
+            return rows.map((row) => {
+                const downloads = downloadsById.get(row.id);
+                if (downloads === undefined || downloads === null) {
+                    throw new CommandExecutionError(`gutenberg search did not provide a download count for ebook ${row.id}`);
+                }
+                return { id: row.id, title: row.title, author: row.author, url: row.url, downloads };
+            });
+        }
+        if (rows.some((row) => row.downloads === null)) {
+            throw new CommandExecutionError('gutenberg search download counts were missing from the downloads-sorted results');
+        }
+        return rows.map((row) => ({ id: row.id, title: row.title, author: row.author, url: row.url, downloads: row.downloads }));
+    },
+});

--- a/clis/gutenberg/search.test.js
+++ b/clis/gutenberg/search.test.js
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './search.js';
+
+const HTML = `<li class="booklink"><a href="/ebooks/1342"><span class="title">Pride and Prejudice</span><span class="subtitle">Jane Austen</span><span class="extra">198,164 downloads</span></a></li>
+<li class="booklink"><a href="/ebooks/42671"><span class="title">Pride and Prejudice</span><span class="subtitle">Jane Austen</span><span class="extra">66,006 downloads</span></a></li>`;
+
+describe('gutenberg search', () => {
+    beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('passes the optional title and sort to the public HTML search', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace(/<span class="extra">[\s\S]*?<\/span>/g, '') })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML });
+        const rows = await getRegistry().get('gutenberg/search').func({ title: 'pride and prejudice', sort: 'title', limit: 1 });
+
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('query=pride+and+prejudice');
+        expect(globalThis.fetch.mock.calls[0][0]).toContain('sort_order=title');
+        expect(rows).toEqual([{ id: '1342', title: 'Pride and Prejudice', author: 'Jane Austen', url: 'https://www.gutenberg.org/ebooks/1342', downloads: 198164 }]);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(globalThis.fetch.mock.calls[1][0]).toContain('sort_order=downloads');
+    });
+
+    it('rejects an invalid limit instead of silently clamping it', async () => {
+        await expect(getRegistry().get('gutenberg/search').func({ limit: 0 })).rejects.toBeInstanceOf(ArgumentError);
+    });
+
+    it('distinguishes explicit empty results from book-list selector drift', async () => {
+        const command = getRegistry().get('gutenberg/search');
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<meta name="totalResults" content="0"><ul class="results"><li class="navlink"><span class="title">No records found.</span></li></ul>' });
+        await expect(command.func({ title: 'missing' })).rejects.toBeInstanceOf(EmptyResultError);
+
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<ul class="results"></ul>' });
+        await expect(command.func({ title: 'missing' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('rejects a malformed book row instead of silently dropping it', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => '<li class="booklink"><a href="/ebooks/not-an-id"><span class="title">Broken book</span></a></li>' });
+        await expect(getRegistry().get('gutenberg/search').func({ title: 'broken' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails when downloads sorting does not expose download counts', async () => {
+        globalThis.fetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace(/<span class="extra">[\s\S]*?<\/span>/g, '') });
+        await expect(getRegistry().get('gutenberg/search').func({ title: 'missing counts' })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+
+    it('fails when a non-download sort cannot be joined to download counts', async () => {
+        globalThis.fetch
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace(/<span class="extra">[\s\S]*?<\/span>/g, '') })
+            .mockResolvedValueOnce({ ok: true, status: 200, text: async () => HTML.replace('href="/ebooks/1342"', 'href="/ebooks/9999"') });
+
+        await expect(getRegistry().get('gutenberg/search').func({ title: 'broken', sort: 'title', limit: 1 })).rejects.toBeInstanceOf(CommandExecutionError);
+    });
+});

--- a/clis/gutenberg/utils.js
+++ b/clis/gutenberg/utils.js
@@ -1,0 +1,500 @@
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+
+export const GUTENBERG_BASE = 'https://www.gutenberg.org';
+const PAGE_SIZE = 25;
+
+export function requireString(value, label) {
+    const text = String(value ?? '').trim();
+    if (!text) throw new ArgumentError(`gutenberg ${label} must not be empty`);
+    return text;
+}
+
+export function requirePositiveInteger(value, defaultValue, label) {
+    const raw = value ?? defaultValue;
+    const number = Number(raw);
+    if (!Number.isInteger(number) || number <= 0) {
+        throw new ArgumentError(`gutenberg ${label} must be a positive integer`);
+    }
+    return number;
+}
+
+export function requireBoundedInt(value, defaultValue, maxValue, label) {
+    const number = requirePositiveInteger(value, defaultValue, label);
+    if (number > maxValue) throw new ArgumentError(`gutenberg ${label} must be <= ${maxValue}`);
+    return number;
+}
+
+export function requireId(value, label = 'id') {
+    const raw = String(value ?? '').trim().replace(/^https?:\/\/www\.gutenberg\.org\/ebooks\//i, '').replace(/\/.*$/, '');
+    if (!/^\d+$/.test(raw) || Number(raw) <= 0) {
+        throw new ArgumentError(`gutenberg ${label} must be a positive integer`);
+    }
+    return raw;
+}
+
+export function requireChoice(value, defaultValue, choices, label) {
+    const selected = String(value ?? defaultValue).trim().toLowerCase();
+    if (!choices.includes(selected)) {
+        throw new ArgumentError(`gutenberg ${label} must be one of: ${choices.join(', ')}`);
+    }
+    return selected;
+}
+
+export function normalizePeriod(value) {
+    const aliases = {
+        yesterday: 'yesterday',
+        '7days': '7days',
+        '30days': '30days',
+    };
+    const period = aliases[String(value ?? 'yesterday').trim().toLowerCase()];
+    if (!period) throw new ArgumentError('gutenberg period must be one of: yesterday, 7days, 30days');
+    return period;
+}
+
+export function normalizeInitial(value) {
+    const initial = String(value ?? '').trim().toUpperCase();
+    if (initial && !/^[A-Z]$/.test(initial)) {
+        throw new ArgumentError('gutenberg initial must be one uppercase letter from A to Z');
+    }
+    return initial;
+}
+
+export async function fetchText(url, label) {
+    let response;
+    try {
+        response = await fetch(url, {
+            headers: {
+                Accept: 'text/html, application/xhtml+xml, application/xml;q=0.9, text/xml;q=0.8',
+            },
+            redirect: 'follow',
+        });
+    } catch (error) {
+        throw new CommandExecutionError(`${label} request failed: ${error?.message || error}`);
+    }
+    if (response.status === 404) throw new EmptyResultError(label, `Gutenberg resource was not found: ${url}`);
+    if (!response.ok) throw new CommandExecutionError(`${label} request failed: HTTP ${response.status}`);
+    try {
+        return await response.text();
+    } catch (error) {
+        throw new CommandExecutionError(`${label} response could not be read: ${error?.message || error}`);
+    }
+}
+
+export function buildUrl(pathname, params = {}) {
+    const url = new URL(pathname, GUTENBERG_BASE);
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null && String(value) !== '') url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+}
+
+export function decodeHtml(value) {
+    return String(value ?? '')
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .replace(/<br\s*\/?>(\s*)/gi, ' ')
+        .replace(/<[^>]*>/g, '')
+        .replace(/&#(x[\da-f]+|\d+);/gi, (_, code) => {
+            const number = code[0].toLowerCase() === 'x' ? parseInt(code.slice(1), 16) : parseInt(code, 10);
+            return Number.isFinite(number) ? String.fromCodePoint(number) : '';
+        })
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&quot;/gi, '"')
+        .replace(/&apos;/gi, "'")
+        .replace(/&#39;/g, "'")
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function attribute(attrs, name) {
+    const match = String(attrs).match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([^"']*)["']`, 'i'));
+    return match ? decodeHtml(match[1]) : '';
+}
+
+function absoluteUrl(href) {
+    return new URL(href, GUTENBERG_BASE).toString();
+}
+
+function parseDownloadCount(value) {
+    const match = decodeHtml(value).replace(/,/g, '').match(/(\d+)\s+downloads?/i);
+    return match ? Number(match[1]) : null;
+}
+
+function parseBookItem(block) {
+    const linkMatch = block.match(/<a\b([^>]*)>[\s\S]*?<\/a>/i);
+    if (!linkMatch) return null;
+    const href = attribute(linkMatch[1], 'href');
+    const id = href.match(/^\/ebooks\/(\d+)(?:\/|$)/)?.[1];
+    const title = decodeHtml(block.match(/<span\s+class=["'][^"']*\btitle\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1]);
+    if (!id || !title) return null;
+    const author = decodeHtml(block.match(/<span\s+class=["'][^"']*\bsubtitle\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1]);
+    const extra = block.match(/<span\s+class=["'][^"']*\bextra\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1];
+    return {
+        id,
+        title,
+        author: author || null,
+        downloads: parseDownloadCount(extra),
+        url: absoluteUrl(`/ebooks/${id}`),
+    };
+}
+
+function hasClass(attrs, className) {
+    return attribute(attrs, 'class').split(/\s+/).includes(className);
+}
+
+function hasExplicitEmptyBookList(html) {
+    const metaPattern = /<meta\b([^>]*)>/gi;
+    let metaMatch;
+    while ((metaMatch = metaPattern.exec(html)) !== null) {
+        if (attribute(metaMatch[1], 'name').toLowerCase() === 'totalresults'
+            && attribute(metaMatch[1], 'content') === '0') return true;
+    }
+    return /<ul\b[^>]*class=["'][^"']*\bresults\b[^"']*["'][^>]*>[\s\S]*?<span\b[^>]*class=["'][^"']*\btitle\b[^"']*["'][^>]*>\s*No records found\.\s*<\/span>[\s\S]*?<\/ul>/i.test(html);
+}
+
+export function parseBookList(html) {
+    const candidates = [];
+    const pattern = /<li\b([^>]*)>[\s\S]*?<\/li>/gi;
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+        if (hasClass(match[1], 'booklink')) candidates.push(match[0]);
+    }
+    const rows = candidates.map(parseBookItem);
+    if (rows.some((row) => !row)) {
+        throw new CommandExecutionError('gutenberg book list contained a row without a valid ebook id or title');
+    }
+    if (!candidates.length && !hasExplicitEmptyBookList(html)) {
+        throw new CommandExecutionError('gutenberg book list selector drift: book rows and the explicit empty-state marker were not found');
+    }
+    return rows;
+}
+
+async function fetchBookPageSet(pathname, params, label, { limit, requiredIds } = {}) {
+    const rows = [];
+    const seen = new Set();
+    const maxPages = requiredIds ? 1000 : Math.ceil(limit / PAGE_SIZE) + 1;
+    for (let page = 1; page <= maxPages && (requiredIds || rows.length < limit); page += 1) {
+        const pageParams = { ...params };
+        if (page > 1) pageParams.start_index = ((page - 1) * PAGE_SIZE) + 1;
+        const pageRows = parseBookList(await fetchText(buildUrl(pathname, pageParams), label));
+        for (const row of pageRows) {
+            if (!seen.has(row.id) && (requiredIds || rows.length < limit)) {
+                seen.add(row.id);
+                rows.push(row);
+            }
+        }
+        if (requiredIds && [...requiredIds].every((id) => seen.has(id))) return rows;
+        if (pageRows.length < PAGE_SIZE) break;
+    }
+    if (requiredIds) {
+        const missing = [...requiredIds].filter((id) => !seen.has(id));
+        if (missing.length) throw new CommandExecutionError(`${label} did not return requested ebook ids: ${missing.join(', ')}`);
+        return rows;
+    }
+    if (!rows.length) throw new EmptyResultError(label, 'Gutenberg returned no matching books');
+    return rows;
+}
+
+export async function fetchBookPages(pathname, params, limit, label) {
+    return fetchBookPageSet(pathname, params, label, { limit });
+}
+
+export async function fetchBookPagesForIds(pathname, params, requiredIds, label) {
+    return fetchBookPageSet(pathname, params, label, { requiredIds });
+}
+
+export function parseBookDetails(html, requestedId) {
+    const tableValue = (label) => decodeHtml(html.match(new RegExp(`<th[^>]*>\\s*${label}\\s*<\\/th>\\s*<td[^>]*>([\\s\\S]*?)<\\/td>`, 'i'))?.[1]);
+    const title = tableValue('Title') || decodeHtml(html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)?.[1]);
+    const ebookNumber = tableValue('eBook-No\\.');
+    if (!title || !ebookNumber) throw new CommandExecutionError(`gutenberg ebook ${requestedId} returned an unexpected page shape`);
+    if (ebookNumber !== String(requestedId)) {
+        throw new CommandExecutionError(`gutenberg ebook ${requestedId} returned ebook ${ebookNumber}`);
+    }
+    const downloads = tableValue('Downloads').replace(/,/g, '').match(/(\d+)/)?.[1];
+    const summary = decodeHtml(html.match(/<div\s+class=["'][^"']*\bsummary-text-container\b[^"']*["'][^>]*>([\s\S]*?)<\/div>/i)?.[1])
+        .replace(/\.\.\.\s*Read more\s*Show less$/i, '').trim();
+    const subjects = [];
+    const subjectPattern = /<td\s+property=["']dcterms:subject["'][^>]*>([\s\S]*?)<\/td>/gi;
+    let subjectMatch;
+    while ((subjectMatch = subjectPattern.exec(html)) !== null) {
+        const subject = decodeHtml(subjectMatch[1]);
+        if (subject) subjects.push(subject);
+    }
+    const readPath = html.match(/<a\s+class=["']read-online-button["'][^>]*\bhref=["']([^"']+)["']/i)?.[1];
+    return {
+        id: ebookNumber,
+        title,
+        author: tableValue('Author') || null,
+        summary: summary || null,
+        language: tableValue('Language') || null,
+        subjects: subjects.length ? subjects.join('; ') : null,
+        releaseDate: tableValue('Release Date') || null,
+        lastUpdate: tableValue('Last Update') || null,
+        copyright: tableValue('Copyright') || null,
+        downloads: downloads ? Number(downloads) : null,
+        readOnlineUrl: readPath ? absoluteUrl(readPath) : null,
+        url: absoluteUrl(`/ebooks/${requestedId}`),
+        formats: parseFormats(html),
+    };
+}
+
+export function parseFormats(html) {
+    const formats = [];
+    const pattern = /<a\s+class=["'][^"']*(?:featured-format-link|other-format-link)[^"']*["']([^>]*)>([\s\S]*?)<\/a>/gi;
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+        const attrs = match[1];
+        const href = attribute(attrs, 'href');
+        if (!href) throw new CommandExecutionError('gutenberg ebook format row was missing its download URL');
+        const type = attribute(attrs, 'type') || null;
+        const title = attribute(attrs, 'title');
+        const visibleName = decodeHtml(match[2].match(/<span\s+class=["'][^"']*format-name[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1]);
+        const name = (visibleName || title || decodeHtml(match[2]))
+            .replace(/^Download\s*/i, '')
+            .replace(/^\((.*)\)$/s, '$1')
+            .replace(/★[\s\S]*$/, '')
+            .trim();
+        const rest = html.slice(match.index + match[0].length);
+        const nextFormatOffset = rest.search(/<a\s+class=["'][^"']*(?:featured-format-link|other-format-link)[^"']*["'][^>]*>/i);
+        const nearby = html.slice(match.index, nextFormatOffset < 0 ? html.length : match.index + match[0].length + nextFormatOffset);
+        const size = decodeHtml(nearby.match(/<span\s+class=["'][^"']*format-size[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1]) || null;
+        formats.push({ name: name || 'Download', mediaType: type, size, url: absoluteUrl(href) });
+    }
+    if (!formats.length) {
+        throw new CommandExecutionError('gutenberg ebook format selector drift: download format links were not found');
+    }
+    return formats;
+}
+
+function sectionItems(html, sectionId, label) {
+    const headingPattern = /<h2\b([^>]*)>[\s\S]*?<\/h2>/gi;
+    let headingMatch;
+    while ((headingMatch = headingPattern.exec(html)) !== null) {
+        if (attribute(headingMatch[1], 'id') !== sectionId) continue;
+        const list = html.slice(headingPattern.lastIndex).match(/^\s*<ol\b[^>]*>([\s\S]*?)<\/ol>/i)?.[1];
+        if (list === undefined) throw new CommandExecutionError(`${label} ranking list was not found after its heading`);
+        const items = [...list.matchAll(/<li\b[^>]*>[\s\S]*?<\/li>/gi)].map((item) => item[0]);
+        if (!items.length) throw new CommandExecutionError(`${label} ranking section contained no rows`);
+        return items;
+    }
+    throw new CommandExecutionError(`${label} ranking section was not found`);
+}
+
+export function parseHotBooks(html, period) {
+    const suffix = period === 'yesterday' ? '1' : period === '7days' ? '7' : '30';
+    const items = sectionItems(html, `books-last${suffix}`, 'gutenberg hot books');
+    return items.map((item) => {
+        const link = item.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+        const href = attribute(link?.[1] || '', 'href');
+        const id = href.match(/^\/ebooks\/(\d+)$/)?.[1];
+        const text = decodeHtml(link?.[2]);
+        const withoutCount = text.replace(/\s+\([\d,]+\)\s*$/g, '').trim();
+        const byIndex = withoutCount.lastIndexOf(' by ');
+        const title = (byIndex > 0 ? withoutCount.slice(0, byIndex) : withoutCount).trim();
+        if (!id || !title) throw new CommandExecutionError('gutenberg hot books contained a row without a valid ebook id or title');
+        return { id, title, url: absoluteUrl(href) };
+    });
+}
+
+export function parseHotAuthors(html, period) {
+    const suffix = period === 'yesterday' ? '1' : period === '7days' ? '7' : '30';
+    const items = sectionItems(html, `authors-last${suffix}`, 'gutenberg hot authors');
+    return items.map((item) => {
+        const link = item.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+        const href = attribute(link?.[1] || '', 'href');
+        const id = href.match(/^\/browse\/authors\/[^#]+#a(\d+)$/i)?.[1];
+        const name = decodeHtml(link?.[2]).replace(/\s+\([\d,]+\)\s*$/g, '').trim();
+        if (!id || !name) throw new CommandExecutionError('gutenberg hot authors contained a row without a valid author id or name');
+        return { id, name, url: absoluteUrl(href) };
+    });
+}
+
+export function parseMainCategories(html) {
+    const rows = [];
+    const blockPattern = /<div\s+class=["']book-list["'][^>]*>([\s\S]*?)<\/div>/gi;
+    let blockMatch;
+    let blockCount = 0;
+    while ((blockMatch = blockPattern.exec(html)) !== null) {
+        blockCount += 1;
+        const parentName = decodeHtml(blockMatch[1].match(/<h2[^>]*>([\s\S]*?)<\/h2>/i)?.[1]);
+        const items = [...blockMatch[1].matchAll(/<li\b[^>]*>[\s\S]*?<\/li>/gi)].map((item) => item[0]);
+        if (!parentName || !items.length) throw new CommandExecutionError('gutenberg main categories contained a malformed category group');
+        for (const item of items) {
+            const link = item.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+            const href = attribute(link?.[1] || '', 'href');
+            const id = href.match(/^\/ebooks\/bookshelf\/(\d+)$/)?.[1];
+            const name = decodeHtml(link?.[2]);
+            if (!id || !name) throw new CommandExecutionError('gutenberg main categories contained a row without a valid category id or name');
+            rows.push({ id, name, parentName, url: absoluteUrl(href) });
+        }
+    }
+    if (!blockCount || !rows.length) throw new CommandExecutionError('gutenberg main categories selector drift: category groups were not found');
+    return rows;
+}
+
+export function parseCollections(html) {
+    const start = html.search(/<h2[^>]*>\s*Collections\s*<\/h2>/i);
+    const end = html.search(/<h2[^>]*>\s*All Reading Lists\s*<\/h2>/i);
+    if (start < 0 || end <= start) throw new CommandExecutionError('gutenberg collections section boundaries were not found');
+    const block = html.slice(start, end);
+    const items = [...block.matchAll(/<li\b[^>]*>[\s\S]*?<\/li>/gi)].map((item) => item[0]);
+    if (!items.length) throw new CommandExecutionError('gutenberg collections section contained no rows');
+    return items.map((item) => {
+        const link = item.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+        const href = attribute(link?.[1] || '', 'href');
+        const validHref = /^\/ebooks\/(?:bookshelves\/search\/[^?#]*\?query=[^#]+|bookshelf\/[^/?#]+)$/.test(href);
+        const name = decodeHtml(link?.[2]);
+        if (!validHref || !name) throw new CommandExecutionError('gutenberg collections contained a row without a valid name or URL');
+        return { name, url: absoluteUrl(href) };
+    });
+}
+
+function parseCategorySearchItem(block) {
+    const link = block.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+    const href = attribute(link?.[1] || '', 'href');
+    const id = href.match(/^\/ebooks\/bookshelf\/([^/?#]+)$/)?.[1];
+    const name = decodeHtml(link?.[2].match(/<span\s+class=["'][^"']*\btitle\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1]);
+    const extra = link?.[2].match(/<span\s+class=["'][^"']*\bextra\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)?.[1];
+    const downloads = parseDownloadCount(extra);
+    if (!id || !name) return null;
+    return { id, name, downloads, url: absoluteUrl(href) };
+}
+
+export function parseCategorySearchList(html) {
+    const candidates = [];
+    const pattern = /<li\b([^>]*)>[\s\S]*?<\/li>/gi;
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+        if (hasClass(match[1], 'navlink')) candidates.push(match[0]);
+    }
+    const rows = candidates.map(parseCategorySearchItem);
+    if (rows.some((row) => !row)) {
+        throw new CommandExecutionError('gutenberg category search contained a row without a valid name, download count, or URL');
+    }
+    if (!candidates.length && !hasExplicitEmptyBookList(html)) {
+        throw new CommandExecutionError('gutenberg category search selector drift: category rows and the explicit empty-state marker were not found');
+    }
+    return rows;
+}
+
+function nextPagePath(html) {
+    const pattern = /<link\b([^>]*)>/gi;
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+        const rel = attribute(match[1], 'rel').toLowerCase().split(/\s+/);
+        if (!rel.includes('next')) continue;
+        const href = attribute(match[1], 'href');
+        if (!href) throw new CommandExecutionError('gutenberg category search next-page link was missing its URL');
+        const url = new URL(href, GUTENBERG_BASE);
+        return `${url.pathname}${url.search}`;
+    }
+    return '';
+}
+
+async function fetchCategorySearchPageSet(query, sort) {
+    const rows = [];
+    const seen = new Set();
+    let nextPath = '/ebooks/bookshelves/search/';
+    for (let page = 0; page < 200 && nextPath; page += 1) {
+        const html = await fetchText(buildUrl(nextPath, { query, sort_order: sort === 'title' ? 'alpha' : sort }), 'gutenberg category search');
+        for (const row of parseCategorySearchList(html)) {
+            if (!seen.has(row.id)) {
+                seen.add(row.id);
+                rows.push(row);
+            }
+        }
+        nextPath = nextPagePath(html);
+    }
+    if (nextPath) throw new CommandExecutionError('gutenberg category search exceeded the pagination safety limit');
+    return rows;
+}
+
+export async function fetchCategorySearchPages(query, sort) {
+    const rows = await fetchCategorySearchPageSet(query, sort);
+    if (!rows.length) throw new EmptyResultError('gutenberg category search', 'Gutenberg returned no matching categories');
+    if (sort === 'downloads') {
+        if (rows.some((row) => row.downloads === null)) {
+            throw new CommandExecutionError('gutenberg category search download counts were missing from the downloads-sorted results');
+        }
+        return rows;
+    }
+
+    const downloadRows = await fetchCategorySearchPageSet(query, 'downloads');
+    const downloadsById = new Map(downloadRows.map((row) => [row.id, row.downloads]));
+    return rows.map((row) => {
+        const downloads = downloadsById.get(row.id);
+        if (downloads === undefined || downloads === null) {
+            throw new CommandExecutionError(`gutenberg category search did not provide a download count for category ${row.id}`);
+        }
+        return { ...row, downloads };
+    });
+}
+
+export function parseCategories(html, initial = '') {
+    const start = html.search(/<h2[^>]*>\s*All Reading Lists\s*<\/h2>/i);
+    if (start < 0) throw new CommandExecutionError('gutenberg categories section was not found');
+    const source = html.slice(start);
+    const rows = [];
+    const blockPattern = /<div\s+class=["']book-list["'][^>]*>([\s\S]*?)<\/div>/gi;
+    let blockMatch;
+    let blockCount = 0;
+    while ((blockMatch = blockPattern.exec(source)) !== null) {
+        blockCount += 1;
+        const letter = decodeHtml(blockMatch[1].match(/<h2[^>]*>([A-Z])<\/h2>/i)?.[1]).toUpperCase();
+        const items = [...blockMatch[1].matchAll(/<li\b[^>]*>[\s\S]*?<\/li>/gi)].map((item) => item[0]);
+        if (!letter || !items.length) throw new CommandExecutionError('gutenberg categories contained a malformed initial group');
+        for (const item of items) {
+            const link = item.match(/<a\b([^>]*)>([\s\S]*?)<\/a>/i);
+            const href = attribute(link?.[1] || '', 'href');
+            const id = href.match(/^\/ebooks\/bookshelf\/([^/?#]+)$/)?.[1];
+            const name = decodeHtml(link?.[2]);
+            if (!id || !name) throw new CommandExecutionError('gutenberg categories contained a row without a valid category id or name');
+            rows.push({ id, initial: letter, name, url: absoluteUrl(href) });
+        }
+    }
+    if (!blockCount || !rows.length) throw new CommandExecutionError('gutenberg categories selector drift: category groups were not found');
+    return initial ? rows.filter((row) => row.initial === initial) : rows;
+}
+
+async function fetchAuthorBookPages(authorId, sort) {
+    const rows = [];
+    const seen = new Set();
+    for (let page = 1; page <= 1000; page += 1) {
+        const params = { sort_order: sort };
+        if (page > 1) params.start_index = ((page - 1) * PAGE_SIZE) + 1;
+        const html = await fetchText(buildUrl(`/ebooks/author/${authorId}`, params), `gutenberg author ${authorId}`);
+        const pageRows = parseBookList(html);
+        for (const row of pageRows) {
+            if (!seen.has(row.id)) {
+                seen.add(row.id);
+                rows.push(row);
+            }
+        }
+        if (!pageRows.length || pageRows.length < PAGE_SIZE) return rows;
+    }
+    throw new CommandExecutionError(`gutenberg author ${authorId} exceeded the pagination safety limit`);
+}
+
+export async function fetchAllAuthorBooks(authorId, sort) {
+    const rows = await fetchAuthorBookPages(authorId, sort);
+    if (!rows.length) throw new EmptyResultError(`gutenberg author ${authorId}`, 'The author has no books');
+    if (sort === 'downloads') {
+        if (rows.some((row) => row.downloads === null)) {
+            throw new CommandExecutionError(`gutenberg author ${authorId} download counts were missing from the downloads-sorted results`);
+        }
+        return rows;
+    }
+
+    const downloadRows = await fetchAuthorBookPages(authorId, 'downloads');
+    const downloadsById = new Map(downloadRows.map((row) => [row.id, row.downloads]));
+    return rows.map((row) => {
+        const downloads = downloadsById.get(row.id);
+        if (downloads === undefined || downloads === null) {
+            throw new CommandExecutionError(`gutenberg author ${authorId} did not provide a download count for ebook ${row.id}`);
+        }
+        return { ...row, downloads };
+    });
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -137,6 +137,7 @@ export default defineConfig({
                 { text: 'Xiaoyuzhou', link: '/adapters/browser/xiaoyuzhou' },
                 { text: 'Yahoo Finance', link: '/adapters/browser/yahoo-finance' },
                 { text: 'Internet Archive', link: '/adapters/browser/archive' },
+                { text: 'Gutenberg', link: '/adapters/browser/gutenberg' },
                 { text: 'arXiv', link: '/adapters/browser/arxiv' },
                 { text: 'dblp', link: '/adapters/browser/dblp' },
                 { text: 'PubMed', link: '/adapters/browser/pubmed' },

--- a/docs/adapters/browser/gutenberg.md
+++ b/docs/adapters/browser/gutenberg.md
@@ -1,0 +1,108 @@
+# Gutenberg
+
+**Mode**: 🌐 Public · **Domain**: `www.gutenberg.org`
+
+Browse Project Gutenberg ebooks, authors, rankings, categories, collections, and bookshelf search results without authentication.
+
+## Commands
+
+| Command                                     | Description |
+|---------------------------------------------|-------------|
+| `opencli gutenberg ebooks <id>`             | Show ebook metadata and download URLs for all available formats |
+| `opencli gutenberg search [title]`          | Search ebooks by title or keyword |
+| `opencli gutenberg author <id>`             | List books by a Gutenberg author |
+| `opencli gutenberg hot-books`               | Show the top book rankings |
+| `opencli gutenberg hot-author`              | Show the top author rankings |
+| `opencli gutenberg main-categories`         | List the main Gutenberg book categories |
+| `opencli gutenberg collections`             | List collections from the Reading Lists page |
+| `opencli gutenberg categories`              | List Reading List categories |
+| `opencli gutenberg category-search <query>` | Search Reading List categories |
+
+## Usage examples
+
+```bash
+# Ebook details and available formats
+opencli gutenberg ebooks 30849 -f json
+
+# Search books by title or keyword
+opencli gutenberg search "pride and prejudice" --sort downloads --limit 10 -f json
+
+# List books by an author
+opencli gutenberg author 69 --sort title -f json
+
+# Browse popular books and authors
+opencli gutenberg hot-books --period yesterday --limit 10 -f json
+opencli gutenberg hot-author --period 7days --limit 10 -f json
+
+# Browse categories and collections
+opencli gutenberg main-categories -f json
+opencli gutenberg collections -f json
+opencli gutenberg categories --initial A -f json
+
+# Search bookshelf categories
+opencli gutenberg category-search \
+  "Atheism | Buddhism | Christianity" \
+  --sort quantity \
+  -f json
+```
+
+## Options
+
+### `search`
+
+| Option | Description |
+|--------|-------------|
+| `title` (positional) | Optional book title or keyword |
+| `--sort` | `title`, `downloads`, or `release_date`; default: `downloads` |
+| `--limit` | Number of results from 1 to 100; default: 10 |
+
+### `author`
+
+| Option | Description |
+|--------|-------------|
+| `id` (positional) | Gutenberg author number, such as `69` |
+| `--sort` | `title`, `downloads`, or `release_date`; default: `downloads` |
+
+### `hot-books` and `hot-author`
+
+| Option | Description |
+|--------|-------------|
+| `--limit` | Number of results from 1 to 100; default: 10 |
+| `--period` | `yesterday`, `7days`, or `30days`; default: `yesterday` |
+
+### `categories`
+
+| Option | Description |
+|--------|-------------|
+| `--initial` | A single letter from A to Z; all categories are returned by default |
+
+### `category-search`
+
+| Option | Description |
+|--------|-------------|
+| `query` (positional) | Category search query |
+| `--sort` | `title`, `downloads`, `quantity`, or `release_date`; default: `downloads` |
+
+## Output columns
+
+| Command | Columns |
+|---------|---------|
+| `ebooks` | `id, title, author, summary, language, subjects, releaseDate, lastUpdate, copyright, downloads, readOnlineUrl, url, formats` |
+| `search` | `id, title, author, url, downloads` |
+| `author` | `id, title, author, url, downloads` |
+| `hot-books` | `id, title, url` |
+| `hot-author` | `id, name, url` |
+| `main-categories` | `id, name, parentName, url` |
+| `collections` | `name, url` |
+| `categories` | `id, initial, name, url` |
+| `category-search` | `name, downloads, url` |
+
+## Notes
+
+- All commands use public, server-rendered Gutenberg pages and do not require login or API credentials.
+- Ebook identifiers and author identifiers must be positive integers. Full ebook URLs are also accepted by `ebooks`.
+- Search and author results support sorting by `title`, `downloads`, or `release_date`.
+- Category search supports sorting by `title`, `downloads`, `quantity`, or `release_date`.
+- The `collections` command returns Gutenberg's collection order and does not expose a sort option.
+- Download counts are returned as numbers when Gutenberg provides them.
+- Empty results and malformed upstream responses are reported as command errors rather than successful incomplete rows.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -146,6 +146,7 @@ Run `opencli list` for the live registry.
 | **[osv](./browser/osv.md)**                       | `vulnerability` `query`                                                                                                                        | 🌐 Public    |
 | **[github-trending](./browser/github-trending.md)** | `repos`                                                                                                                                       | 🌐 Public    |
 | **[goproxy](./browser/goproxy.md)**               | `module` `versions`                                                                                                                            | 🌐 Public    |
+| **[gutenberg](./browser/gutenberg.md)**           | `ebooks` `search` `author` `hot-books` `hot-author` `main-categories` `collections` `categories` `category-search`                         | 🌐 Public    |
 | **[tvmaze](./browser/tvmaze.md)**                 | `search` `show`                                                                                                                                | 🌐 Public    |
 | **[rfc](./browser/rfc.md)**                       | `rfc`                                                                                                                                          | 🌐 Public    |
 | **[wikidata](./browser/wikidata.md)**             | `search` `entity`                                                                                                                              | 🌐 Public    |


### PR DESCRIPTION
  ## Gutenberg adapter

  Adds a public HTML-backed Project Gutenberg adapter with nine commands:

  | Command          | Purpose |
  |------------------|--------|
  | `ebooks <id>`    | Show ebook metadata and download URLs for all available formats |
  | `search [title]` | Search ebooks by title or keyword with optional sorting and limit |
  | `author <id>`    | List all books by a Gutenberg author |
  | `hot-books`      | Show the top book rankings for yesterday, 7 days, or 30 days |
  | `hot-author`     | Show the top author rankings for yesterday, 7 days, or 30 days |
  | `main-categories` | List the main Gutenberg book categories and their parent categories |
  | `collections`    | List collections from the Gutenberg Reading Lists page |
  | `categories`     | List Reading List categories, optionally filtered by initial letter |
  | `category-search <query>` | Search bookshelf categories with title, downloads, quantity, or release date sorting |

  ## Contract and strategy

  - Public reads use server-rendered Gutenberg HTML and declare `Strategy.PUBLIC`.
  - The adapter does not require authentication, browser sessions, or private credentials.
  - Shared request, parsing, pagination, validation, and error-handling logic is implemented in `utils.js`.
  - The adapter returns stable identifiers, names, URLs, authors, download counts, and ebook format links.
  - OpenCLI's `title` sort option is mapped to Gutenberg's `alpha` sort parameter.
  - `category-search` merges download-sorted results when the selected sort mode does not expose download counts directly.
  - Gutenberg pagination links are followed and duplicate results are removed.
  - `collections` preserves Gutenberg's source ordering.
  - `author` supports `title`, `downloads`, and `release_date` sorting.
  - `category-search` supports `title`, `downloads`, `quantity`, and `release_date` sorting.
  - Download counts are normalized to numeric values where available.
  - Empty results, malformed rows, and missing download formats are reported through typed command errors.
  - HTML attributes and entities are decoded consistently across the supported page types.

  ## Verification

  - Focused Gutenberg tests: **9 files / 28 tests pass**.
  - `npm run typecheck`: pass.
  - `npm run build`: pass; manifest compiled 1,375 entries.
  - `opencli validate gutenberg`: 0 errors, 0 warnings.
  - `npm run check:typed-error-lint`: pass with no new violations.
  - `npm run check:silent-column-drop`: pass with no new violations.
  - `git diff --check`: pass.