### PR TITLE
docs: remove duplicate Douban sidebar entry

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -97,7 +97,6 @@ export default defineConfig({
                 { text: 'Sina Blog', link: '/adapters/browser/sinablog' },
                 { text: 'Substack', link: '/adapters/browser/substack' },
                 { text: 'Pixiv', link: '/adapters/browser/pixiv' },
-                { text: 'Douban', link: '/adapters/browser/douban' },
                 { text: 'Doubao', link: '/adapters/browser/doubao' },
                 { text: 'Facebook', link: '/adapters/browser/facebook' },
                 { text: 'Google', link: '/adapters/browser/google' },


### PR DESCRIPTION
## Description

Remove the duplicate Douban entry from the VitePress browser-adapter sidebar. The adapter remains listed once and its documentation route is unchanged.

Related issue: none; this is a one-line documentation navigation cleanup found during a full repository audit.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

- `npm run docs:build` passes
- the sidebar source contains one Douban link after the change
- `git diff --check` passes
