### PR TITLE
feat(tripo3d): add Tripo Studio Smart Mesh adapter

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -40368,6 +40368,488 @@
     "navigateBefore": false
   },
   {
+    "site": "tripo3d",
+    "name": "assets",
+    "description": "List your Tripo projects with their ids, so texture has something to point at",
+    "access": "read",
+    "example": "opencli tripo3d assets --limit 10",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Projects to return, newest first (max 200)"
+      }
+    ],
+    "columns": [
+      "projectId",
+      "projectName",
+      "operatorId",
+      "operatorType",
+      "status",
+      "isTextured",
+      "isSmartMesh",
+      "visibility",
+      "createdAt",
+      "workspaceUrl"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/assets.js",
+    "sourceFile": "tripo3d/assets.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "credits",
+    "description": "Show the Tripo credit balance, plan, monthly export allowance, and remaining Smart Mesh P2 free trials",
+    "access": "read",
+    "example": "opencli tripo3d credits",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [],
+    "columns": [
+      "credits",
+      "expiringCredits",
+      "expiringDate",
+      "plan",
+      "planValidUntil",
+      "exportsUsed",
+      "exportsTotal",
+      "exportsResetAt",
+      "p2TrialsLeft",
+      "p2TrialsTotal"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/credits.js",
+    "sourceFile": "tripo3d/credits.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "image-to-model",
+    "description": "Smart Mesh: generate an untextured 3D mesh from one reference image (spends Tripo credits)",
+    "access": "write",
+    "example": "opencli tripo3d image-to-model ./chest.png --model p2 --topology quad --polycount 4000",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "image",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Local JPG/PNG/WEBP file, max 20MB"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "default": "p1",
+        "required": false,
+        "help": "Smart Mesh engine: p1 = \"P1.0 - Fast\" (35 credits, triangles only), p2 = \"P2.0 - Preview\" (100 credits, quad-capable)",
+        "choices": [
+          "p1",
+          "p2"
+        ]
+      },
+      {
+        "name": "topology",
+        "type": "string",
+        "default": "triangle",
+        "required": false,
+        "help": "Face topology (Topology setting); quad requires --model p2",
+        "choices": [
+          "triangle",
+          "quad"
+        ]
+      },
+      {
+        "name": "polycount",
+        "type": "int",
+        "default": 5000,
+        "required": false,
+        "help": "Target face count, min 500. The ceiling follows --model/--topology: p1/triangle 20000, p2/triangle 50000, p2/quad 25000"
+      },
+      {
+        "name": "visibility",
+        "type": "string",
+        "default": "auto",
+        "required": false,
+        "help": "Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan",
+        "choices": [
+          "auto",
+          "public",
+          "private",
+          "shareable"
+        ]
+      },
+      {
+        "name": "wait",
+        "type": "bool",
+        "default": true,
+        "required": false,
+        "help": "Wait for the mesh to finish before returning"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Seconds to wait when --wait is on"
+      }
+    ],
+    "columns": [
+      "mode",
+      "model",
+      "projectId",
+      "operatorId",
+      "status",
+      "progress",
+      "topology",
+      "polycount",
+      "symmetry",
+      "visibility",
+      "prompt",
+      "images",
+      "projectName",
+      "workspaceUrl"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/image-to-model.js",
+    "sourceFile": "tripo3d/image-to-model.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "multiview-to-model",
+    "description": "Smart Mesh: generate an untextured 3D mesh from front/left/back/right views (spends Tripo credits)",
+    "access": "write",
+    "example": "opencli tripo3d multiview-to-model ./front.png --left ./left.png --back ./back.png",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "front",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Front view — the only required slot"
+      },
+      {
+        "name": "left",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Left view (optional)"
+      },
+      {
+        "name": "back",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Back view (optional)"
+      },
+      {
+        "name": "right",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Right view (optional)"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "default": "p1",
+        "required": false,
+        "help": "Smart Mesh engine: p1 = \"P1.0 - Fast\" (35 credits, triangles only), p2 = \"P2.0 - Preview\" (100 credits, quad-capable)",
+        "choices": [
+          "p1",
+          "p2"
+        ]
+      },
+      {
+        "name": "topology",
+        "type": "string",
+        "default": "triangle",
+        "required": false,
+        "help": "Face topology (Topology setting); quad requires --model p2",
+        "choices": [
+          "triangle",
+          "quad"
+        ]
+      },
+      {
+        "name": "polycount",
+        "type": "int",
+        "default": 5000,
+        "required": false,
+        "help": "Target face count, min 500. The ceiling follows --model/--topology: p1/triangle 20000, p2/triangle 50000, p2/quad 25000"
+      },
+      {
+        "name": "visibility",
+        "type": "string",
+        "default": "auto",
+        "required": false,
+        "help": "Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan",
+        "choices": [
+          "auto",
+          "public",
+          "private",
+          "shareable"
+        ]
+      },
+      {
+        "name": "wait",
+        "type": "bool",
+        "default": true,
+        "required": false,
+        "help": "Wait for the mesh to finish before returning"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Seconds to wait when --wait is on"
+      }
+    ],
+    "columns": [
+      "mode",
+      "model",
+      "projectId",
+      "operatorId",
+      "status",
+      "progress",
+      "topology",
+      "polycount",
+      "symmetry",
+      "visibility",
+      "prompt",
+      "images",
+      "projectName",
+      "workspaceUrl"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/multiview-to-model.js",
+    "sourceFile": "tripo3d/multiview-to-model.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "status",
+    "description": "Check Tripo generation tasks by operator id (the handle every generate/texture command returns)",
+    "access": "read",
+    "example": "opencli tripo3d status 7c3e5a18-90bd-42f6-b1c4-5de8073af921",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "operators",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Comma-separated operator ids"
+      }
+    ],
+    "columns": [
+      "operatorId",
+      "status",
+      "progress",
+      "leftTime"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/status.js",
+    "sourceFile": "tripo3d/status.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "text-to-model",
+    "description": "Smart Mesh: generate an untextured 3D mesh from a text prompt (spends Tripo credits)",
+    "access": "write",
+    "example": "opencli tripo3d text-to-model \"a small stylized wooden treasure chest\" --model p2 --topology quad --polycount 4000",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "prompt",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "What to build, up to 1000 characters"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "default": "p1",
+        "required": false,
+        "help": "Smart Mesh engine: p1 = \"P1.0 - Fast\" (35 credits, triangles only), p2 = \"P2.0 - Preview\" (100 credits, quad-capable)",
+        "choices": [
+          "p1",
+          "p2"
+        ]
+      },
+      {
+        "name": "topology",
+        "type": "string",
+        "default": "triangle",
+        "required": false,
+        "help": "Face topology (Topology setting); quad requires --model p2",
+        "choices": [
+          "triangle",
+          "quad"
+        ]
+      },
+      {
+        "name": "polycount",
+        "type": "int",
+        "default": 5000,
+        "required": false,
+        "help": "Target face count, min 500. The ceiling follows --model/--topology: p1/triangle 20000, p2/triangle 50000, p2/quad 25000"
+      },
+      {
+        "name": "visibility",
+        "type": "string",
+        "default": "auto",
+        "required": false,
+        "help": "Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan",
+        "choices": [
+          "auto",
+          "public",
+          "private",
+          "shareable"
+        ]
+      },
+      {
+        "name": "t-pose",
+        "type": "bool",
+        "default": false,
+        "required": false,
+        "help": "Ask for a T-posed character (characters only)"
+      },
+      {
+        "name": "wait",
+        "type": "bool",
+        "default": true,
+        "required": false,
+        "help": "Wait for the mesh to finish before returning"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 600,
+        "required": false,
+        "help": "Seconds to wait when --wait is on"
+      }
+    ],
+    "columns": [
+      "mode",
+      "model",
+      "projectId",
+      "operatorId",
+      "status",
+      "progress",
+      "topology",
+      "polycount",
+      "symmetry",
+      "visibility",
+      "prompt",
+      "images",
+      "projectName",
+      "workspaceUrl"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/text-to-model.js",
+    "sourceFile": "tripo3d/text-to-model.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "tripo3d",
+    "name": "texture",
+    "description": "Generate a texture for an existing Tripo project mesh (spends Tripo credits)",
+    "access": "write",
+    "example": "opencli tripo3d texture 1f4b0c9a-6d21-4e5f-8a37-2c9de4b170aa --size 4k",
+    "domain": "studio.tripo3d.ai",
+    "strategy": "intercept",
+    "browser": true,
+    "args": [
+      {
+        "name": "project",
+        "type": "string",
+        "required": true,
+        "positional": true,
+        "help": "Project id, or a workspace URL"
+      },
+      {
+        "name": "size",
+        "type": "string",
+        "default": "2k",
+        "required": false,
+        "help": "Texture resolution (4k and 8k cost extra credits)",
+        "choices": [
+          "2k",
+          "4k",
+          "8k"
+        ]
+      },
+      {
+        "name": "alignment",
+        "type": "string",
+        "default": "original_image",
+        "required": false,
+        "help": "Anchor the texture to the source image or to the bare geometry",
+        "choices": [
+          "original_image",
+          "geometry"
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "default": "",
+        "required": false,
+        "help": "Texture description; defaults to the prompt the mesh was generated with"
+      },
+      {
+        "name": "wait",
+        "type": "bool",
+        "default": true,
+        "required": false,
+        "help": "Wait for the texture to finish before returning"
+      },
+      {
+        "name": "timeout",
+        "type": "int",
+        "default": 900,
+        "required": false,
+        "help": "Seconds to wait when --wait is on"
+      }
+    ],
+    "columns": [
+      "projectId",
+      "operatorId",
+      "status",
+      "progress",
+      "size",
+      "quality",
+      "alignment",
+      "prompt",
+      "workspaceUrl"
+    ],
+    "type": "js",
+    "modulePath": "tripo3d/texture.js",
+    "sourceFile": "tripo3d/texture.js",
+    "navigateBefore": false
+  },
+  {
     "site": "tvmaze",
     "name": "search",
     "description": "TVmaze TV show search by title (returns id, name, network, premiered/ended, rating)",

--- a/clis/tripo3d/assets.js
+++ b/clis/tripo3d/assets.js
@@ -1,0 +1,69 @@
+// tripo3d assets — list the projects in the signed-in workspace.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { HOST, api, ensureStudio, requireSession, workspaceUrl } from './utils.js';
+
+const PAGE_SIZE = 20;
+const MAX_LIMIT = 200;
+
+cli({
+    site: 'tripo3d',
+    name: 'assets',
+    description: 'List your Tripo projects with their ids, so texture has something to point at',
+    access: 'read',
+    example: 'opencli tripo3d assets --limit 10',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'limit', type: 'int', default: 20, help: `Projects to return, newest first (max ${MAX_LIMIT})` },
+    ],
+    columns: [
+        'projectId',
+        'projectName',
+        'operatorId',
+        'operatorType',
+        'status',
+        'isTextured',
+        'isSmartMesh',
+        'visibility',
+        'createdAt',
+        'workspaceUrl',
+    ],
+    func: async (page, args) => {
+        const limit = Number(args.limit ?? 20);
+        if (!Number.isInteger(limit) || limit <= 0) throw new ArgumentError('limit must be a positive integer');
+        if (limit > MAX_LIMIT) throw new ArgumentError(`limit must be <= ${MAX_LIMIT}`);
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        const projects = [];
+        for (let offset = 0; projects.length < limit; offset += PAGE_SIZE) {
+            const size = Math.min(PAGE_SIZE, limit - projects.length);
+            const data = await api(page, `/v2/studio/assets/v2?asset_type=mine&offset=${offset}&size=${size}&type=all`, { method: 'GET' });
+            const batch = Array.isArray(data?.projects) ? data.projects : [];
+            projects.push(...batch);
+            if (batch.length < size) break;
+        }
+        if (!projects.length) throw new EmptyResultError('tripo3d assets', 'this workspace has no projects yet');
+
+        return projects.slice(0, limit).map((project) => {
+            const op = project.operator || {};
+            return {
+                projectId: project.id ?? null,
+                projectName: project.project_name ?? null,
+                operatorId: op.operator_id ?? null,
+                operatorType: op.type ?? null,
+                status: op.status ?? null,
+                isTextured: op.is_textured ?? null,
+                // `is_nexus_mesh` is the site's own flag for a Smart Mesh model.
+                isSmartMesh: op.is_nexus_mesh ?? null,
+                visibility: project.visibility ?? null,
+                createdAt: typeof op.created_at === 'number' ? new Date(op.created_at * 1000).toISOString() : null,
+                workspaceUrl: project.id ? workspaceUrl(project.id) : null,
+            };
+        });
+    },
+});

--- a/clis/tripo3d/credits.js
+++ b/clis/tripo3d/credits.js
@@ -1,0 +1,42 @@
+// tripo3d credits — what the account can still spend before a generate command.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { HOST, api, ensureStudio, requireSession, smartMeshP2Trial } from './utils.js';
+
+cli({
+    site: 'tripo3d',
+    name: 'credits',
+    description: 'Show the Tripo credit balance, plan, monthly export allowance, and remaining Smart Mesh P2 free trials',
+    access: 'read',
+    example: 'opencli tripo3d credits',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [],
+    columns: ['credits', 'expiringCredits', 'expiringDate', 'plan', 'planValidUntil', 'exportsUsed', 'exportsTotal', 'exportsResetAt', 'p2TrialsLeft', 'p2TrialsTotal'],
+    func: async (page) => {
+        await ensureStudio(page);
+        await requireSession(page);
+
+        const payment = await api(page, '/v2/studio/user/profile/payment', { method: 'GET' });
+        // The export allowance lives on a different endpoint and is absent for
+        // plans that do not meter exports.
+        const limit = (await api(page, '/v2/studio/marketing/export-limit', { method: 'GET' }).catch(() => null))?.export_limit ?? null;
+        // Free P2 generations. Absent (null) on plans that carry no such pool —
+        // which is not the same as "used them all", so it stays null, not 0.
+        const p2 = await smartMeshP2Trial(page);
+
+        return [{
+            credits: payment?.wallet?.total_credit ?? null,
+            expiringCredits: payment?.wallet?.expiring_credit ?? null,
+            expiringDate: payment?.wallet?.expiring_date ?? null,
+            plan: payment?.member?.type ?? null,
+            planValidUntil: payment?.member?.valid_until ?? null,
+            exportsUsed: limit?.used_count ?? null,
+            exportsTotal: limit?.total_count ?? null,
+            exportsResetAt: limit?.expire_at ?? null,
+            p2TrialsLeft: p2?.remaining ?? null,
+            p2TrialsTotal: p2?.total_count ?? null,
+        }];
+    },
+});

--- a/clis/tripo3d/image-to-model.js
+++ b/clis/tripo3d/image-to-model.js
@@ -1,0 +1,77 @@
+// tripo3d image-to-model — Smart Mesh: one reference image in, mesh out.
+import { basename } from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    GENERATE_COLUMNS,
+    HOST,
+    POLYCOUNT_DEFAULT,
+    POLYCOUNT_HELP,
+    SMART_MESH_CREDITS,
+    SMART_MESH_MODELS,
+    SMART_MESH_MODEL_DEFAULT,
+    TOPOLOGIES,
+    TOPOLOGY_DEFAULT,
+    VISIBILITY_CHOICES,
+    VISIBILITY_DEFAULT,
+    ensureStudio,
+    normalizeTimeout,
+    requireSession,
+    resolveVisibility,
+    resolveSmartMesh,
+    runSmartMesh,
+    uploadImage,
+} from './utils.js';
+
+cli({
+    site: 'tripo3d',
+    name: 'image-to-model',
+    description: 'Smart Mesh: generate an untextured 3D mesh from one reference image (spends Tripo credits)',
+    access: 'write',
+    example: 'opencli tripo3d image-to-model ./chest.png --model p2 --topology quad --polycount 4000',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'image', type: 'string', required: true, positional: true, help: 'Local JPG/PNG/WEBP file, max 20MB' },
+        { name: 'model', type: 'string', default: SMART_MESH_MODEL_DEFAULT, choices: SMART_MESH_MODELS, help: `Smart Mesh engine: p1 = "P1.0 - Fast" (${SMART_MESH_CREDITS.p1} credits, triangles only), p2 = "P2.0 - Preview" (${SMART_MESH_CREDITS.p2} credits, quad-capable)` },
+        { name: 'topology', type: 'string', default: TOPOLOGY_DEFAULT, choices: TOPOLOGIES, help: 'Face topology (Topology setting); quad requires --model p2' },
+        { name: 'polycount', type: 'int', default: POLYCOUNT_DEFAULT, help: POLYCOUNT_HELP },
+        { name: 'visibility', type: 'string', default: VISIBILITY_DEFAULT, choices: VISIBILITY_CHOICES, help: 'Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan' },
+        { name: 'wait', type: 'bool', default: true, help: 'Wait for the mesh to finish before returning' },
+        { name: 'timeout', type: 'int', default: 600, help: 'Seconds to wait when --wait is on' },
+    ],
+    columns: GENERATE_COLUMNS,
+    func: async (page, args) => {
+        const imagePath = String(args.image ?? '').trim();
+        if (!imagePath) throw new ArgumentError('image is required: pass the path to a local JPG/PNG/WEBP file');
+
+        const mesh = resolveSmartMesh(args);
+        const timeoutSec = normalizeTimeout(args.timeout, 600);
+        const wait = args.wait !== false;
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        // Resolved against the account, so it has to wait for a live session.
+        const visibility = await resolveVisibility(page, args.visibility);
+
+        const uploaded = await uploadImage(page, imagePath);
+
+        return runSmartMesh(page, {
+            endpoint: '/v2/studio/operation/image_to_model',
+            mode: 'image',
+            // `image_source` tells the studio this came from the upload box
+            // rather than from its own image generator.
+            payload: { image: { ...uploaded, image_source: 'upload' } },
+            ...mesh,
+            visibility,
+            symmetrySource: uploaded,
+            prompt: null,
+            images: basename(imagePath),
+            wait,
+            timeoutSec,
+        });
+    },
+});

--- a/clis/tripo3d/multiview-to-model.js
+++ b/clis/tripo3d/multiview-to-model.js
@@ -1,0 +1,92 @@
+// tripo3d multiview-to-model — Smart Mesh: up to four orthographic views in, mesh out.
+import { basename } from 'node:path';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    GENERATE_COLUMNS,
+    HOST,
+    POLYCOUNT_DEFAULT,
+    POLYCOUNT_HELP,
+    SMART_MESH_CREDITS,
+    SMART_MESH_MODELS,
+    SMART_MESH_MODEL_DEFAULT,
+    TOPOLOGIES,
+    TOPOLOGY_DEFAULT,
+    VISIBILITY_CHOICES,
+    VISIBILITY_DEFAULT,
+    ensureStudio,
+    normalizeTimeout,
+    requireSession,
+    resolveVisibility,
+    resolveSmartMesh,
+    runSmartMesh,
+    uploadImage,
+} from './utils.js';
+
+/**
+ * Slot order is positional and fixed: the endpoint always receives a four-entry
+ * array in this order, with `null` standing in for a view the caller skipped.
+ * Reordering it would silently model the object back-to-front.
+ */
+const VIEW_SLOTS = ['front', 'left', 'back', 'right'];
+
+cli({
+    site: 'tripo3d',
+    name: 'multiview-to-model',
+    description: 'Smart Mesh: generate an untextured 3D mesh from front/left/back/right views (spends Tripo credits)',
+    access: 'write',
+    example: 'opencli tripo3d multiview-to-model ./front.png --left ./left.png --back ./back.png',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'front', type: 'string', required: true, positional: true, help: 'Front view — the only required slot' },
+        { name: 'left', type: 'string', default: '', help: 'Left view (optional)' },
+        { name: 'back', type: 'string', default: '', help: 'Back view (optional)' },
+        { name: 'right', type: 'string', default: '', help: 'Right view (optional)' },
+        { name: 'model', type: 'string', default: SMART_MESH_MODEL_DEFAULT, choices: SMART_MESH_MODELS, help: `Smart Mesh engine: p1 = "P1.0 - Fast" (${SMART_MESH_CREDITS.p1} credits, triangles only), p2 = "P2.0 - Preview" (${SMART_MESH_CREDITS.p2} credits, quad-capable)` },
+        { name: 'topology', type: 'string', default: TOPOLOGY_DEFAULT, choices: TOPOLOGIES, help: 'Face topology (Topology setting); quad requires --model p2' },
+        { name: 'polycount', type: 'int', default: POLYCOUNT_DEFAULT, help: POLYCOUNT_HELP },
+        { name: 'visibility', type: 'string', default: VISIBILITY_DEFAULT, choices: VISIBILITY_CHOICES, help: 'Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan' },
+        { name: 'wait', type: 'bool', default: true, help: 'Wait for the mesh to finish before returning' },
+        { name: 'timeout', type: 'int', default: 600, help: 'Seconds to wait when --wait is on' },
+    ],
+    columns: GENERATE_COLUMNS,
+    func: async (page, args) => {
+        const paths = VIEW_SLOTS.map((slot) => String(args[slot] ?? '').trim() || null);
+        if (!paths[0]) throw new ArgumentError('front is required: pass the path to the front view');
+
+        const mesh = resolveSmartMesh(args);
+        const timeoutSec = normalizeTimeout(args.timeout, 600);
+        const wait = args.wait !== false;
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        // Resolved against the account, so it has to wait for a live session.
+        const visibility = await resolveVisibility(page, args.visibility);
+
+        // Upload every view before submitting: a bad path halfway through would
+        // otherwise leave orphaned uploads and no job.
+        const slots = [];
+        for (const path of paths) {
+            slots.push(path ? await uploadImage(page, path) : null);
+        }
+
+        return runSmartMesh(page, {
+            endpoint: '/v2/studio/operation/multiview_to_model',
+            mode: 'multiview',
+            payload: { image: slots },
+            ...mesh,
+            visibility,
+            // The page checks symmetry on the "main view", which starts at slot 0
+            // and only moves when a human clicks another thumbnail — so front.
+            symmetrySource: slots[0],
+            prompt: null,
+            images: paths.map((p, i) => (p ? `${VIEW_SLOTS[i]}=${basename(p)}` : null)).filter(Boolean).join(', '),
+            wait,
+            timeoutSec,
+        });
+    },
+});

--- a/clis/tripo3d/status.js
+++ b/clis/tripo3d/status.js
@@ -1,0 +1,44 @@
+// tripo3d status — check one or more Tripo tasks by operator id.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, EmptyResultError } from '@jackwener/opencli/errors';
+import { HOST, api, ensureStudio, requireSession } from './utils.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+cli({
+    site: 'tripo3d',
+    name: 'status',
+    description: 'Check Tripo generation tasks by operator id (the handle every generate/texture command returns)',
+    access: 'read',
+    example: 'opencli tripo3d status 7c3e5a18-90bd-42f6-b1c4-5de8073af921',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'operators', type: 'string', required: true, positional: true, help: 'Comma-separated operator ids' },
+    ],
+    columns: ['operatorId', 'status', 'progress', 'leftTime'],
+    func: async (page, args) => {
+        const ids = String(args.operators ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+        if (!ids.length) throw new ArgumentError('operators is required: pass one or more comma-separated operator ids');
+        const bad = ids.find((id) => !UUID_RE.test(id));
+        if (bad) throw new ArgumentError(`"${bad}" is not an operator id (expected a UUID)`);
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        const rows = await api(page, '/v2/studio/progress', { body: { ids } });
+        if (!Array.isArray(rows) || rows.length === 0) {
+            throw new EmptyResultError('tripo3d status', 'the studio knows none of these operator ids');
+        }
+
+        return rows.map((row) => ({
+            operatorId: row.operator_id ?? row.id ?? null,
+            status: row.status ?? null,
+            progress: row.progress ?? null,
+            // The site reports -1 once a task is no longer running.
+            leftTime: typeof row.left_time === 'number' && row.left_time >= 0 ? row.left_time : null,
+        }));
+    },
+});

--- a/clis/tripo3d/text-to-model.js
+++ b/clis/tripo3d/text-to-model.js
@@ -1,0 +1,89 @@
+// tripo3d text-to-model — Smart Mesh: prompt in, topology-ready mesh out.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError } from '@jackwener/opencli/errors';
+import {
+    GENERATE_COLUMNS,
+    HOST,
+    POLYCOUNT_DEFAULT,
+    POLYCOUNT_HELP,
+    SMART_MESH_CREDITS,
+    SMART_MESH_MODELS,
+    SMART_MESH_MODEL_DEFAULT,
+    TEXT_IMAGE_MODEL,
+    TOPOLOGIES,
+    TOPOLOGY_DEFAULT,
+    VISIBILITY_CHOICES,
+    VISIBILITY_DEFAULT,
+    ensureStudio,
+    normalizeTimeout,
+    requireSession,
+    resolveVisibility,
+    resolveSmartMesh,
+    runSmartMesh,
+} from './utils.js';
+
+const PROMPT_MAX = 1000;
+
+cli({
+    site: 'tripo3d',
+    name: 'text-to-model',
+    description: 'Smart Mesh: generate an untextured 3D mesh from a text prompt (spends Tripo credits)',
+    access: 'write',
+    example: 'opencli tripo3d text-to-model "a small stylized wooden treasure chest" --model p2 --topology quad --polycount 4000',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'prompt', type: 'string', required: true, positional: true, help: `What to build, up to ${PROMPT_MAX} characters` },
+        { name: 'model', type: 'string', default: SMART_MESH_MODEL_DEFAULT, choices: SMART_MESH_MODELS, help: `Smart Mesh engine: p1 = "P1.0 - Fast" (${SMART_MESH_CREDITS.p1} credits, triangles only), p2 = "P2.0 - Preview" (${SMART_MESH_CREDITS.p2} credits, quad-capable)` },
+        { name: 'topology', type: 'string', default: TOPOLOGY_DEFAULT, choices: TOPOLOGIES, help: 'Face topology (Topology setting); quad requires --model p2' },
+        { name: 'polycount', type: 'int', default: POLYCOUNT_DEFAULT, help: POLYCOUNT_HELP },
+        { name: 'visibility', type: 'string', default: VISIBILITY_DEFAULT, choices: VISIBILITY_CHOICES, help: 'Privacy of the new project; auto follows the studio (public on a free plan, shareable for subscribers) — private and shareable need a paid plan' },
+        { name: 't-pose', type: 'bool', default: false, help: 'Ask for a T-posed character (characters only)' },
+        { name: 'wait', type: 'bool', default: true, help: 'Wait for the mesh to finish before returning' },
+        { name: 'timeout', type: 'int', default: 600, help: 'Seconds to wait when --wait is on' },
+    ],
+    columns: GENERATE_COLUMNS,
+    func: async (page, args) => {
+        const prompt = String(args.prompt ?? '').trim();
+        if (!prompt) throw new ArgumentError('prompt is required and cannot be blank');
+        if (prompt.length > PROMPT_MAX) {
+            throw new ArgumentError(`prompt is ${prompt.length} characters; the studio accepts at most ${PROMPT_MAX}`);
+        }
+
+        const mesh = resolveSmartMesh(args);
+        const timeoutSec = normalizeTimeout(args.timeout, 600);
+        const wait = args.wait !== false;
+        const tPose = args['t-pose'] === true;
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        // Resolved against the account, so it has to wait for a live session.
+        const visibility = await resolveVisibility(page, args.visibility);
+
+        return runSmartMesh(page, {
+            endpoint: '/v2/studio/operation/text_to_model',
+            mode: 'text',
+            // The studio renders a reference image first and lifts the mesh from
+            // it; `sketch_to_render` is the line-art path, which Smart Mesh's
+            // text tab never turns on.
+            payload: {
+                gen_image_model_version: TEXT_IMAGE_MODEL,
+                prompt,
+                sketch_to_render: false,
+                t_pose: tPose,
+            },
+            ...mesh,
+            visibility,
+            // A prompt has no reference image, so P2's `symmetry` stays false —
+            // the same literal the page posts from the text tab.
+            symmetrySource: null,
+            prompt,
+            images: null,
+            wait,
+            timeoutSec,
+        });
+    },
+});

--- a/clis/tripo3d/texture.js
+++ b/clis/tripo3d/texture.js
@@ -1,0 +1,93 @@
+// tripo3d texture — bake a texture onto a mesh that was already generated.
+import { cli, Strategy } from '@jackwener/opencli/registry';
+import { CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    HOST,
+    TEXTURE_ALIGNMENTS,
+    TEXTURE_MODEL,
+    TEXTURE_QUALITY_BY_SIZE,
+    api,
+    ensureStudio,
+    normalizeTimeout,
+    parseProjectId,
+    requireSession,
+    resolveChoice,
+    waitForOperator,
+    workspaceUrl,
+} from './utils.js';
+
+const SIZES = Object.keys(TEXTURE_QUALITY_BY_SIZE);
+
+cli({
+    site: 'tripo3d',
+    name: 'texture',
+    description: 'Generate a texture for an existing Tripo project mesh (spends Tripo credits)',
+    access: 'write',
+    example: 'opencli tripo3d texture 1f4b0c9a-6d21-4e5f-8a37-2c9de4b170aa --size 4k',
+    domain: HOST,
+    strategy: Strategy.INTERCEPT,
+    browser: true,
+    navigateBefore: false,
+    args: [
+        { name: 'project', type: 'string', required: true, positional: true, help: 'Project id, or a workspace URL' },
+        { name: 'size', type: 'string', default: '2k', choices: SIZES, help: 'Texture resolution (4k and 8k cost extra credits)' },
+        { name: 'alignment', type: 'string', default: 'original_image', choices: TEXTURE_ALIGNMENTS, help: 'Anchor the texture to the source image or to the bare geometry' },
+        { name: 'prompt', type: 'string', default: '', help: 'Texture description; defaults to the prompt the mesh was generated with' },
+        { name: 'wait', type: 'bool', default: true, help: 'Wait for the texture to finish before returning' },
+        { name: 'timeout', type: 'int', default: 900, help: 'Seconds to wait when --wait is on' },
+    ],
+    columns: ['projectId', 'operatorId', 'status', 'progress', 'size', 'quality', 'alignment', 'prompt', 'workspaceUrl'],
+    func: async (page, args) => {
+        const projectId = parseProjectId(args.project);
+        const size = resolveChoice(args.size, SIZES, 'size');
+        const quality = TEXTURE_QUALITY_BY_SIZE[size];
+        const alignment = resolveChoice(args.alignment, TEXTURE_ALIGNMENTS, 'alignment');
+        const timeoutSec = normalizeTimeout(args.timeout, 900);
+        const wait = args.wait !== false;
+        const promptText = String(args.prompt ?? '').trim();
+
+        await ensureStudio(page);
+        await requireSession(page);
+
+        const body = {
+            model_version: TEXTURE_MODEL,
+            project_id: projectId,
+            texture_alignment: alignment,
+            texture_quality: quality,
+        };
+        // The studio always sends a prompt; when the caller gives none it reuses
+        // the text the mesh was generated from, so the texture matches the shape.
+        if (promptText) body.prompt_text = promptText;
+
+        const created = await api(page, '/v2/studio/operation/texture_model', { body });
+        const operatorId = created?.operator_id || null;
+        if (!operatorId) {
+            throw new CommandExecutionError('texture_model accepted the request but returned no task handle');
+        }
+
+        let jobStatus = 'queued';
+        let jobProgress = null;
+        if (wait) {
+            const done = await waitForOperator(page, operatorId, timeoutSec, 'texture generation');
+            jobStatus = done.status;
+            jobProgress = done.progress ?? null;
+            if (jobStatus !== 'success') {
+                throw new CommandExecutionError(
+                    `texture generation ended as "${jobStatus}" (project ${projectId}, operator ${operatorId}) — open ${workspaceUrl(projectId)} for the site's own explanation`,
+                );
+            }
+        }
+
+        return [{
+            projectId,
+            operatorId,
+            status: jobStatus,
+            progress: jobProgress,
+            size,
+            quality,
+            alignment,
+            prompt: promptText || null,
+            workspaceUrl: workspaceUrl(projectId),
+        }];
+    },
+});

--- a/clis/tripo3d/tripo3d.test.js
+++ b/clis/tripo3d/tripo3d.test.js
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import { getRegistry, Strategy } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from '@jackwener/opencli/errors';
+import {
+    POLYCOUNT_MAX,
+    SMART_MESH_MODEL_VERSIONS,
+    api,
+    normalizePolycount,
+    parseProjectId,
+    resolveChoice,
+    resolveSmartMesh,
+    resolveSymmetry,
+    resolveVisibility,
+    runSmartMesh,
+} from './utils.js';
+import './text-to-model.js';
+import './image-to-model.js';
+import './multiview-to-model.js';
+import './texture.js';
+import './status.js';
+import './assets.js';
+import './credits.js';
+
+/**
+ * Stand-in for the browser page.
+ *
+ * `api()` builds a page-context fetch as a source string with the endpoint path
+ * embedded, so routing on that substring is enough to drive every helper without
+ * a real browser. Every call is recorded so a test can assert on the request the
+ * adapter would actually have sent.
+ */
+function fakePage(routes) {
+    const calls = [];
+    return {
+        calls,
+        async evaluate(src) {
+            const path = Object.keys(routes).find((p) => src.includes(p));
+            if (!path) throw new Error(`unrouted page call: ${src.slice(0, 120)}`);
+            const bodyMatch = /body: (".*?"),\n/s.exec(src);
+            calls.push({ path, body: bodyMatch ? JSON.parse(JSON.parse(bodyMatch[1])) : null });
+            const route = routes[path];
+            return typeof route === 'function' ? route(calls.at(-1)) : route;
+        },
+    };
+}
+
+const ok = (data) => ({ status: 200, json: { code: 0, message: 'OK', data } });
+
+describe('tripo3d polycount bounds', () => {
+    it('ties the ceiling to the engine and the topology', () => {
+        expect(POLYCOUNT_MAX).toEqual({
+            'p1/triangle': 20000,
+            'p2/triangle': 50000,
+            'p2/quad': 25000,
+        });
+    });
+
+    it('accepts a value at each ceiling', () => {
+        expect(normalizePolycount(20000, 'p1', 'triangle')).toBe(20000);
+        expect(normalizePolycount(50000, 'p2', 'triangle')).toBe(50000);
+        expect(normalizePolycount(25000, 'p2', 'quad')).toBe(25000);
+    });
+
+    // The studio clamps silently (Math.round(Math.min(value, ceiling))). Copying
+    // that would bill a 100-credit generation at a face count nobody asked for.
+    it('rejects an over-range value instead of clamping it', () => {
+        expect(() => normalizePolycount(30000, 'p1', 'triangle')).toThrow(ArgumentError);
+        expect(() => normalizePolycount(30000, 'p2', 'quad')).toThrow(/between 500 and 25000 for p2 \+ quad/);
+        expect(() => normalizePolycount(499, 'p2', 'triangle')).toThrow(ArgumentError);
+        expect(() => normalizePolycount(1.5, 'p2', 'triangle')).toThrow(/must be an integer/);
+    });
+});
+
+describe('tripo3d resolveSmartMesh', () => {
+    it('maps each engine onto the model_version the studio sends', () => {
+        expect(resolveSmartMesh({ model: 'p1', topology: 'triangle', polycount: 5000 }).modelVersion)
+            .toBe(SMART_MESH_MODEL_VERSIONS.p1);
+        expect(resolveSmartMesh({ model: 'p2', topology: 'quad', polycount: 5000 }).modelVersion)
+            .toBe(SMART_MESH_MODEL_VERSIONS.p2);
+    });
+
+    // P1 renders the Quad button disabled ("Coming Soon"), so quad on P1 is a
+    // caller mistake, not a value to downgrade behind their back.
+    it('refuses quad on P1 rather than falling back to triangles', () => {
+        expect(() => resolveSmartMesh({ model: 'p1', topology: 'quad', polycount: 5000 }))
+            .toThrow(/quad topology needs --model p2/);
+    });
+
+    it('applies the topology-specific ceiling', () => {
+        expect(() => resolveSmartMesh({ model: 'p2', topology: 'quad', polycount: 30000 }))
+            .toThrow(ArgumentError);
+        expect(resolveSmartMesh({ model: 'p2', topology: 'triangle', polycount: 30000 }).polycount)
+            .toBe(30000);
+    });
+
+    it('rejects an unknown engine or topology', () => {
+        expect(() => resolveSmartMesh({ model: 'p3', topology: 'triangle', polycount: 5000 })).toThrow(ArgumentError);
+        expect(() => resolveSmartMesh({ model: 'p2', topology: 'ngon', polycount: 5000 })).toThrow(ArgumentError);
+    });
+});
+
+describe('tripo3d argument helpers', () => {
+    it('resolves a choice case- and separator-insensitively but never guesses', () => {
+        expect(resolveChoice('Original Image', ['original_image', 'geometry'], 'alignment')).toBe('original_image');
+        expect(() => resolveChoice('geometrics', ['original_image', 'geometry'], 'alignment')).toThrow(ArgumentError);
+    });
+
+    it('pulls the project id out of a slugged workspace URL', () => {
+        const id = '55002487-478d-4bec-a44f-0824c2bfa6f4';
+        expect(parseProjectId(id)).toBe(id);
+        expect(parseProjectId(`https://studio.tripo3d.ai/workspace/generate/calculator-3d-model-${id}`)).toBe(id);
+        expect(() => parseProjectId('calculator-3d-model')).toThrow(ArgumentError);
+    });
+});
+
+describe('tripo3d api error classification', () => {
+    // Measured against the live studio: signed out is 401 + code 1002, while a
+    // refusal against a healthy session is 403 with a business code. Reporting
+    // the latter as an auth failure sends the caller off to re-authenticate a
+    // session that was never broken.
+    it('treats 401 as a lost session', async () => {
+        const page = fakePage({
+            '/v2/studio/operation/quota': {
+                status: 401,
+                json: { code: 1002, message: 'Authentication failed' },
+            },
+        });
+        await expect(api(page, '/v2/studio/operation/quota')).rejects.toThrow(AuthRequiredError);
+    });
+
+    it('surfaces a 403 business refusal with its own code and message', async () => {
+        const page = fakePage({
+            '/v2/studio/operation/image_to_model': {
+                status: 403,
+                json: { code: 6102, message: 'Insufficient membership', suggestion: 'Please check your membership' },
+            },
+        });
+        await expect(api(page, '/v2/studio/operation/image_to_model', { body: {} }))
+            .rejects.toThrow(/HTTP 403, code 6102.*Insufficient membership — Please check your membership/);
+        await expect(api(page, '/v2/studio/operation/image_to_model', { body: {} }))
+            .rejects.not.toThrow(AuthRequiredError);
+    });
+
+    it('reports a non-JSON reply instead of pretending it parsed', async () => {
+        const page = fakePage({
+            '/v2/studio/progress': { status: 503, json: null, raw: '<html>upstream error</html>' },
+        });
+        await expect(api(page, '/v2/studio/progress', { body: {} }))
+            .rejects.toThrow(CommandExecutionError);
+    });
+});
+
+describe('tripo3d symmetry', () => {
+    // A text prompt has no reference image, and the studio posts a literal false
+    // for it rather than calling symmetry_check at all.
+    it('answers false without a request when there is no source image', async () => {
+        const page = fakePage({});
+        expect(await resolveSymmetry(page, null)).toBe(false);
+        expect(page.calls).toHaveLength(0);
+    });
+
+    it('forwards the studio verdict for an uploaded image', async () => {
+        const page = fakePage({ '/v2/studio/operation/symmetry_check': ok({ symmetry: true }) });
+        expect(await resolveSymmetry(page, { bucket: 'tripo-data', key: 'a/b/input.png' })).toBe(true);
+        expect(page.calls[0].body).toEqual({ image: { bucket: 'tripo-data', key: 'a/b/input.png' } });
+    });
+});
+
+describe('tripo3d visibility', () => {
+    // The Privacy control now sits under a "Members Only" heading; a free plan
+    // that asks for anything but public gets 403 6102 after the image upload.
+    it('auto resolves to public on a plan that cannot set privacy', async () => {
+        const page = fakePage({ '/v2/studio/user/profile/payment': ok({ member: { type: 'basic' } }) });
+        expect(await resolveVisibility(page, 'auto')).toBe('public');
+    });
+
+    it('auto resolves to shareable for a subscriber', async () => {
+        const page = fakePage({ '/v2/studio/user/profile/payment': ok({ member: { type: 'pro' } }) });
+        expect(await resolveVisibility(page, 'auto')).toBe('shareable');
+    });
+
+    it('passes an explicit value straight through', async () => {
+        const page = fakePage({});
+        expect(await resolveVisibility(page, 'private')).toBe('private');
+        expect(page.calls).toHaveLength(0);
+    });
+});
+
+describe('tripo3d runSmartMesh payload', () => {
+    const submit = (overrides) => {
+        const page = fakePage({
+            '/v2/studio/operation/symmetry_check': ok({ symmetry: true }),
+            '/v2/studio/operation/text_to_model': ok({
+                operator_id: 'op-1',
+                project_id: 'proj-1',
+            }),
+            '/v2/studio/assets/v2': ok({ projects: [{ id: 'proj-1', project_name: 'stone lantern 3d model' }] }),
+        });
+        return runSmartMesh(page, {
+            endpoint: '/v2/studio/operation/text_to_model',
+            mode: 'text',
+            payload: { prompt: 'a stone lantern' },
+            visibility: 'public',
+            wait: false,
+            timeoutSec: 600,
+            ...resolveSmartMesh({ model: 'p1', topology: 'triangle', polycount: 5000 }),
+            ...overrides,
+        }).then((rows) => ({ rows, calls: page.calls }));
+    };
+
+    it('sends quad as a boolean and never adds symmetry on P1', async () => {
+        const { rows, calls } = await submit({});
+        const body = calls.find((c) => c.path.endsWith('text_to_model')).body;
+        expect(body).toMatchObject({
+            face_limit: 5000,
+            quad: false,
+            visibility: 'public',
+            model_version: SMART_MESH_MODEL_VERSIONS.p1,
+            prompt: 'a stone lantern',
+        });
+        expect('symmetry' in body).toBe(false);
+        expect(calls.some((c) => c.path.includes('symmetry_check'))).toBe(false);
+        expect(rows[0]).toMatchObject({ model: 'p1', topology: 'triangle', symmetry: null });
+    });
+
+    it('attaches the symmetry verdict on P2 and reports the topology it asked for', async () => {
+        const { rows, calls } = await submit({
+            ...resolveSmartMesh({ model: 'p2', topology: 'quad', polycount: 22000 }),
+            symmetrySource: { bucket: 'tripo-data', key: 'a/b/input.png' },
+        });
+        const body = calls.find((c) => c.path.endsWith('text_to_model')).body;
+        expect(body).toMatchObject({
+            face_limit: 22000,
+            quad: true,
+            model_version: SMART_MESH_MODEL_VERSIONS.p2,
+            symmetry: true,
+        });
+        expect(rows[0]).toMatchObject({
+            model: 'p2',
+            topology: 'quad',
+            polycount: 22000,
+            symmetry: true,
+            projectId: 'proj-1',
+            operatorId: 'op-1',
+            status: 'queued',
+            projectName: 'stone lantern 3d model',
+        });
+    });
+
+    it('fails loudly when the endpoint answers without a task handle', async () => {
+        const page = fakePage({ '/v2/studio/operation/text_to_model': ok({}) });
+        await expect(runSmartMesh(page, {
+            endpoint: '/v2/studio/operation/text_to_model',
+            mode: 'text',
+            payload: {},
+            visibility: 'public',
+            wait: false,
+            timeoutSec: 600,
+            ...resolveSmartMesh({ model: 'p1', topology: 'triangle', polycount: 5000 }),
+        })).rejects.toThrow(CommandExecutionError);
+    });
+});
+
+describe('tripo3d command registry', () => {
+    it('registers the Smart Mesh surface with the right access split', () => {
+        for (const name of ['assets', 'credits', 'status']) {
+            expect(getRegistry().get(`tripo3d/${name}`)).toMatchObject({
+                access: 'read',
+                strategy: Strategy.INTERCEPT,
+                domain: 'studio.tripo3d.ai',
+            });
+        }
+        for (const name of ['text-to-model', 'image-to-model', 'multiview-to-model', 'texture']) {
+            expect(getRegistry().get(`tripo3d/${name}`)).toMatchObject({
+                access: 'write',
+                strategy: Strategy.INTERCEPT,
+                domain: 'studio.tripo3d.ai',
+            });
+        }
+    });
+
+    it('offers the engine and topology as declared choices on every generate command', () => {
+        for (const name of ['text-to-model', 'image-to-model', 'multiview-to-model']) {
+            const args = getRegistry().get(`tripo3d/${name}`).args;
+            expect(args.find((a) => a.name === 'model')).toMatchObject({ default: 'p1', choices: ['p1', 'p2'] });
+            expect(args.find((a) => a.name === 'topology')).toMatchObject({
+                default: 'triangle',
+                choices: ['triangle', 'quad'],
+            });
+            expect(args.find((a) => a.name === 'visibility')).toMatchObject({ default: 'auto' });
+        }
+    });
+});

--- a/clis/tripo3d/utils.js
+++ b/clis/tripo3d/utils.js
@@ -1,0 +1,582 @@
+// Shared helpers for the tripo3d adapters (Tripo Studio, Smart Mesh engine).
+//
+// Strategy: PAGE_FETCH for every JSON call.
+//
+//   * The studio API lives on api.tripo3d.ai and authenticates with an HttpOnly
+//     cookie on .tripo3d.ai — the captured requests carry no bearer token and no
+//     CSRF header. api.tripo3d.ai sits behind Cloudflare bot management (__cf_bm),
+//     which binds to the browser's TLS/UA fingerprint, so the calls are issued
+//     from the page's own origin instead of replayed Node-side.
+//   * Tripo also publishes a documented REST API on platform.tripo3d.ai, but it
+//     needs a separate API key rather than the studio session these commands are
+//     built to reuse, so it is not an alternative here.
+//
+// Note on file export: it is NOT a server-side endpoint. `operation/export-lite`
+// returns `{}` and only bumps the account's monthly export counter; the FBX/OBJ/
+// STL file is produced inside the page and handed to the browser as a Blob, so
+// exporting a finished model has to drive the studio's own Export dialog. That
+// command is not part of this adapter yet.
+import { readFile } from 'node:fs/promises';
+import { createHash, createHmac } from 'node:crypto';
+import { basename, extname } from 'node:path';
+import {
+    ArgumentError,
+    AuthRequiredError,
+    CommandExecutionError,
+    TimeoutError,
+} from '@jackwener/opencli/errors';
+
+export const HOST = 'studio.tripo3d.ai';
+export const STUDIO_ORIGIN = 'https://studio.tripo3d.ai';
+export const API_ORIGIN = 'https://api.tripo3d.ai';
+export const WORKSPACE_URL = `${STUDIO_ORIGIN}/workspace/generate`;
+
+/**
+ * Smart Mesh is the Nexus engine, and its AI Model dropdown offers two of them.
+ * The other tab ("HD Model") runs v2.5/v3.x with a different option set, so only
+ * the two Nexus lines are selectable here — every command in this suite is
+ * Smart Mesh only.
+ */
+export const SMART_MESH_MODELS = ['p1', 'p2'];
+
+export const SMART_MESH_MODEL_VERSIONS = {
+    p1: 'Nexus-v1.0-20260214',
+    p2: 'Nexus-v2.0-20260801',
+};
+
+/**
+ * The studio itself now defaults the dropdown to P2, but this suite stays on P1:
+ * P2 is nearly 3x the price, and flipping the default would silently retag every
+ * existing command line from 35 credits to 100. Opt in with `--model p2`.
+ */
+export const SMART_MESH_MODEL_DEFAULT = 'p1';
+
+/** Credits the Generate button quotes per job, before the P2 free trial. */
+export const SMART_MESH_CREDITS = { p1: 35, p2: 100 };
+
+/** Texture generation runs on its own model line, independent of the mesh engine. */
+export const TEXTURE_MODEL = 'v3.0-20250812';
+
+/** Text-to-model first renders a reference image with this generator. */
+export const TEXT_IMAGE_MODEL = 'flux.1_dev';
+
+/**
+ * Topology toggle in the Topology popover. Quad is **P2 only**: on P1 the button
+ * renders disabled with a "Coming Soon" label, so `--topology quad --model p1` is
+ * rejected rather than quietly downgraded to triangles.
+ */
+export const TOPOLOGIES = ['triangle', 'quad'];
+export const TOPOLOGY_DEFAULT = 'triangle';
+
+/** Polycount slider bounds read off the Topology popover. */
+export const POLYCOUNT_MIN = 500;
+export const POLYCOUNT_DEFAULT = 5000;
+
+/**
+ * The slider's ceiling moves with the engine and the topology — a quad job packs
+ * four-sided faces, so the same budget buys fewer of them.
+ */
+export const POLYCOUNT_MAX = {
+    'p1/triangle': 20000,
+    'p2/triangle': 50000,
+    'p2/quad': 25000,
+};
+
+export const POLYCOUNT_HELP =
+    `Target face count, min ${POLYCOUNT_MIN}. The ceiling follows --model/--topology: `
+    + Object.entries(POLYCOUNT_MAX).map(([k, v]) => `${k} ${v}`).join(', ');
+
+/** Privacy dropdown values, in the site's own order. */
+export const VISIBILITIES = ['public', 'private', 'shareable'];
+
+/**
+ * `auto` is not one of the site's values: it means "whatever the studio would
+ * preselect for this account".
+ *
+ * The whole Privacy control now sits under a "Members Only" heading — on a free
+ * plan clicking it opens the pricing dialog instead of a dropdown, and asking the
+ * API for anything but `public` comes back as HTTP 403 `6102 Insufficient
+ * membership`, *after* the reference image has already been uploaded. Defaulting
+ * to `auto` keeps a free account working without ever publishing a subscriber's
+ * model more widely than the site would have.
+ */
+export const VISIBILITY_CHOICES = ['auto', ...VISIBILITIES];
+export const VISIBILITY_DEFAULT = 'auto';
+
+/** Texture Resolution → the API's texture_quality code. */
+export const TEXTURE_QUALITY_BY_SIZE = {
+    '2k': 'standard',
+    '4k': 'detailed',
+    '8k': 'extreme',
+};
+
+/** How the texture is anchored: to the source image, or to the bare geometry. */
+export const TEXTURE_ALIGNMENTS = ['original_image', 'geometry'];
+
+/** A task stops moving once it reaches one of these. */
+export const TERMINAL_STATUSES = ['success', 'failed', 'banned', 'cancelled', 'expired'];
+
+const MIME_BY_EXT = {
+    '.png': { mime: 'image/png', format: 'png' },
+    '.jpg': { mime: 'image/jpeg', format: 'jpg' },
+    '.jpeg': { mime: 'image/jpeg', format: 'jpg' },
+    '.webp': { mime: 'image/webp', format: 'webp' },
+};
+
+/** The uploader mirrors the site's own limit ("JPG,PNG,WEBP Size ≤ 20MB"). */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Arguments
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a bounded integer without silently clamping it: a polycount outside
+ * the slider's range is a caller mistake, and quietly generating 5000 faces when
+ * 50000 was asked for would bill a generation the caller did not want.
+ *
+ * The page *does* clamp (`Math.round(Math.min(t, ceiling))`), which is exactly
+ * why this does not — a clamp the caller cannot see is a 100-credit surprise.
+ */
+export function normalizePolycount(value, model, topology) {
+    const max = POLYCOUNT_MAX[`${model}/${topology}`];
+    if (!max) throw new ArgumentError(`no polycount range is defined for model ${model} + topology ${topology}`);
+
+    const n = Number(value ?? POLYCOUNT_DEFAULT);
+    if (!Number.isInteger(n)) throw new ArgumentError('polycount must be an integer');
+    if (n < POLYCOUNT_MIN || n > max) {
+        throw new ArgumentError(
+            `polycount must be between ${POLYCOUNT_MIN} and ${max} for ${model} + ${topology} (Smart Mesh slider range), got ${n}`,
+        );
+    }
+    return n;
+}
+
+/**
+ * Resolve the three coupled Topology arguments in one place, so all three
+ * generate commands reject the same combinations with the same wording.
+ */
+export function resolveSmartMesh({ model, topology, polycount }) {
+    const engine = resolveChoice(model, SMART_MESH_MODELS, 'model');
+    const topo = resolveChoice(topology, TOPOLOGIES, 'topology');
+    if (topo === 'quad' && engine !== 'p2') {
+        throw new ArgumentError(
+            `quad topology needs --model p2: on ${engine} the studio renders the Quad button disabled ("Coming Soon") and the engine only emits triangles`,
+        );
+    }
+    return {
+        model: engine,
+        topology: topo,
+        modelVersion: SMART_MESH_MODEL_VERSIONS[engine],
+        polycount: normalizePolycount(polycount, engine, topo),
+    };
+}
+
+/** Positive integer seconds, with a floor so a too-eager timeout cannot abort a live task. */
+export function normalizeTimeout(value, defaultValue, { min = 30 } = {}) {
+    const n = Number(value ?? defaultValue);
+    if (!Number.isInteger(n) || n <= 0) throw new ArgumentError('timeout must be a positive integer (seconds)');
+    if (n < min) throw new ArgumentError(`timeout must be >= ${min} seconds`);
+    return n;
+}
+
+/** Case- and spacing-insensitive key shared by every "resolve a label" helper. */
+const foldKey = (value) => String(value ?? '').trim().toLowerCase().replace(/[\s_-]+/g, '');
+
+/**
+ * Map user input onto one of `allowed`, rejecting anything else rather than
+ * falling back to the default — a typo must not silently publish a model or
+ * spend credits on the wrong setting.
+ */
+export function resolveChoice(value, allowed, label) {
+    const key = foldKey(value);
+    const hit = allowed.find((a) => foldKey(a) === key);
+    if (!hit) throw new ArgumentError(`Unknown ${label} "${value}". Valid: ${allowed.join(' / ')}`);
+    return hit;
+}
+
+/**
+ * Accept a bare project id or any workspace URL that ends in one.
+ *
+ * The site's own links are slugged (`/workspace/generate/red-apple-…-<uuid>`),
+ * so pasting one back has to keep working.
+ */
+export function parseProjectId(value) {
+    const raw = String(value ?? '').trim();
+    if (!raw) throw new ArgumentError('project is required: pass a project id or a workspace URL');
+    const uuid = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.exec(raw);
+    if (!uuid) {
+        throw new ArgumentError(`"${raw}" does not contain a project id (expected a UUID, or a studio.tripo3d.ai workspace URL)`);
+    }
+    return uuid[0].toLowerCase();
+}
+
+/** Workspace deep link for a project — the handle a human needs to see the result. */
+export const workspaceUrl = (projectId) => `${STUDIO_ORIGIN}/workspace/generate/${projectId}`;
+
+// ---------------------------------------------------------------------------
+// Page + API
+// ---------------------------------------------------------------------------
+
+/**
+ * Make sure the tab is on the studio origin.
+ *
+ * Every API call runs as a page-context fetch, and api.tripo3d.ai only answers
+ * credentialed requests whose Origin is the studio — a stray tab would fail CORS
+ * long before it ever failed auth.
+ */
+export async function ensureStudio(page, url = WORKSPACE_URL) {
+    let origin = null;
+    try {
+        origin = await page.evaluate('location.origin');
+    } catch {
+        origin = null;
+    }
+    if (origin === STUDIO_ORIGIN) return;
+    await page.goto(url, { waitUntil: 'load' });
+}
+
+/**
+ * Call one studio endpoint from inside the page and return its `data` payload.
+ *
+ * @throws {AuthRequiredError} when the session cookie is gone or rejected
+ * @throws {CommandExecutionError} for a non-JSON reply or a non-zero `code`
+ */
+export async function api(page, path, { method = 'POST', body = null } = {}) {
+    const src = `(async () => {
+        let res;
+        try {
+            res = await fetch(${JSON.stringify(API_ORIGIN + path)}, {
+                method: ${JSON.stringify(method)},
+                credentials: 'include',
+                headers: ${body === null ? '{}' : "{ 'content-type': 'application/json' }"},
+                body: ${body === null ? 'undefined' : JSON.stringify(JSON.stringify(body))},
+            });
+        } catch (error) {
+            return { failed: String(error && error.message || error) };
+        }
+        const raw = await res.text();
+        try {
+            return { status: res.status, json: JSON.parse(raw) };
+        } catch {
+            return { status: res.status, json: null, raw: raw.slice(0, 300) };
+        }
+    })()`;
+
+    const reply = await page.evaluate(src);
+    if (!reply || reply.failed) {
+        throw new CommandExecutionError(`request to ${path} could not be sent from the page: ${reply?.failed || 'no response'}`);
+    }
+    // 401 is the only status that means "signed out" — the studio answers it with
+    // code 1002 "Authentication failed". A 403 is a *business* refusal against a
+    // perfectly good session (6102 "Insufficient membership" when a free plan asks
+    // for a private model), and calling that a login failure sends the caller off
+    // to re-authenticate something that was never broken.
+    if (reply.status === 401) throw new AuthRequiredError(HOST);
+    if (!reply.json) {
+        throw new CommandExecutionError(`${path} returned a non-JSON response (HTTP ${reply.status}): ${reply.raw || '(empty)'}`);
+    }
+
+    const { code, message, suggestion, data } = reply.json;
+    if (code !== 0) {
+        const detail = [message, suggestion].filter(Boolean).join(' — ') || `code ${code}`;
+        throw new CommandExecutionError(`${path} failed (HTTP ${reply.status}, code ${code}): ${detail}`);
+    }
+    return data;
+}
+
+/**
+ * Turn `--visibility auto` into the value the studio's own Privacy dropdown
+ * would be holding, and pass every explicit choice straight through.
+ */
+export async function resolveVisibility(page, value) {
+    const choice = resolveChoice(value, VISIBILITY_CHOICES, 'visibility');
+    if (choice !== 'auto') return choice;
+
+    const payment = await api(page, '/v2/studio/user/profile/payment', { method: 'GET' }).catch(() => null);
+    // The store preselects Sharing Only for subscribers and Public for everyone
+    // else, off exactly this test: `payment.member.type !== 'basic'`.
+    const plan = payment?.member?.type ?? null;
+    return plan && plan !== 'basic' ? 'shareable' : 'public';
+}
+
+/** Fail fast with a typed error when the browser is not signed in to the studio. */
+export async function requireSession(page) {
+    const profile = await api(page, '/v2/studio/wm-biz/user/profile', { body: {} });
+    if (!profile?.user_id) throw new AuthRequiredError(HOST);
+    return profile;
+}
+
+/**
+ * Poll one operator (task) until it stops moving.
+ *
+ * `progress` is the only signal the site has: there is no webhook and no
+ * completion event on the REST surface, so the UI polls the same endpoint.
+ *
+ * @returns the terminal progress row
+ * @throws {TimeoutError} when the deadline passes while it is still running
+ */
+export async function waitForOperator(page, operatorId, timeoutSec, label) {
+    const deadline = Date.now() + timeoutSec * 1000;
+    let last = null;
+    for (;;) {
+        const rows = await api(page, '/v2/studio/progress', { body: { ids: [operatorId] } });
+        last = (Array.isArray(rows) ? rows : []).find((r) => r.operator_id === operatorId) || last;
+        if (last && TERMINAL_STATUSES.includes(last.status)) return last;
+        if (Date.now() >= deadline) throw new TimeoutError(label, timeoutSec);
+        await sleep(3000);
+    }
+}
+
+/**
+ * Look the project up in the asset list so a generate command can report the
+ * name the site assigned. Scoped to the first pages: a project that was just
+ * created is always at the top, and this is decoration, never a hard failure.
+ */
+export async function findProject(page, projectId, { pages = 2, size = 20 } = {}) {
+    for (let i = 0; i < pages; i++) {
+        const data = await api(page, `/v2/studio/assets/v2?asset_type=mine&offset=${i * size}&size=${size}&type=all`, { method: 'GET' });
+        const hit = (data?.projects || []).find((p) => p.id === projectId);
+        if (hit) return hit;
+        if ((data?.projects || []).length < size) break;
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Image upload (temporary STS token → S3 PUT → moderation)
+// ---------------------------------------------------------------------------
+
+const sha256hex = (buf) => createHash('sha256').update(buf).digest('hex');
+const hmac = (key, data) => createHmac('sha256', key).update(data).digest();
+
+/**
+ * Sign and PUT the image straight to S3 from Node.
+ *
+ * The studio hands out short-lived STS credentials and the page uploads with the
+ * AWS SDK. Node-side signing keeps the image bytes off the browser bridge (a
+ * 20 MB base64 round-trip through `evaluate` does not survive), and S3 itself is
+ * not the Cloudflare-fronted host, so there is no session to reuse here.
+ */
+async function putToS3(token, bytes, contentType) {
+    const region = String(token.host || '').split('.')[1] || 'us-west-2';
+    const host = `${token.resource_bucket}.${token.host}`;
+    const canonicalUri = `/${String(token.resource_uri).split('/').map(encodeURIComponent).join('/')}`;
+    const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
+    const dateStamp = amzDate.slice(0, 8);
+    const payloadHash = sha256hex(bytes);
+
+    const headers = {
+        host,
+        'content-type': contentType,
+        'x-amz-content-sha256': payloadHash,
+        'x-amz-date': amzDate,
+        'x-amz-security-token': token.session_token,
+    };
+    const names = Object.keys(headers).sort();
+    const signedHeaders = names.join(';');
+    const canonicalHeaders = names.map((k) => `${k}:${headers[k]}\n`).join('');
+    const canonicalRequest = ['PUT', canonicalUri, '', canonicalHeaders, signedHeaders, payloadHash].join('\n');
+    const scope = `${dateStamp}/${region}/s3/aws4_request`;
+    const stringToSign = [
+        'AWS4-HMAC-SHA256',
+        amzDate,
+        scope,
+        sha256hex(Buffer.from(canonicalRequest)),
+    ].join('\n');
+
+    let signingKey = hmac(Buffer.from(`AWS4${token.sts_sk}`), dateStamp);
+    for (const part of [region, 's3', 'aws4_request']) signingKey = hmac(signingKey, part);
+    const signature = createHmac('sha256', signingKey).update(stringToSign).digest('hex');
+
+    headers.authorization = `AWS4-HMAC-SHA256 Credential=${token.sts_ak}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+    delete headers.host;
+
+    let res;
+    try {
+        res = await fetch(`https://${host}${canonicalUri}`, { method: 'PUT', headers, body: bytes });
+    } catch (error) {
+        throw new CommandExecutionError(`image upload to storage failed: ${error?.message || error}`);
+    }
+    if (!res.ok) {
+        throw new CommandExecutionError(`image upload to storage failed: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`);
+    }
+    return { bucket: token.resource_bucket, key: token.resource_uri };
+}
+
+/** Read one local image and reject anything the studio would not accept. */
+async function readImage(path) {
+    const ext = extname(path).toLowerCase();
+    const kind = MIME_BY_EXT[ext];
+    if (!kind) {
+        throw new ArgumentError(`unsupported image type "${ext || path}" (use ${Object.keys(MIME_BY_EXT).join(' / ')})`);
+    }
+    let bytes;
+    try {
+        bytes = await readFile(path);
+    } catch (error) {
+        throw new ArgumentError(`cannot read image "${path}": ${error?.message || error}`);
+    }
+    if (bytes.length === 0) throw new ArgumentError(`image "${path}" is empty`);
+    if (bytes.length > MAX_IMAGE_BYTES) {
+        throw new ArgumentError(`image "${path}" is larger than the studio's 20MB limit (${bytes.length} bytes)`);
+    }
+    return { bytes, ...kind };
+}
+
+/**
+ * Upload one image and run it through the studio's moderation gate.
+ *
+ * @returns the image reference the generate endpoints expect
+ * @throws {CommandExecutionError} when moderation does not return `pass`
+ */
+export async function uploadImage(page, path) {
+    const { bytes, mime, format } = await readImage(path);
+    const token = await api(page, '/v2/studio/storage/temporary_token', { body: { client: 'aws', format } });
+    if (!token?.sts_ak || !token?.resource_uri) {
+        throw new CommandExecutionError(`the studio did not issue an upload token for "${basename(path)}"`);
+    }
+
+    const stored = await putToS3(token, bytes, mime);
+    const audit = await api(page, '/v2/studio/audit/image', { body: { image: stored } });
+    const result = audit?.result || null;
+    if (result !== 'pass') {
+        throw new CommandExecutionError(
+            `"${basename(path)}" was rejected by the studio's image moderation (result: ${result ?? 'unknown'})`,
+        );
+    }
+    return { ...stored, image_audit_result: result };
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+/** Columns shared by the three Smart Mesh generate commands. */
+export const GENERATE_COLUMNS = [
+    'mode',
+    'model',
+    'projectId',
+    'operatorId',
+    'status',
+    'progress',
+    'topology',
+    'polycount',
+    'symmetry',
+    'visibility',
+    'prompt',
+    'images',
+    'projectName',
+    'workspaceUrl',
+];
+
+/**
+ * Ask the studio whether the reference image is bilaterally symmetric.
+ *
+ * P2 takes a `symmetry` flag that the UI never exposes as a control: the page
+ * runs `symmetry_check` on whichever image the viewer is looking at and forwards
+ * the verdict. Text mode has no reference image at all, so the page posts a
+ * literal `false` — passing `null` here reproduces that.
+ */
+export async function resolveSymmetry(page, image) {
+    if (!image) return false;
+    const data = await api(page, '/v2/studio/operation/symmetry_check', {
+        body: { image: { bucket: image.bucket, key: image.key } },
+    });
+    return data?.symmetry === true;
+}
+
+/**
+ * Remaining P2 free trials, or null when the account has no such pool.
+ *
+ * The site gates P2 on this: run out as a non-subscriber and the studio pops its
+ * pricing dialog and silently resets the dropdown back to P1.
+ */
+export async function smartMeshP2Trial(page) {
+    // POST with no body, the way the page sends it (`{}` is accepted too).
+    const data = await api(page, '/v2/studio/operation/quota').catch(() => null);
+    return data?.quota?.generation?.smart_mesh_v2 ?? null;
+}
+
+/**
+ * Submit one Smart Mesh job and, unless told otherwise, wait for it to land.
+ *
+ * Every generate endpoint takes the same envelope (face_limit / quad /
+ * visibility / model_version) and answers with the same handle, so the three
+ * commands differ only in the mode-specific keys they merge in.
+ *
+ * @param symmetrySource the reference image P2 should run `symmetry_check` on,
+ *   or null for a text prompt (which has no image and therefore no symmetry)
+ */
+export async function runSmartMesh(page, {
+    endpoint,
+    mode,
+    payload,
+    model,
+    topology,
+    modelVersion,
+    polycount,
+    visibility,
+    symmetrySource = null,
+    prompt = null,
+    images = null,
+    wait = true,
+    timeoutSec,
+}) {
+    // P1 has no `symmetry` key at all: the page only attaches one once the
+    // dropdown is on P2, so the older engine never sees the field.
+    const symmetry = model === 'p2' ? await resolveSymmetry(page, symmetrySource) : null;
+
+    const created = await api(page, endpoint, {
+        body: {
+            face_limit: polycount,
+            quad: topology === 'quad',
+            visibility,
+            model_version: modelVersion,
+            ...(symmetry === null ? {} : { symmetry }),
+            ...payload,
+        },
+    });
+
+    const operatorId = created?.operator_id || created?.task_id || null;
+    const projectId = created?.project_id || null;
+    if (!operatorId || !projectId) {
+        throw new CommandExecutionError(`${endpoint} accepted the request but returned no task handle`);
+    }
+
+    // Keys are job-prefixed so they can never collide with an output column —
+    // a same-named intermediate is what makes a dropped column silent.
+    let jobStatus = 'queued';
+    let jobProgress = null;
+    if (wait) {
+        const done = await waitForOperator(page, operatorId, timeoutSec, `${mode} generation`);
+        jobStatus = done.status;
+        jobProgress = done.progress ?? null;
+        if (jobStatus !== 'success') {
+            throw new CommandExecutionError(
+                `${mode} generation ended as "${jobStatus}" (project ${projectId}, operator ${operatorId}) — open ${workspaceUrl(projectId)} for the site's own explanation`,
+            );
+        }
+    }
+
+    const project = await findProject(page, projectId).catch(() => null);
+
+    return [{
+        mode,
+        model,
+        projectId,
+        operatorId,
+        status: jobStatus,
+        progress: jobProgress,
+        topology,
+        polycount,
+        symmetry,
+        visibility,
+        prompt,
+        images,
+        projectName: project?.project_name ?? null,
+        workspaceUrl: workspaceUrl(projectId),
+    }];
+}

--- a/docs/adapters/browser/tripo3d.md
+++ b/docs/adapters/browser/tripo3d.md
@@ -1,0 +1,82 @@
+# Tripo3D
+
+**Mode**: 🔐 Browser · **Domain**: `studio.tripo3d.ai`
+
+Drive [Tripo Studio](https://studio.tripo3d.ai)'s **Smart Mesh** engine from the CLI: turn a prompt, a reference image, or a set of orthographic views into a 3D mesh, bake a texture onto it, and track the jobs and the credits they cost.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `opencli tripo3d text-to-model <prompt>` | Generate an untextured mesh from a text prompt |
+| `opencli tripo3d image-to-model <image>` | Generate an untextured mesh from one reference image |
+| `opencli tripo3d multiview-to-model <front>` | Generate an untextured mesh from front/left/back/right views |
+| `opencli tripo3d texture <project>` | Bake a texture onto an existing project's mesh |
+| `opencli tripo3d status <operators>` | Check generation tasks by operator id |
+| `opencli tripo3d assets` | List workspace projects with their ids |
+| `opencli tripo3d credits` | Credit balance, plan, export allowance, and P2 free trials |
+
+## Usage Examples
+
+```bash
+# Check what a run will cost before spending anything
+opencli tripo3d credits -f json
+
+# Smart Mesh P1: fast, triangles only, 35 credits
+opencli tripo3d text-to-model "a small stylized wooden treasure chest" --polycount 4000 -f json
+
+# Smart Mesh P2: quad topology, 100 credits (2 free trials on a new account)
+opencli tripo3d image-to-model ./chest.png --model p2 --topology quad --polycount 22000 -f json
+
+# Four orthographic views; only the front one is required
+opencli tripo3d multiview-to-model ./front.png --left ./left.png --back ./back.png -f json
+
+# Fire and forget, then poll
+opencli tripo3d text-to-model "a low poly stone lantern" --wait false -f json
+opencli tripo3d status 7c3e5a18-90bd-42f6-b1c4-5de8073af921 -f json
+
+# Bake a 4K texture onto a mesh that already exists
+opencli tripo3d assets --limit 10 -f json
+opencli tripo3d texture 1f4b0c9a-6d21-4e5f-8a37-2c9de4b170aa --size 4k -f json
+```
+
+`texture` and the project argument of any command accept a bare project id or a full slugged `studio.tripo3d.ai/workspace/generate/...` URL. `status` takes one or more comma-separated **operator** ids — the handle every generate command returns — not project ids.
+
+## Smart Mesh engines and topology
+
+The Smart Mesh tab offers two engines, and they differ in more than speed:
+
+| | `--model p1` | `--model p2` |
+|---|---|---|
+| Studio label | P1.0 - Fast | P2.0 - Preview |
+| Quad topology | not available | `--topology quad` |
+| `--polycount` range | 500–20000 | 500–50000 triangle, 500–25000 quad |
+| Credits | 35 | 100, with 2 free trials per account |
+
+`p1` is the default even though the studio's own dropdown now defaults to P2, so an existing command line keeps costing what it always did. Ask for `--model p2` to opt into the newer engine, and check `credits` for `p2TrialsLeft` before a batch.
+
+`--topology quad` requires `--model p2`; asking for it on P1 is an error rather than a silent downgrade to triangles, because the studio renders that button disabled. Polycount is likewise validated against the engine and topology instead of being clamped, so a value the engine would quietly round down is reported before the credits are spent.
+
+P2 also sends a `symmetry` flag that the studio has no control for: it runs its own symmetry check on the main reference image and forwards the verdict. The adapter reproduces that — a text prompt has no reference image and sends `false`, an image sends the checked verdict, and multi-view uses the front slot.
+
+## Privacy
+
+`--visibility` defaults to `auto`, which resolves to whatever the studio's own Privacy dropdown would hold for the account: `public` on a free plan, `shareable` for a subscriber. The control sits behind a "Members Only" gate, so asking for `private` or `shareable` without a paid plan is refused by the API — after the reference image has already been uploaded.
+
+## Output
+
+Generate commands return the project and operator ids, the job status and progress, and the settings the request actually carried (`model`, `topology`, `polycount`, `symmetry`, `visibility`) plus a workspace URL for a human to open. `assets` returns each project's ids, name, operator type, texture state, and visibility. `status` returns the raw progress rows. `credits` returns the wallet, plan, monthly export allowance, and remaining P2 trials.
+
+Every JSON call is issued from the studio's own page context: `api.tripo3d.ai` authenticates with an HttpOnly cookie and sits behind Cloudflare bot management, so replaying the requests from Node risks intermittent challenges. Tripo's documented REST API on `platform.tripo3d.ai` is a separate product that needs its own API key rather than the studio session these commands reuse.
+
+## Prerequisites
+
+- Chrome running with the [Browser Bridge extension](/guide/browser-bridge) installed
+- A signed-in Tripo Studio session — every command needs it
+- Credits for `text-to-model`, `image-to-model`, `multiview-to-model`, and `texture`; the read commands are free
+
+## Not covered yet
+
+Exporting a finished model to a local FBX/OBJ/GLB is not a server-side endpoint — `operation/export-lite` returns `{}` and only bumps a counter, while the file itself is built inside the page and handed to the browser as a Blob. A `download` command therefore has to drive the studio's Export dialog, which is left for a follow-up. The `operation/download_with_name` endpoint does hand back a signed URL to the mesh the studio already stores for an operator, so that is the cheaper path when the native asset is enough and no format conversion is needed.
+
+The studio's other tools — HD Model, Segment, Retopo, Texture Edit/Upscale/PBR, Rigging, Generate in Parts — are separate engines with their own option sets and are not wrapped here.


### PR DESCRIPTION
## What

A browser adapter for [Tripo Studio](https://studio.tripo3d.ai) (`studio.tripo3d.ai`), wrapping its **Smart Mesh** engine — text / image / multi-view to 3D mesh, texture baking, and the read commands needed to drive them.

| Command | |
|---|---|
| `text-to-model <prompt>` | untextured mesh from a prompt |
| `image-to-model <image>` | untextured mesh from one reference image |
| `multiview-to-model <front>` | untextured mesh from front/left/back/right views |
| `texture <project>` | bake a texture onto an existing mesh |
| `status <operators>` | poll tasks by operator id |
| `assets` | list workspace projects + ids |
| `credits` | wallet, plan, export allowance, P2 free trials |

## Strategy

`PAGE_FETCH` for every call. `api.tripo3d.ai` authenticates with an HttpOnly cookie on `.tripo3d.ai` — the captured requests carry no bearer token and no CSRF header — and sits behind Cloudflare bot management (`__cf_bm`), which binds to the browser's TLS/UA fingerprint. Replaying the calls from Node risks intermittent 403s, so they are issued from the studio's own origin.

Tripo does publish a documented REST API on `platform.tripo3d.ai`, but it needs a separate API key rather than the studio session these commands reuse, so it is not an alternative here.

## Design decisions worth reviewing

**Two engines, and the cheaper one stays the default.** Smart Mesh's AI Model dropdown offers `Nexus-v1.0` (P1, 35 credits, triangles only) and `Nexus-v2.0` (P2, 100 credits, quad-capable). The studio itself now defaults to P2; the adapter defaults to `--model p1` on purpose, so an existing command line does not silently start costing 3x. `--model p2` opts in.

**Errors instead of silent coercion**, in three places where the page does the opposite:

- `--topology quad` on P1 is rejected, not downgraded to triangles — the studio renders the Quad button disabled on that engine.
- The polycount ceiling depends on both flags (p1 20000 · p2 triangle 50000 · p2 quad 25000). The page clamps with `Math.round(Math.min(value, ceiling))`; the adapter throws, because a clamp the caller cannot see is a 100-credit generation at a face count nobody asked for.
- A `403` is no longer reported as a lost session. Measured against the live studio: signed out is **HTTP 401 + code 1002**, while a plan refusal is **HTTP 403** with a real business code (`6102 Insufficient membership`, `9103 Project count limit exceeded`). Only 401 raises `AuthRequiredError` now.

**`symmetry` is P2-only and has no UI control.** The page attaches it only once the dropdown is on P2, filling it from `operation/symmetry_check` run against the main reference image. The adapter mirrors that exactly: text mode has no reference image and sends a literal `false`, image mode checks the uploaded image, multi-view checks the front slot.

**`--visibility` defaults to `auto`.** Privacy now sits under a "Members Only" heading; on a free plan the combobox opens the pricing dialog rather than a dropdown, and the API answers anything but `public` with 403 `6102` — *after* the reference image has already been uploaded. `auto` resolves the way the store does (`payment.member.type !== 'basic'` → `shareable`, else `public`); explicit values pass straight through.

## Testing

`clis/tripo3d/tripo3d.test.js` — 22 tests covering the polycount matrix, the quad/P1 rejection, the 401-vs-403 split, symmetry forwarding, visibility resolution, and the exact request body `runSmartMesh` builds for each engine. Each guard was reverse-validated by injecting the corresponding regression and confirming it fails.

```
npx tsc --noEmit                                  # clean
npm run check:silent-column-drop                  # no new violations
npm run check:typed-error-lint                    # no new violations
npx vitest run --project adapter clis/tripo3d/    # 22 passed
```

`npm test` was also run in full; the 11 failing files it reports are pre-existing on this Windows checkout (path/home-expansion assertions in `suno`, `twitter`, `instagram`, `xiaoyuzhou`, `src/cli.test.ts`) and fail identically with this branch stashed.

Verified live against a real account (`opencli browser verify` green for `assets`, `credits`, `status`; an end-to-end `image-to-model --model p2 --topology quad --polycount 22000` came back `success`, and `project/detail/v3` echoed the stored operator as `{"quad":true,"face_limit":22000,"model_version":"Nexus-v2.0-20260801","symmetry":false}`).

## Deliberately not included

A `download` command. File export is **not** a server-side endpoint here: `operation/export-lite` returns `{}` and only bumps the account's monthly export counter, while the FBX/OBJ/STL is produced inside the page and handed to the browser as a Blob — so it has to drive the studio's Export dialog. That surface drifted three times in 24 hours while this was being prepared (the project deep link rendering the SPA's error boundary, the viewer switching from `.glb` to `output_mesh_<operator_id>.fbx`, and the Export dialog not opening in a background window), so it is left as a follow-up rather than shipped half-working. `operation/download_with_name` remains the cheap path for the stored native asset when no format conversion is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPFwuPThapaSgr1QFBtXsQ
