### PR TITLE
feat(browser): OPENCLI_BROWSER_IDLE_TIMEOUT 环境变量覆盖自动化窗口空闲超时

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ When the site you need is not yet covered, use the `opencli-adapter-author` skil
 | `OPENCLI_SITE_SESSION` | adapter default | Set to `ephemeral` or `persistent` to override `siteSession` metadata for browser-backed adapter commands. `ephemeral` closes the one-shot automation window when the command finishes; `persistent` reuses the site's session. Per-command `--site-session` takes precedence. |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `45` | Seconds to wait for browser connection |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | Seconds to wait for a single browser command |
+| `OPENCLI_BROWSER_IDLE_TIMEOUT` | extension default | Seconds an owned automation window stays open after its last command. Raise it for polling pipelines so consecutive runs reuse one window instead of recreating it. Per-command `idleTimeout` takes precedence. |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol endpoint for remote browser or Electron apps |
 | `OPENCLI_CDP_TARGET` | — | Filter CDP targets by URL substring (e.g. `detail.1688.com`) |
 | `OPENCLI_VERBOSE` | `false` | Enable verbose logging (`-v` flag also works) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,6 +159,7 @@ Agent 在内部自动处理所有 `opencli browser` 命令——你只需用自�
 | `OPENCLI_SITE_SESSION` | adapter 默认值 | 设为 `ephemeral` 或 `persistent`，覆盖浏览器型 adapter 命令的 `siteSession` 元数据。`ephemeral` 会在命令结束时关闭一次性自动化窗口；`persistent` 会复用该站点的 session。命令级 `--site-session` 优先。 |
 | `OPENCLI_BROWSER_CONNECT_TIMEOUT` | `45` | 浏览器连接超时（秒） |
 | `OPENCLI_BROWSER_COMMAND_TIMEOUT` | `60` | 单个浏览器命令超时（秒） |
+| `OPENCLI_BROWSER_IDLE_TIMEOUT` | 扩展默认值 | 自动化窗口在最后一条命令之后保持打开的秒数。轮询型流水线可调大，让连续多次运行复用同一个窗口而不是反复重建。单条命令的 `idleTimeout` 优先 |
 | `OPENCLI_CDP_ENDPOINT` | — | Chrome DevTools Protocol 端点，用于远程浏览器或 Electron 应用 |
 | `OPENCLI_CDP_TARGET` | — | 按 URL 子串过滤 CDP target（如 `detail.1688.com`） |
 | `OPENCLI_VERBOSE` | `false` | 启用详细日志（`-v` 也可以） |

--- a/src/browser/daemon-client.test.ts
+++ b/src/browser/daemon-client.test.ts
@@ -365,6 +365,45 @@ describe('daemon-client', () => {
     expect(body.windowMode).toBe('background');
   });
 
+  it('sendCommand forwards OPENCLI_BROWSER_IDLE_TIMEOUT (seconds) as idleTimeout', async () => {
+    vi.stubEnv('OPENCLI_BROWSER_IDLE_TIMEOUT', '300');
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { idleTimeout?: number };
+    expect(body.idleTimeout).toBe(300);
+  });
+
+  it('sendCommand uses explicit idleTimeout before OPENCLI_BROWSER_IDLE_TIMEOUT env fallback', async () => {
+    vi.stubEnv('OPENCLI_BROWSER_IDLE_TIMEOUT', '300');
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1', idleTimeout: 45 });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { idleTimeout?: number };
+    expect(body.idleTimeout).toBe(45);
+  });
+
+  it.each(['0', '-5', '1.5', 'abc', ''])('sendCommand ignores invalid OPENCLI_BROWSER_IDLE_TIMEOUT=%j', async (raw) => {
+    vi.stubEnv('OPENCLI_BROWSER_IDLE_TIMEOUT', raw);
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ id: 'server', ok: true, data: 'ok' }),
+    } as Response);
+
+    await sendCommand('exec', { code: '1 + 1' });
+
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)) as { idleTimeout?: number };
+    expect(body.idleTimeout).toBeUndefined();
+  });
+
   it('sendCommand retries executor-transient errors ONCE with a NEW id (re-execution is a new logical attempt)', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock

--- a/src/browser/daemon-client.ts
+++ b/src/browser/daemon-client.ts
@@ -340,6 +340,17 @@ async function sendCommandRaw(
   const contextId = routing.contextId;
   const preferredContextId = routing.preferredContextId;
   const windowMode = params.windowMode ?? envWindowMode;
+  // OPENCLI_BROWSER_IDLE_TIMEOUT: seconds the owned automation window stays
+  // alive after its last command. Polling pipelines that fire a command every
+  // minute or two want this above the extension default so each run reuses
+  // the same window instead of paying a fresh windows.create() (and, on
+  // macOS, a focus flash). Explicit params.idleTimeout takes precedence; the
+  // extension ignores 0, so only positive integers are forwarded.
+  const rawIdleTimeout = process.env.OPENCLI_BROWSER_IDLE_TIMEOUT;
+  const envIdleTimeout = rawIdleTimeout && /^\d+$/.test(rawIdleTimeout) && Number(rawIdleTimeout) > 0
+    ? Number(rawIdleTimeout)
+    : undefined;
+  const idleTimeout = params.idleTimeout ?? envIdleTimeout;
 
   let id = generateId();
   let ensureUsed = false;
@@ -381,6 +392,7 @@ async function sendCommandRaw(
       ...(contextId && { contextId }),
       ...(preferredContextId && { preferredContextId }),
       ...(windowMode && { windowMode }),
+      ...(idleTimeout !== undefined && { idleTimeout }),
       // Carry the run identity so the daemon can acquire/refresh the write
       // lease on the persistent site session. The same runId across every exec
       // of one command is the heartbeat that keeps a long-running holder alive.


### PR DESCRIPTION
## 动机

这是 #1868 关闭时维护者建议**单独拆出**的那部分：只做环境变量 → 命令字段的映射，不碰 tab active 语义、窗口创建方式和 transport 路径。

extension 早已支持命令字段 `idleTimeout`（秒）覆盖 owned 窗口的空闲回收时间（`background.ts` 里 `setSessionOverride(leaseKey, { idleTimeoutMs })`），但 CLI 侧没有任何入口能设置它——只能改调用方代码。轮询型流水线（每一两分钟跑一条 adapter 命令）在默认空闲超时下每次都要重新 `windows.create()`，在 macOS 上还伴随一次焦点闪烁；把空闲时间调到覆盖轮询间隔即可复用同一窗口。

## 改动

- `daemon-client.sendCommandRaw`：读取 `OPENCLI_BROWSER_IDLE_TIMEOUT`（**秒**，与 `OPENCLI_BROWSER_CONNECT_TIMEOUT` / `OPENCLI_BROWSER_COMMAND_TIMEOUT` 同单位同前缀），仅正整数生效（extension 侧本来就忽略 0）；显式 `params.idleTimeout` 优先
- 测试：env 生效、显式参数优先、非法值（`0` / 负数 / 小数 / 非数字 / 空）忽略
- `README.md` / `README.zh-CN.md` 配置表补一行

## 验证

- `npm run typecheck` 通过
- `src/browser/daemon-client.test.ts` 45 个用例通过（新增 7 个）
