### PR TITLE
feat(twitter): 读命令透出 author_avatar / views / media_durations，视频直链取最高码率

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -40617,7 +40617,8 @@
       "url",
       "has_media",
       "media_urls",
-      "media_posters"
+      "media_posters",
+      "media_durations"
     ],
     "type": "js",
     "modulePath": "twitter/bookmark-folder.js",
@@ -40704,7 +40705,8 @@
       "url",
       "has_media",
       "media_urls",
-      "media_posters"
+      "media_posters",
+      "media_durations"
     ],
     "type": "js",
     "modulePath": "twitter/bookmarks.js",
@@ -41121,7 +41123,8 @@
       "url",
       "has_media",
       "media_urls",
-      "media_posters"
+      "media_posters",
+      "media_durations"
     ],
     "type": "js",
     "modulePath": "twitter/likes.js",
@@ -41420,16 +41423,19 @@
     "columns": [
       "id",
       "author",
+      "author_avatar",
       "bio",
       "text",
       "likes",
       "retweets",
       "replies",
+      "views",
       "created_at",
       "url",
       "has_media",
       "media_urls",
       "media_posters",
+      "media_durations",
       "card",
       "quoted_tweet"
     ],
@@ -41880,6 +41886,7 @@
     "columns": [
       "id",
       "author",
+      "author_avatar",
       "bio",
       "text",
       "created_at",
@@ -41889,6 +41896,7 @@
       "has_media",
       "media_urls",
       "media_posters",
+      "media_durations",
       "card",
       "quoted_tweet"
     ],
@@ -41931,14 +41939,17 @@
     "columns": [
       "id",
       "author",
+      "author_avatar",
       "bio",
       "text",
       "likes",
       "retweets",
+      "views",
       "url",
       "has_media",
       "media_urls",
       "media_posters",
+      "media_durations",
       "card",
       "quoted_tweet"
     ],
@@ -41996,6 +42007,7 @@
       "has_media",
       "media_urls",
       "media_posters",
+      "media_durations",
       "card",
       "quoted_tweet"
     ],
@@ -42083,6 +42095,7 @@
       "has_media",
       "media_urls",
       "media_posters",
+      "media_durations",
       "quoted_tweet"
     ],
     "type": "js",

--- a/clis/twitter/bookmark-folder.js
+++ b/clis/twitter/bookmark-folder.js
@@ -129,7 +129,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of bookmarks to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the folder by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations'],
     func: async (page, kwargs) => {
         const folderId = String(kwargs['folder-id'] || '').trim();
         if (!folderId || !FOLDER_ID_PATTERN.test(folderId)) {

--- a/clis/twitter/bookmark-folder.test.js
+++ b/clis/twitter/bookmark-folder.test.js
@@ -100,6 +100,7 @@ describe('twitter bookmark-folder timeline parser', () => {
                 has_media: false,
                 media_urls: [],
                 media_posters: [],
+                media_durations: [],
             },
         ]);
         expect(nextCursor).toBe('NEXT_CURSOR');

--- a/clis/twitter/bookmarks.js
+++ b/clis/twitter/bookmarks.js
@@ -180,7 +180,7 @@ cli({
         { name: 'max-pages', type: 'int', help: `Optional pagination safety cap (default ${DEFAULT_MAX_PAGINATION_PAGES}; raised automatically with --all).` },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the bookmarks by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (saved-time) ordering. Incompatible with --output-file.' },
     ],
-    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
+    columns: ['id', 'author', 'text', 'likes', 'retweets', 'bookmarks', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations'],
     func: async (page, kwargs) => {
         const fetchAll = Boolean(kwargs.all);
         const limit = fetchAll ? Number.POSITIVE_INFINITY : (kwargs.limit || 20);

--- a/clis/twitter/bookmarks.test.js
+++ b/clis/twitter/bookmarks.test.js
@@ -31,6 +31,7 @@ describe('twitter bookmarks parser', () => {
             has_media: false,
             media_urls: [],
             media_posters: [],
+            media_durations: [],
         });
     });
 

--- a/clis/twitter/likes.js
+++ b/clis/twitter/likes.js
@@ -199,7 +199,7 @@ cli({
         { name: 'max-pages', type: 'int', help: `Optional pagination safety cap (default ${DEFAULT_MAX_PAGINATION_PAGES}; raised automatically with --all).` },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the liked tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the API\'s native (recency) ordering. Incompatible with --output-file.' },
     ],
-    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters'],
+    columns: ['id', 'author', 'name', 'text', 'likes', 'retweets', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations'],
     func: async (page, kwargs) => {
         const fetchAll = Boolean(kwargs.all);
         const limit = fetchAll ? Number.POSITIVE_INFINITY : (kwargs.limit || 20);

--- a/clis/twitter/list-tweets.js
+++ b/clis/twitter/list-tweets.js
@@ -2,7 +2,7 @@ import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { BROWSER_JSON_SNIFF_FN, throwIfLoginWall } from '@jackwener/opencli/utils';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
-import { extractCard, extractQuotedTweet, extractMedia, describeTwitterApiError } from './shared.js';
+import { extractAuthorAvatar, extractCard, extractQuotedTweet, extractMedia, describeTwitterApiError } from './shared.js';
 
 const LIST_TWEETS_QUERY_ID = 'RlZzktZY_9wJynoepm8ZsA';
 const OPERATION_NAME = 'ListLatestTweetsTimeline';
@@ -68,11 +68,15 @@ export function extractTimelineTweet(result, seen) {
         id: tw.rest_id,
         author: screenName,
         name: displayName,
+        author_avatar: extractAuthorAvatar(user),
         bio,
         text: noteText || legacy.full_text || '',
         likes: legacy.favorite_count || 0,
         retweets: legacy.retweet_count || 0,
         replies: legacy.reply_count || 0,
+        // Same shape `twitter search` emits: a numeric string, '0' when X omits it.
+        // Also feeds the log10(views) term of --top-by-engagement, which scored 0 before.
+        views: tw.views?.count || '0',
         created_at: legacy.created_at || '',
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
         ...extractMedia(legacy),
@@ -125,7 +129,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the list timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the list\'s native (recency) ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'author_avatar', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const listId = String(kwargs.listId || '').trim();
         if (!listId || !/^\d+$/.test(listId)) {

--- a/clis/twitter/list-tweets.test.js
+++ b/clis/twitter/list-tweets.test.js
@@ -24,16 +24,19 @@ describe('twitter list-tweets parser', () => {
             id: '99',
             author: 'bob',
             name: 'Bob',
+            author_avatar: '',
             bio: 'List author bio',
             text: 'hello list',
             likes: 3,
             retweets: 1,
             replies: 2,
+            views: '0',
             created_at: 'Wed Apr 16 10:00:00 +0000 2026',
             url: 'https://x.com/bob/status/99',
             has_media: false,
             media_urls: [],
             media_posters: [],
+            media_durations: [],
             card: null,
             quoted_tweet: null,
         });
@@ -74,7 +77,28 @@ describe('twitter list-tweets parser', () => {
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/x.jpg'],
             media_posters: ['https://pbs.twimg.com/media/x.jpg'],
+            media_durations: [0],
         });
+    });
+
+    it('exposes views and the author avatar when X returns them', () => {
+        const tweet = extractTimelineTweet({
+            rest_id: '77',
+            legacy: { full_text: 'metrics' },
+            views: { count: '12345' },
+            core: {
+                user_results: {
+                    result: {
+                        legacy: {
+                            screen_name: 'carol',
+                            profile_image_url_https: 'https://pbs.twimg.com/profile_images/1/c_normal.jpg',
+                        },
+                    },
+                },
+            },
+        }, new Set());
+        expect(tweet?.views).toBe('12345');
+        expect(tweet?.author_avatar).toBe('https://pbs.twimg.com/profile_images/1/c_400x400.jpg');
     });
 
     it('includes photo media URLs from extended_entities', () => {

--- a/clis/twitter/search.js
+++ b/clis/twitter/search.js
@@ -1,6 +1,6 @@
 import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { extractMedia, extractCard, extractQuotedTweet, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata, describeTwitterApiError } from './shared.js';
+import { extractAuthorAvatar, extractMedia, extractCard, extractQuotedTweet, normalizeTwitterGraphqlPayload, resolveTwitterOperationMetadata, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 
 // ── Public-search operator surface ─────────────────────────────────────
@@ -216,6 +216,7 @@ function tweetToRow(result, seen) {
     return {
         id: tweet.rest_id,
         author: tweetUser?.core?.screen_name || tweetUser?.legacy?.screen_name || '',
+        author_avatar: extractAuthorAvatar(tweetUser),
         bio,
         text: tweet.note_tweet?.note_tweet_results?.result?.text || tweet.legacy?.full_text || '',
         created_at: tweet.legacy?.created_at || '',
@@ -275,7 +276,7 @@ cli({
         { name: 'limit', type: 'int', default: 15, help: 'Maximum number of tweets to return (default 15). Result count after server-side filtering.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the results by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'author_avatar', 'bio', 'text', 'created_at', 'likes', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const finalQuery = buildSearchQuery(kwargs.query, kwargs);
         if (!finalQuery) {

--- a/clis/twitter/search.test.js
+++ b/clis/twitter/search.test.js
@@ -81,6 +81,7 @@ describe('twitter search command', () => {
             {
                 id: '1',
                 author: 'alice',
+                author_avatar: '',
                 bio: 'Search author bio',
                 text: 'hello world',
                 created_at: 'Thu Mar 26 10:30:00 +0000 2026',
@@ -90,6 +91,7 @@ describe('twitter search command', () => {
                 has_media: false,
                 media_urls: [],
                 media_posters: [],
+                media_durations: [],
                 card: null,
                 quoted_tweet: null,
             },

--- a/clis/twitter/shared.js
+++ b/clis/twitter/shared.js
@@ -360,32 +360,60 @@ export async function resolveTwitterQueryId(page, operationName, fallbackId) {
  * for photos it equals the photo URL itself. Each entry is a non-null string —
  * it falls back to the media URL if a thumbnail is somehow absent, preserving
  * alignment.
+ *
+ * And `media_durations`, also index-aligned 1:1: `video_info.duration_millis`
+ * in milliseconds for videos / animated GIFs, `0` for photos (and for videos
+ * where X omits the duration). This is the only place the tweet's video length
+ * is available — the timeline row itself carries no duration.
  */
 export function extractMedia(legacy) {
     const media = legacy?.extended_entities?.media || legacy?.entities?.media;
     if (!Array.isArray(media) || media.length === 0) {
-        return { has_media: false, media_urls: [], media_posters: [] };
+        return { has_media: false, media_urls: [], media_posters: [], media_durations: [] };
     }
     const urls = [];
     const posters = [];
+    const durations = [];
     for (const m of media) {
         if (!m) continue;
         if (m.type === 'video' || m.type === 'animated_gif') {
             const variants = m.video_info?.variants || [];
-            const mp4 = variants.find((v) => v?.content_type === 'video/mp4');
-            const url = mp4?.url || m.media_url_https;
+            // X returns variants in ascending bitrate order, so picking the first mp4
+            // always yielded the lowest rendition (480x270). Take the highest bitrate.
+            let best = null;
+            for (const v of variants) {
+                if (v?.content_type !== 'video/mp4' || !v.url) continue;
+                const bitrate = Number(v.bitrate) || 0;
+                if (!best || bitrate > best.bitrate) best = { url: v.url, bitrate };
+            }
+            const url = best?.url || m.media_url_https;
             if (url) {
                 urls.push(url);
                 posters.push(m.media_url_https || url);
+                durations.push(Number(m.video_info?.duration_millis) || 0);
             }
         } else {
             if (m.media_url_https) {
                 urls.push(m.media_url_https);
                 posters.push(m.media_url_https);
+                durations.push(0);
             }
         }
     }
-    return { has_media: urls.length > 0, media_urls: urls, media_posters: posters };
+    return { has_media: urls.length > 0, media_urls: urls, media_posters: posters, media_durations: durations };
+}
+
+/**
+ * Author avatar URL from a GraphQL `user_results.result` object.
+ *
+ * Reads `legacy.profile_image_url_https` (older schema) or `avatar.image_url`
+ * (newer schema, the one that also moved `screen_name` under `core`). X serves
+ * that URL at the 48x48 `_normal` size; swapping the suffix for `_400x400`
+ * returns the same image at a usable resolution. Returns '' when absent.
+ */
+export function extractAuthorAvatar(user) {
+    const raw = user?.legacy?.profile_image_url_https || user?.avatar?.image_url || '';
+    return String(raw).replace(/_normal(\.[A-Za-z0-9]+)?(\?.*)?$/, '_400x400$1$2');
 }
 
 /**
@@ -526,6 +554,7 @@ export function extractQuotedTweet(tweet) {
         has_media: qMedia.has_media,
         media_urls: qMedia.media_urls,
         media_posters: qMedia.media_posters,
+        media_durations: qMedia.media_durations,
     };
     if (qCard) out.card = qCard;
     return out;
@@ -577,6 +606,7 @@ export const __test__ = {
     normalizeTwitterGraphqlPayload,
     normalizeTwitterScreenName,
     extractMedia,
+    extractAuthorAvatar,
     extractCard,
     extractQuotedTweet,
     parseTweetUrl,

--- a/clis/twitter/shared.test.js
+++ b/clis/twitter/shared.test.js
@@ -5,6 +5,7 @@ import { ArgumentError } from '@jackwener/opencli/errors';
 
 const {
     extractMedia,
+    extractAuthorAvatar,
     extractCard,
     extractQuotedTweet,
     parseTweetUrl,
@@ -403,12 +404,13 @@ describe('twitter buildTwitterArticleScopeSource', () => {
 
 describe('twitter extractMedia', () => {
     it('returns false + empty list when legacy has no media', () => {
-        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [], media_posters: [] });
-        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [], media_posters: [] });
+        expect(extractMedia({})).toEqual({ has_media: false, media_urls: [], media_posters: [], media_durations: [] });
+        expect(extractMedia(undefined)).toEqual({ has_media: false, media_urls: [], media_posters: [], media_durations: [] });
         expect(extractMedia({ extended_entities: { media: [] } })).toEqual({
             has_media: false,
             media_urls: [],
             media_posters: [],
+            media_durations: [],
         });
     });
 
@@ -490,6 +492,7 @@ describe('twitter extractMedia', () => {
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/thumb.jpg'],
             media_posters: ['https://pbs.twimg.com/media/thumb.jpg'],
+            media_durations: [0],
         });
     });
 
@@ -505,7 +508,80 @@ describe('twitter extractMedia', () => {
             has_media: true,
             media_urls: ['https://pbs.twimg.com/media/c.jpg'],
             media_posters: ['https://pbs.twimg.com/media/c.jpg'],
+            media_durations: [0],
         });
+    });
+
+    it('picks the highest-bitrate mp4 variant, not the first one', () => {
+        const result = extractMedia({
+            extended_entities: {
+                media: [
+                    {
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/media/thumb.jpg',
+                        video_info: {
+                            duration_millis: 30500,
+                            // X returns variants ascending by bitrate; 480x270 comes first.
+                            variants: [
+                                { content_type: 'video/mp4', bitrate: 288000, url: 'https://video.twimg.com/480x270.mp4' },
+                                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/640x360.mp4' },
+                                { content_type: 'application/x-mpegURL', url: 'https://video.twimg.com/x.m3u8' },
+                                { content_type: 'video/mp4', bitrate: 2176000, url: 'https://video.twimg.com/1280x720.mp4' },
+                            ],
+                        },
+                    },
+                ],
+            },
+        });
+        expect(result.media_urls).toEqual(['https://video.twimg.com/1280x720.mp4']);
+        expect(result.media_durations).toEqual([30500]);
+    });
+
+    it('reports media_durations index-aligned with media_urls (0 for photos)', () => {
+        const result = extractMedia({
+            extended_entities: {
+                media: [
+                    { type: 'photo', media_url_https: 'https://pbs.twimg.com/media/a.jpg' },
+                    {
+                        type: 'video',
+                        media_url_https: 'https://pbs.twimg.com/media/thumb.jpg',
+                        video_info: {
+                            duration_millis: 12345,
+                            variants: [{ content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/v.mp4' }],
+                        },
+                    },
+                    {
+                        // Video with no duration_millis: still aligned, reported as 0.
+                        type: 'animated_gif',
+                        media_url_https: 'https://pbs.twimg.com/tweet_video_thumb/g.jpg',
+                        video_info: {
+                            variants: [{ content_type: 'video/mp4', url: 'https://video.twimg.com/g.mp4' }],
+                        },
+                    },
+                ],
+            },
+        });
+        expect(result.media_urls).toHaveLength(3);
+        expect(result.media_durations).toEqual([0, 12345, 0]);
+    });
+});
+
+describe('twitter extractAuthorAvatar', () => {
+    it('upgrades the _normal suffix to _400x400', () => {
+        expect(extractAuthorAvatar({
+            legacy: { profile_image_url_https: 'https://pbs.twimg.com/profile_images/1/abc_normal.jpg' },
+        })).toBe('https://pbs.twimg.com/profile_images/1/abc_400x400.jpg');
+    });
+
+    it('reads the newer avatar.image_url shape', () => {
+        expect(extractAuthorAvatar({
+            avatar: { image_url: 'https://pbs.twimg.com/profile_images/1/abc_normal.png' },
+        })).toBe('https://pbs.twimg.com/profile_images/1/abc_400x400.png');
+    });
+
+    it('returns an empty string when the user object carries no avatar', () => {
+        expect(extractAuthorAvatar({})).toBe('');
+        expect(extractAuthorAvatar(undefined)).toBe('');
     });
 });
 
@@ -787,6 +863,7 @@ describe('twitter extractQuotedTweet', () => {
             has_media: false,
             media_urls: [],
             media_posters: [],
+            media_durations: [],
         });
     });
 

--- a/clis/twitter/thread.js
+++ b/clis/twitter/thread.js
@@ -1,7 +1,7 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
 import { AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
 import { BROWSER_JSON_SNIFF_FN, throwIfLoginWall } from '@jackwener/opencli/utils';
-import { extractMedia, extractCard, extractQuotedTweet, describeTwitterApiError } from './shared.js';
+import { extractAuthorAvatar, extractMedia, extractCard, extractQuotedTweet, describeTwitterApiError } from './shared.js';
 import { TWITTER_BEARER_TOKEN, applyTopByEngagement } from './utils.js';
 // ── Twitter GraphQL constants ──────────────────────────────────────────
 const TWEET_DETAIL_QUERY_ID = 'nBS-WpgA6ZG0CyNHD517JQ';
@@ -11,6 +11,8 @@ const FEATURES = {
     creator_subscriptions_tweet_preview_api_enabled: true,
     responsive_web_graphql_timeline_navigation_enabled: true,
     responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    // Without this flag TweetDetail omits views.count entirely and every row reports '0'.
+    view_counts_everywhere_api_enabled: true,
     longform_notetweets_consumption_enabled: true,
     longform_notetweets_rich_text_read_enabled: true,
     longform_notetweets_inline_media_enabled: true,
@@ -51,10 +53,14 @@ function extractTweet(r, seen) {
     return {
         id: tw.rest_id,
         author: screenName,
+        author_avatar: extractAuthorAvatar(u),
         bio,
         text: noteText || l.full_text || '',
         likes: l.favorite_count || 0,
         retweets: l.retweet_count || 0,
+        // Same shape `twitter search` emits: a numeric string, '0' when X omits it.
+        // Also feeds the log10(views) term of --top-by-engagement, which scored 0 before.
+        views: tw.views?.count || '0',
         in_reply_to: l.in_reply_to_status_id_str || undefined,
         created_at: l.created_at,
         url: `https://x.com/${screenName}/status/${tw.rest_id}`,
@@ -114,7 +120,7 @@ cli({
         { name: 'limit', type: 'int', default: 50 },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the thread by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the conversation\'s structural ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'author_avatar', 'bio', 'text', 'likes', 'retweets', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         let tweetId = kwargs['tweet-id'];
         const urlMatch = tweetId.match(/\/status\/(\d+)/);

--- a/clis/twitter/thread.test.js
+++ b/clis/twitter/thread.test.js
@@ -5,7 +5,7 @@ import { __test__ } from './thread.js';
 describe('twitter thread parser', () => {
     it('extracts author bio from tweet user entity', () => {
         const command = getRegistry().get('twitter/thread');
-        expect(command?.columns).toEqual(['id', 'author', 'bio', 'text', 'likes', 'retweets', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet']);
+        expect(command?.columns).toEqual(['id', 'author', 'author_avatar', 'bio', 'text', 'likes', 'retweets', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'card', 'quoted_tweet']);
         const result = __test__.parseTweetDetail({
             data: {
                 threaded_conversation_with_injections_v2: {

--- a/clis/twitter/timeline.js
+++ b/clis/twitter/timeline.js
@@ -156,7 +156,7 @@ cli({
         { name: 'limit', type: 'int', default: 20, help: 'Maximum number of tweets to return (default 20).' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the timeline by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps X\'s native ordering.' },
     ],
-    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'card', 'quoted_tweet'],
+    columns: ['id', 'author', 'bio', 'text', 'likes', 'retweets', 'replies', 'views', 'created_at', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'card', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = kwargs.limit || 20;
         const timelineType = kwargs.type === 'following' ? 'following' : 'for-you';

--- a/clis/twitter/tweets.js
+++ b/clis/twitter/tweets.js
@@ -117,7 +117,7 @@ cli({
         { name: 'page-delay', type: 'int', default: DEFAULT_PAGE_DELAY_SECONDS, help: 'Seconds to wait between paginated timeline requests to reduce rate-limit risk. Use 0 to disable.' },
         { name: 'top-by-engagement', type: 'int', default: 0, help: 'When set to N>0, re-rank the tweets by weighted engagement (likes×1 + retweets×3 + replies×2 + bookmarks×5 + log10(views+1)×0.5) and return the top N. Default 0 keeps the chronological ordering.' },
     ],
-    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet'],
+    columns: ['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'quoted_tweet'],
     func: async (page, kwargs) => {
         const limit = normalizeLimit(kwargs.limit);
         const pageDelaySeconds = normalizePageDelaySeconds(kwargs['page-delay']);

--- a/clis/twitter/tweets.test.js
+++ b/clis/twitter/tweets.test.js
@@ -65,14 +65,14 @@ describe('twitter tweets helpers', () => {
         expect(cmd?.columns).toEqual([
             'id', 'author', 'created_at', 'is_retweet', 'text', 'likes',
             'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls',
-            'media_posters', 'quoted_tweet',
+            'media_posters', 'media_durations', 'quoted_tweet',
         ]);
         expect(buildUserTweetsUrl('query', '42', 20, 'cursor')).toContain('/UserTweets');
     });
 
     it('registers id and is_retweet in the default columns', () => {
         const cmd = getRegistry().get('twitter/tweets');
-        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'quoted_tweet']);
+        expect(cmd?.columns).toEqual(['id', 'author', 'created_at', 'is_retweet', 'text', 'likes', 'retweets', 'replies', 'views', 'url', 'has_media', 'media_urls', 'media_posters', 'media_durations', 'quoted_tweet']);
     });
 
     it('makes the username argument optional so it can default to the logged-in user', () => {

--- a/docs/adapters/browser/twitter.md
+++ b/docs/adapters/browser/twitter.md
@@ -93,3 +93,9 @@ opencli twitter trending -v
 
 - Chrome running and **logged into** twitter.com
 - [Browser Bridge extension](/guide/browser-bridge) installed
+
+## Notes
+
+- Timeline-shaped commands emit `media_durations`, index-aligned 1:1 with `media_urls`: video length in milliseconds, `0` for photos
+- Video `media_urls` point at the highest-bitrate mp4 variant X offers (previously the lowest, 480x270)
+- `list-tweets`, `thread` and `search` emit `author_avatar` (the `_400x400` profile image) and `views` (numeric string, `'0'` when X omits it)


### PR DESCRIPTION
## 动机

推文 GraphQL 响应里本来就带着作者头像、浏览量和每条媒体的时长，只是没进 columns；视频直链则一直取到**最低**码率变体（480x270）。这批改动**零新请求、零新登录态，老列的名字和格式全部保持不变**。

## 改动

- `extractMedia` 按 bitrate 取最高码率 mp4。此前 `find(mp4)` 取的是第一个变体，而 X 按码率升序返回，直链恒为 480x270
- `extractMedia` 新增 `media_durations`（毫秒，与 `media_urls` 1:1 对齐，图片为 0），这是推文视频时长的唯一来源；落到全部带媒体的命令与 `quoted_tweet`
- `list-tweets` / `thread` 补 `views`（与 `search` 同形：数字字符串，X 没给时为 `'0'`）；`list-tweets` / `thread` / `search` 补 `author_avatar`（`_normal` → `_400x400`）
- `thread` 的 FEATURES 补 `view_counts_everywhere_api_enabled`，否则 TweetDetail 根本不返 `views.count`，`views` 恒为 `'0'`

## 验证

- `clis/twitter` 560 个用例通过（shared / list-tweets / search / thread / tweets 等补断言）
- `cli-manifest.json` 已重新生成，`check:silent-column-drop` 无新增违规
- `docs/adapters/browser/twitter.md` 补充说明
