### PR TITLE
fix(xiaohongshu): emit xsec_source=pc_share instead of an empty value in signed note URLs

### DIFF
--- a/clis/xiaohongshu/ask.js
+++ b/clis/xiaohongshu/ask.js
@@ -146,7 +146,7 @@ export function buildNoteUrl(noteId, xsecToken) {
     const url = new URL(`https://${XHS_WEB_HOST}/explore/${noteId}`);
     if (xsecToken) {
         url.searchParams.set('xsec_token', xsecToken);
-        url.searchParams.set('xsec_source', '');
+        url.searchParams.set('xsec_source', 'pc_share');
     }
     return url.toString();
 }

--- a/clis/xiaohongshu/ask.test.js
+++ b/clis/xiaohongshu/ask.test.js
@@ -70,7 +70,7 @@ describe('xiaohongshu ask', () => {
             rank: 1,
             type: 'note',
             title: '新手露营有哪些建议？',
-            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=tok+123&xsec_source=',
+            url: 'https://www.xiaohongshu.com/explore/69d6fc08000000001f007646?xsec_token=tok+123&xsec_source=pc_share',
             note_id: '69d6fc08000000001f007646',
             xsec_token: 'tok 123',
             author: '郑小喜',

--- a/clis/xiaohongshu/feed.js
+++ b/clis/xiaohongshu/feed.js
@@ -74,10 +74,11 @@ function toCleanString(value) {
  * Build a signed note URL for the given web host. Falls back to the bare
  * /explore/{id} URL when the caller intentionally passes no token.
  *
- * The `xsec_source` param mirrors what XHS itself renders into feed-page note
- * links: an empty value. Only `xsec_token` is actually required by the note
- * detail endpoint (verified: the source value is not validated), so we
- * reproduce the real-world shape rather than inventing a source label.
+ * `xsec_source` must carry a real context label — an empty value is an
+ * anomalous shape no official surface produces and interacts badly with
+ * token validation / risk control. `pc_share` is the generic web share
+ * context that validates across consumers (profile-context builders in this
+ * adapter use `pc_user` for the same reason).
  */
 export function buildFeedNoteUrl(webHost, id, xsecToken) {
     const cleanId = toCleanString(id);
@@ -86,7 +87,7 @@ export function buildFeedNoteUrl(webHost, id, xsecToken) {
     if (!cleanToken)
         return url.toString();
     url.searchParams.set('xsec_token', cleanToken);
-    url.searchParams.set('xsec_source', '');
+    url.searchParams.set('xsec_source', 'pc_share');
     return url.toString();
 }
 

--- a/clis/xiaohongshu/feed.test.js
+++ b/clis/xiaohongshu/feed.test.js
@@ -30,9 +30,9 @@ function entry(id, overrides = {}) {
 }
 
 describe('xiaohongshu/feed buildFeedNoteUrl', () => {
-    it('appends xsec_token and an empty xsec_source when a token is present', () => {
+    it('appends xsec_token and xsec_source=pc_share when a token is present', () => {
         expect(buildFeedNoteUrl(HOST, 'abc123', 'TOK')).toBe(
-            `https://${HOST}/explore/abc123?xsec_token=TOK&xsec_source=`,
+            `https://${HOST}/explore/abc123?xsec_token=TOK&xsec_source=pc_share`,
         );
     });
 
@@ -42,7 +42,7 @@ describe('xiaohongshu/feed buildFeedNoteUrl', () => {
 
     it('URL-encodes xsec_token instead of interpolating raw query text', () => {
         expect(buildFeedNoteUrl(HOST, 'abc123', 'a&b=c d')).toBe(
-            `https://${HOST}/explore/abc123?xsec_token=a%26b%3Dc+d&xsec_source=`,
+            `https://${HOST}/explore/abc123?xsec_token=a%26b%3Dc+d&xsec_source=pc_share`,
         );
     });
 });
@@ -58,15 +58,15 @@ describe('xiaohongshu/feed func', () => {
         const page = createPageMock({ items: [entry('id1'), entry('id2')] });
         const rows = await feed.func(page, { limit: 20 });
         expect(rows).toEqual([
-            { id: 'id1', title: 'title-id1', type: 'normal', author: 'author-id1', likes: '100', url: `https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=` },
-            { id: 'id2', title: 'title-id2', type: 'normal', author: 'author-id2', likes: '100', url: `https://${HOST}/explore/id2?xsec_token=tok-id2&xsec_source=` },
+            { id: 'id1', title: 'title-id1', type: 'normal', author: 'author-id1', likes: '100', url: `https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=pc_share` },
+            { id: 'id2', title: 'title-id2', type: 'normal', author: 'author-id2', likes: '100', url: `https://${HOST}/explore/id2?xsec_token=tok-id2&xsec_source=pc_share` },
         ]);
     });
 
     it('unwraps Browser Bridge evaluate envelopes', async () => {
         const page = createPageMock({ session: { id: 's1' }, data: { items: [entry('id1')] } });
         const rows = await feed.func(page, { limit: 20 });
-        expect(rows[0].url).toBe(`https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=`);
+        expect(rows[0].url).toBe(`https://${HOST}/explore/id1?xsec_token=tok-id1&xsec_source=pc_share`);
     });
 
     it('typed-fails when a feed entry is missing its note token', async () => {


### PR DESCRIPTION
`buildFeedNoteUrl` (shared with the rednote adapter) and `ask`'s citation URL builder emitted `xsec_source=` with an empty value, on the in-code theory that it mirrored the site's own feed links and that the value was not validated. An empty source is an anomalous shape no official surface produces and interacts badly with token validation / risk control — the signed-URL context should be labeled explicitly. This sets `pc_share` (the generic web share context), consistent with the `pc_user` label the profile-context builders in this adapter already use.

Two call sites fixed (`feed.js`, `ask.js`); the elsewhere-correct `pc_user` sites are untouched. Test expectations updated (feed/ask/rednote suites — 364 adapter tests green, full suite 7316, gates clean). Verified live: feed URLs now carry `xsec_source=pc_share` and drill-down via `xiaohongshu note` on those URLs keeps working.

Part of the xiaohongshu arc: #2470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)