### PR TITLE
feat(xiaohongshu): lives — list live rooms with directly playable FLV stream URLs

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46049,6 +46049,38 @@
   },
   {
     "site": "xiaohongshu",
+    "name": "lives",
+    "description": "小红书直播列表（含可直接播放的 FLV 流地址）",
+    "access": "read",
+    "domain": "www.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of live rooms to return"
+      }
+    ],
+    "columns": [
+      "rank",
+      "room_id",
+      "title",
+      "host",
+      "viewers",
+      "stream_url",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/lives.js",
+    "sourceFile": "xiaohongshu/lives.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "xiaohongshu",
     "name": "login",
     "description": "Open xiaohongshu login and wait until the browser session is authenticated",
     "access": "write",

--- a/clis/xiaohongshu/lives.js
+++ b/clis/xiaohongshu/lives.js
@@ -1,0 +1,146 @@
+/**
+ * Xiaohongshu lives — list currently-live rooms with playable stream URLs.
+ *
+ * The /livelist page server-renders `__INITIAL_STATE__.liveList.liveList`
+ * with everything a viewer needs: room id/title/viewer count
+ * (`live.tRoomInfo`), host identity (`live.tLiveHostInfo`), and — inside the
+ * double-nested JSON string `live.roomExtraInfo.live_stream_info` — the FLV
+ * master URL, which plays without cookies (verified: plain HTTP 200 from the
+ * CDN). No room-page visit is needed for discovery or playback.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
+
+const LIVELIST_URL = 'https://www.xiaohongshu.com/livelist?channel_id=&channel_type=explore_feed';
+
+/**
+ * Private copy of the shared navigateFresh pattern (PR #2461 adds it to
+ * shared.js) so this command stays merge-order independent; switch to the
+ * shared import once that lands. A warm persistent tab at the target URL
+ * fast-paths a plain goto without loading anything, so force a real reload.
+ */
+async function navigateFresh(page, url) {
+    const current = typeof page.getCurrentUrl === 'function'
+        ? await page.getCurrentUrl().catch(() => null)
+        : null;
+    if (current === url) {
+        try {
+            await page.evaluate('location.reload()');
+            return;
+        }
+        catch {
+            // fall through to the plain goto below
+        }
+    }
+    await page.goto(url);
+}
+
+const LIVES_READ_JS = `
+  (() => {
+    const store = window.__INITIAL_STATE__?.liveList;
+    const raw = store?.liveList?._value ?? store?.liveList;
+    if (!Array.isArray(raw)) return { error: 'no_live_store' };
+    return {
+      items: raw
+        .filter((entry) => entry && entry.type === 'live' && entry.live)
+        .map((entry) => ({
+          roomIdRaw: String(entry.live.tRoomInfo?.roomIdStr ?? ''),
+          title: String(entry.live.tRoomInfo?.name ?? ''),
+          viewers: Number(entry.live.tRoomInfo?.displayCount ?? 0),
+          linkRaw: String(entry.live.tRoomInfo?.link ?? ''),
+          host: String(entry.live.tLiveHostInfo?.nickname ?? ''),
+          roomExtraInfoRaw: typeof entry.live.roomExtraInfo === 'string' ? entry.live.roomExtraInfo : '',
+        })),
+    };
+  })()
+`;
+
+/**
+ * Resolve the playable stream URL for a live-list row. Primary source is the
+ * default stream's master_url inside roomExtraInfo -> live_stream_info (both
+ * JSON strings); fallback is the flvUrl param of the xhsdiscover:// deeplink.
+ */
+export function extractLiveStreamUrl(roomExtraInfo, link) {
+    try {
+        const outer = JSON.parse(roomExtraInfo);
+        const inner = JSON.parse(outer.live_stream_info);
+        const streams = Array.isArray(inner?.streams) ? inner.streams : [];
+        const chosen = streams.find((s) => s?.default_stream === 1) ?? streams[0];
+        if (chosen?.master_url) return String(chosen.master_url);
+    }
+    catch {
+        // fall through to the deeplink fallback
+    }
+    const match = /[?&]flvUrl=([^&]+)/.exec(String(link ?? ''));
+    if (match) {
+        try {
+            return decodeURIComponent(match[1]);
+        }
+        catch {
+            return '';
+        }
+    }
+    return '';
+}
+
+function parseLimit(raw) {
+    const parsed = Number(raw ?? 20);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1) {
+        throw new ArgumentError(`--limit must be a positive integer, got ${JSON.stringify(raw)}`);
+    }
+    return parsed;
+}
+
+export const command = cli({
+    site: 'xiaohongshu',
+    name: 'lives',
+    access: 'read',
+    description: '小红书直播列表（含可直接播放的 FLV 流地址）',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    siteSession: 'persistent',
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: 'Number of live rooms to return' },
+    ],
+    columns: ['rank', 'room_id', 'title', 'host', 'viewers', 'stream_url', 'url'],
+    func: async (page, kwargs) => {
+        const limit = parseLimit(kwargs.limit);
+        // Live listings churn constantly; a warm tab must reload for real.
+        await navigateFresh(page, LIVELIST_URL);
+        await page.wait({ time: 2 });
+        let data = unwrapEvaluateResult(await page.evaluate(LIVES_READ_JS));
+        if (!data || typeof data !== 'object' || data.error || !Array.isArray(data.items) || data.items.length === 0) {
+            // One hydration retry: the SSR store may land a beat after load.
+            await page.wait({ time: 2 });
+            data = unwrapEvaluateResult(await page.evaluate(LIVES_READ_JS));
+        }
+        if (!data || typeof data !== 'object') {
+            throw new CommandExecutionError('xiaohongshu lives: unexpected evaluate response');
+        }
+        if (data.error) {
+            throw new CommandExecutionError(`xiaohongshu lives: ${data.error}`, 'The live list SPA may still be hydrating; retry in a moment.');
+        }
+        if (!Array.isArray(data.items)) {
+            throw new CommandExecutionError('xiaohongshu lives: unexpected items payload shape');
+        }
+        const rows = data.items
+            .filter((item) => item && typeof item === 'object' && item.roomIdRaw)
+            .slice(0, limit)
+            .map((item, index) => ({
+            rank: index + 1,
+            room_id: item.roomIdRaw,
+            title: item.title,
+            host: item.host,
+            viewers: item.viewers,
+            stream_url: extractLiveStreamUrl(item.roomExtraInfoRaw, item.linkRaw),
+            url: `https://www.xiaohongshu.com/livestream/${item.roomIdRaw}`,
+        }));
+        if (rows.length === 0) {
+            throw new EmptyResultError('xiaohongshu lives', 'No live rooms in the hydrated live-list store.');
+        }
+        return rows;
+    },
+});

--- a/clis/xiaohongshu/lives.test.js
+++ b/clis/xiaohongshu/lives.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { extractLiveStreamUrl } from './lives.js';
+import './lives.js';
+
+const FLV = 'http://live-source-play.xhscdn.com/live/570440785846563714.flv';
+const LIVELIST_URL = 'https://www.xiaohongshu.com/livelist?channel_id=&channel_type=explore_feed';
+
+function roomExtraInfo(flv = FLV) {
+    return JSON.stringify({
+        cover_type: 1,
+        live_stream_info: JSON.stringify({
+            ver: 103,
+            media: { room_id: 570440785846563714 },
+            streams: [
+                { default_stream: 0, id: 1, master_url: 'http://live.xhscdn.com/backup.flv', protocol: 'flv' },
+                { default_stream: 1, id: 5, master_url: flv, protocol: 'flv', quality_type_name: '原画' },
+            ],
+        }),
+    });
+}
+
+function storeItem(overrides = {}) {
+    return {
+        roomIdRaw: '570440785846563714',
+        title: '直播间讲透高远球正确鞭打发力',
+        host: '羽球小宋老师',
+        viewers: 87,
+        linkRaw: `xhsdiscover://live_audience?room_id=570440785846563714&flvUrl=${encodeURIComponent(FLV)}&source=live_web_square`,
+        roomExtraInfoRaw: roomExtraInfo(),
+        ...overrides,
+    };
+}
+
+function makePage(evaluateResult, currentUrl) {
+    const page = {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn(async (script) => {
+            if (String(script).includes('location.reload')) return undefined;
+            return evaluateResult;
+        }),
+    };
+    if (currentUrl !== undefined) page.getCurrentUrl = vi.fn().mockResolvedValue(currentUrl);
+    return page;
+}
+
+describe('extractLiveStreamUrl', () => {
+    it('parses the default stream master_url out of the double-nested JSON', () => {
+        expect(extractLiveStreamUrl(roomExtraInfo(), '')).toBe(FLV);
+    });
+    it('falls back to the flvUrl deeplink param when roomExtraInfo is malformed', () => {
+        const link = `xhsdiscover://live_audience?room_id=1&flvUrl=${encodeURIComponent(FLV)}&x=1`;
+        expect(extractLiveStreamUrl('not json', link)).toBe(FLV);
+        expect(extractLiveStreamUrl('', link)).toBe(FLV);
+    });
+    it('returns empty when neither source yields a URL', () => {
+        expect(extractLiveStreamUrl('', '')).toBe('');
+        expect(extractLiveStreamUrl(JSON.stringify({ live_stream_info: '{}' }), 'xhsdiscover://x?a=1')).toBe('');
+    });
+});
+
+describe('xiaohongshu/lives command', () => {
+    const getCommand = () => getRegistry().get('xiaohongshu/lives');
+
+    it('registers persistent with adapter-owned navigation', () => {
+        const cmd = getCommand();
+        expect(cmd).toBeDefined();
+        expect(cmd.navigateBefore).toBe(false);
+        expect(cmd.siteSession).toBe('persistent');
+    });
+
+    it('maps live-list store rows into playable results', async () => {
+        const page = makePage({ items: [storeItem()] });
+        const rows = await getCommand().func(page, { limit: 5 });
+        expect(rows).toEqual([{
+            rank: 1,
+            room_id: '570440785846563714',
+            title: '直播间讲透高远球正确鞭打发力',
+            host: '羽球小宋老师',
+            viewers: 87,
+            stream_url: FLV,
+            url: 'https://www.xiaohongshu.com/livestream/570440785846563714',
+        }]);
+        expect(page.goto).toHaveBeenCalledWith(LIVELIST_URL);
+    });
+
+    it('honors --limit', async () => {
+        const page = makePage({ items: [storeItem(), storeItem({ roomIdRaw: '2', title: 'b' }), storeItem({ roomIdRaw: '3', title: 'c' })] });
+        const rows = await getCommand().func(page, { limit: 2 });
+        expect(rows.length).toBe(2);
+    });
+
+    it('forces a reload when the persistent tab already shows the live list', async () => {
+        const page = makePage({ items: [storeItem()] }, LIVELIST_URL);
+        await getCommand().func(page, { limit: 5 });
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.evaluate).toHaveBeenCalledWith('location.reload()');
+    });
+
+    it('retries once through hydration before failing on a missing store', async () => {
+        let calls = 0;
+        const page = {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async () => (calls++ === 0 ? { error: 'no_live_store' } : { items: [storeItem()] })),
+        };
+        const rows = await getCommand().func(page, { limit: 5 });
+        expect(rows.length).toBe(1);
+    });
+
+    it('throws EMPTY_RESULT when no rooms are live', async () => {
+        const page = makePage({ items: [] });
+        await expect(getCommand().func(page, { limit: 5 })).rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+});

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -11,6 +11,7 @@
 | `opencli xiaohongshu note` | Read full note content (title, author, description, likes, collects, comments, tags) |
 | `opencli xiaohongshu comments` | Read comments from a note (`--with-replies` for nested 楼中楼 replies) |
 | `opencli xiaohongshu feed` | Home feed recommendations (reads the hydrated Pinia store; URLs carry `xsec_token` for drill-down) |
+| `opencli xiaohongshu lives` | Currently-live rooms with host, viewer count, and a directly playable FLV `stream_url` |
 | `opencli xiaohongshu notifications` | User notifications (mentions, likes, connections) |
 | `opencli xiaohongshu user` | Get public notes from a user profile |
 | `opencli xiaohongshu saved` | List saved/collected notes (`/user/profile/<id>?tab=fav&subTab=note`) |


### PR DESCRIPTION
> **Standalone** — based directly on `main`, merge-order independent of #2461. The only shared logic is a ~15-line `navigateFresh` helper that #2461 also introduces in `shared.js`; this PR carries a deliberate private copy (no file overlap, so no merge conflict either way) and will switch to the shared import once #2461 lands.

## What

`xiaohongshu lives` lists currently-live rooms with, per room: id, title, host, viewer count, room URL — and a **directly playable FLV `stream_url`**. `mpv <stream_url>` plays the room; no room-page visit needed.

## How

The web `/livelist` page server-renders `__INITIAL_STATE__.liveList` with everything already in it; the stream URL sits inside the double-nested JSON string `roomExtraInfo.live_stream_info` (`streams[].master_url`, default-stream preferred), and the CDN serves it **without cookies** — verified live: HTTP 200, `video/x-flv`, 1.6MB delivered in an 8-second probe. `extractLiveStreamUrl` parses the nested JSON node-side and falls back to the `flvUrl` param of the `xhsdiscover://` deeplink for malformed payloads. The command follows the feed pattern from #2461: persistent session + always-fresh navigation (live listings churn constantly) + one hydration retry.

## Verification

TDD: 9 unit tests (nested-JSON parsing, deeplink fallback, row mapping, `--limit`, warm-tab forced reload, hydration retry, EMPTY_RESULT) written first; boundary convention test includes `lives` in the persistent list; doc table row added; manifest regenerated (1367 entries). Live: returned 4 real rooms with titles/hosts/viewer counts and working stream URLs.

Known v1 limits (stated intentionally): SSR first screen only (~26 rooms, no scroll pagination), no category filter yet (`liveList.categories` exists in the store — a `--channel` arg is a natural follow-up), no in-room interaction.

Part of the xiaohongshu arc: #2470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
