### PR TITLE
fix(facebook): support current feed DOM

### DIFF
--- a/clis/facebook/feed.js
+++ b/clis/facebook/feed.js
@@ -27,7 +27,7 @@ function buildFeedExtractScript(limit) {
       // Strip zero-width / bidi control chars first: Facebook injects them into
       // decoy nodes to poison scrapers. See issue #2089.
       return String(value || '')
-        .replace(/[\\u200b-\\u200f\\u202a-\\u202e\\u2060\\ufeff]/g, '')
+        .replace(/[\\u034f\\u200b-\\u200f\\u202a-\\u202e\\u2060\\ufeff]/g, '')
         .replace(/\\s+/g, ' ')
         .trim();
     }
@@ -39,6 +39,8 @@ function buildFeedExtractScript(limit) {
       if (!text) return true;
       if (/^\\d{8,}$/.test(text)) return true;
       if (/^(?:\\S ){4,}\\S$/.test(text) && text.replace(/\\s/g, '').length <= 12) return true;
+      if (/^[a-z0-9]{6,}\\.(com|net|org)$/i.test(text)) return true;
+      if (/^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-z0-9_-]{24,}$/i.test(text)) return true;
       return false;
     }
 
@@ -52,6 +54,10 @@ function buildFeedExtractScript(limit) {
 
     function labelOf(el) {
       return clean(el && el.getAttribute && el.getAttribute('aria-label'));
+    }
+
+    function isPostActionLabel(label) {
+      return /^(Actions for this post(?: by .+)?|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test(label);
     }
 
     function isAuthPage() {
@@ -87,7 +93,8 @@ function buildFeedExtractScript(limit) {
     }
 
     function isTimestampText(text) {
-      return /^(\\d+\\s*(s|m|h|d|w|mo|yr|min|sec|second|minute|hour|day|week|month|year)s?|Just now|Yesterday|刚刚|昨天|\\d+小时|\\d+天)(\\s*[·•.])?$/i.test(text);
+      return /^(\\d+\\s*(s|m|h|d|w|mo|yr|min|sec|second|minute|hour|day|week|month|year)s?|Just now|Yesterday|刚刚|昨天|\\d+小时|\\d+天)(\\s*[·•.])?$/i.test(text)
+        || /(?:·\\s*)?Shared with Public$/i.test(text);
     }
 
     function postUrlFrom(root) {
@@ -124,6 +131,13 @@ function buildFeedExtractScript(limit) {
     }
 
     function findAuthor(root) {
+      for (const el of root.querySelectorAll('[aria-label]')) {
+        const match = labelOf(el).match(/^Actions for this post by (.+)$/i);
+        if (match) {
+          const text = clean(match[1]);
+          if (text.length > 1 && text.length <= 80 && !isDecoyText(text)) return text;
+        }
+      }
       const links = [
         root.querySelector('h2 a[href], h3 a[href], h4 a[href], strong a[href]'),
         ...Array.from(root.querySelectorAll('a[role="link"][href]')),
@@ -131,13 +145,15 @@ function buildFeedExtractScript(limit) {
       for (const link of links) {
         const text = textOf(link);
         const href = link.href || link.getAttribute('href') || '';
+        const isGroupScopedUser = /\\/groups\\/[^/]+\\/user\\/[^/?#]+/i.test(href);
         if (text.length > 1 && text.length <= 80
           && !isActionText(text)
           && !isMetricText(text)
           && !isTimestampText(text)
           && !isDecoyText(text)
           && !/^[\\d\\s.,-]+$/.test(text)   // reject all-digit decoy names, but keep "Class of 2024" (#2089)
-          && !/\\/groups\\/|\\/watch\\/|\\/reel\\/|\\/events\\/|\\/friends\\//i.test(href)) {
+          && (isGroupScopedUser || !/\\/groups\\//i.test(href))
+          && !/\\/watch\\/|\\/reel\\/|\\/events\\/|\\/friends\\//i.test(href)) {
           return text;
         }
       }
@@ -189,19 +205,25 @@ function buildFeedExtractScript(limit) {
 
     function primaryContainers() {
       return Array.from(document.querySelectorAll('[role="article"]'))
-        .filter((el) => textOf(el).length > 30);
+        .filter((el) => {
+          if (textOf(el).length <= 30) return false;
+          const hasCommentScopedLink = Boolean(el.querySelector('a[href*="comment_id="]'));
+          const hasPostMenu = Array.from(el.querySelectorAll('[aria-label]'))
+            .some((node) => isPostActionLabel(labelOf(node)));
+          return !hasCommentScopedLink || hasPostMenu;
+        });
     }
 
     // Modern Facebook no longer wraps posts in [role="article"] nor exposes the
-    // Like/Comment/Share aria-labels the fallback keyed on. Every post still
-    // carries one "Actions for this post" control (the ⋯ menu). Anchor on it and
-    // walk up to the HIGHEST ancestor that still contains exactly one such
-    // control — that bounds the node to a single post. See issue #2089.
+    // Like/Comment/Share aria-labels the fallback keyed on. Real posts and some
+    // suggestion cards both carry an "Actions for this post" control. Walk up
+    // only to the NEAREST ancestor with actual post evidence, and stop as soon
+    // as suggestion chrome is encountered.
     function actionMenuAnchors() {
       // Post menus only — NOT "Actions for this comment", so the anchor set,
       // countMenus, and loadFeedPosts all key on the same thing (#2089).
-      return Array.from(document.querySelectorAll('[aria-label]')).filter((el) =>
-        /^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test(labelOf(el)));
+      return Array.from(document.querySelectorAll('[aria-label]'))
+        .filter((el) => isPostActionLabel(labelOf(el)));
     }
 
     function actionAnchoredContainers() {
@@ -211,7 +233,7 @@ function buildFeedExtractScript(limit) {
       const countMenus = (node) => {
         let n = 0;
         for (const el of node.querySelectorAll('[aria-label]')) {
-          if (/^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test(labelOf(el))) n += 1;
+          if (isPostActionLabel(labelOf(el))) n += 1;
         }
         return n;
       };
@@ -223,7 +245,19 @@ function buildFeedExtractScript(limit) {
           // Never let a single-post page climb the container up to a page
           // landmark (role=main/feed/...) and emit the whole region as a post.
           if (LANDMARK_ROLES.has(node.getAttribute('role') || '')) break;
-          if (countMenus(node) === 1) best = node; else break;
+          if (countMenus(node) !== 1) break;
+          const fullText = textOf(node);
+          if (isSuggestionOrChrome(fullText)) break;
+          const author = findAuthor(node);
+          if (!author) continue;
+          const blocks = contentBlocks(node, author);
+          if (blocks.length > 0) {
+            best = node;
+            break;
+          }
+          // A permalink can live in the header while the body is its sibling.
+          // Keep it only as a fallback and continue upward looking for content.
+          if (!best && postUrlFrom(node)) best = node;
         }
         if (best && !seen.has(best) && textOf(best).length > 30) {
           seen.add(best);
@@ -306,7 +340,7 @@ async function loadFeedPosts(page, limit) {
     await sleep(800);
     return document.querySelectorAll('[aria-label]').length
       ? document.querySelectorAll('[role="article"]').length
-        + Array.from(document.querySelectorAll('[aria-label]')).filter((el) => /^(Actions for this post|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test((el.getAttribute('aria-label') || '').trim())).length
+        + Array.from(document.querySelectorAll('[aria-label]')).filter((el) => /^(Actions for this post(?: by .+)?|此帖子的操作|针对此帖子的操作|贴文的操作)$/i.test((el.getAttribute('aria-label') || '').trim())).length
       : 0;
   })()`;
   const extractStep = buildFeedExtractScript(limit);

--- a/clis/facebook/feed.test.js
+++ b/clis/facebook/feed.test.js
@@ -270,4 +270,143 @@ describe('facebook feed', () => {
     expect(payload.rows[0].author).toBe('Real Human');
     expect(payload.rows[0].content).not.toContain('1234567890123');
   });
+
+  it('extracts authors from the group-scoped user links used by current Facebook', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/groups/123/user/456/">Group Author</a></h3>
+            <div dir="auto">A genuine freelance group post with enough useful text to extract.</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows[0].author).toBe('Group Author');
+  });
+
+  it('removes combining-grapheme anti-scrape characters from decoy blocks', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div>
+            <h3><a role="link" href="https://www.facebook.com/real-author">Real Author</a></h3>
+            <div dir="auto">Genuine post content that remains after current Facebook decoys are removed.</div>
+            <div dir="auto">a͏ b͏ c͏ d͏ e͏ f͏</div>
+            <div aria-label="Actions for this post" role="button"></div>
+          </div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows[0].content).toBe('Genuine post content that remains after current Facebook decoys are removed.');
+  });
+
+  it('does not let a misleading post menu in people suggestions consume surrounding page chrome', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div dir="auto">Facebook navigation label with enough characters to look like content.</div>
+          <section>
+            <h2 dir="auto">People you may know</h2>
+            <div>
+              <div dir="auto">Suggested Person</div>
+              <div dir="auto">12 mutual friends</div>
+              <button aria-label="Actions for this post"></button>
+            </div>
+          </section>
+          <div dir="auto">Unrelated page text that must never become a feed row.</div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('no_rows');
+    expect(payload.rows).toEqual([]);
+  });
+
+  it('extracts current post action labels that include the author name', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div dir="auto">Current Facebook post body with enough meaningful text to extract.</div>
+          <button aria-label="Actions for this post by Current Author"></button>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows[0].author).toBe('Current Author');
+    expect(payload.rows[0].content).toContain('Current Facebook post body');
+  });
+
+  it('does not treat current role=article comment nodes as feed posts', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div role="article">
+          <a role="link" href="https://www.facebook.com/commenter?comment_id=abc">Comment Author</a>
+          <div dir="auto">A long reply that is a comment, not a top-level Facebook feed post.</div>
+          <a href="https://www.facebook.com/author/posts/123?comment_id=abc">12h</a>
+          <button aria-label="Like"></button>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('no_rows');
+    expect(payload.rows).toEqual([]);
+  });
+
+  it('keeps walking past a permalink header to include its sibling post body', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <header>
+            <h3><a role="link" href="https://www.facebook.com/alice">Alice Poster</a></h3>
+            <a href="https://www.facebook.com/alice/posts/123">2h</a>
+            <button aria-label="Actions for this post by Alice Poster"></button>
+          </header>
+          <div dir="auto">The actual post body is a sibling of the header containing the action menu.</div>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows[0].author).toBe('Alice Poster');
+    expect(payload.rows[0].content).toBe('The actual post body is a sibling of the header containing the action menu.');
+  });
+
+  it('does not emit an authorless suggestion card with long descriptive text', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <div dir="auto">Suggested profile description long enough to resemble genuine post content.</div>
+          <button aria-label="Actions for this post"></button>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('no_rows');
+    expect(payload.rows).toEqual([]);
+  });
+
+  it('removes injected random-domain and opaque-token decoy blocks', () => {
+    const payload = runExtract(`
+      <main role="main">
+        <div>
+          <h3><a role="link" href="https://www.facebook.com/real-author">Real Author</a></h3>
+          <div dir="auto">Genuine post body that should remain readable after decoy filtering.</div>
+          <div dir="auto">wA4xvbU.com</div>
+          <div dir="auto">8Mt4DKRlTLDjXTjnl4iAP5YS4DzIxQF52c7togr51dUFTo</div>
+          <div dir="auto">onspeodSrtt5A12f71: 501aut12gi250s 8liui54P1u0cf 352Mf2617t · Shared with Public</div>
+          <button aria-label="Actions for this post by Real Author"></button>
+        </div>
+      </main>
+    `);
+
+    expect(payload.status).toBe('ok');
+    expect(payload.rows[0].content).toBe('Genuine post body that should remain readable after decoy filtering.');
+  });
 });


### PR DESCRIPTION
## Summary
- recognize current `Actions for this post by <author>` controls
- exclude comment articles, authorless suggestions, reels, and page chrome
- keep walking past permalink-only headers to include sibling post bodies
- support group-scoped author links and current injected formatting/decoy blocks

## Verification
- `npm run build`
- `npm run typecheck`
- `npm run dev -- validate facebook` (14 commands, 0 errors/warnings)
- `npm test -- --run clis/facebook/feed.test.js --reporter=dot` (22 passed)
- live read-only checks against the current Facebook feed returned top-level posts with correct authors and clean content
- full `npm test`: 7,320 passed and 4 unrelated tests hit the 5s timeout under the parallel runner; all four affected files passed when rerun individually (88 tests)

No account data or captured Facebook markup is included in the fixtures.