### PR TITLE
feat(xiaohongshu): persistent site session for self-guarding commands + real reload on soft-block retry

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -45535,7 +45535,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/ask.js",
     "sourceFile": "xiaohongshu/ask.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -45583,7 +45584,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/comments.js",
     "sourceFile": "xiaohongshu/comments.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -45706,7 +45708,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/creator-profile.js",
     "sourceFile": "xiaohongshu/creator-profile.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -45737,7 +45740,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/creator-stats.js",
     "sourceFile": "xiaohongshu/creator-stats.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -45806,7 +45810,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/download.js",
     "sourceFile": "xiaohongshu/download.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46008,7 +46013,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/follow.js",
     "sourceFile": "xiaohongshu/follow.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46102,7 +46108,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/note.js",
     "sourceFile": "xiaohongshu/note.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46367,7 +46374,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/unfollow.js",
     "sourceFile": "xiaohongshu/unfollow.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46350,7 +46350,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/search.js",
     "sourceFile": "xiaohongshu/search.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -45986,7 +45986,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/feed.js",
     "sourceFile": "xiaohongshu/feed.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46051,7 +46052,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/liked.js",
     "sourceFile": "xiaohongshu/liked.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46246,7 +46248,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/saved.js",
     "sourceFile": "xiaohongshu/saved.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",
@@ -46411,7 +46414,8 @@
     "type": "js",
     "modulePath": "xiaohongshu/user.js",
     "sourceFile": "xiaohongshu/user.js",
-    "navigateBefore": false
+    "navigateBefore": false,
+    "siteSession": "persistent"
   },
   {
     "site": "xiaohongshu",

--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -430,6 +430,7 @@ export const command = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'query', positional: true, required: true, help: 'Question for 点点' },
         { name: 'timeout', type: 'int', default: 90, help: 'Seconds to wait for the 点点 answer' },

--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -146,7 +146,7 @@ export function buildNoteUrl(noteId, xsecToken) {
     const url = new URL(`https://${XHS_WEB_HOST}/explore/${noteId}`);
     if (xsecToken) {
         url.searchParams.set('xsec_token', xsecToken);
-        url.searchParams.set('xsec_source', '');
+        url.searchParams.set('xsec_source', 'pc_share');
     }
     return url.toString();
 }

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -70,7 +70,7 @@ describe('xiaohongshu ask', () => {
             rank: 1,
             type: 'note',
             title: '新手露营有哪些建议？',
-            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=tok+123&xsec_source=',
+            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=tok+123&xsec_source=pc_share',
             note_id: '69d6fc08000000001f007646',
             xsec_token: 'tok 123',
             author: '郑小喜',

--- a/clis/xiaohongshu/collection-helpers.js
+++ b/clis/xiaohongshu/collection-helpers.js
@@ -1,5 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { buildXhsNoteUrl, normalizeXhsUserId } from './user-helpers.js';
+import { navigateFresh } from './shared.js';
 
 export const COLLECT_API_PATTERN = 'note/collect/page';
 export const LIKE_API_PATTERN = 'note/like/page';
@@ -210,18 +211,44 @@ async function accumulateInterceptedNotes(page, bucket, fallbackUserId) {
     return extractNotesFromResponses(bucket, fallbackUserId);
 }
 
-export async function resolveXhsUserId(page, rawId) {
-    if (rawId)
-        return normalizeXhsUserId(String(rawId));
-    await page.goto('https://www.xiaohongshu.com/explore');
-    await page.wait(2);
-    await throwIfLoginWall(page);
-    const userId = unwrapBrowserResult(await page.evaluate(`() => {
+const SELF_UID_JS = `() => {
       const user = window.__INITIAL_STATE__?.user?.userInfo;
       const info = user?._value ?? user ?? {};
       return info.user_id || info.userId || info.userID || '';
-    }`));
-    const clean = toCleanString(userId);
+    }`;
+
+async function readSelfUserId(page) {
+    return toCleanString(unwrapBrowserResult(await page.evaluate(SELF_UID_JS)));
+}
+
+async function pollSelfUserId(page, attempts = 3, waitSeconds = 1.5) {
+    let clean = await readSelfUserId(page);
+    // An empty uid right after navigation usually means __INITIAL_STATE__ has
+    // not hydrated yet (location.reload() resolves before the page loads), so
+    // poll through the hydration window before concluding anything.
+    for (let i = 0; !clean && i < attempts; i += 1) {
+        await page.wait(waitSeconds);
+        clean = await readSelfUserId(page);
+    }
+    return clean;
+}
+
+export async function resolveXhsUserId(page, rawId) {
+    if (rawId)
+        return normalizeXhsUserId(String(rawId));
+    await navigateFresh(page, 'https://www.xiaohongshu.com/explore');
+    await page.wait(2);
+    await throwIfLoginWall(page);
+    let clean = await pollSelfUserId(page);
+    if (!clean) {
+        // Polling exhausted on a loaded page: a warm persistent tab may
+        // predate a login-state change and still show the old
+        // __INITIAL_STATE__. Reload once and poll again before concluding
+        // the user is logged out.
+        await page.evaluate('location.reload()').catch(() => { });
+        await page.wait(2);
+        clean = await pollSelfUserId(page);
+    }
     if (!clean) {
         throw new AuthRequiredError('www.xiaohongshu.com', 'Not logged into Xiaohongshu (could not resolve current user id)');
     }
@@ -244,8 +271,14 @@ export async function fetchXhsCollectionNotes(page, {
     emptyLabel,
 }) {
     const capturedRequests = [];
+    // Navigate FIRST: the interceptor is an in-page patch on window, and a
+    // navigation wipes it — installed before the goto it never captured
+    // anything, silently leaving the DOM fallback to do all the work.
+    // navigateFresh additionally forces a real reload when a warm persistent
+    // tab already shows this collection page (a fast-pathed goto would reread
+    // stale SSR content).
+    await navigateFresh(page, buildProfileCollectionUrl(userId, profileTab));
     await page.installInterceptor(apiPattern);
-    await page.goto(buildProfileCollectionUrl(userId, profileTab));
     await page.wait(2);
     await assertOnCollectionProfile(page, userId);
     let notes = [];

--- a/clis/xiaohongshu/collection-helpers.test.js
+++ b/clis/xiaohongshu/collection-helpers.test.js
@@ -1,125 +1,96 @@
-import { describe, expect, it } from 'vitest';
-import { CommandExecutionError } from '@jackwener/opencli/errors';
-import {
-    COLLECT_API_PATTERN,
-    LIKE_API_PATTERN,
-    LIKED_PROFILE_TAB,
-    SAVED_PROFILE_TAB,
-    buildProfileCollectionUrl,
-    extractNotesFromResponses,
-    mapCollectionNote,
-    parseCollectionLimit,
-    readSelfUserIdFromState,
-} from './collection-helpers.js';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthRequiredError } from '@jackwener/opencli/errors';
+import { fetchXhsCollectionNotes, resolveXhsUserId } from './collection-helpers.js';
 
-describe('xiaohongshu collection helpers', () => {
-    it('reads the logged-in user id from INITIAL_STATE', () => {
-        expect(readSelfUserIdFromState({
-            user: {
-                userInfo: {
-                    _value: { user_id: 'abc123' },
-                },
-            },
-        })).toBe('abc123');
-    });
+const EXPLORE = 'https://www.xiaohongshu.com/explore';
+const FAV_URL = 'https://www.xiaohongshu.com/user/profile/self-user?tab=fav&subTab=note';
 
-    it('unwraps Browser Bridge envelopes when reading logged-in user id', () => {
-        expect(readSelfUserIdFromState({
-            session: 's1',
-            data: {
-                user: {
-                    userInfo: { userId: 'self-user' },
-                },
-            },
-        })).toBe('self-user');
-    });
-
-    it('validates collection limits instead of silently clamping', () => {
-        expect(parseCollectionLimit('20')).toBe(20);
-        expect(() => parseCollectionLimit(0)).toThrow(/between 1 and 100/);
-        expect(() => parseCollectionLimit(101)).toThrow(/between 1 and 100/);
-        expect(() => parseCollectionLimit('1.5')).toThrow(/integer/);
-    });
-
-    it('maps collect API notes with xsec_token into profile URLs', () => {
-        const row = mapCollectionNote({
+const API_NOTE = {
+    data: {
+        notes: [{
             note_id: '662908190000000001007366',
-            xsec_token: 'token-1',
+            xsec_token: 'tok',
             note_card: {
-                display_title: 'Saved note',
+                display_title: '收藏笔记',
                 type: 'normal',
-                user: { user_id: 'user-1', nickname: 'Alice' },
-                interact_info: { liked_count: '12' },
+                user: { user_id: 'self-user', nickname: 'Me' },
+                interact_info: { liked_count: '8' },
             },
-        }, { fallbackUserId: 'fallback' });
-        expect(row).toMatchObject({
-            id: '662908190000000001007366',
-            title: 'Saved note',
-            author: 'Alice',
-            likes: '12',
-            type: 'normal',
-            url: 'https://www.xiaohongshu.com/user/profile/user-1/662908190000000001007366?xsec_token=token-1&xsec_source=pc_user',
-        });
+        }],
+    },
+};
+
+function dispatchPage({ uidResults = ['self-user'], loginWall = false, location, intercepted = [API_NOTE], currentUrl } = {}) {
+    let uidIndex = 0;
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        autoScroll: vi.fn().mockResolvedValue(undefined),
+        installInterceptor: vi.fn().mockResolvedValue(undefined),
+        getInterceptedRequests: vi.fn().mockResolvedValue(intercepted),
+        evaluate: vi.fn(async (script) => {
+            const s = String(script);
+            if (s.includes('location.reload')) return undefined;
+            if (s.includes('登录后')) return loginWall;
+            if (s.includes('hostname: location.hostname')) {
+                return location ?? { hostname: 'www.xiaohongshu.com', pathname: '/user/profile/self-user', href: FAV_URL };
+            }
+            if (s.includes('userInfo')) return uidResults[Math.min(uidIndex++, uidResults.length - 1)];
+            return [];
+        }),
+    };
+    if (currentUrl !== undefined) page.getCurrentUrl = vi.fn().mockResolvedValue(currentUrl);
+    return page;
+}
+
+describe('resolveXhsUserId warm-tab staleness', () => {
+    it('polls through the hydration window without reloading (reload returns before the page loads)', async () => {
+        // location.reload() resolves immediately; __INITIAL_STATE__ hydrates
+        // later. An empty uid right after navigation usually means "not
+        // hydrated yet", never reload straight away (observed live: the
+        // reload-first version raced hydration twice and failed logged-in).
+        const page = dispatchPage({ uidResults: ['', '', 'self-user'] });
+        await expect(resolveXhsUserId(page, '')).resolves.toBe('self-user');
+        expect(page.evaluate.mock.calls.some(([s]) => String(s).includes('location.reload'))).toBe(false);
     });
 
-    it('dedupes notes across multiple intercepted responses', () => {
-        const requests = [
-            {
-                data: {
-                    notes: [
-                        {
-                            note_id: 'note-1',
-                            xsec_token: 'tok-1',
-                            title: 'First',
-                            user: { nickname: 'A' },
-                            interact_info: { liked_count: '1' },
-                        },
-                    ],
-                },
-            },
-            {
-                data: {
-                    notes: [
-                        {
-                            note_id: 'note-1',
-                            xsec_token: 'tok-1b',
-                            title: 'First duplicate',
-                            user: { nickname: 'A' },
-                            interact_info: { liked_count: '1' },
-                        },
-                        {
-                            note_id: 'note-2',
-                            xsec_token: 'tok-2',
-                            title: 'Second',
-                            user: { nickname: 'B' },
-                            interact_info: { liked_count: '2' },
-                        },
-                    ],
-                },
-            },
-        ];
-        const rows = extractNotesFromResponses(requests, 'self');
-        expect(rows).toHaveLength(2);
-        expect(rows.map((row) => row.id)).toEqual(['note-1', 'note-2']);
+    it('reloads once when polling exhausts, then polls again (stale login-state tab)', async () => {
+        // initial read + 3 hydration polls all empty -> one reload -> success.
+        const page = dispatchPage({ uidResults: ['', '', '', '', 'self-user'] });
+        await expect(resolveXhsUserId(page, '')).resolves.toBe('self-user');
+        expect(page.evaluate.mock.calls.filter(([s]) => String(s).includes('location.reload')).length).toBe(1);
     });
 
-    it('fails closed when intercepted collection payload shape is malformed', () => {
-        expect(() => extractNotesFromResponses([{ data: { notes: null } }], 'self'))
-            .toThrow(CommandExecutionError);
-        expect(() => extractNotesFromResponses([{ data: { notes: [{ note_id: 'note-1' }] } }], 'self'))
-            .toThrow(/stable id\/xsec token/);
+    it('throws AuthRequiredError only after the reload retry also exhausts its polls', async () => {
+        const page = dispatchPage({ uidResults: [''] });
+        await expect(resolveXhsUserId(page, '')).rejects.toBeInstanceOf(AuthRequiredError);
+        expect(page.evaluate.mock.calls.filter(([s]) => String(s).includes('location.reload')).length).toBe(1);
     });
 
-    it('uses the expected API patterns', () => {
-        expect(COLLECT_API_PATTERN).toBe('note/collect/page');
-        expect(LIKE_API_PATTERN).toBe('note/like/page');
+    it('forces a fresh load when the tab already sits on /explore', async () => {
+        const page = dispatchPage({ currentUrl: EXPLORE });
+        await expect(resolveXhsUserId(page, '')).resolves.toBe('self-user');
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+});
+
+describe('fetchXhsCollectionNotes navigation and interceptor order', () => {
+    const opts = { userId: 'self-user', profileTab: 'fav', apiPattern: '/collect', limit: 5, emptyLabel: 'saved' };
+
+    it('installs the interceptor AFTER navigation so the page load cannot wipe the in-page patch', async () => {
+        const page = dispatchPage({});
+        const rows = await fetchXhsCollectionNotes(page, opts);
+        expect(rows.length).toBe(1);
+        const gotoOrder = page.goto.mock.invocationCallOrder[0];
+        const installOrder = page.installInterceptor.mock.invocationCallOrder[0];
+        expect(installOrder).toBeGreaterThan(gotoOrder);
     });
 
-    it('builds profile URLs for saved and liked tabs', () => {
-        const userId = '66c876f7000000001d023624';
-        expect(buildProfileCollectionUrl(userId, SAVED_PROFILE_TAB))
-            .toBe('https://www.xiaohongshu.com/user/profile/66c876f7000000001d023624?tab=fav&subTab=note');
-        expect(buildProfileCollectionUrl(userId, LIKED_PROFILE_TAB))
-            .toBe('https://www.xiaohongshu.com/user/profile/66c876f7000000001d023624?tab=liked&subTab=note');
+    it('forces a reload instead of a fast-pathed goto when the tab already shows this collection page', async () => {
+        const page = dispatchPage({ currentUrl: FAV_URL });
+        const rows = await fetchXhsCollectionNotes(page, opts);
+        expect(rows.length).toBe(1);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate.mock.calls.some(([s]) => String(s).includes('location.reload'))).toBe(true);
     });
 });

--- a/clis/xiaohongshu/comments.js
+++ b/clis/xiaohongshu/comments.js
@@ -290,6 +290,7 @@ export const command = cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'note-id', required: true, positional: true, help: 'Full Xiaohongshu note URL with xsec_token' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of top-level comments (max 50)' },

--- a/clis/xiaohongshu/creator-profile.js
+++ b/clis/xiaohongshu/creator-profile.js
@@ -17,6 +17,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [],
     columns: ['field', 'value'],
     func: async (page, _kwargs) => {

--- a/clis/xiaohongshu/creator-stats.js
+++ b/clis/xiaohongshu/creator-stats.js
@@ -18,6 +18,7 @@ cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         {
             name: 'period',

--- a/clis/xiaohongshu/download.js
+++ b/clis/xiaohongshu/download.js
@@ -211,6 +211,7 @@ export const command = cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'note-id', positional: true, required: true, help: 'Full Xiaohongshu note URL with xsec_token, or xhslink short link' },
         { name: 'output', default: './xiaohongshu-downloads', help: 'Output directory' },

--- a/clis/xiaohongshu/feed.js
+++ b/clis/xiaohongshu/feed.js
@@ -74,10 +74,11 @@ function toCleanString(value) {
  * Build a signed note URL for the given web host. Falls back to the bare
  * /explore/{id} URL when the caller intentionally passes no token.
  *
- * The `xsec_source` param mirrors what XHS itself renders into feed-page note
- * links: an empty value. Only `xsec_token` is actually required by the note
- * detail endpoint (verified: the source value is not validated), so we
- * reproduce the real-world shape rather than inventing a source label.
+ * `xsec_source` must carry a real context label — an empty value is an
+ * anomalous shape no official surface produces and interacts badly with
+ * token validation / risk control. `pc_share` is the generic web share
+ * context that validates across consumers (profile-context builders in this
+ * adapter use `pc_user` for the same reason).
  */
 export function buildFeedNoteUrl(webHost, id, xsecToken) {
     const cleanId = toCleanString(id);
@@ -86,7 +87,7 @@ export function buildFeedNoteUrl(webHost, id, xsecToken) {
     if (!cleanToken)
         return url.toString();
     url.searchParams.set('xsec_token', cleanToken);
-    url.searchParams.set('xsec_source', '');
+    url.searchParams.set('xsec_source', 'pc_share');
     return url.toString();
 }
 

--- a/clis/xiaohongshu/feed.js
+++ b/clis/xiaohongshu/feed.js
@@ -14,7 +14,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './shared.js';
+import { navigateFresh, unwrapEvaluateResult } from './shared.js';
 
 function parseLimit(raw) {
     const parsed = Number(raw ?? 20);
@@ -96,7 +96,10 @@ export function buildFeedNoteUrl(webHost, id, xsecToken) {
  */
 export async function runFeed(page, kwargs, webHost) {
     const limit = parseLimit(kwargs.limit);
-    await page.goto(`https://${webHost}/explore`);
+    // A warm persistent tab parked on /explore serves the identical hydrated
+    // feed forever if navigation fast-paths (observed live). Feed exists to
+    // deliver fresh content; force a real page load every time.
+    await navigateFresh(page, `https://${webHost}/explore`);
     // Pinia store hydrates from SSR; give the page a beat to finish
     // bootstrapping before reading the array.
     await page.wait({ time: 2 });
@@ -149,6 +152,7 @@ export const command = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'limit', type: 'int', default: 20, help: 'Number of items to return' },
     ],

--- a/clis/xiaohongshu/feed.test.js
+++ b/clis/xiaohongshu/feed.test.js
@@ -30,9 +30,9 @@ function entry(id, overrides = {}) {
 }
 
 describe('xiaohongshu/feed buildFeedNoteUrl', () => {
-    it('appends xsec_token and an empty xsec_source when a token is present', () => {
+    it('appends xsec_token and xsec_source=pc_share when a token is present', () => {
         expect(buildFeedNoteUrl(HOST, 'abc123', 'TOK')).toBe(
-            `https://${HOST}/explore/abc123?xsec_token=TOK&xsec_source=`,
+            `https://${HOST}/explore/abc123?xsec_token=TOK&xsec_source=pc_share`,
         );
     });
 
@@ -42,7 +42,7 @@ describe('xiaohongshu/feed buildFeedNoteUrl', () => {
 
     it('URL-encodes xsec_token instead of interpolating raw query text', () => {
         expect(buildFeedNoteUrl(HOST, 'abc123', 'a&b=c d')).toBe(
-            `https://${HOST}/explore/abc123?xsec_token=a%26b%3Dc+d&xsec_source=`,
+            `https://${HOST}/explore/abc123?xsec_token=a%26b%3Dc+d&xsec_source=pc_share`,
         );
     });
 });
@@ -58,15 +58,15 @@ describe('xiaohongshu/feed func', () => {
         const page = createPageMock({ items: [entry('id1'), entry('id2')] });
         const rows = await feed.func(page, { limit: 20 });
         expect(rows).toEqual([
-            { id: 'id1', title: 'title-id1', type: 'normal', author: 'author-id1', likes: '100', url: `https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=` },
-            { id: 'id2', title: 'title-id2', type: 'normal', author: 'author-id2', likes: '100', url: `https://${HOST}/explore/id2?xsec_token=tok-id2&xsec_source=` },
+            { id: 'id1', title: 'title-id1', type: 'normal', author: 'author-id1', likes: '100', url: `https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=pc_share` },
+            { id: 'id2', title: 'title-id2', type: 'normal', author: 'author-id2', likes: '100', url: `https://${HOST}/explore/id2?xsec_token=tok-id2&xsec_source=pc_share` },
         ]);
     });
 
     it('unwraps Browser Bridge evaluate envelopes', async () => {
         const page = createPageMock({ session: { id: 's1' }, data: { items: [entry('id1')] } });
         const rows = await feed.func(page, { limit: 20 });
-        expect(rows[0].url).toBe(`https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=`);
+        expect(rows[0].url).toBe(`https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=pc_share`);
     });
 
     it('typed-fails when a feed entry is missing its note token', async () => {

--- a/clis/xiaohongshu/feed.test.js
+++ b/clis/xiaohongshu/feed.test.js
@@ -124,3 +124,23 @@ describe('xiaohongshu/feed func', () => {
         expect(rows[0].url).toContain('xsec_token=note-token');
     });
 });
+
+describe('xiaohongshu/feed warm-tab freshness', () => {
+    it('forces a reload when the persistent tab already sits on /explore — the store must not be reread stale', async () => {
+        const command = getRegistry().get('xiaohongshu/feed');
+        const page = createPageMock({ items: [entry('n1')] });
+        page.getCurrentUrl = vi.fn().mockResolvedValue('https://www.xiaohongshu.com/explore');
+        const rows = await command.func(page, { limit: 1 });
+        expect(rows[0].id).toBe('n1');
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).toHaveBeenCalledWith('location.reload()');
+    });
+
+    it('navigates normally when the tab is elsewhere', async () => {
+        const command = getRegistry().get('xiaohongshu/feed');
+        const page = createPageMock({ items: [entry('n1')] });
+        page.getCurrentUrl = vi.fn().mockResolvedValue('https://www.xiaohongshu.com/user/profile/x');
+        await command.func(page, { limit: 1 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.xiaohongshu.com/explore');
+    });
+});

--- a/clis/xiaohongshu/follow.js
+++ b/clis/xiaohongshu/follow.js
@@ -155,6 +155,7 @@ cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     browser: true,
     args: [
         {

--- a/clis/xiaohongshu/liked.js
+++ b/clis/xiaohongshu/liked.js
@@ -9,6 +9,7 @@ cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     browser: true,
     args: [
         { name: 'id', type: 'string', help: 'User id or profile URL (defaults to current logged-in user)' },

--- a/clis/xiaohongshu/navigation.test.js
+++ b/clis/xiaohongshu/navigation.test.js
@@ -65,6 +65,11 @@ describe('xiaohongshu siteSession phase boundary', () => {
         'xiaohongshu/user',
         'xiaohongshu/saved',
         'xiaohongshu/liked',
+        // Phase 3: search — its replaceCollapsedTab recovery is safe under a
+        // persistent session (the extension rebinds preferredTabId on tab
+        // create BEFORE the old tab closes), and navigateFresh handles the
+        // repeated-same-query fast-path.
+        'xiaohongshu/search',
     ];
     it.each(persistent)('%s opts into the persistent site session', (name) => {
         const cmd = getRegistry().get(name);
@@ -77,7 +82,6 @@ describe('xiaohongshu siteSession phase boundary', () => {
     // capture trio needs navigation to fire signed XHRs; publish/delete-note
     // and the draft commands would inherit a dirty composer.
     const ephemeral = [
-        'xiaohongshu/search',
         'xiaohongshu/publish',
         'xiaohongshu/delete-note',
         'xiaohongshu/drafts',

--- a/clis/xiaohongshu/navigation.test.js
+++ b/clis/xiaohongshu/navigation.test.js
@@ -59,6 +59,12 @@ describe('xiaohongshu siteSession phase boundary', () => {
         'xiaohongshu/creator-stats',
         'xiaohongshu/follow',
         'xiaohongshu/unfollow',
+        // Phase 2: page-state readers, converted WITH staleness handling —
+        // navigateFresh forces a real reload on a warm same-URL tab.
+        'xiaohongshu/feed',
+        'xiaohongshu/user',
+        'xiaohongshu/saved',
+        'xiaohongshu/liked',
     ];
     it.each(persistent)('%s opts into the persistent site session', (name) => {
         const cmd = getRegistry().get(name);
@@ -67,16 +73,11 @@ describe('xiaohongshu siteSession phase boundary', () => {
     });
 
     // Deliberately NOT converted (do not flip these without solving their
-    // documented hazard): feed/user/saved/liked read page state that goes
-    // stale on a warm tab; search replaces the session tab; the creator
+    // documented hazard): search replaces the session tab; the creator
     // capture trio needs navigation to fire signed XHRs; publish/delete-note
     // and the draft commands would inherit a dirty composer.
     const ephemeral = [
         'xiaohongshu/search',
-        'xiaohongshu/user',
-        'xiaohongshu/saved',
-        'xiaohongshu/liked',
-        'xiaohongshu/feed',
         'xiaohongshu/publish',
         'xiaohongshu/delete-note',
         'xiaohongshu/drafts',

--- a/clis/xiaohongshu/navigation.test.js
+++ b/clis/xiaohongshu/navigation.test.js
@@ -13,6 +13,15 @@ import './creator-profile.js';
 import './creator-stats.js';
 import './saved.js';
 import './liked.js';
+import './ask.js';
+import './follow.js';
+import './unfollow.js';
+import './feed.js';
+import './delete-note.js';
+import './drafts.js';
+import './draft-open.js';
+import './draft-delete.js';
+import './draft-clear.js';
 
 describe('xiaohongshu navigateBefore hardening', () => {
     const expectedFalse = [
@@ -34,5 +43,53 @@ describe('xiaohongshu navigateBefore hardening', () => {
         const cmd = getRegistry().get(name);
         expect(cmd).toBeDefined();
         expect(cmd.navigateBefore).toBe(false);
+    });
+});
+
+describe('xiaohongshu siteSession phase boundary', () => {
+    // Phase-1 persistent conversions: commands whose navigation target is
+    // either parameterized (a new URL navigates for real every time) or a
+    // fixed URL whose repeat goto safely fast-paths on a warm tab.
+    const persistent = [
+        'xiaohongshu/note',
+        'xiaohongshu/comments',
+        'xiaohongshu/download',
+        'xiaohongshu/ask',
+        'xiaohongshu/creator-profile',
+        'xiaohongshu/creator-stats',
+        'xiaohongshu/follow',
+        'xiaohongshu/unfollow',
+    ];
+    it.each(persistent)('%s opts into the persistent site session', (name) => {
+        const cmd = getRegistry().get(name);
+        expect(cmd).toBeDefined();
+        expect(cmd.siteSession).toBe('persistent');
+    });
+
+    // Deliberately NOT converted (do not flip these without solving their
+    // documented hazard): feed/user/saved/liked read page state that goes
+    // stale on a warm tab; search replaces the session tab; the creator
+    // capture trio needs navigation to fire signed XHRs; publish/delete-note
+    // and the draft commands would inherit a dirty composer.
+    const ephemeral = [
+        'xiaohongshu/search',
+        'xiaohongshu/user',
+        'xiaohongshu/saved',
+        'xiaohongshu/liked',
+        'xiaohongshu/feed',
+        'xiaohongshu/publish',
+        'xiaohongshu/delete-note',
+        'xiaohongshu/drafts',
+        'xiaohongshu/draft-open',
+        'xiaohongshu/draft-delete',
+        'xiaohongshu/draft-clear',
+        'xiaohongshu/creator-notes',
+        'xiaohongshu/creator-note-detail',
+        'xiaohongshu/creator-notes-summary',
+    ];
+    it.each(ephemeral)('%s stays on the ephemeral default', (name) => {
+        const cmd = getRegistry().get(name);
+        expect(cmd).toBeDefined();
+        expect(cmd.siteSession).toBeUndefined();
     });
 });

--- a/clis/xiaohongshu/note.js
+++ b/clis/xiaohongshu/note.js
@@ -70,6 +70,7 @@ export const command = cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'note-id', required: true, positional: true, help: 'Full Xiaohongshu note URL with xsec_token' },
     ],

--- a/clis/xiaohongshu/risk-control.js
+++ b/clis/xiaohongshu/risk-control.js
@@ -59,10 +59,13 @@ export async function readXhsDetailPage(page, {
     cooldownMaxS = 18,
     rand = Math.random,
 } = {}) {
-    const readOnce = async () => {
-        await page.goto(url);
+    const settleAndExtract = async () => {
         await page.wait({ time: jitterSeconds(settleMinS, settleMaxS, rand) });
         return page.evaluate(extractJs);
+    };
+    const readOnce = async () => {
+        await page.goto(url);
+        return settleAndExtract();
     };
 
     let data = await readOnce();
@@ -72,7 +75,21 @@ export async function readXhsDetailPage(page, {
     // choice of retry count.
     if (retryOnBlock && isSecurityBlock(data)) {
         await page.wait({ time: jitterSeconds(cooldownMinS, cooldownMaxS, rand) });
-        data = await readOnce();
+        // The in-page block variant renders "安全限制" at an unchanged URL, and
+        // the extension fast-paths a goto to the tab's current URL without
+        // reloading — the retry must force a real reload or it re-reads the
+        // same blocked document. The redirect variant changes the URL, so a
+        // plain goto navigates for real.
+        const currentUrl = typeof page.getCurrentUrl === 'function'
+            ? await page.getCurrentUrl().catch(() => null)
+            : null;
+        if (currentUrl === url) {
+            await page.evaluate('location.reload()');
+            data = await settleAndExtract();
+        }
+        else {
+            data = await readOnce();
+        }
     }
 
     if (isSecurityBlock(data)) {

--- a/clis/xiaohongshu/risk-control.js
+++ b/clis/xiaohongshu/risk-control.js
@@ -29,6 +29,27 @@ export function isSecurityBlock(data) {
     return Boolean(data && typeof data === 'object' && !Array.isArray(data) && data.securityBlock);
 }
 
+const NOTE_PATH_ID_RE = /\/(?:search_result|explore|note)\/([0-9a-f]{24})(?=[/?#]|$)/i;
+
+function noteIdFromUrl(value) {
+    const match = NOTE_PATH_ID_RE.exec(String(value ?? ''));
+    return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Persistent site sessions share one tab, so a concurrent command can
+ * navigate it away between our goto and extract — the extract then reads a
+ * DIFFERENT note. Only flag payloads that carry a pageUrl with an
+ * extractable note id that differs from the requested one; login walls and
+ * error pages have no note id and are handled by their own paths.
+ */
+export function isWrongNotePage(data, url) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+    const requested = noteIdFromUrl(url);
+    const landed = noteIdFromUrl(data.pageUrl);
+    return Boolean(requested && landed && requested !== landed);
+}
+
 /**
  * Navigate to a XHS detail page and run `extractJs`, retrying once through a long
  * randomized cooldown when risk control soft-blocks the page. Returns the extract
@@ -97,6 +118,28 @@ export async function readXhsDetailPage(page, {
             'SECURITY_BLOCK',
             'Xiaohongshu security block: the note detail page was blocked by risk control.',
             securityHelp,
+        );
+    }
+
+    // Shared-tab contention: a concurrent command navigated the persistent
+    // tab away mid-read and the extract returned ANOTHER note. Returning it
+    // silently is data corruption (observed live with two parallel `note`
+    // runs) — re-navigate once to win the slot back, then fail typed.
+    if (isWrongNotePage(data, url)) {
+        data = await readOnce();
+    }
+    if (isSecurityBlock(data)) {
+        throw new CliError(
+            'SECURITY_BLOCK',
+            'Xiaohongshu security block: the note detail page was blocked by risk control.',
+            securityHelp,
+        );
+    }
+    if (isWrongNotePage(data, url)) {
+        throw new CliError(
+            'TAB_CONTENTION',
+            'Xiaohongshu detail page was navigated away mid-read by a concurrent command on the same site session.',
+            'Run xiaohongshu commands for the same profile sequentially — parallel reads share one browser tab under the persistent site session.',
         );
     }
     return data;

--- a/clis/xiaohongshu/risk-control.test.js
+++ b/clis/xiaohongshu/risk-control.test.js
@@ -133,3 +133,53 @@ describe('xiaohongshu risk-control readXhsDetailPage', () => {
             .rejects.toBeInstanceOf(CliError);
     });
 });
+
+describe('xiaohongshu risk-control shared-tab contention', () => {
+    // Persistent site sessions share one tab; a concurrent command can
+    // navigate it away between our goto and extract, and the extract then
+    // reads the WRONG note (observed live: parallel `note` A returned note
+    // B's content with a success exit).
+    const url = 'https://www.xiaohongshu.com/explore/aaaaaaaaaaaaaaaaaaaaaaaa?xsec_token=tok';
+    const extractJs = '(() => ({}))()';
+    const rightPage = { title: 'right', securityBlock: false, pageUrl: url };
+    const wrongPage = {
+        title: 'stolen',
+        securityBlock: false,
+        pageUrl: 'https://www.xiaohongshu.com/explore/bbbbbbbbbbbbbbbbbbbbbbbb?xsec_token=other',
+    };
+
+    it('re-navigates once and returns the payload when the retry lands on the right note', async () => {
+        const page = makePage([wrongPage, rightPage]);
+        const data = await readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 });
+        expect(data).toEqual(rightPage);
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws TAB_CONTENTION instead of returning another note silently', async () => {
+        const page = makePage([wrongPage, wrongPage, wrongPage]);
+        await expect(readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 }))
+            .rejects.toMatchObject({ code: 'TAB_CONTENTION' });
+        // structural single retry — never a loop
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('honors the never-return-a-block contract when the contention retry lands on a block', async () => {
+        const page = makePage([wrongPage, { securityBlock: true }]);
+        await expect(readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 }))
+            .rejects.toMatchObject({ code: 'SECURITY_BLOCK' });
+    });
+
+    it('skips the check when the payload has no extractable note id (login walls, error pages)', async () => {
+        const noId = { loginWall: true, securityBlock: false, pageUrl: 'https://www.xiaohongshu.com/login' };
+        const page = makePage([noId]);
+        const data = await readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 });
+        expect(data).toEqual(noId);
+        expect(page.goto).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the check for payloads without pageUrl (older extract shapes)', async () => {
+        const page = makePage([{ title: 'legacy', securityBlock: false }]);
+        const data = await readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 });
+        expect(data).toEqual({ title: 'legacy', securityBlock: false });
+    });
+});

--- a/clis/xiaohongshu/risk-control.test.js
+++ b/clis/xiaohongshu/risk-control.test.js
@@ -62,6 +62,32 @@ describe('xiaohongshu risk-control readXhsDetailPage', () => {
         expect(page.wait).toHaveBeenCalledWith({ time: 13 });
     });
 
+    it('retry reloads in place when the soft block rendered at the target URL', async () => {
+        // The in-page block variant ("安全限制" at an unchanged URL): a plain
+        // goto to the tab's current URL fast-paths in the extension without
+        // reloading, so the retry would re-read the same blocked document.
+        const page = makePage([
+            { securityBlock: true },
+            undefined, // location.reload()
+            { title: 'recovered', securityBlock: false },
+        ]);
+        page.getCurrentUrl = vi.fn().mockResolvedValue(url);
+        const data = await readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 });
+        expect(data).toEqual({ title: 'recovered', securityBlock: false });
+        expect(page.goto).toHaveBeenCalledTimes(1);
+        expect(page.evaluate.mock.calls[1][0]).toContain('location.reload()');
+    });
+
+    it('retry re-navigates when the soft block redirected to the error URL', async () => {
+        const page = makePage([{ securityBlock: true }, { title: 'recovered', securityBlock: false }]);
+        page.getCurrentUrl = vi.fn().mockResolvedValue(
+            'https://www.xiaohongshu.com/website-login/error?error_code=300017',
+        );
+        const data = await readXhsDetailPage(page, { url, extractJs, rand: () => 0.5 });
+        expect(data).toEqual({ title: 'recovered', securityBlock: false });
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
     it('throws SECURITY_BLOCK (with the hint) when still blocked after the one retry — never hammers', async () => {
         const page = makePage([{ securityBlock: true }, { securityBlock: true }, { securityBlock: true }]);
         await expect(readXhsDetailPage(page, {

--- a/clis/xiaohongshu/saved.js
+++ b/clis/xiaohongshu/saved.js
@@ -9,6 +9,7 @@ cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     browser: true,
     args: [
         { name: 'id', type: 'string', help: 'User id or profile URL (defaults to current logged-in user)' },

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -404,10 +404,17 @@ function buildApplySearchFiltersJs(requestedFilters) {
           }
           const options = visibleMatches(groups[0], '.tag-container > .tags')
             .filter((option) => text(option) === request.option);
-          if (options.length !== 1) {
+          // The live layout renders each chip twice, stacked at the exact
+          // same position. Pixel-identical matches are one visual control,
+          // not an ambiguity; matches at distinct positions still fail closed.
+          const rectKey = (element) => {
+            const rect = element.getBoundingClientRect();
+            return [rect.left, rect.top, rect.width, rect.height].map((v) => Math.round(v || 0)).join(',');
+          };
+          if (!options.length || new Set(options.map(rectKey)).size !== 1) {
             return { status: 'layout', detail: options.length ? 'ambiguous_option' : 'option_not_found' };
           }
-          return { status: 'ok', option: options[0] };
+          return { status: 'ok', option: options.find((o) => o.classList.contains('active')) || options[0] };
         };
         const isActive = (option) => option.classList.contains('active');
         const ready = () => visibleMatches(document, 'section.note-item, section:has(a[href*="/search_result/"]), section:has(a[href*="/explore/"]), .search-empty-wrapper').length > 0;

--- a/clis/xiaohongshu/search.js
+++ b/clis/xiaohongshu/search.js
@@ -7,7 +7,7 @@
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { ArgumentError, AuthRequiredError, CliError, CommandExecutionError, EmptyResultError, TimeoutError } from '@jackwener/opencli/errors';
-import { unwrapEvaluateResult } from './shared.js';
+import { navigateFresh, unwrapEvaluateResult } from './shared.js';
 /**
  * Wait for search results or login wall using MutationObserver (max 5s).
  * Returns 'content' if note items appeared, a typed wall state when login or
@@ -870,6 +870,7 @@ export const command = cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'query', required: true, positional: true, help: 'Search keyword' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
@@ -886,7 +887,10 @@ export const command = cli({
             const requestedFilters = resolveSearchFilters(kwargs);
             const keyword = encodeURIComponent(kwargs.query);
             const url = `https://www.xiaohongshu.com/search_result?keyword=${keyword}&source=web_search_result_notes`;
-            await page.goto(url);
+            // Repeating the same query on a warm persistent tab must load
+            // fresh results; a fast-pathed goto would reread the previous
+            // run's scroll-accumulated DOM.
+            await navigateFresh(page, url);
             let harvest = await collectSearchHarvest(page, limit, requestedFilters);
             if (isCollapsedRender(harvest.diag)) {
                 await replaceCollapsedTab(page, url);

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -196,6 +196,7 @@ function createFilterBehaviorPage(options = {}) {
     const page = createPageMock([]);
     page.evaluate.mockImplementation(async (script) => {
         const source = String(script);
+        if (source.includes('location.reload')) return undefined;
         if (source.includes('findNoteCard')) return 'content';
         if (source.includes('const requestedFilters =')) {
             return Function(
@@ -1052,5 +1053,43 @@ describe('noteIdToDate (ObjectID timestamp parsing)', () => {
     it('returns empty string when timestamp is out of range', () => {
         // All zeros → ts = 0
         expect(noteIdToDate('https://www.xiaohongshu.com/search_result/000000000000000000000000')).toBe('');
+    });
+});
+
+describe('xiaohongshu search warm-tab freshness', () => {
+    it('forces a reload when the persistent tab already shows this exact search URL', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage();
+            page.getCurrentUrl = vi.fn().mockResolvedValue(
+                'https://www.xiaohongshu.com/search_result?keyword=test&source=web_search_result_notes',
+            );
+            const reloadCalls = () => page.evaluate.mock.calls.filter(([s]) => String(s).includes('location.reload')).length;
+            // The filter fixture's URL is baked as keyword=test; run the same query.
+            const result = await runFilterCommand(page, { query: 'test' });
+            expect(result.length).toBeGreaterThan(0);
+            expect(page.goto).not.toHaveBeenCalled();
+            expect(reloadCalls()).toBe(1);
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('navigates normally for a different query URL', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage();
+            page.getCurrentUrl = vi.fn().mockResolvedValue(
+                'https://www.xiaohongshu.com/search_result?keyword=other&source=web_search_result_notes',
+            );
+            await runFilterCommand(page, { query: 'test' });
+            expect(page.goto).toHaveBeenCalledWith(
+                'https://www.xiaohongshu.com/search_result?keyword=test&source=web_search_result_notes',
+            );
+        }
+        finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/clis/xiaohongshu/search.test.js
+++ b/clis/xiaohongshu/search.test.js
@@ -17,6 +17,9 @@ import {
 function markVisible(el) {
     el.getBoundingClientRect = () => ({ width: 100, height: 100, top: 0 });
 }
+function markVisibleAt(el, top) {
+    el.getBoundingClientRect = () => ({ width: 100, height: 100, top });
+}
 function createPageMock(evaluateResults) {
     const queuedResults = [...evaluateResults];
     const evaluate = vi.fn(async (script) => {
@@ -144,8 +147,12 @@ function createFilterBehaviorPage(options = {}) {
             const container = document.createElement('div');
             container.className = 'tag-container';
             for (const choice of choices) {
-                if (options.missing === `${groupLabel}/${choice}`) continue;
-                const copies = options.ambiguous === `${groupLabel}/${choice}` ? 2 : 1;
+                const key = `${groupLabel}/${choice}`;
+                if (options.missing === key) continue;
+                // `duplicated` doubles every chip at the same rect (the live
+                // 2026-09 layout); `ambiguous` places the second copy at a
+                // different position — genuinely two distinct controls.
+                const copies = options.ambiguous === key || options.duplicated ? 2 : 1;
                 for (let copy = 0; copy < copies; copy++) {
                     const option = document.createElement('div');
                     option.className = `tags${state[groupLabel] === choice ? ' active' : ''}`;
@@ -173,7 +180,8 @@ function createFilterBehaviorPage(options = {}) {
                         }, 300);
                     });
                     container.append(option);
-                    markVisible(option);
+                    if (copy > 0 && options.ambiguous === key) markVisibleAt(option, 60);
+                    else markVisible(option);
                     markVisible(optionLabel);
                 }
             }
@@ -697,6 +705,19 @@ describe('xiaohongshu search filter behavior', () => {
                 '发布时间': '一天内',
                 '搜索范围': '已关注',
             });
+        }
+        finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('treats stacked duplicate chips (identical rects) as one option — live layout 2026-09', async () => {
+        vi.useFakeTimers();
+        try {
+            const page = createFilterBehaviorPage({ duplicated: true });
+            const result = await runFilterCommand(page, { sort: 'latest' });
+            expect(result[0].title).toBe('最新');
+            expect(page.filterState).toMatchObject({ '排序依据': '最新' });
         }
         finally {
             vi.useRealTimers();

--- a/clis/xiaohongshu/shared.js
+++ b/clis/xiaohongshu/shared.js
@@ -1,4 +1,29 @@
 /**
+ * Navigate to `url`, forcing a REAL page load even when the persistent tab
+ * already sits at that exact URL. The extension fast-paths a goto to the
+ * tab's current URL without loading anything, which is right for cookie-only
+ * commands but wrong for page-state readers (Pinia stores, __INITIAL_STATE__
+ * snapshots) — they would reread the same stale document forever. If the
+ * in-place reload cannot be issued (context destroyed mid-evaluate), fall
+ * back to a plain goto, which at worst degrades to the fast-path status quo.
+ */
+export async function navigateFresh(page, url) {
+    const current = typeof page.getCurrentUrl === 'function'
+        ? await page.getCurrentUrl().catch(() => null)
+        : null;
+    if (current === url) {
+        try {
+            await page.evaluate('location.reload()');
+            return;
+        }
+        catch {
+            // fall through to the plain goto below
+        }
+    }
+    await page.goto(url);
+}
+
+/**
  * Unwrap a Browser Bridge `{ session, data }` envelope while preserving raw
  * payload identity. Named array properties do not survive Bridge/CDP JSON.
  */

--- a/clis/xiaohongshu/shared.test.js
+++ b/clis/xiaohongshu/shared.test.js
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { unwrapEvaluateResult } from './shared.js';
+import { describe, expect, it, vi } from 'vitest';
+import { navigateFresh, unwrapEvaluateResult } from './shared.js';
 
 describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
     it('returns non-envelope arrays by identity', () => {
@@ -23,5 +23,51 @@ describe('unwrapEvaluateResult (browser-bridge envelope normalization)', () => {
     it('passes through raw JSON primitives', () => {
         expect(unwrapEvaluateResult(null)).toBe(null);
         expect(unwrapEvaluateResult(42)).toBe(42);
+    });
+});
+
+describe('navigateFresh (warm persistent tab must not serve a stale document)', () => {
+    const url = 'https://www.xiaohongshu.com/explore';
+
+    function makePage(currentUrl) {
+        return {
+            getCurrentUrl: vi.fn().mockResolvedValue(currentUrl),
+            goto: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn().mockResolvedValue(undefined),
+        };
+    }
+
+    it('forces a real reload when the tab already sits at the target URL', async () => {
+        // The extension fast-paths a goto to the current URL without loading
+        // anything — feed would read the same Pinia store forever.
+        const page = makePage(url);
+        await navigateFresh(page, url);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).toHaveBeenCalledWith('location.reload()');
+    });
+
+    it('navigates normally when the tab is elsewhere', async () => {
+        const page = makePage('https://www.xiaohongshu.com/user/profile/abc');
+        await navigateFresh(page, url);
+        expect(page.goto).toHaveBeenCalledWith(url);
+        expect(page.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('navigates when getCurrentUrl is unavailable or rejects', async () => {
+        const bare = { goto: vi.fn().mockResolvedValue(undefined), evaluate: vi.fn() };
+        await navigateFresh(bare, url);
+        expect(bare.goto).toHaveBeenCalledWith(url);
+
+        const failing = makePage(null);
+        failing.getCurrentUrl = vi.fn().mockRejectedValue(new Error('detached'));
+        await navigateFresh(failing, url);
+        expect(failing.goto).toHaveBeenCalledWith(url);
+    });
+
+    it('falls back to goto when the in-place reload evaluate rejects', async () => {
+        const page = makePage(url);
+        page.evaluate = vi.fn().mockRejectedValue(new Error('context destroyed'));
+        await navigateFresh(page, url);
+        expect(page.goto).toHaveBeenCalledWith(url);
     });
 });

--- a/clis/xiaohongshu/unfollow.js
+++ b/clis/xiaohongshu/unfollow.js
@@ -186,6 +186,7 @@ cli({
     domain: 'www.xiaohongshu.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
+    siteSession: 'persistent',
     browser: true,
     args: [
         {

--- a/clis/xiaohongshu/user.js
+++ b/clis/xiaohongshu/user.js
@@ -1,6 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { AuthRequiredError, CliError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
 import { extractXhsUserNotes, normalizeXhsUserId } from './user-helpers.js';
+import { navigateFresh } from './shared.js';
 /**
  * Host-agnostic IIFE that snapshots the user profile's Pinia store. Exported
  * so the rednote adapter can reuse it without copying the safeClone block.
@@ -26,6 +27,7 @@ export const USER_SNAPSHOT_JS = `
       const pathName = (typeof location !== 'undefined' && location.pathname) ? location.pathname : '';
       const onLoginPage = pathName.indexOf('/login') === 0;
       return {
+        pathname: pathName,
         noteGroups: safeClone(rawNotes || []),
         pageData: safeClone(rawPageData || {}),
         storePresent: hasUserStore,
@@ -78,13 +80,30 @@ function throwLoginWallAuthRequired() {
  * `page.wait` 后重试至多 maxRetries 次。命中登录墙立即停（再等无用，交给 caller 抛 AUTH_REQUIRED）；
  * 真·空号（销号/私密/全删）走满重试后返回空快照，由下游 EmptyResultError 正确收尾。导出供测试。
  */
-export async function readUserSnapshotHydrated(page, maxRetries = 8, waitSeconds = 2) {
+export async function readUserSnapshotHydrated(page, maxRetries = 8, waitSeconds = 2, expectedPath = null) {
     let snapshot = await readUserSnapshot(page);
-    for (let i = 0; i < maxRetries && !isLoginWallSnapshot(snapshot) && countFlatNotes(snapshot) === 0; i += 1) {
+    for (let i = 0; i < maxRetries
+        && !isLoginWallSnapshot(snapshot)
+        && !isWrongProfilePath(snapshot, expectedPath)
+        && countFlatNotes(snapshot) === 0; i += 1) {
         await page.wait({ time: waitSeconds });
         snapshot = await readUserSnapshot(page);
     }
     return snapshot;
+}
+/**
+ * A snapshot taken from a page whose pathname is a DIFFERENT profile (or a
+ * non-profile page): a concurrent command on the shared persistent tab
+ * navigated it away mid-read. Snapshots without a pathname (older extract
+ * shapes, rednote fixtures) are never flagged.
+ */
+function isWrongProfilePath(snapshot, expectedPath) {
+    if (!expectedPath)
+        return false;
+    const landed = snapshot && typeof snapshot === 'object' ? snapshot.pathname : null;
+    if (typeof landed !== 'string' || landed === '')
+        return false;
+    return landed !== expectedPath && !landed.startsWith(`${expectedPath}/`);
 }
 export const command = cli({
     site: 'xiaohongshu',
@@ -95,6 +114,7 @@ export const command = cli({
     strategy: Strategy.COOKIE,
     browser: true,
     navigateBefore: false,
+    siteSession: 'persistent',
     args: [
         { name: 'id', type: 'string', required: true, positional: true, help: 'User id or profile URL' },
         { name: 'limit', type: 'int', default: 15, help: 'Number of notes to return' },
@@ -103,8 +123,22 @@ export const command = cli({
     func: async (page, kwargs) => {
         const userId = normalizeXhsUserId(String(kwargs.id));
         const limit = Math.max(1, Number(kwargs.limit ?? 15));
-        await page.goto(`https://www.xiaohongshu.com/user/profile/${userId}`);
-        let snapshot = await readUserSnapshotHydrated(page);
+        const url = `https://www.xiaohongshu.com/user/profile/${userId}`;
+        const expectedPath = `/user/profile/${userId}`;
+        // Warm persistent tab on this same profile: force a real reload so the
+        // __INITIAL_STATE__ snapshot is current, not the last visit's.
+        await navigateFresh(page, url);
+        let snapshot = await readUserSnapshotHydrated(page, 8, 2, expectedPath);
+        if (isWrongProfilePath(snapshot, expectedPath)) {
+            // Shared-tab contention: another command navigated the tab away
+            // mid-read. One re-navigation wins the tab back; a second mismatch
+            // fails typed instead of returning another profile's notes.
+            await page.goto(url);
+            snapshot = await readUserSnapshotHydrated(page, 8, 2, expectedPath);
+            if (isWrongProfilePath(snapshot, expectedPath)) {
+                throw new CliError('TAB_CONTENTION', 'Xiaohongshu profile page was navigated away mid-read by a concurrent command on the same site session.', 'Run xiaohongshu commands for the same profile sequentially — parallel reads share one browser tab under the persistent site session.');
+            }
+        }
         if (isLoginWallSnapshot(snapshot)) {
             // profile 页登录态失效 → 302 到 /login。绝不能误报成 "Malformed user store" /
             // EMPTY_RESULT —— 那会让下游（ml-scout 等）把登录失效当解析失败 / 空号，白等

--- a/clis/xiaohongshu/user.test.js
+++ b/clis/xiaohongshu/user.test.js
@@ -139,3 +139,59 @@ describe('assertReadableUserSnapshot (既有契约保持)', () => {
         expect(() => assertReadableUserSnapshot(NOTES_SNAP)).not.toThrow();
     });
 });
+
+describe('xiaohongshu/user warm-tab freshness and contention', () => {
+    const uid = '5d8f88dc0000000001005d3a';
+    const url = `https://www.xiaohongshu.com/user/profile/${uid}`;
+    const rightSnap = snap({ noteGroups: [[noteEntry('aaa')], []], pathname: `/user/profile/${uid}` });
+    const stolenSnap = snap({ noteGroups: [[noteEntry('zzz')], []], pathname: '/user/profile/ffffffffffffffffffffffff' });
+    const getCommand = () => getRegistry().get('xiaohongshu/user');
+
+    it('forces a reload when the persistent tab already shows this profile', async () => {
+        const page = createPageMock(vi.fn().mockResolvedValue(rightSnap));
+        page.getCurrentUrl = vi.fn().mockResolvedValue(url);
+        const rows = await getCommand().func(page, { id: uid, limit: 1 });
+        expect(rows.length).toBe(1);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).toHaveBeenCalledWith('location.reload()');
+    });
+
+    it('re-navigates once when the snapshot shows another profile, then succeeds', async () => {
+        const page = createPageMock(vi.fn()
+            .mockResolvedValueOnce(stolenSnap)
+            .mockResolvedValue(rightSnap));
+        const rows = await getCommand().func(page, { id: uid, limit: 1 });
+        expect(rows[0].id).toBe('aaa');
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws TAB_CONTENTION instead of returning another profile silently', async () => {
+        const page = createPageMock(vi.fn().mockResolvedValue(stolenSnap));
+        await expect(getCommand().func(page, { id: uid, limit: 1 }))
+            .rejects.toMatchObject({ code: 'TAB_CONTENTION' });
+        expect(page.goto).toHaveBeenCalledTimes(2);
+    });
+
+    it('hydration retry stops immediately on a wrong-profile snapshot instead of burning 8 waits', async () => {
+        // Empty notes + wrong path: without the path check this would burn all
+        // 8 hydration retries waiting for notes that belong to another page.
+        const stolenEmpty = snap({ noteGroups: [[], []], pathname: '/user/profile/ffffffffffffffffffffffff' });
+        const evaluate = vi.fn().mockResolvedValue(stolenEmpty);
+        const page = createPageMock(evaluate);
+        const result = await readUserSnapshotHydrated(page, 8, 2, `/user/profile/${uid}`);
+        expect(result).toEqual(stolenEmpty);
+        expect(evaluate).toHaveBeenCalledTimes(1);
+        expect(page.wait).not.toHaveBeenCalled();
+    });
+
+    it('keeps working with snapshots that lack a pathname (older extract shapes)', async () => {
+        const page = createPageMock(vi.fn().mockResolvedValue(NOTES_SNAP));
+        const rows = await getCommand().func(page, { id: uid, limit: 1 });
+        expect(rows.length).toBe(1);
+    });
+
+    it('USER_SNAPSHOT_JS exposes the landed pathname for the contention check', async () => {
+        const { USER_SNAPSHOT_JS } = await import('./user.js');
+        expect(USER_SNAPSHOT_JS).toContain('pathname: pathName');
+    });
+});


### PR DESCRIPTION
## Why

Same motivation as the weibo conversion (#2442), with a sharper reason here: xiaohongshu's own `sitemaps/xiaohongshu/pitfalls.md` documents that its risk control triggers on *velocity* — "短时间高频访问". Every ephemeral command pays a fresh tab + navigation; a batch run over notes turns one logical read into a tab-open/homepage-load pattern no human produces. Reusing one warm `site:xiaohongshu` tab both speeds commands up and makes the traffic look like what it actually is: one logged-in user reading notes.

## What converts, and why exactly these eight

`note` / `comments` / `download` / `follow` / `unfollow` navigate to **parameterized** URLs — a new target always really navigates, and follow/unfollow additionally verify `location.href` matches the requested profile before clicking. `ask` / `creator-profile` / `creator-stats` goto **fixed** URLs that the extension's same-URL fast-path skips harmlessly on a warm tab (verified live: the relative `/api/galaxy/*` fetches read live cookies, and `ask`'s conversation store reboots cleanly or reuses the booted SPA the way the chat adapters do).

Unlike weibo (#2442), none of these navigates to a domain root, so **no adapter-side origin guard is needed** — the conversion is declaration-only. A new convention block in `navigation.test.js` locks the boundary in *both* directions: these eight must declare `persistent`, and the commands with documented warm-tab hazards must stay ephemeral until each hazard is actually solved — `feed`/`user`/`saved`/`liked` (read `__INITIAL_STATE__`/Pinia state that goes stale on a warm tab; measured live: a warm `/explore` tab returns the identical feed forever), `search` (replaces the session tab mid-run), the creator capture trio (their signed x-s XHRs only fire *because* navigation happens), and `publish`/`delete-note`/`draft-*` (a warm composer can still hold the previous note's content, and XHS autosaves drafts — data-integrity, not flakiness).

## Bug fix folded in: the soft-block retry never actually reloaded

Pre-existing, but persistence would have amplified it: `readXhsDetailPage`'s single cooldown retry re-ran `page.goto(url)` — which the extension fast-paths without reloading when the tab is already at that URL. The in-page block variant ("安全限制" rendered at an unchanged URL) therefore retried against the *same blocked document*. The retry now forces `location.reload()` when the tab still sits at the target URL; the redirect variant (`error_code=300017/300031`, URL changed) keeps the plain goto. The healthy-page path deliberately keeps the fast-path: `note` → `comments` on the same URL reads the warm DOM with zero extra server traffic.

## Verification

- TDD: 8 declaration tests + 14 ephemeral-boundary tests + 2 retry-variant tests written first and watched fail. 388 xiaohongshu+rednote adapter tests green; full suite, typecheck, and both lint gates clean; manifest regenerated (8 entries).
- Live, logged in, with `OPENCLI_SITE_SESSION=persistent` before baking in, then re-verified after: `whoami` → `creator-profile` warm 1.3s with live data; `note` → `comments` same URL 4.6s off the warm DOM (real comments); `ask` twice (11.6s cold boot from a note page, 7.9s warm store reuse); `creator-stats` crossing back from `www` to `creator` cleanly.
- `follow`/`unfollow`: the property that makes them warm-tab-safe — abort when the landed URL is a different profile or a non-xiaohongshu host — is covered by existing unit tests for both commands (`follow.test.js:80-85,132-138` and the unfollow block at `follow.test.js:178-191`). They were deliberately **not** exercised live — a live test mutates a real social graph.

Part of the persistent-session series: weibo (#2442) → xiaohongshu (this) → bilibili/twitter planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Phase 2 (added 2026-09-06): page-state readers, with their staleness hazards solved

`feed` / `user` / `saved` / `liked` read in-page state (Pinia store, `__INITIAL_STATE__`) that a warm persistent tab serves stale forever — the extension fast-paths a goto to the tab's current URL without loading anything (verified live: a warm `/explore` tab returned the identical feed on every call). Each converts **with** its hazard handled, and the `navigation.test.js` boundary block moves them from the must-stay-ephemeral list to the must-be-persistent list:

- **shared `navigateFresh(page, url)`** — forces `location.reload()` when the tab already sits at the target URL, plain goto otherwise. `feed` uses it unconditionally (its purpose *is* fresh content); measured live: warm reload 2.5s vs 5.6s cold, and consecutive runs return different content again.
- **`user`** — `USER_SNAPSHOT_JS` now carries `location.pathname`, giving `user` the same landed-page verification `follow`/`unfollow` already had: a snapshot from another profile re-navigates once, then fails typed `TAB_CONTENTION` instead of returning another user's notes. The hydration retry also stops immediately on a wrong-profile snapshot instead of burning 8×2s.
- **`saved`/`liked`** — two pre-existing bugs fixed along the way: (1) the XHR interceptor was installed *before* the goto, so navigation wiped the in-page patch and the capture path never captured anything — the DOM fallback silently did all the work; install now happens after navigation. (2) `resolveXhsUserId` now polls through the hydration window before reloading — `location.reload()` resolves before the page loads, and a reload-eager first version raced hydration and reported a logged-in user as logged out (caught live, regression-tested).

Phase-2 verification: 15 new unit tests (navigateFresh matrix, feed warm-freshness, user contention interleavings, resolveXhsUserId polling/reload semantics, interceptor ordering), boundary lists re-asserted both ways, full suite 7355 green on this branch, and live: feed twice with different content, `saved` returning correct EMPTY_RESULT semantics on an account with no saved notes.


---

## Phase 3 (added 2026-09-06): search

The blocker was `replaceCollapsedTab`: it creates a fresh tab and closes the one that, under a persistent session, *is* the stable `site:xiaohongshu` tab. Verified against `extension/src/background.ts` that this is safe by construction — the tabs-create handler rebinds the lease's `preferredTabId` to the new tab via `setLeaseSession` **before** the old tab closes, so `tabs.onRemoved` no longer matches the session and the lease survives on the replacement tab.

`search` navigates to a query-parameterized URL, so different queries always load for real; repeating the *same* query on a warm tab would fast-path onto the previous run's scroll-accumulated DOM — it now goes through `navigateFresh`. Live: same query twice returns fresh (re-ranked, partially new) results; the warm same-query repeat costs ~16s vs ~3s for a new query, because the reload re-runs content-wait and filter settling — a rare path (callers dedupe repeated queries) traded deliberately for correctness. Note: search stays *functionally* broken until #2460 (the stacked-chip filter fix) also lands; the two changes are code-independent and tested together on an integration branch (combined suite 7382 green).

The must-stay-ephemeral boundary list now contains only `publish`/`delete-note`/`draft-*` (dirty composer hazard) and the creator capture trio (navigation-triggered signed XHRs) — each with its reason asserted in `navigation.test.js`.



---

Part of the xiaohongshu risk-control/persistence arc — umbrella issue with full motivation and cross-PR context: #2470


---

## Also included (2026-09-06): xsec_source=pc_share fix

`buildFeedNoteUrl` (shared with rednote) and `ask`'s citation URL builder emitted `xsec_source=` with an empty value — an anomalous shape no official surface produces, which interacts badly with token validation / risk control. Both now label the context explicitly as `pc_share` (profile-context builders already correctly use `pc_user`). Verified live: feed URLs carry `pc_share` and note drill-down on them keeps working. (Originally opened as #2474, folded here since this PR already touches both files.)
