### PR TITLE
fix(download): classify relative media URLs instead of throwing

### DIFF
--- a/src/download/index.test.ts
+++ b/src/download/index.test.ts
@@ -196,5 +196,15 @@ describe('video-platform host detection', () => {
 
   it('returns false for an unparseable URL instead of throwing', () => {
     expect(requiresYtdlp('not a url')).toBe(false);
+    expect(detectContentType('not a url')).toBe('binary');
+  });
+
+  it('classifies relative and protocol-relative media URLs by extension', () => {
+    // Site JSON often returns unqualified media paths; `new URL()` rejects
+    // them, so classification has to fall back to the raw path.
+    expect(detectContentType('/media/photo.jpg')).toBe('image');
+    expect(detectContentType('//cdn.example.com/clip.mp4')).toBe('video');
+    expect(detectContentType('media/notes.md?v=2')).toBe('document');
+    expect(detectContentType('/media/photo.jpg?w=320#top')).toBe('image');
   });
 });

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -75,6 +75,24 @@ function isVideoPlatformUrl(url: string): boolean {
   return VIDEO_PLATFORM_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`));
 }
 
+/**
+ * Path portion of a URL, for extension sniffing.
+ *
+ * `new URL()` throws on relative (`/media/a.jpg`) and protocol-relative
+ * (`//cdn.example.com/a.jpg`) values, which adapters hand us whenever a site's
+ * JSON returns unqualified media paths. Trimming the query and hash by hand
+ * keeps those classified by extension instead of throwing out of a caller that
+ * has no reason to expect it. Mirrors the tolerance `isVideoPlatformUrl`
+ * already has.
+ */
+function urlPathForExtension(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url.split(/[?#]/, 1)[0];
+  }
+}
+
 const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.ico', '.bmp', '.avif']);
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.avi', '.mov', '.mkv', '.flv', '.m3u8', '.ts']);
 const DOC_EXTENSIONS = new Set(['.html', '.htm', '.json', '.xml', '.txt', '.md', '.markdown']);
@@ -89,7 +107,7 @@ export function detectContentType(url: string, contentType?: string): 'image' | 
     if (contentType.startsWith('text/') || contentType.includes('json') || contentType.includes('xml')) return 'document';
   }
 
-  const ext = path.extname(new URL(url).pathname).toLowerCase();
+  const ext = path.extname(urlPathForExtension(url)).toLowerCase();
 
   if (IMAGE_EXTENSIONS.has(ext)) return 'image';
   if (VIDEO_EXTENSIONS.has(ext)) return 'video';

--- a/src/pipeline/steps/download.test.ts
+++ b/src/pipeline/steps/download.test.ts
@@ -135,4 +135,35 @@ describe('stepDownload', () => {
     );
     expect(mockYtdlpDownload).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps downloading the rest of a batch when one item has an unparseable URL', async () => {
+    mockHttpDownload.mockImplementation(async (url: string) => (
+      url.startsWith('http')
+        ? { success: true, size: 2 }
+        : { success: false, size: 0, error: 'Failed to parse URL' }
+    ));
+
+    const results = await stepDownload(
+      null,
+      {
+        url: '${{ item.url }}',
+        dir: path.join(os.tmpdir(), 'opencli-download-test'),
+        filename: '${{ index }}.jpg',
+        progress: false,
+        concurrency: 1,
+        skip_existing: false,
+      },
+      [
+        { url: '/media/photo.jpg' },
+        { url: 'https://a.example/photo.jpg' },
+      ],
+      {},
+    );
+
+    expect(mockHttpDownload).toHaveBeenCalledTimes(2);
+    expect(results).toMatchObject([
+      { _download: { status: 'failed' } },
+      { _download: { status: 'success' } },
+    ]);
+  });
 });


### PR DESCRIPTION
## Description

`detectContentType()` builds the extension it classifies on from `new URL(url).pathname` (`src/download/index.ts:92`). `new URL()` rejects a relative path like `/media/photo.jpg` and a protocol-relative one like `//cdn.example.com/clip.mp4`, so the call throws `TypeError: Invalid URL` on exactly the values adapters produce when a site's JSON returns unqualified media paths.

The pipeline download step calls it at `src/pipeline/steps/download.ts:238`, which sits above the per-item `try` block. The `TypeError` escapes the `mapConcurrent` worker and rejects the whole step, so one bad row kills every other download in the batch and the step's own `{ status: 'failed' }` result for that row is never produced. `requiresYtdlp()` sitting right next to it already tolerates unparseable URLs (there is a test for that); `detectContentType()` did not, even though the test above it calls both on the same URLs.

Extension sniffing now goes through a small `urlPathForExtension()` helper that falls back to trimming the query and hash by hand when `new URL()` rejects the input. `/media/photo.jpg` classifies as `image` and `//cdn.example.com/clip.mp4` as `video`, and a genuinely unusable URL now fails as one item (`httpDownload` reports it) instead of as the batch.

Related issue:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Screenshots / Output

Three regression tests were added. On `main` without the source change all three fail with `TypeError: Invalid URL` raised at `src/download/index.ts:92`, the pipeline one through `mapConcurrent` at `src/utils.ts:31`:

```
FAIL |unit| src/download/index.test.ts > returns false for an unparseable URL instead of throwing
FAIL |unit| src/download/index.test.ts > classifies relative and protocol-relative media URLs by extension
FAIL |unit| src/pipeline/steps/download.test.ts > keeps downloading the rest of a batch when one item has an unparseable URL
Tests  3 failed | 12 passed (15)
```

With the fix:

```
npx vitest run --project unit src/download/index.test.ts src/pipeline/steps/download.test.ts
Test Files  2 passed (2)
Tests  15 passed (15)

npx tsc --noEmit
(clean)

npm test
Test Files  631 passed (631)
Tests  7318 passed | 1 skipped (7319)

npm run check:silent-column-drop
Silent-column-drop gate: current=94, baseline=94, new=0, resolved=0

npm run check:typed-error-lint
Typed-error lint gate: current=130, baseline=130, new=0, resolved=0

npm run build && git diff --exit-code -- cli-manifest.json
(no drift)
```
