### PR TITLE
fix(chatgpt): fall back to DOM upload when setFileInput times out

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -2402,7 +2402,7 @@ export async function uploadChatGPTImages(page, imagePaths) {
             uploaded = true;
         } catch (err) {
             const msg = String(err?.message || err);
-            if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found')) {
+            if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found') && !msg.includes('fileChooserOpened')) {
                 throw err;
             }
         }
@@ -3095,7 +3095,7 @@ export async function uploadChatGPTProjectFiles(page, projectId, filePaths) {
                 break;
             } catch (err) {
                 const msg = String(err?.message || err);
-                if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found')) {
+                if (!msg.includes('Unknown action') && !msg.includes('not supported') && !msg.includes('Not allowed') && !msg.includes('No element found') && !msg.includes('fileChooserOpened')) {
                     throw err;
                 }
             }

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1762,6 +1762,33 @@ describe('chatgpt image upload helper', () => {
         expect(fallbackScript).toContain('stopPropagation()');
     });
 
+    it('falls back to DOM upload when setFileInput times out waiting for a file chooser', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
+        tempDirs.push(dir);
+        const filePath = path.join(dir, 'cat.png');
+        fs.writeFileSync(filePath, 'fake-png');
+
+        const page = {
+            setFileInput: vi.fn().mockRejectedValue(new Error('Page.fileChooserOpened not received within 5s')),
+            wait: vi.fn().mockResolvedValue(undefined),
+            sleep: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn((script) => {
+                if (String(script).includes('new DataTransfer()')) {
+                    return Promise.resolve({ ok: true });
+                }
+                return Promise.resolve(true);
+            }),
+        };
+
+        const result = await uploadChatGPTImages(page, [filePath]);
+
+        expect(result).toEqual({ ok: true, files: [filePath] });
+        const fallbackScript = page.evaluate.mock.calls
+            .map(([script]) => String(script))
+            .find(script => script.includes('new DataTransfer()'));
+        expect(fallbackScript).toContain('new DataTransfer()');
+    });
+
     it('does not treat generic upload controls as uploaded image previews', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencli-chatgpt-'));
         tempDirs.push(dir);


### PR DESCRIPTION
## Problem

Uploading a reference image in ChatGPT could fail with:

```
Page.fileChooserOpened not received within 5s — the input may not have opened a file chooser
```

When the file input exists but no native chooser opens, `page.setFileInput` throws this timeout and the error was rethrown before the existing DOM `DataTransfer` fallback could run, so the reference image was never attached.

## Change

Treat the `fileChooserOpened` timeout like the other already-handled `setFileInput` failures (`Unknown action`, `not supported`, `Not allowed`, `No element found`) in both:

- `uploadChatGPTImages` (image/reference-image upload)
- `uploadChatGPTProjectFiles` (project file upload)

This lets the adapter fall through to the DOM upload path that injects the file via `new DataTransfer()` instead of surfacing the timeout as a hard failure.

## Test

Adds a regression test that rejects `setFileInput` with the `fileChooserOpened` timeout and asserts the DOM `DataTransfer` fallback runs and the upload reports success.

```
npx vitest run --project adapter clis/chatgpt/utils.test.js
Test Files  1 passed (1)
Tests      120 passed (120)
```