### PR TITLE
fix(chatgpt): add Traditional Chinese tool labels so --deep-research and --web-search work on zh-TW UI

### DIFF
--- a/clis/chatgpt/utils.js
+++ b/clis/chatgpt/utils.js
@@ -74,8 +74,8 @@ function debugChatGPTModel(message) {
 }
 
 const CHATGPT_TOOL_OPTIONS = {
-    'deep-research': { label: 'Deep Research', labels: ['深度研究', 'Deep Research'] },
-    'web-search': { label: 'Web Search', labels: ['网页搜索', '搜索', 'Web Search', 'Search'] },
+    'deep-research': { label: 'Deep Research', labels: ['深入研究', '深度研究', 'Deep Research'] },
+    'web-search': { label: 'Web Search', labels: ['網頁搜尋', '网页搜索', '搜索', 'Web Search', 'Search'] },
 };
 export const CHATGPT_TOOL_CHOICES = Object.keys(CHATGPT_TOOL_OPTIONS);
 

--- a/clis/chatgpt/utils.test.js
+++ b/clis/chatgpt/utils.test.js
@@ -1329,8 +1329,10 @@ describe('chatgpt current model detection', () => {
 
 describe('chatgpt current tool detection', () => {
     it.each([
+        ['深入研究', { tool: 'deep-research', label: 'Deep Research' }],
         ['深度研究', { tool: 'deep-research', label: 'Deep Research' }],
         ['Deep Research', { tool: 'deep-research', label: 'Deep Research' }],
+        ['網頁搜尋', { tool: 'web-search', label: 'Web Search' }],
         ['网页搜索', { tool: 'web-search', label: 'Web Search' }],
         ['搜索', { tool: 'web-search', label: 'Web Search' }],
         ['Web Search', { tool: 'web-search', label: 'Web Search' }],


### PR DESCRIPTION
## Summary

`opencli chatgpt ask --deep-research` and `--web-search` fail on a Traditional Chinese (zh-TW) ChatGPT UI. The tool labels in `CHATGPT_TOOL_OPTIONS` cover only Simplified Chinese and English.

## Root cause

`clis/chatgpt/utils.js`:

```js
'deep-research': { label: 'Deep Research', labels: ['深度研究', 'Deep Research'] },
'web-search':    { label: 'Web Search',    labels: ['网页搜索', '搜索', 'Web Search', 'Search'] },
```

The zh-TW UI uses different wording, not the Traditional-character form of those strings:

| Tool | Simplified UI | Traditional (zh-TW) UI |
|---|---|---|
| Deep Research | 深度研究 | **深入**研究 |
| Web Search | 网页搜索 | 網頁搜**尋** |

Character conversion does not close the gap: 深度研究 converted character-by-character is still 深度研究, which never appears in the zh-TW menu. `selectChatGPTTool` matches menu entries by visible text, so the lookup finds nothing and throws.

## Fix

Prepend the Traditional Chinese wording to both label arrays, and cover both in the existing `chatgpt current tool detection` cases. Data-only change; Simplified and English UIs keep their existing behaviour.

## Verification

`OPENCLI_CONFIG_DIR=$(mktemp -d) npx vitest run clis/chatgpt/utils.test.js` — 121 passed. Filtering to the tool-label cases shows the two new ones running:

```
✓ detects the visible 深入研究 tool label
✓ detects the visible 深度研究 tool label
✓ detects the visible Deep Research tool label
✓ detects the visible 網頁搜尋 tool label
✓ detects the visible 网页搜索 tool label
✓ detects the visible Web Search tool label
Tests  7 passed | 114 skipped (121)
```

Behavioural check on a zh-TW Pro account. Before:

```
$ opencli chatgpt ask "ping" --new --deep-research --wait false
ok: false
error:
  code: COMMAND_EXEC
  message: Could not find the ChatGPT Deep Research tool option.
```

After:

```
$ opencli chatgpt ask "ping" --new --deep-research --wait false
- conversationId: <redacted>
  tool: Deep Research
  response: ''
```

The resulting conversation shows the tool applied — the user turn reads:

```
深入研究
 ping
```

Tested against opencli 1.8.7 (npm latest at time of writing) with extension v1.0.24.

Related: #2462 reports a separate, unfixed breakage in the same adapter (`chatgpt model` tier switching). This PR does not address that one.
