### PR TITLE
fix(xiaohongshu): accept stacked duplicate filter chips in the search panel

### DIFF
--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -404,10 +404,17 @@ function buildApplySearchFiltersJs(requestedFilters) {
           }
           const options = visibleMatches(groups[0], '.tag-container > .tags')
             .filter((option) => text(option) === request.option);
-          if (options.length !== 1) {
+          // The live layout renders each chip twice, stacked at the exact
+          // same position. Pixel-identical matches are one visual control,
+          // not an ambiguity; matches at distinct positions still fail closed.
+          const rectKey = (element) => {
+            const rect = element.getBoundingClientRect();
+            return [rect.left, rect.top, rect.width, rect.height].map((v) => Math.round(v || 0)).join(',');
+          };
+          if (!options.length || new Set(options.map(rectKey)).size !== 1) {
             return { status: 'layout', detail: options.length ? 'ambiguous_option' : 'option_not_found' };
           }
-          return { status: 'ok', option: options[0] };
+          return { status: 'ok', option: options.find((o) => o.classList.contains('active')) || options[0] };
         };
         const isActive = (option) => option.classList.contains('active');
         const ready = () => visibleMatches(document, 'section.note-item, section:has(a[href*="/search_result/"]), section:has(a[href*="/explore/"]), .search-empty-wrapper').length > 0;

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -17,6 +17,9 @@ import {
 function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0 });
 }
+function markVisibleAt(el, top) {
+    el.getBoundingClientRect = () => ({ width: 100, height: 100, top });
+}
 function createPageMock(evaluateResults) {
     const queuedResults = [...evaluateResults];
     const evaluate = vi.fn(async (script) => {
@@ -144,8 +147,12 @@ function createFilterBehaviorPage(options = {}) {
             const container = document.createElement('div');
             container.className = 'tag-container';
             for (const choice of choices) {
-                if (options.missing === `${groupLabel}/${choice}`) continue;
-                const copies = options.ambiguous === `${groupLabel}/${choice}` ? 2 : 1;
+                const key = `${groupLabel}/${choice}`;
+                if (options.missing === key) continue;
+                // `duplicated` doubles every chip at the same rect (the live
+                // 2026-09 layout); `ambiguous` places the second copy at a
+                // different position — genuinely two distinct controls.
+                const copies = options.ambiguous === key || options.duplicated ? 2 : 1;
                 for (let copy = 0; copy < copies; copy++) {
                     const option = document.createElement('div');
                     option.className = `tags${state[groupLabel] === choice ? ' active' : ''}`;
@@ -173,7 +180,8 @@ function createFilterBehaviorPage(options = {}) {
                         }, 300);
                     });
                     container.append(option);
-                    markVisible(option);
+                    if (copy > 0 && options.ambiguous === key) markVisibleAt(option, 60);
+                    else markVisible(option);
                     markVisible(optionLabel);
                 }
             }
@@ -696,6 +704,19 @@ describe('xiaohongshu search filter behavior', () => {
                 '发布时间': '一天内',
                 '搜索范围': '已关注',
             });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('treats stacked duplicate chips (identical rects) as one option — live layout 2026-09', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ duplicated: true });
+            const result = await runFilterCommand(page, { sort: 'latest' });
+            expect(result[0].title).toBe('最新');
+            expect(page.filterState).toMatchObject({ '排序依据': '最新' });
         }
         finally {
             vi.useRealTimers();


### PR DESCRIPTION
## Problem

`xiaohongshu search` currently fails on every invocation with:

```
COMMAND_EXEC: Xiaohongshu search filter layout did not match the expected visible panel (ambiguous_option).
```

Inspecting the live `search_result` page shows why: the current layout renders **every filter chip twice inside the same `.tag-container`**, both copies passing the visibility check, at pixel-identical bounding rects (verified: two `最新` chips both at `{x:936, y:187, 96×40}`, same parent chain). `findOption` requires exactly one visible text match per group, so filter application — which runs for all five groups even at defaults — dies on the first group.

## Fix

Matches whose bounding rects are identical are one visual control stacked on itself, not an ambiguity: dedupe them and click through (preferring the copy carrying `.active`, so the activation wait-loop and the final verification see the active state regardless of which clone the site marks). Matches at **distinct** positions still fail closed as `ambiguous_option` — the fail-closed contract from #1506-era layout drift is preserved, and the test fixture now places the second copy of a genuinely ambiguous chip at a different rect to keep that path covered.

## Verification

- New JSDOM test mirrors the live layout (every chip duplicated at identical rects) and asserts a `--sort latest` run succeeds end-to-end; written test-first against the real filter script.
- Existing distinct-rect ambiguity test still rejects with `ambiguous_option` (65 search tests, 341 xiaohongshu adapter tests, 24 rednote tests — all green; full suite 7317 passed, typecheck and both lint gates clean).
- Live against www.xiaohongshu.com (logged in): default-filter search returns results in 2.7s; `--sort latest`, which clicks a deduplicated chip, applies and returns latest-sorted results in 4.8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Part of the xiaohongshu risk-control/persistence arc — umbrella issue with full motivation and cross-PR context: #2470
