### PR TITLE
fix(registry): preserve existing commands on alias conflicts

### DIFF
--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -90,6 +90,29 @@ describe('cli() registration', () => {
     expect(registry.get('test-registry/legacy-name')).toBe(cmd);
   });
 
+  it('does not let an alias overwrite an existing command', () => {
+    const original = cli({
+      site: 'test-alias-collision',
+      name: 'status', access: 'read',
+      description: 'original command',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+    });
+    const incoming = cli({
+      site: 'test-alias-collision',
+      name: 'inspect', access: 'read',
+      description: 'command with one conflicting alias',
+      strategy: Strategy.PUBLIC,
+      browser: false,
+      aliases: ['status', 'legacy-inspect'],
+    });
+
+    const registry = getRegistry();
+    expect(registry.get('test-alias-collision/status')).toBe(original);
+    expect(incoming.aliases).toEqual(['legacy-inspect']);
+    expect(registry.get('test-alias-collision/legacy-inspect')).toBe(incoming);
+  });
+
   it('preserves defaultFormat on the registered command', () => {
     const cmd = cli({
       site: 'test-registry',

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -229,7 +229,12 @@ export function registerCommand(cmd: RawCliCommand): void {
     }
   }
 
-  const aliases = normalizeAliases(normalized.aliases, normalized.name);
+  // An alias must not silently replace an existing command (or a previously
+  // registered alias) for the same site. This is especially important for
+  // plugins, whose load order must not change an established command route.
+  const aliases = normalizeAliases(normalized.aliases, normalized.name).filter(
+    (alias) => !_registry.has(`${normalized.site}/${alias}`),
+  );
   normalized.aliases = aliases.length > 0 ? aliases : undefined;
   _registry.set(canonicalKey, normalized);
   for (const alias of aliases) {


### PR DESCRIPTION
## Description

A command alias could silently overwrite an already registered command with the same site/name. That made adapter and plugin load order change which implementation ran for an established command.

The registry now ignores only the conflicting alias while continuing to register any remaining unique aliases. A regression test proves that the original command remains routable and a unique alias still works.

Related issue: None.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

    npx vitest run --project unit src/registry.test.ts
    22 passed

    npm run typecheck
    tsc --noEmit

Note: the full npm test run was also attempted. Its unrelated plugin/download/adapter failures require local listener or download capabilities unavailable in this environment; the focused registry suite and typecheck pass.