### PR TITLE
fix(weixin): wait for article content instead of DOM quietness

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -43713,7 +43713,7 @@
     "type": "js",
     "modulePath": "weixin/download.js",
     "sourceFile": "weixin/download.js",
-    "navigateBefore": "https://mp.weixin.qq.com"
+    "navigateBefore": false
   },
   {
     "site": "weixin",

--- a/clis/weixin/download-verification.test.js
+++ b/clis/weixin/download-verification.test.js
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { runInNewContext } from 'node:vm';
+
+const mocks = vi.hoisted(() => ({ cli: vi.fn(), downloadArticle: vi.fn() }));
+vi.mock('@jackwener/opencli/registry', () => ({ cli: mocks.cli, Strategy: { COOKIE: 'cookie' } }));
+vi.mock('@jackwener/opencli/download/article-download', () => ({ downloadArticle: mocks.downloadArticle }));
+
+import { buildDetectWechatAccessIssueJs, buildWechatArticleSnapshotJs, detectWechatAccessIssue, waitForWechatArticle } from './download.js';
+
+const articleUrl = 'https://mp.weixin.qq.com/s/example';
+const challengeUrl = 'https://mp.weixin.qq.com/mp/wappoc_appmsgcaptcha?target_url=example';
+const article = '<h1 id="activity-name">Article title</h1><div id="js_content"><p>Actual article body</p></div>';
+const verification = 'environment verification required';
+const windows = [];
+
+function mockPage(html = '', url = articleUrl) {
+    const dom = new JSDOM(html, { url, runScripts: 'outside-only' });
+    windows.push(dom.window);
+    Object.defineProperty(dom.window.document, 'readyState', { value: 'complete', configurable: true });
+    Object.defineProperty(dom.window.document.body, 'innerText', { get() { return this.textContent; } });
+    return {
+        dom,
+        page: {
+            goto: vi.fn().mockResolvedValue(undefined),
+            wait: vi.fn().mockResolvedValue(undefined),
+            evaluate: vi.fn(async script => dom.window.eval(script)),
+        },
+    };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+    for (const window of windows.splice(0)) window.close();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    mocks.downloadArticle.mockReset();
+});
+
+describe('explicit WeChat interaction prompts', () => {
+    it.each([
+        ['环境异常 完成验证后即可继续访问 去验证', '<a id="js_verify">去验证</a>', false, verification],
+        ['安全验证 请拖动物体完成验证', '', false, verification],
+        ['环境异常，请拖动物体完成验证', '', false, verification],
+        ['', '<iframe src="/secitptpage/verify.html"></iframe>', false, ''],
+        ['安全验证 请拖动物体完成验证', '<div id="js_content">Article about verification</div>', true, ''],
+    ])('matches the self-contained browser helper', (text, html, hasArticle, expected) => {
+        expect(detectWechatAccessIssue(text, html, hasArticle)).toBe(expected);
+        const inPage = runInNewContext(buildDetectWechatAccessIssueJs());
+        expect(inPage(text, html, hasArticle)).toBe(expected);
+    });
+});
+
+describe('article readiness on the same page', () => {
+    it('waits through a quiet loading shell until title and body arrive', async () => {
+        const { page, dom } = mockPage('<div>Loading</div>');
+        const done = vi.fn();
+        const pending = waitForWechatArticle(page, { timeoutMs: 2000 }).then(done);
+        setTimeout(() => { dom.window.document.body.innerHTML = article; }, 1100);
+        await vi.advanceTimersByTimeAsync(600);
+        expect(done).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(700);
+        await pending;
+        expect(done.mock.calls[0][0]).toMatchObject({ ready: true, title: 'Article title' });
+        expect(done.mock.calls[0][0].contentHtml).toContain('Actual article body');
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(page.wait).not.toHaveBeenCalled();
+    });
+
+    it('lets an opaque intermediate page advance naturally to the article', async () => {
+        const { page, dom } = mockPage('<iframe></iframe>', challengeUrl);
+        setTimeout(() => { dom.reconfigure({ url: articleUrl }); dom.window.document.body.innerHTML = article; }, 800);
+        const pending = waitForWechatArticle(page, { timeoutMs: 2000 });
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(await pending).toMatchObject({ ready: true, errorHint: '' });
+        expect(page.goto).not.toHaveBeenCalled();
+    });
+
+    it('stops immediately when explicit human interaction is requested', async () => {
+        const { page } = mockPage('<div>安全验证</div><div>请拖动物体完成验证</div>', challengeUrl);
+        expect(await waitForWechatArticle(page)).toMatchObject({ ready: false, errorHint: verification });
+        expect(page.evaluate).toHaveBeenCalledOnce();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('times out an opaque intermediate page without inferring a verification requirement', async () => {
+        const { page } = mockPage('<iframe></iframe>', challengeUrl);
+        const result = expect(waitForWechatArticle(page, { timeoutMs: 1000 }))
+            .rejects.toMatchObject({ code: 'TIMEOUT' });
+        await vi.advanceTimersByTimeAsync(1000);
+        await result;
+        expect(page.evaluate).toHaveBeenCalledTimes(4);
+    });
+
+    it.each([
+        '',
+        '<h1 id="activity-name">Title only</h1><div id="js_content"> <script>not article text</script></div>',
+        '<div id="js_content"><p>Body without title</p></div>',
+    ])('times out incomplete content without restarting the budget', async html => {
+        const { page } = mockPage(html);
+        const result = expect(waitForWechatArticle(page, { timeoutMs: 1000 })).rejects.toMatchObject({ code: 'TIMEOUT' });
+        await vi.advanceTimersByTimeAsync(1000);
+        await result;
+        expect(page.evaluate).toHaveBeenCalledTimes(4);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('does not accept a late browser response or dispatch another probe after the budget', async () => {
+        const page = { evaluate: vi.fn(() => new Promise(resolve => {
+            setTimeout(() => resolve({ ready: true }), 1500);
+        })) };
+        const result = expect(waitForWechatArticle(page, { timeoutMs: 1000 }))
+            .rejects.toMatchObject({ code: 'TIMEOUT' });
+        await vi.advanceTimersByTimeAsync(1500);
+        await result;
+        expect(page.evaluate).toHaveBeenCalledOnce();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('propagates browser transport failures without masking them as page loading', async () => {
+        const failure = new Error('Extension disconnected');
+        const page = { evaluate: vi.fn().mockRejectedValue(failure) };
+        await expect(waitForWechatArticle(page)).rejects.toBe(failure);
+        expect(page.evaluate).toHaveBeenCalledOnce();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('waits for the document to finish parsing even if content nodes already exist', async () => {
+        const { page, dom } = mockPage(article);
+        Object.defineProperty(dom.window.document, 'readyState', { value: 'loading', configurable: true });
+        const done = vi.fn();
+        const pending = waitForWechatArticle(page).then(done);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(done).not.toHaveBeenCalled();
+        Object.defineProperty(dom.window.document, 'readyState', { value: 'interactive', configurable: true });
+        await vi.advanceTimersByTimeAsync(250);
+        await pending;
+        expect(done.mock.calls[0][0].ready).toBe(true);
+    });
+
+    it('accepts image-only articles and does not mutate the live content while extracting', async () => {
+        const html = '<h1 id="js_text_title">Image article</h1><div id="js_content"><img data-src="https://example.com/image.png"><script>example()</script></div>';
+        const { page, dom } = mockPage(html);
+        const before = dom.window.document.body.innerHTML;
+        const data = await waitForWechatArticle(page);
+        expect(data.ready).toBe(true);
+        expect(data.imageUrls).toEqual(['https://example.com/image.png']);
+        expect(data.contentHtml).not.toContain('<script>');
+        expect(dom.window.document.body.innerHTML).toBe(before);
+    });
+
+    it('extracts an article discussing verification without treating its links as a challenge', async () => {
+        const { page } = mockPage('<h1 id="activity-name">Verification guide</h1><div id="js_content">安全验证 请拖动物体完成验证 <a href="/secitptpage/verify.html">example</a></div>');
+        expect(await waitForWechatArticle(page)).toMatchObject({ ready: true, errorHint: '' });
+    });
+});
+
+describe('download integration', () => {
+    it('navigates once, waits for real content, and only then saves the snapshot', async () => {
+        const { page, dom } = mockPage('<div>Loading</div>');
+        const adapter = mocks.cli.mock.calls[0][0];
+        expect(adapter.navigateBefore).toBe(false);
+        const input = 'https://mp.weixin.qq.com/s?__biz=example&mid=123&idx=1&sn=abc&scene=21#wechat_redirect';
+        mocks.downloadArticle.mockResolvedValue([{ status: 'success' }]);
+        const pending = adapter.func(page, { url: input, output: '/unused-test-output' });
+        await vi.advanceTimersByTimeAsync(600);
+        expect(mocks.downloadArticle).not.toHaveBeenCalled();
+        dom.window.document.body.innerHTML = article;
+        await vi.advanceTimersByTimeAsync(250);
+        expect(await pending).toEqual([{ status: 'success' }]);
+        expect(page.goto).toHaveBeenCalledExactlyOnceWith(input);
+        expect(mocks.downloadArticle.mock.calls[0][0]).toMatchObject({ title: 'Article title', sourceUrl: input });
+    });
+
+    it('does not save or navigate again after an interactive verification prompt', async () => {
+        const { page } = mockPage('安全验证 请拖动物体完成验证', challengeUrl);
+        const adapter = mocks.cli.mock.calls[0][0];
+        const rows = await adapter.func(page, { url: articleUrl, output: '/unused-test-output' });
+        expect(rows[0].status).toBe('failed — verification required in WeChat browser page');
+        expect(mocks.downloadArticle).not.toHaveBeenCalled();
+        expect(page.goto).toHaveBeenCalledExactlyOnceWith(articleUrl);
+    });
+
+    it('never downloads when the default readiness deadline expires', async () => {
+        const { page } = mockPage('Loading');
+        const adapter = mocks.cli.mock.calls[0][0];
+        const result = expect(adapter.func(page, { url: articleUrl, output: '/unused-test-output' }))
+            .rejects.toMatchObject({ code: 'TIMEOUT' });
+        await vi.advanceTimersByTimeAsync(15000);
+        await result;
+        expect(mocks.downloadArticle).not.toHaveBeenCalled();
+        expect(page.goto).toHaveBeenCalledOnce();
+    });
+});

--- a/clis/weixin/download.js
+++ b/clis/weixin/download.js
@@ -7,6 +7,7 @@
  *   opencli weixin download --url "https://mp.weixin.qq.com/s/xxx" --output ./weixin
  */
 import { cli, Strategy } from '@jackwener/opencli/registry';
+import { TimeoutError } from '@jackwener/opencli/errors';
 import { downloadArticle } from '@jackwener/opencli/download/article-download';
 // ============================================================
 // URL Normalization
@@ -140,13 +141,14 @@ export function extractWechatPublishTime(publishTimeText, htmlStr) {
 /**
  * Detect WeChat anti-bot / verification gate pages before we try to parse the article.
  */
-export function detectWechatAccessIssue(pageText, htmlStr) {
-    const normalizedText = (pageText || '').replace(/\s+/g, ' ').trim();
-    if (/环境异常/.test(normalizedText) &&
-        /(完成验证后即可继续访问|去验证)/.test(normalizedText)) {
-        return 'environment verification required';
-    }
-    if (/secitptpage\/verify\.html/.test(htmlStr) || /id=["']js_verify["']/.test(htmlStr)) {
+export function detectWechatAccessIssue(pageText, htmlStr, hasArticle = false) {
+    if (hasArticle) return '';
+    const text = (pageText || '').replace(/\s+/g, ' ').trim();
+    // Only explicit interaction prompts stop the wait early. A redirect URL
+    // or an opaque iframe alone does not tell us whether the page will advance.
+    if (/id=["']js_verify["']/.test(htmlStr || '') ||
+        (/(环境异常|安全验证)/.test(text) &&
+            /(完成验证后即可继续访问|去验证|请拖动物体完成验证|拖动.*完成验证)/.test(text))) {
         return 'environment verification required';
     }
     return '';
@@ -201,47 +203,15 @@ export function buildExtractWechatPublishTimeJs() {
  * Build a self-contained access-issue detector for execution inside page.evaluate().
  */
 export function buildDetectWechatAccessIssueJs() {
-    return `(${function detectWechatAccessIssueInPage(pageText, htmlStr) {
-        const normalizedText = (pageText || '').replace(/\s+/g, ' ').trim();
-        if (/环境异常/.test(normalizedText) &&
-            /(完成验证后即可继续访问|去验证)/.test(normalizedText)) {
-            return 'environment verification required';
-        }
-        if (/secitptpage\/verify\.html/.test(htmlStr) || /id=["']js_verify["']/.test(htmlStr)) {
-            return 'environment verification required';
-        }
-        return '';
-    }.toString()})`;
+    // Keep the browser and directly-tested detector identical. The detector
+    // must stay self-contained because it runs without this module's scope.
+    return `(${detectWechatAccessIssue.toString()})`;
 }
-// ============================================================
-// CLI Registration
-// ============================================================
-cli({
-    site: 'weixin',
-    name: 'download',
-    access: 'read',
-    description: '下载微信公众号文章为 Markdown 格式',
-    domain: 'mp.weixin.qq.com',
-    strategy: Strategy.COOKIE,
-    args: [
-        { name: 'url', required: true, help: 'WeChat article URL (mp.weixin.qq.com/s/xxx)' },
-        { name: 'output', default: './weixin-articles', help: 'Output directory' },
-        { name: 'download-images', type: 'boolean', default: true, help: 'Download images locally' },
-    ],
-    columns: ['title', 'author', 'publish_time', 'status', 'size', 'saved'],
-    func: async (page, kwargs) => {
-        const rawUrl = kwargs.url;
-        const url = normalizeWechatUrl(rawUrl);
-        if (!url.startsWith('https://mp.weixin.qq.com/')) {
-            return [{ title: 'Error', author: '-', publish_time: '-', status: 'invalid URL', size: '-', saved: '-' }];
-        }
-        // Navigate and wait for content to load
-        await page.goto(url);
-        await page.wait(5);
-        // Extract article data in browser context
-        const data = await page.evaluate(`
+export function buildWechatArticleSnapshotJs() {
+    return `
       (() => {
         const result = {
+          ready: false,
           title: '',
           author: '',
           publishTime: '',
@@ -266,6 +236,26 @@ cli({
           '.rich_media_title',
         );
 
+        // Inspect a clone: polling must not rewrite the live page or consume
+        // code blocks before the article is ready.
+        const contentEl = document.querySelector('#js_content')?.cloneNode(true);
+        contentEl?.querySelectorAll('script, style').forEach(el => el.remove());
+        const hasContent = Boolean(contentEl && (
+          contentEl.textContent?.trim() ||
+          contentEl.querySelector('img[src], img[data-src], video, audio, iframe[src], iframe[data-src]')
+        ));
+        const articleLocation = window.location.hostname === 'mp.weixin.qq.com' &&
+          /^\\/s(?:\\/|$)/.test(window.location.pathname);
+        const detectWechatAccessIssue = ${buildDetectWechatAccessIssueJs()};
+        result.errorHint = detectWechatAccessIssue(
+          document.body ? document.body.innerText : '',
+          document.documentElement.innerHTML,
+          hasContent,
+        );
+        if (result.errorHint || !result.title || !hasContent || !articleLocation ||
+            document.readyState === 'loading') return result;
+        result.ready = true;
+
         result.author = pickFirstText(
           '#js_name',
           '.wx_follow_nickname',
@@ -281,17 +271,6 @@ cli({
           publishTimeEl ? publishTimeEl.textContent : '',
           document.documentElement.innerHTML,
         );
-
-        const detectWechatAccessIssue = ${buildDetectWechatAccessIssueJs()};
-        result.errorHint = detectWechatAccessIssue(
-          document.body ? document.body.innerText : '',
-          document.documentElement.innerHTML,
-        );
-        if (result.errorHint) return result;
-
-        // Content processing
-        const contentEl = document.querySelector('#js_content');
-        if (!contentEl) return result;
 
         // Fix lazy-loaded images: data-src -> src
         contentEl.querySelectorAll('img').forEach(img => {
@@ -338,7 +317,54 @@ cli({
         result.contentHtml = contentEl.innerHTML;
         return result;
       })()
-    `);
+    `;
+}
+
+/** Observe the same tab until content is extractable. Browser requests retain
+ * their transport timeout; the readiness budget starts after navigation.
+ */
+export async function waitForWechatArticle(page, { timeoutMs = 15000, pollIntervalMs = 250 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    const script = buildWechatArticleSnapshotJs();
+    while (Date.now() < deadline) {
+        const snapshot = await page.evaluate(script);
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        if (snapshot?.errorHint || snapshot?.ready) return snapshot;
+        await new Promise(resolve => setTimeout(resolve, Math.min(pollIntervalMs, remaining)));
+    }
+    throw new TimeoutError(
+        'WeChat article readiness', timeoutMs / 1000,
+        'The page did not expose a title and article content. Inspect it for loading or access restrictions.',
+    );
+}
+// ============================================================
+// CLI Registration
+// ============================================================
+cli({
+    site: 'weixin',
+    name: 'download',
+    access: 'read',
+    description: '下载微信公众号文章为 Markdown 格式',
+    domain: 'mp.weixin.qq.com',
+    strategy: Strategy.COOKIE,
+    navigateBefore: false,
+    args: [
+        { name: 'url', required: true, help: 'WeChat article URL (mp.weixin.qq.com/s/xxx)' },
+        { name: 'output', default: './weixin-articles', help: 'Output directory' },
+        { name: 'download-images', type: 'boolean', default: true, help: 'Download images locally' },
+    ],
+    columns: ['title', 'author', 'publish_time', 'status', 'size', 'saved'],
+    func: async (page, kwargs) => {
+        const rawUrl = kwargs.url;
+        const url = normalizeWechatUrl(rawUrl);
+        if (!url.startsWith('https://mp.weixin.qq.com/')) {
+            return [{ title: 'Error', author: '-', publish_time: '-', status: 'invalid URL', size: '-', saved: '-' }];
+        }
+        // Navigate and wait for content to load
+        await page.goto(url);
+        // Extract article data in browser context
+        const data = await waitForWechatArticle(page);
         if (data?.errorHint === 'environment verification required') {
             return [{
                     title: 'Error',

--- a/docs/adapters/browser/weixin.md
+++ b/docs/adapters/browser/weixin.md
@@ -60,3 +60,23 @@ Downloads to `<output>/<article-title>/`:
 - Chrome running and **logged into** mp.weixin.qq.com (for articles behind login wall)
 - [Browser Bridge extension](/guide/browser-bridge) installed
 - `create-draft` with `--cover-image` requires Browser Bridge file upload support
+
+## Article loading and verification
+
+`download` opens the supplied article directly, without first visiting the Official
+Account homepage. After navigation it polls the same tab with a 15-second
+readiness budget, waiting for the document to finish parsing and expose both a
+title and non-empty `#js_content` (text or embedded media). A quiet loading shell
+is not sufficient. Content is cleaned on a clone without modifying the live page.
+
+An intermediate page can advance naturally within that budget. An explicit
+interaction prompt stops the command with the existing verification-required
+result; no CAPTCHA interaction, refresh, or alternate-URL retry is performed.
+Other pages without extractable content raise `TIMEOUT`, including intermediate
+pages that never advance. Navigation and observation requests retain the browser
+layer's transport timeout and errors; an in-flight request can exceed the
+readiness budget, but a late response is not downloaded or followed by another probe.
+
+This checks that extractable article content is present, not that dynamically
+appended content or every image and video has finished loading.
+`--download-images` still controls image downloads.


### PR DESCRIPTION
## Description

`weixin download` uses `page.wait(5)` before extraction. Numeric `wait` can return after just 500 ms of DOM quietness, allowing an empty loading shell to reach extraction before the article arrives.

Poll the same tab for a parsed document, an article URL, a title and non-empty `#js_content` (text or media). The adapter owns its single navigation, skipping the Official Account homepage. Extraction cleans a clone without modifying the live page, and metadata is extracted only once content is ready.

The readiness loop uses a 15-second budget after navigation. Browser requests retain their existing transport timeout and errors; there is no additional RPC timeout wrapper. An in-flight request can exceed the readiness budget, but a late response is neither downloaded nor followed by another probe.

Explicit verification interaction prompts retain the existing failure result. Other incomplete pages raise `TIMEOUT`; intermediate URLs and opaque iframes are not classified as verification failures. Pages may advance naturally while waiting, without refresh, URL rewriting or CAPTCHA interaction. Readiness means extractable content is present, not that all dynamically appended content or media have finished loading.

Related: #2045. This addresses premature extraction; it does not establish that the challenge in that report resolves without interaction. #1770's stdout work is separate.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

## Validation

- Current revision: all 65 tests across four WeChat adapter test files pass, including delayed content, natural redirects, explicit interaction prompts, incomplete pages, late responses, transport errors, parsing state, media-only articles and download ordering.
- Current revision: build, typecheck, silent-column-drop and typed-error gates pass.
- Before this simplification, the full suite passed with an isolated `OPENCLI_CONFIG_DIR`: 632 files, 7336 tests passed, 1 skipped. The full suite was not rerun for this scoped simplification.
- Current revision live check through the protected ego-lite route: the public article downloaded successfully (16.0 KB); Markdown title, metadata and body were read back.
- Earlier live testing: a public short-link article downloaded successfully; the supplied long-parameter article remained verification-blocked and produced no Markdown. The change does not establish improved access success rates.

This remains a draft.
