### PR TITLE
feat(xiaohongshu): live-comments — stream a live room's comments via an in-page MutationObserver watcher

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46049,6 +46049,52 @@
   },
   {
     "site": "xiaohongshu",
+    "name": "live-comments",
+    "description": "采集小红书直播间评论流（页内 MutationObserver 持续捕获，跨调用不丢）",
+    "access": "read",
+    "domain": "www.xiaohongshu.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "room-url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Room URL from `xiaohongshu lives` (or a bare numeric room id)"
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 15,
+        "required": false,
+        "help": "Seconds to collect before draining (0-60; 0 = drain what accumulated since the last call)"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 200,
+        "required": false,
+        "help": "Maximum comments to return"
+      }
+    ],
+    "columns": [
+      "seq",
+      "nickname",
+      "user_id",
+      "msg",
+      "comment_type",
+      "fans_group",
+      "comment_id"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/live-comments.js",
+    "sourceFile": "xiaohongshu/live-comments.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "xiaohongshu",
     "name": "login",
     "description": "Open xiaohongshu login and wait until the browser session is authenticated",
     "access": "write",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46116,12 +46116,9 @@
     ],
     "columns": [
       "seq",
+      "kind",
       "nickname",
-      "user_id",
-      "msg",
-      "comment_type",
-      "fans_group",
-      "comment_id"
+      "msg"
     ],
     "type": "js",
     "modulePath": "xiaohongshu/live-comments.js",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -46049,6 +46049,42 @@
   },
   {
     "site": "xiaohongshu",
+    "name": "live-comment-send",
+    "description": "在小红书直播间发送一条评论（发送后以输入框清空 + 评论流出现为后置证据）",
+    "access": "write",
+    "domain": "www.xiaohongshu.com",
+    "strategy": "ui",
+    "browser": true,
+    "args": [
+      {
+        "name": "room-url",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Room URL from `xiaohongshu lives` (or a bare numeric room id)"
+      },
+      {
+        "name": "text",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "Comment text (max 200 chars)"
+      }
+    ],
+    "columns": [
+      "status",
+      "room_id",
+      "msg",
+      "comment_id"
+    ],
+    "type": "js",
+    "modulePath": "xiaohongshu/live-comment-send.js",
+    "sourceFile": "xiaohongshu/live-comment-send.js",
+    "navigateBefore": false,
+    "siteSession": "persistent"
+  },
+  {
+    "site": "xiaohongshu",
     "name": "live-comments",
     "description": "采集小红书直播间评论流（页内 MutationObserver 持续捕获，跨调用不丢）",
     "access": "read",

--- a/clis/xiaohongshu/live-comment-send.js
+++ b/clis/xiaohongshu/live-comment-send.js
@@ -49,14 +49,32 @@ export function buildSendVerifyJs(text) {
     return `
     (() => { // __send_verify
       const box = document.querySelector('.input-editable');
-      const cleared = !box || (box.innerText || '').trim() === '';
+      const cleared = !box || (box.textContent || '').trim() === '';
+      // Primary evidence: our own nickname + the exact text rendered in the
+      // chat DOM. The store echo is unreliable (the liveStream.comments store
+      // freezes after the SSR batch — observed live: real sends "failed"
+      // verification while the watcher saw them land in chat).
+      const userInfo = window.__INITIAL_STATE__?.user?.userInfo;
+      const ownNick = String((userInfo?._value ?? userInfo)?.nickname ?? '').trim();
+      const domHit = ownNick !== '' && [...document.querySelectorAll('.virtual-list-item')].some((item) => {
+        const nickEl = item.querySelector('.nickname');
+        if (!nickEl || (nickEl.textContent || '').trim() !== ownNick) return false;
+        const contentEl = item.querySelector('.msg-content') ?? item;
+        let msg = '';
+        for (const node of contentEl.childNodes) {
+          if (node === nickEl || (node.nodeType === 1 && node.contains(nickEl))) continue;
+          msg += node.textContent ?? '';
+        }
+        return msg.replace(/\s+/g, ' ').trim() === ${JSON.stringify(text)};
+      });
+      // Secondary: the store echo, when it happens, carries the server id.
       const ls = window.__INITIAL_STATE__?.liveStream;
       const raw = ls?.comments?._value ?? ls?.comments;
       const mine = (Array.isArray(raw) ? raw : [])
         .filter((c) => String(c?.msg ?? '') === ${JSON.stringify(text)})
         .map((c) => String(c?.commentId ?? ''))
         .filter(Boolean);
-      return { sent: cleared && mine.length > 0, cleared, commentId: mine[mine.length - 1] ?? '' };
+      return { sent: cleared && (domHit || mine.length > 0), cleared, commentId: mine[mine.length - 1] ?? '' };
     })()
   `;
 }

--- a/clis/xiaohongshu/live-comment-send.js
+++ b/clis/xiaohongshu/live-comment-send.js
@@ -1,0 +1,121 @@
+/**
+ * Xiaohongshu live-comment-send — post one comment into a live room.
+ *
+ * UI-driving write: focus the room's contenteditable composer, insert the
+ * text (verifying the box shows exactly what was requested before anything
+ * is clicked), click the send control that appears, then poll a
+ * postcondition — the input cleared AND the comment appeared in the
+ * structured liveStream.comments store — before reporting success.
+ * Navigates with a plain goto so a live-comments watcher on the same warm
+ * tab stays alive.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
+import { parseRoomUrl } from './live-comments.js';
+
+const MAX_COMMENT_LENGTH = 200;
+
+export function buildSendPrepareJs(text) {
+    return `
+    (() => {
+      const box = document.querySelector('.input-editable');
+      if (!box) return { ok: false, reason: 'no_input_box' };
+      box.focus();
+      const selection = window.getSelection();
+      selection.selectAllChildren(box);
+      document.execCommand('delete', false, null);
+      document.execCommand('insertText', false, ${JSON.stringify(text)});
+      const sendButton = [...document.querySelectorAll('button, [class*="send"]')]
+        .find((el) => el.getBoundingClientRect().width > 0 && /发送/.test(el.innerText || ''));
+      return { ok: true, content: (box.innerText || '').trim(), sendVisible: Boolean(sendButton) };
+    })()
+  `;
+}
+
+export function buildSendClickJs() {
+    return `
+    (() => { // __send_click
+      const sendButton = [...document.querySelectorAll('button, [class*="send"]')]
+        .find((el) => el.getBoundingClientRect().width > 0 && /发送/.test(el.innerText || ''));
+      if (!sendButton) return { clicked: false, reason: 'send_button_not_found' };
+      sendButton.click();
+      return { clicked: true };
+    })()
+  `;
+}
+
+export function buildSendVerifyJs(text) {
+    return `
+    (() => { // __send_verify
+      const box = document.querySelector('.input-editable');
+      const cleared = !box || (box.innerText || '').trim() === '';
+      const ls = window.__INITIAL_STATE__?.liveStream;
+      const raw = ls?.comments?._value ?? ls?.comments;
+      const mine = (Array.isArray(raw) ? raw : [])
+        .filter((c) => String(c?.msg ?? '') === ${JSON.stringify(text)})
+        .map((c) => String(c?.commentId ?? ''))
+        .filter(Boolean);
+      return { sent: cleared && mine.length > 0, cleared, commentId: mine[mine.length - 1] ?? '' };
+    })()
+  `;
+}
+
+function parseCommentText(raw) {
+    const text = String(raw ?? '').trim();
+    if (!text) {
+        throw new ArgumentError('live-comment-send text cannot be empty');
+    }
+    if (text.length > MAX_COMMENT_LENGTH) {
+        throw new ArgumentError(`live-comment-send text must be at most ${MAX_COMMENT_LENGTH} characters`);
+    }
+    return text;
+}
+
+export const command = cli({
+    site: 'xiaohongshu',
+    name: 'live-comment-send',
+    access: 'write',
+    description: '在小红书直播间发送一条评论（发送后以输入框清空 + 评论流出现为后置证据）',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.UI,
+    browser: true,
+    navigateBefore: false,
+    siteSession: 'persistent',
+    args: [
+        { name: 'room-url', required: true, positional: true, help: 'Room URL from `xiaohongshu lives` (or a bare numeric room id)' },
+        { name: 'text', required: true, positional: true, help: `Comment text (max ${MAX_COMMENT_LENGTH} chars)` },
+    ],
+    columns: ['status', 'room_id', 'msg', 'comment_id'],
+    func: async (page, kwargs) => {
+        const url = parseRoomUrl(kwargs['room-url']);
+        const text = parseCommentText(kwargs.text);
+        const roomId = (/\/livestream\/(\d+)/.exec(url) ?? [])[1] ?? '';
+        // Plain goto: a warm tab in this room keeps a live-comments watcher
+        // (and the composer state) intact.
+        await page.goto(url);
+        await page.wait({ time: 2 });
+        const prepared = unwrapEvaluateResult(await page.evaluate(buildSendPrepareJs(text)));
+        if (!prepared || typeof prepared !== 'object' || prepared.ok !== true) {
+            throw new CommandExecutionError(`xiaohongshu live-comment-send: comment box unavailable (${String(prepared?.reason ?? 'unknown')})`, 'Log into www.xiaohongshu.com in Chrome and confirm the room is still live.');
+        }
+        if (String(prepared.content ?? '') !== text) {
+            throw new CommandExecutionError(`xiaohongshu live-comment-send: typed content mismatch (expected ${JSON.stringify(text)}, box shows ${JSON.stringify(String(prepared.content ?? ''))}) — refusing to send`, 'The composer may have interfered with the input; retry.');
+        }
+        const clicked = unwrapEvaluateResult(await page.evaluate(buildSendClickJs()));
+        if (!clicked || clicked.clicked !== true) {
+            throw new CommandExecutionError(`xiaohongshu live-comment-send: send control not clickable (${String(clicked?.reason ?? 'unknown')})`);
+        }
+        let verified = null;
+        for (let i = 0; i < 5; i += 1) {
+            await page.wait({ time: 1 });
+            verified = unwrapEvaluateResult(await page.evaluate(buildSendVerifyJs(text)));
+            if (verified?.sent === true) break;
+        }
+        if (verified?.sent !== true) {
+            throw new CommandExecutionError('xiaohongshu live-comment-send: send not confirmed — the input did not clear or the comment never appeared in the stream', 'The room may have comment restrictions (fans-only chat, slow mode, or muted account).');
+        }
+        return [{ status: 'sent', room_id: roomId, msg: text, comment_id: String(verified.commentId ?? '') }];
+    },
+});
+

--- a/clis/xiaohongshu/live-comment-send.test.js
+++ b/clis/xiaohongshu/live-comment-send.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getRegistry } from '@jackwener/opencli/registry';
+import { JSDOM } from 'jsdom';
+import { buildSendVerifyJs } from './live-comment-send.js';
 import './live-comment-send.js';
 
 const ROOM_URL = 'https://www.xiaohongshu.com/livestream/570440812909234340?xsec_token=ABtok';
@@ -60,5 +62,54 @@ describe('xiaohongshu/live-comment-send command', () => {
         const page = makeSendPage({ verify: { sent: false, cleared: false } });
         await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: '666' }))
             .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('not confirmed') });
+    });
+});
+
+
+describe('buildSendVerifyJs (DOM-primary confirmation, JSDOM)', () => {
+    function makeVerifyDom({ boxText = '', chat = [], storeEcho = null, ownNick = '啊啊啊啊啊嚏' } = {}) {
+        const dom = new JSDOM('<div class="input-editable"></div><div class="live-chat"><div class="virtual-list"></div></div>', {
+            url: 'https://www.xiaohongshu.com/livestream/1',
+        });
+        const win = dom.window;
+        win.document.querySelector('.input-editable').textContent = boxText;
+        const list = win.document.querySelector('.virtual-list');
+        for (const [nick, msg] of chat) {
+            const item = win.document.createElement('div');
+            item.className = 'virtual-list-item';
+            item.innerHTML = '<div class="msg-wrapper"><div class="msg-content"><span class="nickname">' + nick + '</span> ' + msg + '</div></div>';
+            list.appendChild(item);
+        }
+        win.__INITIAL_STATE__ = {
+            user: { userInfo: { _value: { nickname: ownNick } } },
+            liveStream: { comments: { _value: storeEcho ? [storeEcho] : [] } },
+        };
+        return (script) => Function('window', 'document', `return (${script})`)(win, win.document);
+    }
+
+    it('confirms via the DOM when our nickname+text appear in chat (frozen store, no echo)', () => {
+        const run = makeVerifyDom({ chat: [['路人', '好耶'], ['啊啊啊啊啊嚏', '白鹿白鹿白鹿']] });
+        const v = run(buildSendVerifyJs('白鹿白鹿白鹿'));
+        expect(v.sent).toBe(true);
+        expect(v.commentId).toBe('');
+    });
+
+    it('attaches the server comment id when the store echo exists', () => {
+        const run = makeVerifyDom({
+            chat: [['啊啊啊啊啊嚏', '加油']],
+            storeEcho: { msg: '加油', commentId: '777' },
+        });
+        const v = run(buildSendVerifyJs('加油'));
+        expect(v).toMatchObject({ sent: true, commentId: '777' });
+    });
+
+    it('does not confirm when only someone ELSE posted the same text', () => {
+        const run = makeVerifyDom({ chat: [['路人', '白鹿白鹿白鹿']] });
+        expect(run(buildSendVerifyJs('白鹿白鹿白鹿')).sent).toBe(false);
+    });
+
+    it('does not confirm while the input box still holds the text', () => {
+        const run = makeVerifyDom({ boxText: '白鹿白鹿白鹿', chat: [['啊啊啊啊啊嚏', '白鹿白鹿白鹿']] });
+        expect(run(buildSendVerifyJs('白鹿白鹿白鹿')).sent).toBe(false);
     });
 });

--- a/clis/xiaohongshu/live-comment-send.test.js
+++ b/clis/xiaohongshu/live-comment-send.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './live-comment-send.js';
+
+const ROOM_URL = 'https://www.xiaohongshu.com/livestream/570440812909234340?xsec_token=ABtok';
+
+describe('xiaohongshu/live-comment-send command', () => {
+    const getCommand = () => getRegistry().get('xiaohongshu/live-comment-send');
+
+    function makeSendPage({ prepare = { ok: true, content: '666', sendVisible: true }, clicked = { clicked: true }, verify = { sent: true, commentId: 'c9', cleared: true } } = {}) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                const s = String(script);
+                if (s.includes('insertText')) return prepare;
+                if (s.includes('__send_click')) return clicked;
+                if (s.includes('__send_verify')) return verify;
+                throw new Error(`unexpected script: ${s.slice(0, 40)}`);
+            }),
+        };
+    }
+
+    it('registers as a persistent write with adapter-owned navigation', () => {
+        const cmd = getCommand();
+        expect(cmd).toBeDefined();
+        expect(cmd.access).toBe('write');
+        expect(cmd.siteSession).toBe('persistent');
+        expect(cmd.navigateBefore).toBe(false);
+    });
+
+    it('sends and reports the verified comment', async () => {
+        const page = makeSendPage();
+        const rows = await getCommand().func(page, { 'room-url': ROOM_URL, text: '666' });
+        expect(rows).toEqual([{ status: 'sent', room_id: '570440812909234340', msg: '666', comment_id: 'c9' }]);
+        expect(page.goto).toHaveBeenCalledWith(ROOM_URL);
+    });
+
+    it('rejects empty or over-long text before navigation', async () => {
+        const page = makeSendPage();
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: '   ' })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: 'x'.repeat(201) })).rejects.toMatchObject({ code: 'ARGUMENT' });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('fails typed when the comment box is missing (logged out / room ended)', async () => {
+        const page = makeSendPage({ prepare: { ok: false, reason: 'no_input_box' } });
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: '666' }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('no_input_box') });
+    });
+
+    it('fails when the typed content does not match before sending (never sends garbled input)', async () => {
+        const page = makeSendPage({ prepare: { ok: true, content: '66', sendVisible: true } });
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: '666' }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('mismatch') });
+        expect(page.evaluate.mock.calls.every(([s]) => !String(s).includes('__send_click'))).toBe(true);
+    });
+
+    it('fails when the postcondition never confirms the comment landed', async () => {
+        const page = makeSendPage({ verify: { sent: false, cleared: false } });
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, text: '666' }))
+            .rejects.toMatchObject({ code: 'COMMAND_EXEC', message: expect.stringContaining('not confirmed') });
+    });
+});

--- a/clis/xiaohongshu/live-comments.js
+++ b/clis/xiaohongshu/live-comments.js
@@ -1,0 +1,159 @@
+/**
+ * Xiaohongshu live-comments — capture the comment stream of a live room.
+ *
+ * Architecture (the MutationObserverWatcher pattern from
+ * DimensionDev/Holoflows-Kit, re-implemented clean-room — that library is
+ * AGPL-3.0 and OpenCLI is Apache-2.0, so the pattern is adopted, not the
+ * code): an in-page watcher installed once per room observes the chat area
+ * with a MutationObserver; each DOM mutation triggers a merge of the
+ * structured `__INITIAL_STATE__.liveStream.comments` store (msg, nickName,
+ * userId, commentId, fansGroup, ...) into a capped buffer, deduped by
+ * commentId. The DOM is only the trigger — the store is the data source, so
+ * rows carry full metadata instead of scraped text.
+ *
+ * The watcher lives on the persistent site tab ACROSS CLI invocations:
+ * install once, then repeated `--duration 0` calls drain only what arrived
+ * since the last call — a streaming loop out of one-shot commands, with
+ * nothing lost between calls even when the page's own comment window slides.
+ * This command therefore navigates with a PLAIN goto: the extension's
+ * same-URL fast-path is what keeps the installed watcher alive. Running
+ * other xiaohongshu commands in between navigates the shared tab away and
+ * resets the watcher — keep a comment-capture loop on its own profile, or
+ * accept a fresh install on the next call.
+ */
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { unwrapEvaluateResult } from './shared.js';
+
+const MAX_DURATION_S = 60;
+const BUFFER_CAP = 2000;
+const SEEN_CAP = 10000;
+
+export function buildLiveWatcherInstallJs() {
+    return `
+    (() => {
+      if (window.__opencli_live_watch?.installed) return { installed: true, fresh: false };
+      const state = { installed: true, buf: [], seen: new Set() };
+      const readStore = () => {
+        const ls = window.__INITIAL_STATE__?.liveStream;
+        const raw = ls?.comments?._value ?? ls?.comments;
+        return Array.isArray(raw) ? raw : [];
+      };
+      const merge = () => {
+        for (const c of readStore()) {
+          const id = String(c?.commentId ?? '');
+          if (!id || state.seen.has(id)) continue;
+          state.seen.add(id);
+          try { state.buf.push(JSON.parse(JSON.stringify(c))); } catch { continue; }
+          if (state.buf.length > ${BUFFER_CAP}) state.buf.shift();
+        }
+        if (state.seen.size > ${SEEN_CAP}) state.seen = new Set([...state.seen].slice(-${SEEN_CAP / 2}));
+      };
+      merge();
+      const area = document.querySelector('.live-chat')
+        ?? document.querySelector('[class*="chat-area"]')
+        ?? document.body;
+      const observer = new MutationObserver(merge);
+      observer.observe(area, { childList: true, subtree: true });
+      state.observer = observer;
+      window.__opencli_live_watch = state;
+      return { installed: true, fresh: true };
+    })()
+  `;
+}
+
+export function buildLiveWatcherDrainJs() {
+    return `
+    (() => {
+      const state = window.__opencli_live_watch;
+      if (!state?.installed) return { installed: false, items: [] };
+      return { installed: true, items: state.buf.splice(0, state.buf.length) };
+    })()
+  `;
+}
+
+function parseRoomUrl(raw) {
+    const input = String(raw ?? '').trim();
+    if (/^\d{6,}$/.test(input)) {
+        return `https://www.xiaohongshu.com/livestream/${input}`;
+    }
+    let parsed;
+    try {
+        parsed = new URL(input);
+    }
+    catch {
+        throw new ArgumentError('room-url must be a numeric room id or a full https://www.xiaohongshu.com/livestream/... URL');
+    }
+    if (parsed.hostname !== 'www.xiaohongshu.com' || !/^\/livestream\/\d+/.test(parsed.pathname)) {
+        throw new ArgumentError('room-url must point at www.xiaohongshu.com/livestream/<room_id>', 'Use a room URL from `xiaohongshu lives` or the live list page.');
+    }
+    return parsed.toString();
+}
+
+function parseDuration(raw) {
+    const parsed = Number(raw ?? 15);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0 || parsed > MAX_DURATION_S) {
+        throw new ArgumentError(`--duration must be an integer between 0 and ${MAX_DURATION_S} seconds, got ${JSON.stringify(raw)}`, '0 drains whatever accumulated since the previous call.');
+    }
+    return parsed;
+}
+
+export const command = cli({
+    site: 'xiaohongshu',
+    name: 'live-comments',
+    access: 'read',
+    description: '采集小红书直播间评论流（页内 MutationObserver 持续捕获，跨调用不丢）',
+    domain: 'www.xiaohongshu.com',
+    strategy: Strategy.COOKIE,
+    browser: true,
+    navigateBefore: false,
+    siteSession: 'persistent',
+    args: [
+        { name: 'room-url', required: true, positional: true, help: 'Room URL from `xiaohongshu lives` (or a bare numeric room id)' },
+        { name: 'duration', type: 'int', default: 15, help: `Seconds to collect before draining (0-${MAX_DURATION_S}; 0 = drain what accumulated since the last call)` },
+        { name: 'limit', type: 'int', default: 200, help: 'Maximum comments to return' },
+    ],
+    columns: ['seq', 'nickname', 'user_id', 'msg', 'comment_type', 'fans_group', 'comment_id'],
+    func: async (page, kwargs) => {
+        const url = parseRoomUrl(kwargs['room-url']);
+        const duration = parseDuration(kwargs.duration);
+        const limit = Math.max(1, Number(kwargs.limit ?? 200));
+        // Plain goto on purpose: a warm tab already in this room fast-paths
+        // without reloading, which keeps the installed watcher (and its
+        // dedupe state) alive across CLI invocations.
+        await page.goto(url);
+        await page.wait({ time: 2 });
+        const install = unwrapEvaluateResult(await page.evaluate(buildLiveWatcherInstallJs()));
+        if (!install || typeof install !== 'object' || install.installed !== true) {
+            throw new CommandExecutionError('xiaohongshu live-comments: failed to install the in-page comment watcher');
+        }
+        if (duration > 0) {
+            await page.wait({ time: duration });
+        }
+        const drained = unwrapEvaluateResult(await page.evaluate(buildLiveWatcherDrainJs()));
+        if (!drained || typeof drained !== 'object' || !Array.isArray(drained.items)) {
+            throw new CommandExecutionError('xiaohongshu live-comments: watcher drain returned a malformed payload');
+        }
+        const rows = drained.items
+            .filter((item) => item && typeof item === 'object' && item.commentId)
+            .slice(0, limit)
+            .map((item, index) => ({
+            seq: index + 1,
+            nickname: String(item.nickName ?? ''),
+            user_id: String(item.userId ?? ''),
+            msg: String(item.msg ?? ''),
+            comment_type: Number(item.commentType ?? 0),
+            fans_group: String(item.fansGroup?.groupName ?? ''),
+            comment_id: String(item.commentId),
+        }));
+        if (rows.length === 0) {
+            if (duration === 0 && install.fresh === true) {
+                throw new EmptyResultError('xiaohongshu live-comments', 'The watcher was freshly installed on this call (the tab had navigated away or this is the first call for this room) — nothing was buffered yet. Call again to drain from here on.');
+            }
+            throw new EmptyResultError('xiaohongshu live-comments', duration > 0
+                ? `No comments arrived within ${duration}s — the room may be quiet or the stream ended.`
+                : 'The watcher stayed alive but nothing new arrived since the previous drain.');
+        }
+        return rows;
+    },
+});

--- a/clis/xiaohongshu/live-comments.js
+++ b/clis/xiaohongshu/live-comments.js
@@ -72,7 +72,7 @@ export function buildLiveWatcherDrainJs() {
   `;
 }
 
-function parseRoomUrl(raw) {
+export function parseRoomUrl(raw) {
     const input = String(raw ?? '').trim();
     if (/^\d{6,}$/.test(input)) {
         return `https://www.xiaohongshu.com/livestream/${input}`;

--- a/clis/xiaohongshu/live-comments.js
+++ b/clis/xiaohongshu/live-comments.js
@@ -4,12 +4,15 @@
  * Architecture (the MutationObserverWatcher pattern from
  * DimensionDev/Holoflows-Kit, re-implemented clean-room — that library is
  * AGPL-3.0 and OpenCLI is Apache-2.0, so the pattern is adopted, not the
- * code): an in-page watcher installed once per room observes the chat area
- * with a MutationObserver; each DOM mutation triggers a merge of the
- * structured `__INITIAL_STATE__.liveStream.comments` store (msg, nickName,
- * userId, commentId, fansGroup, ...) into a capped buffer, deduped by
- * commentId. The DOM is only the trigger — the store is the data source, so
- * rows carry full metadata instead of scraped text.
+ * code): an in-page watcher observes document.body with a MutationObserver
+ * and captures every `.virtual-list-item` chat node exactly once (WeakSet on
+ * node identity — identical repeated texts stay distinct events). The DOM is
+ * the data source ON PURPOSE: `__INITIAL_STATE__.liveStream.comments` looks
+ * richer (userId/commentId) but holds only the SSR-initial batch plus local
+ * echoes of the viewer's own sends — crowd comments stream over WebSocket
+ * straight into the DOM and never touch that store (verified live in a
+ * 1600-viewer room: the store stayed frozen while chat flowed). Items are
+ * classified by shape: chat / enter ("XX 来了") / like / notice.
  *
  * The watcher lives on the persistent site tab ACROSS CLI invocations:
  * install once, then repeated `--duration 0` calls drain only what arrived
@@ -27,35 +30,51 @@ import { unwrapEvaluateResult } from './shared.js';
 
 const MAX_DURATION_S = 60;
 const BUFFER_CAP = 2000;
-const SEEN_CAP = 10000;
+const WATCHER_VERSION = 3;
 
 export function buildLiveWatcherInstallJs() {
     return `
     (() => {
-      if (window.__opencli_live_watch?.installed) return { installed: true, fresh: false };
-      const state = { installed: true, buf: [], seen: new Set() };
-      const readStore = () => {
-        const ls = window.__INITIAL_STATE__?.liveStream;
-        const raw = ls?.comments?._value ?? ls?.comments;
-        return Array.isArray(raw) ? raw : [];
-      };
-      const merge = () => {
-        for (const c of readStore()) {
-          const id = String(c?.commentId ?? '');
-          if (!id || state.seen.has(id)) continue;
-          state.seen.add(id);
-          try { state.buf.push(JSON.parse(JSON.stringify(c))); } catch { continue; }
-          if (state.buf.length > ${BUFFER_CAP}) state.buf.shift();
+      const existing = window.__opencli_live_watch;
+      if (existing?.installed && existing.v === ${WATCHER_VERSION}) return { installed: true, fresh: false };
+      try { existing?.observer?.disconnect?.(); } catch { /* replace anyway */ }
+      const state = { installed: true, v: ${WATCHER_VERSION}, buf: [], seen: new WeakSet() };
+      const extract = (item) => {
+        if (item.querySelector('.risk-text')) {
+          const text = (item.textContent || '').replace(/\s+/g, ' ').replace(/^通知\s*/, '').trim();
+          return { kind: 'notice', nickname: '', msg: text };
         }
-        if (state.seen.size > ${SEEN_CAP}) state.seen = new Set([...state.seen].slice(-${SEEN_CAP / 2}));
+        const nickEl = item.querySelector('.nickname');
+        const contentEl = item.querySelector('.msg-content') ?? item;
+        const nickname = (nickEl?.textContent || '').trim();
+        let msg = '';
+        for (const node of contentEl.childNodes) {
+          if (nickEl && (node === nickEl || (node.nodeType === 1 && node.contains(nickEl)))) continue;
+          msg += node.textContent ?? '';
+        }
+        msg = msg.replace(/\s+/g, ' ').trim();
+        const kind = msg === '来了' ? 'enter' : msg === '为主播点赞了' ? 'like' : 'chat';
+        return { kind, nickname, msg };
       };
-      merge();
-      const area = document.querySelector('.live-chat')
-        ?? document.querySelector('[class*="chat-area"]')
-        ?? document.body;
-      const observer = new MutationObserver(merge);
-      observer.observe(area, { childList: true, subtree: true });
+      const capture = (item) => {
+        if (state.seen.has(item)) return;
+        state.seen.add(item);
+        const row = extract(item);
+        if (!row.msg && !row.nickname) return;
+        state.buf.push(row);
+        if (state.buf.length > ${BUFFER_CAP}) state.buf.shift();
+      };
+      const sweep = () => {
+        for (const item of document.querySelectorAll('.virtual-list-item')) capture(item);
+      };
+      sweep();
+      // Observe document.body, not the chat container: the SPA tears down and
+      // recreates the chat node on re-renders, which silently kills an
+      // observer attached to it (seen live). body is never replaced.
+      const observer = new MutationObserver(sweep);
+      observer.observe(document.body, { childList: true, subtree: true });
       state.observer = observer;
+      state.sweep = sweep;
       window.__opencli_live_watch = state;
       return { installed: true, fresh: true };
     })()
@@ -67,6 +86,8 @@ export function buildLiveWatcherDrainJs() {
     (() => {
       const state = window.__opencli_live_watch;
       if (!state?.installed) return { installed: false, items: [] };
+      // Final sweep: items rendered without a caught mutation are never lost.
+      try { state.sweep?.(); } catch { /* drain what we have */ }
       return { installed: true, items: state.buf.splice(0, state.buf.length) };
     })()
   `;
@@ -113,7 +134,7 @@ export const command = cli({
         { name: 'duration', type: 'int', default: 15, help: `Seconds to collect before draining (0-${MAX_DURATION_S}; 0 = drain what accumulated since the last call)` },
         { name: 'limit', type: 'int', default: 200, help: 'Maximum comments to return' },
     ],
-    columns: ['seq', 'nickname', 'user_id', 'msg', 'comment_type', 'fans_group', 'comment_id'],
+    columns: ['seq', 'kind', 'nickname', 'msg'],
     func: async (page, kwargs) => {
         const url = parseRoomUrl(kwargs['room-url']);
         const duration = parseDuration(kwargs.duration);
@@ -135,16 +156,13 @@ export const command = cli({
             throw new CommandExecutionError('xiaohongshu live-comments: watcher drain returned a malformed payload');
         }
         const rows = drained.items
-            .filter((item) => item && typeof item === 'object' && item.commentId)
+            .filter((item) => item && typeof item === 'object' && (item.msg || item.nickname))
             .slice(0, limit)
             .map((item, index) => ({
             seq: index + 1,
-            nickname: String(item.nickName ?? ''),
-            user_id: String(item.userId ?? ''),
+            kind: String(item.kind ?? 'chat'),
+            nickname: String(item.nickname ?? ''),
             msg: String(item.msg ?? ''),
-            comment_type: Number(item.commentType ?? 0),
-            fans_group: String(item.fansGroup?.groupName ?? ''),
-            comment_id: String(item.commentId),
         }));
         if (rows.length === 0) {
             if (duration === 0 && install.fresh === true) {

--- a/clis/xiaohongshu/live-comments.test.js
+++ b/clis/xiaohongshu/live-comments.test.js
@@ -34,39 +34,113 @@ function makeRoomDom(initialComments) {
     return { win, run, touchChat };
 }
 
-describe('live-comments in-page watcher (real MutationObserver in JSDOM)', () => {
-    it('captures the initial store snapshot on install and drains it once', async () => {
-        const { run } = makeRoomDom([comment('c1', '这个咖啡机怎么卖')]);
+describe('live-comments in-page watcher v3 (DOM-sourced, real MutationObserver in JSDOM)', () => {
+    function chatItem(doc, nickname, msg, { notice = false } = {}) {
+        const item = doc.createElement('div');
+        item.className = 'virtual-list-item';
+        if (notice) {
+            item.innerHTML = '<div class="risk-text"><div class="risk-item"><span class="risk-tip">通知</span>' + msg + '</div></div>';
+            return item;
+        }
+        const wrapper = doc.createElement('div');
+        wrapper.className = 'msg-wrapper';
+        const content = doc.createElement('div');
+        content.className = 'msg-content';
+        const nick = doc.createElement('span');
+        nick.className = 'nickname';
+        nick.textContent = nickname;
+        content.appendChild(nick);
+        content.appendChild(doc.createTextNode(' ' + msg));
+        wrapper.appendChild(content);
+        item.appendChild(wrapper);
+        return item;
+    }
+
+    function makeRoom(initial = []) {
+        const dom = new JSDOM('<div class="live-chat"><div class="virtual-list"></div></div>', {
+            url: 'https://www.xiaohongshu.com/livestream/1',
+        });
+        const win = dom.window;
+        const list = win.document.querySelector('.virtual-list');
+        for (const [nick, msg, opts] of initial) list.appendChild(chatItem(win.document, nick, msg, opts));
+        const run = (script) => Function('window', 'document', 'MutationObserver', `return (${script})`)(
+            win, win.document, win.MutationObserver,
+        );
+        const addComment = async (nick, msg, opts) => {
+            list.appendChild(chatItem(win.document, nick, msg, opts));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        };
+        return { win, run, addComment };
+    }
+
+    it('captures the initial chat items on install and drains them once', () => {
+        const { run } = makeRoom([['晶晶', '这个咖啡机怎么卖']]);
         expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: true });
         const first = run(buildLiveWatcherDrainJs());
-        expect(first.installed).toBe(true);
-        expect(first.items.map((i) => i.commentId)).toEqual(['c1']);
+        expect(first.items).toEqual([{ kind: 'chat', nickname: '晶晶', msg: '这个咖啡机怎么卖' }]);
         expect(run(buildLiveWatcherDrainJs()).items).toEqual([]);
     });
 
-    it('merges new store comments when the chat DOM mutates, deduped by commentId', async () => {
-        const { win, run, touchChat } = makeRoomDom([comment('c1', 'a')]);
+    it('captures comments appended after install — including identical repeated texts', async () => {
+        const { run, addComment } = makeRoom();
         run(buildLiveWatcherInstallJs());
-        run(buildLiveWatcherDrainJs());
-        // Virtual-list style churn: the store window slides, old + new coexist.
-        win.__INITIAL_STATE__.liveStream.comments._value = [comment('c1', 'a'), comment('c2', 'b')];
-        await touchChat();
+        await addComment('甲', '666');
+        await addComment('乙', '666');
+        await addComment('甲', '666');
         const drained = run(buildLiveWatcherDrainJs());
-        expect(drained.items.map((i) => i.commentId)).toEqual(['c2']);
+        expect(drained.items.map((i) => i.nickname + ':' + i.msg)).toEqual(['甲:666', '乙:666', '甲:666']);
     });
 
-    it('is idempotent: a second install keeps the buffer and reports fresh=false', async () => {
-        const { win, run, touchChat } = makeRoomDom([comment('c1', 'a')]);
+    it('classifies enter/like/notice events', async () => {
+        const { run, addComment } = makeRoom();
         run(buildLiveWatcherInstallJs());
-        win.__INITIAL_STATE__.liveStream.comments._value = [comment('c2', 'b')];
-        await touchChat();
-        expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: false });
+        await addComment('路人', '来了');
+        await addComment('小可爱', '为主播点赞了');
+        await addComment('', '平台倡导文明健康的直播环境', { notice: true });
+        await addComment('丙', '主播加油');
         const drained = run(buildLiveWatcherDrainJs());
-        expect(drained.items.map((i) => i.commentId)).toEqual(['c1', 'c2']);
+        expect(drained.items.map((i) => i.kind)).toEqual(['enter', 'like', 'notice', 'chat']);
+        expect(drained.items[3]).toEqual({ kind: 'chat', nickname: '丙', msg: '主播加油' });
+    });
+
+    it('keeps capturing after the chat container node is replaced by the SPA', async () => {
+        const { win, run } = makeRoom([['甲', 'a']]);
+        run(buildLiveWatcherInstallJs());
+        run(buildLiveWatcherDrainJs());
+        const doc = win.document;
+        doc.querySelector('.live-chat').remove();
+        const fresh = doc.createElement('div');
+        fresh.className = 'live-chat';
+        fresh.innerHTML = '<div class="virtual-list"></div>';
+        doc.body.appendChild(fresh);
+        fresh.querySelector('.virtual-list').appendChild(chatItem(doc, '乙', 'b'));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const drained = run(buildLiveWatcherDrainJs());
+        expect(drained.items).toEqual([{ kind: 'chat', nickname: '乙', msg: 'b' }]);
+    });
+
+    it('drain performs a final sweep so items rendered without a caught mutation are never missed', () => {
+        const { win, run } = makeRoom([['甲', 'a']]);
+        run(buildLiveWatcherInstallJs());
+        run(buildLiveWatcherDrainJs());
+        // Appended synchronously with no microtask yield: observer callback never ran.
+        win.document.querySelector('.virtual-list').appendChild(chatItem(win.document, '乙', 'b'));
+        const drained = run(buildLiveWatcherDrainJs());
+        expect(drained.items).toEqual([{ kind: 'chat', nickname: '乙', msg: 'b' }]);
+    });
+
+    it('is idempotent for the current version and replaces outdated watchers', () => {
+        const { win, run } = makeRoom([['甲', 'a']]);
+        run(buildLiveWatcherInstallJs());
+        expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: false });
+        win.__opencli_live_watch = { installed: true, v: 1, buf: [], observer: { disconnect: () => {} } };
+        expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: true });
+        const drained = run(buildLiveWatcherDrainJs());
+        expect(drained.items).toEqual([{ kind: 'chat', nickname: '甲', msg: 'a' }]);
     });
 
     it('drain on a page without the watcher reports installed=false', () => {
-        const { run } = makeRoomDom([]);
+        const { run } = makeRoom();
         expect(run(buildLiveWatcherDrainJs())).toEqual({ installed: false, items: [] });
     });
 });
@@ -74,7 +148,7 @@ describe('live-comments in-page watcher (real MutationObserver in JSDOM)', () =>
 describe('xiaohongshu/live-comments command', () => {
     const getCommand = () => getRegistry().get('xiaohongshu/live-comments');
 
-    function makePage({ drains = [{ installed: true, items: [comment('c1', '好优雅', 'Joce1yn')] }], fresh = true } = {}) {
+    function makePage({ drains = [{ installed: true, items: [{ kind: 'chat', nickname: 'Joce1yn', msg: '好优雅' }] }], fresh = true } = {}) {
         let drainIndex = 0;
         return {
             goto: vi.fn().mockResolvedValue(undefined),
@@ -106,15 +180,7 @@ describe('xiaohongshu/live-comments command', () => {
     it('maps drained comments into rows', async () => {
         const page = makePage();
         const rows = await getCommand().func(page, { 'room-url': ROOM_URL, duration: 0 });
-        expect(rows).toEqual([{
-            seq: 1,
-            nickname: 'Joce1yn',
-            user_id: 'u-c1',
-            msg: '好优雅',
-            comment_type: 0,
-            fans_group: '毛毛拖鞋',
-            comment_id: 'c1',
-        }]);
+        expect(rows).toEqual([{ seq: 1, kind: 'chat', nickname: 'Joce1yn', msg: '好优雅' }]);
     });
 
     it('waits out --duration before draining', async () => {

--- a/clis/xiaohongshu/live-comments.test.js
+++ b/clis/xiaohongshu/live-comments.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { buildLiveWatcherDrainJs, buildLiveWatcherInstallJs } from './live-comments.js';
+import './live-comments.js';
+
+const ROOM_URL = 'https://www.xiaohongshu.com/livestream/570440812909234340?xsec_token=ABtok';
+
+function comment(id, msg, nick = '晶晶') {
+    return {
+        commentId: id,
+        msg,
+        nickName: nick,
+        userId: `u-${id}`,
+        commentType: 0,
+        avatar: 'https://a/b.jpg',
+        fansGroup: { groupName: '毛毛拖鞋', groupLevel: 2 },
+    };
+}
+
+function makeRoomDom(initialComments) {
+    const dom = new JSDOM('<div class="live-chat"><div class="virtual-list"></div></div>', {
+        url: 'https://www.xiaohongshu.com/livestream/1',
+    });
+    const win = dom.window;
+    win.__INITIAL_STATE__ = { liveStream: { comments: { _value: initialComments } } };
+    const run = (script) => Function('window', 'document', 'MutationObserver', `return (${script})`)(
+        win, win.document, win.MutationObserver,
+    );
+    const touchChat = async () => {
+        win.document.querySelector('.virtual-list').appendChild(win.document.createElement('div'));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+    return { win, run, touchChat };
+}
+
+describe('live-comments in-page watcher (real MutationObserver in JSDOM)', () => {
+    it('captures the initial store snapshot on install and drains it once', async () => {
+        const { run } = makeRoomDom([comment('c1', '这个咖啡机怎么卖')]);
+        expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: true });
+        const first = run(buildLiveWatcherDrainJs());
+        expect(first.installed).toBe(true);
+        expect(first.items.map((i) => i.commentId)).toEqual(['c1']);
+        expect(run(buildLiveWatcherDrainJs()).items).toEqual([]);
+    });
+
+    it('merges new store comments when the chat DOM mutates, deduped by commentId', async () => {
+        const { win, run, touchChat } = makeRoomDom([comment('c1', 'a')]);
+        run(buildLiveWatcherInstallJs());
+        run(buildLiveWatcherDrainJs());
+        // Virtual-list style churn: the store window slides, old + new coexist.
+        win.__INITIAL_STATE__.liveStream.comments._value = [comment('c1', 'a'), comment('c2', 'b')];
+        await touchChat();
+        const drained = run(buildLiveWatcherDrainJs());
+        expect(drained.items.map((i) => i.commentId)).toEqual(['c2']);
+    });
+
+    it('is idempotent: a second install keeps the buffer and reports fresh=false', async () => {
+        const { win, run, touchChat } = makeRoomDom([comment('c1', 'a')]);
+        run(buildLiveWatcherInstallJs());
+        win.__INITIAL_STATE__.liveStream.comments._value = [comment('c2', 'b')];
+        await touchChat();
+        expect(run(buildLiveWatcherInstallJs())).toEqual({ installed: true, fresh: false });
+        const drained = run(buildLiveWatcherDrainJs());
+        expect(drained.items.map((i) => i.commentId)).toEqual(['c1', 'c2']);
+    });
+
+    it('drain on a page without the watcher reports installed=false', () => {
+        const { run } = makeRoomDom([]);
+        expect(run(buildLiveWatcherDrainJs())).toEqual({ installed: false, items: [] });
+    });
+});
+
+describe('xiaohongshu/live-comments command', () => {
+    const getCommand = () => getRegistry().get('xiaohongshu/live-comments');
+
+    function makePage({ drains = [{ installed: true, items: [comment('c1', '好优雅', 'Joce1yn')] }], fresh = true } = {}) {
+        let drainIndex = 0;
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                const s = String(script);
+                if (s.includes('splice')) return drains[Math.min(drainIndex++, drains.length - 1)];
+                if (s.includes('__opencli_live_watch')) return { installed: true, fresh };
+                throw new Error(`unexpected script: ${s.slice(0, 40)}`);
+            }),
+        };
+    }
+
+    it('registers persistent with adapter-owned navigation', () => {
+        const cmd = getCommand();
+        expect(cmd).toBeDefined();
+        expect(cmd.navigateBefore).toBe(false);
+        expect(cmd.siteSession).toBe('persistent');
+    });
+
+    it('navigates with a PLAIN goto so a warm tab keeps the installed watcher', async () => {
+        const page = makePage();
+        page.getCurrentUrl = vi.fn().mockResolvedValue(ROOM_URL);
+        await getCommand().func(page, { 'room-url': ROOM_URL, duration: 0 });
+        expect(page.goto).toHaveBeenCalledWith(ROOM_URL);
+        expect(page.evaluate).not.toHaveBeenCalledWith('location.reload()');
+    });
+
+    it('maps drained comments into rows', async () => {
+        const page = makePage();
+        const rows = await getCommand().func(page, { 'room-url': ROOM_URL, duration: 0 });
+        expect(rows).toEqual([{
+            seq: 1,
+            nickname: 'Joce1yn',
+            user_id: 'u-c1',
+            msg: '好优雅',
+            comment_type: 0,
+            fans_group: '毛毛拖鞋',
+            comment_id: 'c1',
+        }]);
+    });
+
+    it('waits out --duration before draining', async () => {
+        const page = makePage();
+        await getCommand().func(page, { 'room-url': ROOM_URL, duration: 10 });
+        const waited = page.wait.mock.calls.reduce((sum, [arg]) => sum + (arg?.time ?? arg ?? 0), 0);
+        expect(waited).toBeGreaterThanOrEqual(10);
+    });
+
+    it('rejects durations beyond the command timeout budget', async () => {
+        const page = makePage();
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, duration: 999 }))
+            .rejects.toMatchObject({ code: 'ARGUMENT' });
+    });
+
+    it('accepts a bare room id', async () => {
+        const page = makePage();
+        await getCommand().func(page, { 'room-url': '570440812909234340', duration: 0 });
+        expect(page.goto).toHaveBeenCalledWith('https://www.xiaohongshu.com/livestream/570440812909234340');
+    });
+
+    it('throws EMPTY_RESULT when nothing new arrived', async () => {
+        const page = makePage({ drains: [{ installed: true, items: [] }] });
+        await expect(getCommand().func(page, { 'room-url': ROOM_URL, duration: 0 }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT' });
+    });
+});
+
+describe('xiaohongshu/live-comments empty-drain diagnostics', () => {
+    const getCommand = () => getRegistry().get('xiaohongshu/live-comments');
+    function makeEmptyPage(fresh) {
+        return {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async (script) => {
+                const s = String(script);
+                if (s.includes('splice')) return { installed: true, items: [] };
+                if (s.includes('__opencli_live_watch')) return { installed: true, fresh };
+                throw new Error('unexpected script');
+            }),
+        };
+    }
+
+    it('tells the caller when an empty drain is due to a fresh install (watcher was lost)', async () => {
+        await expect(getCommand().func(makeEmptyPage(true), { 'room-url': ROOM_URL, duration: 0 }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('freshly installed') });
+    });
+
+    it('tells the caller when the watcher survived but nothing new arrived', async () => {
+        await expect(getCommand().func(makeEmptyPage(false), { 'room-url': ROOM_URL, duration: 0 }))
+            .rejects.toMatchObject({ code: 'EMPTY_RESULT', hint: expect.stringContaining('stayed alive') });
+    });
+});

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -11,6 +11,7 @@
 | `opencli xiaohongshu note` | Read full note content (title, author, description, likes, collects, comments, tags) |
 | `opencli xiaohongshu comments` | Read comments from a note (`--with-replies` for nested 楼中楼 replies) |
 | `opencli xiaohongshu feed` | Home feed recommendations (reads the hydrated Pinia store; URLs carry `xsec_token` for drill-down) |
+| `opencli xiaohongshu live-comments` | Capture a live room's comment stream (in-page MutationObserver watcher survives across calls; `--duration 0` drains since last call) |
 | `opencli xiaohongshu notifications` | User notifications (mentions, likes, connections) |
 | `opencli xiaohongshu user` | Get public notes from a user profile |
 | `opencli xiaohongshu saved` | List saved/collected notes (`/user/profile/<id>?tab=fav&subTab=note`) |

--- a/docs/adapters/browser/xiaohongshu.md
+++ b/docs/adapters/browser/xiaohongshu.md
@@ -12,6 +12,8 @@
 | `opencli xiaohongshu comments` | Read comments from a note (`--with-replies` for nested 楼中楼 replies) |
 | `opencli xiaohongshu feed` | Home feed recommendations (reads the hydrated Pinia store; URLs carry `xsec_token` for drill-down) |
 | `opencli xiaohongshu live-comments` | Capture a live room's comment stream (in-page MutationObserver watcher survives across calls; `--duration 0` drains since last call) |
+| `opencli xiaohongshu live-comment-send` | Post a comment into a live room (verified by input clearing + the comment appearing in the stream) |
+| `opencli xiaohongshu live-comment-send` | Post a comment into a live room (verified by input clearing + the comment appearing in the stream) |
 | `opencli xiaohongshu notifications` | User notifications (mentions, likes, connections) |
 | `opencli xiaohongshu user` | Get public notes from a user profile |
 | `opencli xiaohongshu saved` | List saved/collected notes (`/user/profile/<id>?tab=fav&subTab=note`) |


### PR DESCRIPTION
> **Standalone** — based on `main`, no dependency on the other open PRs. Companion to #2471 (`lives`, which discovers rooms); works independently of it.

## What

Two commands covering a live room's comment surface:

- **`xiaohongshu live-comments <room-url> [--duration N]`** captures the room's event stream — `kind` (`chat` / `enter` / `like` / `notice`), `nickname`, `msg`. The streaming loop: `--duration N` collects for N seconds; **`--duration 0` drains exactly what arrived since the previous call**, because the in-page watcher survives on the persistent site tab across CLI invocations. A caller loops one-shot commands and misses nothing.
- **`xiaohongshu live-comment-send <room-url> <text>`** posts a comment by driving the web composer, refusing to click send unless the box shows *exactly* the requested text, and confirming success with DOM-primary evidence: the input cleared **and** the viewer's *own nickname* + exact text rendered in chat (someone else posting the same text never confirms; a store echo, when present, additionally supplies the server `comment_id`).

## Architecture — and why the DOM is the data source

The watcher is the MutationObserverWatcher pattern from [DimensionDev/Holoflows-Kit](https://github.com/DimensionDev/holoflows-kit), re-implemented clean-room (AGPL-3.0 vs this repo's Apache-2.0 — the pattern is adopted, not the code), fused with this repo's install-hook idiom: an idempotent, **versioned** in-page IIFE observes `document.body` and captures every `.virtual-list-item` chat node exactly once via a **WeakSet on node identity** — so identical repeated texts stay distinct events, with no external id needed.

The DOM being the source is a *finding*, not a shortcut: `__INITIAL_STATE__.liveStream.comments` looks richer (userId/commentId per entry) but holds only the SSR-initial batch plus occasional local echoes of the viewer's own sends — **crowd comments stream over WebSocket straight into the DOM and never touch that store**. Measured in a 1600-viewer room: the store stayed frozen at 5 entries while the chat DOM appended 15 nodes in 12 seconds. A store-based v1 of this PR captured the initial batch and then nothing (and gave `live-comment-send` a false-negative postcondition — a send it reported as failed was visible in chat). Round-trip testing — send a comment, then require it to reappear through our own watcher — falsified that design and produced this one.

Robustness details, each regression-tested: observe `document.body` (the SPA tears down and recreates the chat container, silently killing an observer attached to it); a final sweep on drain so items rendered without a caught mutation are never lost; a versioned watcher state so outdated in-page instances are replaced, not kept; empty drains are diagnosable ("watcher stayed alive, room quiet" vs "freshly installed — the tab had navigated away"). The commands navigate with a *plain* goto on purpose: the extension's same-URL fast-path is what keeps the watcher alive between invocations.

## Verification

- TDD throughout: 32 unit tests, including **real-MutationObserver JSDOM behavioral suites** for both the watcher (initial sweep, append capture with repeated identical texts, kind classification, chat-container replacement survival, drain final-sweep, version upgrade) and the send verification (DOM-primary confirm, store-echo id attachment, same-text-by-someone-else never confirms, uncleared box never confirms). Full suite 7342 green; typecheck and both lint gates clean; manifest + doc rows updated.
- Live, in rooms of 170–1660 viewers, with the account owner's explicit approval for the write path: 24 crowd events captured in 10s (kinds classified); a `--duration 0` drain returned comments buffered between invocations; full loop closed — a sent comment (`主播加油`) confirmed by the command and then drained back through our own watcher among 31 crowd events.

Recon context (FLV endpoints, the frozen-store finding, goods shelf being App-only on web) is documented in the umbrella issue #2470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
