### PR TITLE
docs(browser): guide recovery from incomplete extraction

### DIFF
--- a/skills/opencli-browser/SKILL.md
+++ b/skills/opencli-browser/SKILL.md
@@ -84,7 +84,7 @@ If `browser open` or `browser analyze` returns `sitemap.available: true`, switch
 <target> ::= <numeric-ref> | <css-selector>
 ```
 
-- **Numeric ref** — the `[N]` index from `state` or `find`. Cheap, resilient to soft DOM drift.
+- **Numeric ref** — the `[N]` index from `state` or `find`. Cheap, resilient to soft DOM drift. Do not substitute array positions from `eval` (such as the index in `document.querySelectorAll('*')`); those are not OpenCLI refs.
 - **CSS selector** — anything `querySelectorAll` accepts. Must be unambiguous on write ops, or pair with `--nth <n>`.
 
 ### Envelope on success
@@ -192,6 +192,20 @@ state, elapsedMs}` on success and a JSON error envelope on timeout/failure.
 - **`web read --url <url>`** — One-shot Markdown reader for arbitrary pages. It expands relevant same-origin iframes by default, so old iframe-shell sites work better than with a top-document-only scrape. Use `--frames all-same-origin` when completeness matters more than Markdown noise. For AJAX shell pages use `opencli web read --url <url> --wait-for "<selector>" --wait-until networkidle --diagnose`; diagnostics show frame URLs, empty containers, and API-like XHRs. If the value you need is table/API data, switch to `browser network` or a dedicated adapter instead of relying on Markdown.
 - **`browser eval <js> [--frame N]`** — Run an expression in the page (or in a cross-origin frame via `--frame`). Wrap in an IIFE and return JSON. Read-only: no `document.forms[0].submit()`, no clicks, no navigations. If the result is a string, stdout is the raw string; otherwise it's JSON.
 - **`browser extract [--selector <css>] [--chunk-size N] [--start N]`** — Markdown extraction of long-form content with a continuation cursor. Returns `{url, title, selector, total_chars, chunk_size, start, end, next_start_char, content}`. Loop on `next_start_char` until it is `null`. Auto-scopes to `<main>`/`<article>`/`<body>` if you don't pass `--selector`.
+
+### When extraction is empty or incomplete
+
+An empty `eval` result or a successful command does not establish that the page has no data. Before changing selectors, verify the target in the same named session:
+
+```bash
+opencli browser research get url
+opencli browser research get title
+```
+
+- If the URL is unexpectedly `about:blank`, a login page, or another document, restore the intended page using the session lifecycle above before extracting again. Reopening an owned session's known URL and rebinding a user tab are different operations; do not navigate an unexpected user tab as a shortcut. Take a fresh `state` after recovery.
+- If the document is correct but code blocks or custom controls are missing from DOM output, try `opencli browser research state --source ax` and wait for the relevant content to load. AX is a fallback, not a guarantee that every widget exposes its data.
+- For virtualized grids or canvas-based sheets, visible rows are only a partial view. Prefer the site's data API or export; otherwise traverse the grid and check coverage against its row count or end-of-data indicator. Finishing `extract`'s text cursor only exhausts the extracted text, not unloaded rows. A screenshot can help identify the widget or export control, but cannot establish whole-sheet completeness.
+- If coverage remains unknown, report what was actually read and what is missing. Do not call a visible subset the complete list, or keep retrying the same failed selector/ref without new page evidence.
 
 ### Network
 


### PR DESCRIPTION
## Description

When extraction returns an empty body or only visible spreadsheet rows, an agent can keep trying selectors on the wrong page or report a partial result as complete. The browser skill now directs the agent to verify its named session's URL/title, recover the intended page, try AX for missing code-card text, and check full grid coverage through an API, export, or traversal. It also clarifies that an arbitrary DOM array position is not an OpenCLI interaction ref.

Related issue: Closes #2482. Complements #2478, which documents session visibility and binding. This is a documentation change based on a historical 1.6.1 transcript and a review of current main; it does not claim to reproduce or fix the old runtime session-loss behavior.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🌐 New site adapter
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build / tooling

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

Validation: the skill validator and `git diff --check` pass. The URL/title, AX, session, and numeric-target instructions were checked against current CLI registrations and the existing session contract. No runtime code changed; browser E2E, build, and unit suites were not run. The original logged-in environment was not available for reproduction.

### Documentation (if adding/modifying an adapter)

N/A — no adapter changes.

- [ ] Added doc page under `docs/adapters/` (if new adapter)
- [ ] Updated `docs/adapters/index.md` table (if new adapter)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (if new adapter)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed
- [ ] Used positional args for the command's primary subject unless a named flag is clearly better
- [ ] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Screenshots / Output

```text
Skill is valid!
git diff --check: passed
1 file changed, 15 insertions(+), 1 deletion(-)
```

For review, consider an unexpected blank page, code blocks missing from DOM output, a sheet exposing only a few visible rows, and a DOM enumeration returning `i=216`. The guidance should lead to checking the target first, choosing an appropriate extraction fallback, reporting unverified coverage as partial, and obtaining a real interaction ref before acting. A screenshot or a fully consumed text cursor is explicitly not treated as proof of whole-sheet completeness.
