### PR TITLE
feat(facebook): add marketplace-search command

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -14296,6 +14296,92 @@
   },
   {
     "site": "facebook",
+    "name": "marketplace-search",
+    "description": "Search Facebook Marketplace listings for sale (buyer side)",
+    "access": "read",
+    "domain": "www.facebook.com",
+    "strategy": "cookie",
+    "browser": true,
+    "args": [
+      {
+        "name": "query",
+        "type": "str",
+        "required": true,
+        "positional": true,
+        "help": "What to search for, e.g. \"road bike\""
+      },
+      {
+        "name": "location",
+        "type": "str",
+        "required": false,
+        "help": "City slug or numeric city id from a Marketplace URL (chicago, nyc, 108659242498155). Defaults to your saved location"
+      },
+      {
+        "name": "limit",
+        "type": "int",
+        "default": 20,
+        "required": false,
+        "help": "Number of listings (1-100); scrolls for more than 24"
+      },
+      {
+        "name": "min-price",
+        "type": "int",
+        "required": false,
+        "help": "Minimum price"
+      },
+      {
+        "name": "max-price",
+        "type": "int",
+        "required": false,
+        "help": "Maximum price"
+      },
+      {
+        "name": "sort",
+        "type": "str",
+        "default": "best",
+        "required": false,
+        "help": "Sort order",
+        "choices": [
+          "best",
+          "newest",
+          "price-asc",
+          "price-desc",
+          "distance"
+        ]
+      },
+      {
+        "name": "days",
+        "type": "int",
+        "required": false,
+        "help": "Only listings posted within the last N days (1, 7, 30)"
+      },
+      {
+        "name": "exact",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Require an exact phrase match"
+      }
+    ],
+    "columns": [
+      "index",
+      "id",
+      "title",
+      "price",
+      "currency",
+      "originalPrice",
+      "location",
+      "badge",
+      "image",
+      "url"
+    ],
+    "type": "js",
+    "modulePath": "facebook/marketplace-search.js",
+    "sourceFile": "facebook/marketplace-search.js",
+    "navigateBefore": false
+  },
+  {
+    "site": "facebook",
     "name": "memories",
     "description": "Get your Facebook memories (On This Day)",
     "access": "read",

--- a/clis/facebook/marketplace-search.js
+++ b/clis/facebook/marketplace-search.js
@@ -1,0 +1,410 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { cli, Strategy } from '@jackwener/opencli/registry';
+
+// Buyer-side Facebook Marketplace search: browse listings for sale near a
+// location. Complements the seller-side `marketplace-listings` /
+// `marketplace-inbox` commands.
+//
+// Strategy: UI_SELECTOR (visible-ui contract). Every result card on
+// /marketplace/<location>/search is an <a href="/marketplace/item/<id>/…">
+// whose aria-label carries the whole row in a fixed, comma-separated shape:
+//
+//   "<title>, <price>[, reduced from <price>], <city>, <state>, listing <id>"
+//
+// Location is empty for shipped-only items ("…, $40, , listing 123"). The
+// aria-label is Facebook's own accessibility contract and survived every DOM
+// class reshuffle observed so far; the inner <span>s are used only as a
+// fallback when the label is missing or unparseable.
+
+const MAX_LIMIT = 100;
+const PAGE_SIZE = 24; // cards Facebook renders per scroll batch
+const MAX_SCROLL_ROUNDS = 12;
+const SORT_MAP = {
+  best: null,
+  newest: 'creation_time_descend',
+  'price-asc': 'price_ascend',
+  'price-desc': 'price_descend',
+  distance: 'distance_ascend',
+};
+const DAYS_CHOICES = [1, 7, 30];
+
+function requireQuery(value) {
+  const q = String(value ?? '').trim();
+  if (!q) throw new ArgumentError('facebook marketplace-search requires a non-empty query');
+  return q;
+}
+
+function requireLimit(value) {
+  const n = Number(value ?? 20);
+  if (!Number.isInteger(n) || n < 1 || n > MAX_LIMIT) {
+    throw new ArgumentError(`facebook marketplace-search --limit must be an integer between 1 and ${MAX_LIMIT}`);
+  }
+  return n;
+}
+
+function optionalPrice(value, flag) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new ArgumentError(`facebook marketplace-search ${flag} must be a non-negative number`);
+  }
+  return n;
+}
+
+function optionalLocation(value) {
+  const slug = String(value ?? '').trim().toLowerCase();
+  if (!slug) return null;
+  if (!/^[a-z0-9]+$/.test(slug)) {
+    throw new ArgumentError(
+      'facebook marketplace-search --location must be a Marketplace city slug or numeric city id (letters/digits only), e.g. chicago, nyc, 108659242498155',
+    );
+  }
+  return slug;
+}
+
+function requireSort(value) {
+  const key = String(value ?? 'best').trim().toLowerCase();
+  if (!(key in SORT_MAP)) {
+    throw new ArgumentError(`facebook marketplace-search --sort must be one of: ${Object.keys(SORT_MAP).join(', ')}`);
+  }
+  return key;
+}
+
+function optionalDays(value) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  if (!DAYS_CHOICES.includes(n)) {
+    throw new ArgumentError(`facebook marketplace-search --days must be one of: ${DAYS_CHOICES.join(', ')}`);
+  }
+  return n;
+}
+
+function buildSearchUrl(opts) {
+  const base = opts.location
+    ? `https://www.facebook.com/marketplace/${opts.location}/search`
+    : 'https://www.facebook.com/marketplace/category/search/';
+  const params = new URLSearchParams();
+  params.set('query', opts.query);
+  if (opts.minPrice !== null && opts.minPrice !== undefined) params.set('minPrice', String(opts.minPrice));
+  if (opts.maxPrice !== null && opts.maxPrice !== undefined) params.set('maxPrice', String(opts.maxPrice));
+  const sortBy = SORT_MAP[opts.sort ?? 'best'];
+  if (sortBy) params.set('sortBy', sortBy);
+  if (opts.days) params.set('daysSinceListed', String(opts.days));
+  if (opts.exact) params.set('exact', 'true');
+  return `${base}?${params.toString()}`;
+}
+
+// "$1,234" / "CA$80" / "€50" / "£9.99" / "Free" → { price, currency }
+const PRICE_RE = /^(free|[A-Z]{0,3}[$€£¥₹])\s?([\d.,]*)$/i;
+
+function parsePrice(text) {
+  const m = String(text ?? '').trim().match(PRICE_RE);
+  if (!m) return null;
+  if (/^free$/i.test(m[1])) return { price: 0, currency: null };
+  const n = Number(m[2].replace(/,/g, ''));
+  if (!Number.isFinite(n)) return null;
+  return { price: n, currency: m[1] };
+}
+
+// Parse Facebook's card aria-label. Returns null when the label does not have
+// the expected shape so the caller can fall back to the span-based reading.
+function parseListingLabel(label) {
+  const text = String(label ?? '').replace(/\s+/g, ' ').trim();
+  const idMatch = text.match(/, listing (\d+)$/);
+  if (!idMatch) return null;
+  const parts = text.slice(0, -idMatch[0].length).split(', ');
+  // Walk from the right: [title…, price, (reduced from X)?, location…]
+  let priceIdx = -1;
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    if (parsePrice(parts[i])) { priceIdx = i; break; }
+  }
+  if (priceIdx < 1) return null; // no price, or nothing left for a title
+  const priced = parsePrice(parts[priceIdx]);
+  const title = parts.slice(0, priceIdx).join(', ');
+  const rest = parts.slice(priceIdx + 1);
+  let originalPrice = null;
+  if (rest.length && /^reduced from /i.test(rest[0])) {
+    const orig = parsePrice(rest.shift().replace(/^reduced from /i, ''));
+    originalPrice = orig ? orig.price : null;
+  }
+  const location = rest.join(', ').trim();
+  return {
+    id: idMatch[1],
+    title,
+    price: priced.price,
+    currency: priced.currency,
+    originalPrice,
+    location: location || null,
+  };
+}
+
+// Fallback for cards without a usable aria-label: inner spans are
+// [badge?, price, title, location?] with each repeated for a11y.
+function parseListingSpans(spans) {
+  const uniq = [];
+  for (const s of spans || []) {
+    const t = String(s ?? '').replace(/\s+/g, ' ').trim();
+    if (t && !uniq.includes(t)) uniq.push(t);
+  }
+  const priceIdx = uniq.findIndex((t) => parsePrice(t));
+  if (priceIdx < 0) return null;
+  const priced = parsePrice(uniq[priceIdx]);
+  const after = uniq.slice(priceIdx + 1);
+  if (!after.length) return null;
+  return {
+    title: after[0],
+    price: priced.price,
+    currency: priced.currency,
+    originalPrice: null,
+    location: after[1] || null,
+  };
+}
+
+function unwrapBrowserResult(value) {
+  if (value && typeof value === 'object' && 'data' in value) return value.data;
+  return value;
+}
+
+function isNavigationRejected(error) {
+  return /Navigation rejected/i.test(String(error?.message || error));
+}
+
+// The Browser Bridge occasionally rejects the very first navigation of a
+// fresh automation tab ("Navigation rejected") and succeeds immediately on
+// retry. Mirror google/images.js: retry once, then fall back to a new tab.
+async function navigateWithRetry(page, url) {
+  const opts = { settleMs: 4000 };
+  try {
+    await page.goto(url, opts);
+    return;
+  } catch (error) {
+    if (!isNavigationRejected(error)) throw error;
+  }
+  try {
+    await page.goto(url, opts);
+    return;
+  } catch (error) {
+    if (!isNavigationRejected(error)) throw error;
+    if (typeof page.newTab === 'function' && typeof page.setActivePage === 'function') {
+      const pageId = await page.newTab(url);
+      if (pageId) {
+        await page.setActivePage(pageId);
+        return;
+      }
+    }
+    throw error;
+  }
+}
+
+function isAuthPageJs() {
+  return `
+    function isAuthPage() {
+      const path = window.location && window.location.pathname ? window.location.pathname : '';
+      const body = String(document.body && document.body.textContent || '').replace(/\\s+/g, ' ').trim();
+      return /^\\/(login|checkpoint)(\\/|$|\\.php)/.test(path)
+        || /^(Log in to Facebook|Facebook登录|登录 Facebook)/i.test(body)
+        || /You must log in to continue/i.test(body);
+    }`;
+}
+
+// Scroll to the bottom, give Facebook a moment to append the next batch, and
+// report how many listing cards are present.
+function buildScrollScript() {
+  return `(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    window.scrollTo(0, document.body.scrollHeight);
+    await sleep(1200);
+    return document.querySelectorAll('a[href*="/marketplace/item/"]').length;
+  })()`;
+}
+
+function buildExtractScript(limit) {
+  return `(() => {
+    const limit = ${limit};
+    ${isAuthPageJs()}
+    const clean = (v) => String(v || '').replace(/[\\u200b-\\u200f\\u202a-\\u202e\\u2060\\ufeff]/g, '').replace(/\\s+/g, ' ').trim();
+    if (isAuthPage()) return { status: 'auth', href: location.href, rows: [], diagnostics: {} };
+
+    const anchors = Array.from(document.querySelectorAll('a[href*="/marketplace/item/"]'));
+    const seen = new Set();
+    const rows = [];
+    for (const a of anchors) {
+      const href = a.getAttribute('href') || '';
+      const idMatch = href.match(/\\/marketplace\\/item\\/(\\d+)/);
+      if (!idMatch) continue;
+      const id = idMatch[1];
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const spans = Array.from(a.querySelectorAll('span')).map((s) => clean(s.textContent)).filter(Boolean);
+      const img = a.querySelector('img');
+      rows.push({
+        id,
+        label: clean(a.getAttribute('aria-label')),
+        spans,
+        image: img ? (img.currentSrc || img.src || '') : '',
+      });
+      if (rows.length >= limit) break;
+    }
+    return {
+      status: rows.length ? 'ok' : 'no_rows',
+      href: location.href,
+      rows,
+      diagnostics: {
+        anchorCount: anchors.length,
+        mainTextLength: clean((document.querySelector('[role="main"]') || {}).textContent).length,
+        hasMarketplaceNav: /Marketplace/i.test(clean(document.body && document.body.textContent).slice(0, 4000)),
+      },
+    };
+  })()`;
+}
+
+const BADGE_RE = /^(Just listed|Pending|Sold|Free shipping|Ships to you|Sponsored)$/i;
+
+function normalizeRows(rawRows, limit) {
+  const out = [];
+  for (const raw of rawRows) {
+    const parsed = parseListingLabel(raw.label) || parseListingSpans(raw.spans);
+    if (!parsed || !parsed.title) continue;
+    const badge = (raw.spans || []).find((s) => BADGE_RE.test(String(s).trim())) || null;
+    out.push({
+      index: out.length + 1,
+      id: String(raw.id),
+      title: parsed.title,
+      price: parsed.price,
+      currency: parsed.currency,
+      originalPrice: parsed.originalPrice,
+      location: parsed.location,
+      badge: badge ? String(badge).trim() : null,
+      image: raw.image || null,
+      url: `https://www.facebook.com/marketplace/item/${raw.id}/`,
+    });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+async function searchMarketplace(page, kwargs) {
+  if (!page) throw new CommandExecutionError('Browser session required for facebook marketplace-search');
+  const query = requireQuery(kwargs.query);
+  const limit = requireLimit(kwargs.limit);
+  const location = optionalLocation(kwargs.location);
+  const minPrice = optionalPrice(kwargs['min-price'] ?? kwargs.minPrice, '--min-price');
+  const maxPrice = optionalPrice(kwargs['max-price'] ?? kwargs.maxPrice, '--max-price');
+  if (minPrice !== null && maxPrice !== null && minPrice > maxPrice) {
+    throw new ArgumentError('facebook marketplace-search --min-price cannot exceed --max-price');
+  }
+  const sort = requireSort(kwargs.sort);
+  const days = optionalDays(kwargs.days);
+  const exact = kwargs.exact === true;
+
+  const url = buildSearchUrl({ query, location, minPrice, maxPrice, sort, days, exact });
+  try {
+    await navigateWithRetry(page, url);
+  } catch (err) {
+    throw new CommandExecutionError(
+      `Failed to open Facebook Marketplace search: ${err instanceof Error ? err.message : err}`,
+      'Check that facebook.com is reachable and the browser extension is connected.',
+    );
+  }
+
+  // Facebook renders ~24 cards per batch; scroll for more when asked for more.
+  if (limit > PAGE_SIZE) {
+    let prev = -1;
+    let stalled = 0;
+    for (let i = 0; i < MAX_SCROLL_ROUNDS; i += 1) {
+      let count = 0;
+      try { count = Number(unwrapBrowserResult(await page.evaluate(buildScrollScript()))) || 0; } catch { break; }
+      if (count >= limit) break;
+      if (count <= prev) {
+        stalled += 1;
+        if (stalled >= 2) break;
+      } else {
+        stalled = 0;
+      }
+      prev = count;
+    }
+  }
+
+  let payload;
+  try {
+    payload = unwrapBrowserResult(await page.evaluate(buildExtractScript(limit)));
+  } catch (err) {
+    throw new CommandExecutionError(
+      `Failed to read Facebook Marketplace results: ${err instanceof Error ? err.message : err}`,
+      'Facebook may not have rendered or the Marketplace markup may have changed.',
+    );
+  }
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.rows)) {
+    throw new CommandExecutionError('facebook marketplace-search returned malformed extraction payload');
+  }
+  if (payload.status === 'auth') {
+    throw new AuthRequiredError('www.facebook.com', 'Open Chrome and log in to Facebook before retrying.');
+  }
+
+  // Facebook silently drops an unknown city slug and redirects to
+  // /marketplace/category/search/ (the account's saved location). Surface
+  // that instead of returning results for the wrong place.
+  if (location && typeof payload.href === 'string' && !payload.href.includes(`/marketplace/${location}/`)) {
+    throw new ArgumentError(
+      `Facebook did not recognize --location "${location}" and fell back to your saved location. ` +
+      'Use the city slug or numeric city id from a Marketplace URL (e.g. chicago, nyc, 108659242498155); only major cities have a named slug. Omit --location to use your saved location.',
+    );
+  }
+
+  const rows = normalizeRows(payload.rows, limit);
+  if (rows.length > 0) return rows;
+
+  const d = payload.diagnostics || {};
+  if (d.anchorCount) {
+    throw new CommandExecutionError(
+      'Facebook Marketplace rendered listing cards but none could be parsed',
+      `Diagnostics: anchors=${d.anchorCount}, mainTextLength=${d.mainTextLength || 0}. The card aria-label format may have changed.`,
+    );
+  }
+  throw new EmptyResultError(
+    'facebook marketplace-search',
+    `No Marketplace listings were visible for "${query}"${location ? ` near ${location}` : ''}. Try a broader query, a wider price range, or a different --location.`,
+  );
+}
+
+const command = {
+  site: 'facebook',
+  name: 'marketplace-search',
+  access: 'read',
+  description: 'Search Facebook Marketplace listings for sale (buyer side)',
+  domain: 'www.facebook.com',
+  strategy: Strategy.COOKIE,
+  browser: true,
+  navigateBefore: false,
+  args: [
+    { name: 'query', required: true, positional: true, help: 'What to search for, e.g. "road bike"' },
+    { name: 'location', help: 'City slug or numeric city id from a Marketplace URL (chicago, nyc, 108659242498155). Defaults to your saved location' },
+    { name: 'limit', type: 'int', default: 20, help: `Number of listings (1-${MAX_LIMIT}); scrolls for more than ${PAGE_SIZE}` },
+    { name: 'min-price', type: 'int', help: 'Minimum price' },
+    { name: 'max-price', type: 'int', help: 'Maximum price' },
+    { name: 'sort', default: 'best', choices: Object.keys(SORT_MAP), help: 'Sort order' },
+    { name: 'days', type: 'int', help: 'Only listings posted within the last N days (1, 7, 30)' },
+    { name: 'exact', type: 'boolean', default: false, help: 'Require an exact phrase match' },
+  ],
+  columns: ['index', 'id', 'title', 'price', 'currency', 'originalPrice', 'location', 'badge', 'image', 'url'],
+  func: searchMarketplace,
+};
+
+cli(command);
+
+export const __test__ = {
+  buildExtractScript,
+  buildSearchUrl,
+  command,
+  normalizeRows,
+  optionalDays,
+  optionalLocation,
+  optionalPrice,
+  parseListingLabel,
+  parseListingSpans,
+  parsePrice,
+  requireLimit,
+  requireQuery,
+  requireSort,
+  searchMarketplace,
+};

--- a/clis/facebook/marketplace-search.test.js
+++ b/clis/facebook/marketplace-search.test.js
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import { ArgumentError, AuthRequiredError, CommandExecutionError, EmptyResultError } from '@jackwener/opencli/errors';
+import { __test__ } from './marketplace-search.js';
+
+const {
+  buildSearchUrl,
+  normalizeRows,
+  optionalDays,
+  optionalLocation,
+  parseListingLabel,
+  parseListingSpans,
+  parsePrice,
+  requireLimit,
+  requireSort,
+} = __test__;
+
+function makePage(overrides = {}) {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue({ status: 'no_rows', href: '', rows: [], diagnostics: {} }),
+    ...overrides,
+  };
+}
+
+function okPayload(rows, href = 'https://www.facebook.com/marketplace/category/search/?query=bike') {
+  return { status: 'ok', href, rows, diagnostics: { anchorCount: rows.length } };
+}
+
+const CARD_BIKE = {
+  id: '1727594701690671',
+  label: 'Bike. 20” mongoose, $50, Holt, MI, listing 1727594701690671',
+  spans: ['$50', '$50', 'Bike. 20” mongoose', 'Bike. 20” mongoose', 'Holt, MI', 'Holt, MI'],
+  image: 'https://scontent.xx.fbcdn.net/v/t39.84726-6/bike.jpg',
+};
+const CARD_JUST_LISTED = {
+  id: '1441153484591442',
+  label: 'Guardian Balance Bike, $100, Dewitt, MI, listing 1441153484591442',
+  spans: ['Just listed', 'Just listed', '$100', '$100', 'Guardian Balance Bike', 'Dewitt, MI'],
+  image: '',
+};
+const CARD_REDUCED = {
+  id: '1567958064993284',
+  label: 'Schwinn steel bike vintage, $60, reduced from $100, Chicago, IL, listing 1567958064993284',
+  spans: ['$60', '$100', 'Schwinn steel bike vintage', 'Chicago, IL'],
+  image: '',
+};
+const CARD_SHIPPED = {
+  id: '1060564333042157',
+  label: 'North Face Borealis Black Backpack, $40, , listing 1060564333042157',
+  spans: ['$40', 'North Face Borealis Black Backpack'],
+  image: '',
+};
+
+describe('facebook marketplace-search helpers', () => {
+  it('parses plain, currency-prefixed, thousands-separated and free prices', () => {
+    expect(parsePrice('$50')).toEqual({ price: 50, currency: '$' });
+    expect(parsePrice('CA$80')).toEqual({ price: 80, currency: 'CA$' });
+    expect(parsePrice('$1,234,567')).toEqual({ price: 1234567, currency: '$' });
+    expect(parsePrice('£9.99')).toEqual({ price: 9.99, currency: '£' });
+    expect(parsePrice('Free')).toEqual({ price: 0, currency: null });
+    expect(parsePrice('Holt, MI')).toBeNull();
+    expect(parsePrice('')).toBeNull();
+  });
+
+  it('parses the standard aria-label shape', () => {
+    expect(parseListingLabel(CARD_BIKE.label)).toEqual({
+      id: '1727594701690671',
+      title: 'Bike. 20” mongoose',
+      price: 50,
+      currency: '$',
+      originalPrice: null,
+      location: 'Holt, MI',
+    });
+  });
+
+  it('keeps commas inside the title and reads reduced-from prices', () => {
+    expect(parseListingLabel('Trek, 21 speed, mint, $250, reduced from $300, Troy, MI, listing 42')).toEqual({
+      id: '42',
+      title: 'Trek, 21 speed, mint',
+      price: 250,
+      currency: '$',
+      originalPrice: 300,
+      location: 'Troy, MI',
+    });
+  });
+
+  it('returns null location for shipped-only items with an empty location segment', () => {
+    expect(parseListingLabel(CARD_SHIPPED.label)).toMatchObject({
+      id: '1060564333042157',
+      title: 'North Face Borealis Black Backpack',
+      price: 40,
+      location: null,
+    });
+  });
+
+  it('rejects labels without a listing id or price', () => {
+    expect(parseListingLabel('Just some text')).toBeNull();
+    expect(parseListingLabel('No price here, Holt, MI, listing 1')).toBeNull();
+    expect(parseListingLabel('$50, listing 1')).toBeNull(); // price with no title
+  });
+
+  it('falls back to span order when the label is unusable', () => {
+    expect(parseListingSpans(CARD_JUST_LISTED.spans)).toEqual({
+      title: 'Guardian Balance Bike',
+      price: 100,
+      currency: '$',
+      originalPrice: null,
+      location: 'Dewitt, MI',
+    });
+    expect(parseListingSpans(['no', 'price'])).toBeNull();
+  });
+
+  it('normalizes rows with badge, image, absolute url and 1-based index', () => {
+    const rows = normalizeRows([CARD_BIKE, CARD_JUST_LISTED, CARD_REDUCED, CARD_SHIPPED], 10);
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toEqual({
+      index: 1,
+      id: '1727594701690671',
+      title: 'Bike. 20” mongoose',
+      price: 50,
+      currency: '$',
+      originalPrice: null,
+      location: 'Holt, MI',
+      badge: null,
+      image: 'https://scontent.xx.fbcdn.net/v/t39.84726-6/bike.jpg',
+      url: 'https://www.facebook.com/marketplace/item/1727594701690671/',
+    });
+    expect(rows[1].badge).toBe('Just listed');
+    expect(rows[1].image).toBeNull();
+    expect(rows[2].originalPrice).toBe(100);
+    expect(rows[3].location).toBeNull();
+  });
+
+  it('uses the span fallback when a card has no aria-label', () => {
+    const rows = normalizeRows([{ ...CARD_BIKE, label: '' }], 10);
+    expect(rows[0]).toMatchObject({ title: 'Bike. 20” mongoose', price: 50, location: 'Holt, MI' });
+  });
+
+  it('honours limit in normalizeRows', () => {
+    expect(normalizeRows([CARD_BIKE, CARD_JUST_LISTED], 1)).toHaveLength(1);
+  });
+
+  it('builds the search url with every supported filter', () => {
+    expect(buildSearchUrl({ query: 'road bike' })).toBe(
+      'https://www.facebook.com/marketplace/category/search/?query=road+bike',
+    );
+    expect(buildSearchUrl({
+      query: 'bike', location: 'chicago', minPrice: 100, maxPrice: 300, sort: 'newest', days: 7, exact: true,
+    })).toBe(
+      'https://www.facebook.com/marketplace/chicago/search?query=bike&minPrice=100&maxPrice=300&sortBy=creation_time_descend&daysSinceListed=7&exact=true',
+    );
+    expect(buildSearchUrl({ query: 'bike', sort: 'price-asc' })).toContain('sortBy=price_ascend');
+    expect(buildSearchUrl({ query: 'bike', sort: 'price-desc' })).toContain('sortBy=price_descend');
+    expect(buildSearchUrl({ query: 'bike', sort: 'distance' })).toContain('sortBy=distance_ascend');
+    expect(buildSearchUrl({ query: 'bike', sort: 'best' })).not.toContain('sortBy');
+  });
+
+  it('validates limit, sort, days and location upfront', () => {
+    expect(requireLimit(undefined)).toBe(20);
+    expect(() => requireLimit(0)).toThrow(ArgumentError);
+    expect(() => requireLimit(101)).toThrow(ArgumentError);
+    expect(() => requireLimit('abc')).toThrow(ArgumentError);
+    expect(requireSort(undefined)).toBe('best');
+    expect(requireSort('Newest')).toBe('newest');
+    expect(() => requireSort('cheapest')).toThrow(ArgumentError);
+    expect(optionalDays(undefined)).toBeNull();
+    expect(optionalDays(7)).toBe(7);
+    expect(() => optionalDays(3)).toThrow(ArgumentError);
+    expect(optionalLocation(' Chicago ')).toBe('chicago');
+    expect(optionalLocation('')).toBeNull();
+    expect(() => optionalLocation('east lansing')).toThrow(ArgumentError);
+  });
+});
+
+describe('facebook marketplace-search command', () => {
+  it('is registered with the expected args and columns', () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    expect(command).toBeDefined();
+    expect(command.access).toBe('read');
+    expect(command.args.map((a) => a.name)).toEqual([
+      'query', 'location', 'limit', 'min-price', 'max-price', 'sort', 'days', 'exact',
+    ]);
+    expect(command.columns).toEqual([
+      'index', 'id', 'title', 'price', 'currency', 'originalPrice', 'location', 'badge', 'image', 'url',
+    ]);
+  });
+
+  it('navigates to the filtered search url and returns normalized rows', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage({
+      evaluate: vi.fn().mockResolvedValue(okPayload([CARD_BIKE, CARD_JUST_LISTED], 'https://www.facebook.com/marketplace/chicago/search?query=bike')),
+    });
+
+    const rows = await command.func(page, { query: 'bike', location: 'chicago', limit: 5, 'min-price': 10, 'max-price': 500, sort: 'newest' });
+
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://www.facebook.com/marketplace/chicago/search?query=bike&minPrice=10&maxPrice=500&sortBy=creation_time_descend',
+      { settleMs: 4000 },
+    );
+    // limit <= page size: extract only, no scroll round
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
+    expect(rows.map((r) => r.title)).toEqual(['Bike. 20” mongoose', 'Guardian Balance Bike']);
+    expect(rows[1].badge).toBe('Just listed');
+  });
+
+  it('scrolls for more cards when limit exceeds one batch and stops once enough are loaded', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(24) // scroll round 1
+      .mockResolvedValueOnce(42) // scroll round 2 -> >= limit, stop
+      .mockResolvedValueOnce(okPayload(Array.from({ length: 40 }, (_, i) => ({ ...CARD_BIKE, id: String(i + 1), label: `Item ${i + 1}, $${i + 1}, Holt, MI, listing ${i + 1}` }))));
+    const page = makePage({ evaluate });
+
+    const rows = await command.func(page, { query: 'bike', limit: 40 });
+
+    expect(evaluate).toHaveBeenCalledTimes(3);
+    expect(rows).toHaveLength(40);
+    expect(rows[39].id).toBe('40');
+  });
+
+  it('stops scrolling after two stalled rounds', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(24)
+      .mockResolvedValueOnce(24) // stalled 1
+      .mockResolvedValueOnce(24) // stalled 2 -> stop
+      .mockResolvedValueOnce(okPayload([CARD_BIKE]));
+    const page = makePage({ evaluate });
+
+    const rows = await command.func(page, { query: 'bike', limit: 60 });
+
+    expect(evaluate).toHaveBeenCalledTimes(4);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('retries once when the bridge rejects the first navigation', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const goto = vi.fn()
+      .mockRejectedValueOnce(new Error('Navigation rejected.'))
+      .mockResolvedValueOnce(undefined);
+    const page = makePage({ goto, evaluate: vi.fn().mockResolvedValue(okPayload([CARD_BIKE])) });
+
+    const rows = await command.func(page, { query: 'bike' });
+
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('falls back to a new tab when navigation is rejected twice', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const goto = vi.fn().mockRejectedValue(new Error('Navigation rejected.'));
+    const newTab = vi.fn().mockResolvedValue('tab-2');
+    const setActivePage = vi.fn();
+    const page = makePage({ goto, newTab, setActivePage, evaluate: vi.fn().mockResolvedValue(okPayload([CARD_BIKE])) });
+
+    const rows = await command.func(page, { query: 'bike' });
+
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(newTab).toHaveBeenCalledWith(expect.stringContaining('/marketplace/category/search/?query=bike'));
+    expect(setActivePage).toHaveBeenCalledWith('tab-2');
+    expect(rows).toHaveLength(1);
+  });
+
+  it('does not retry non-navigation errors', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const goto = vi.fn().mockRejectedValue(new Error('Extension not connected'));
+    const page = makePage({ goto });
+
+    await expect(command.func(page, { query: 'bike' })).rejects.toThrow(CommandExecutionError);
+    expect(goto).toHaveBeenCalledTimes(1);
+  });
+
+  it('raises AuthRequiredError when Facebook shows a login page', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage({ evaluate: vi.fn().mockResolvedValue({ status: 'auth', href: 'https://www.facebook.com/login/', rows: [], diagnostics: {} }) });
+
+    await expect(command.func(page, { query: 'bike' })).rejects.toThrow(AuthRequiredError);
+  });
+
+  it('raises ArgumentError when Facebook drops an unknown location slug', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage({
+      evaluate: vi.fn().mockResolvedValue(okPayload([CARD_BIKE], 'https://www.facebook.com/marketplace/category/search/?query=bike')),
+    });
+
+    await expect(command.func(page, { query: 'bike', location: 'eastlansing' })).rejects.toThrow(/did not recognize --location/);
+  });
+
+  it('raises EmptyResultError when no cards rendered at all', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage({ evaluate: vi.fn().mockResolvedValue({ status: 'no_rows', href: '', rows: [], diagnostics: { anchorCount: 0 } }) });
+
+    await expect(command.func(page, { query: 'zzzz' })).rejects.toThrow(EmptyResultError);
+  });
+
+  it('raises CommandExecutionError when cards rendered but none parsed', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage({
+      evaluate: vi.fn().mockResolvedValue({ status: 'ok', href: '', rows: [{ id: '1', label: 'garbage', spans: ['garbage'], image: '' }], diagnostics: { anchorCount: 1 } }),
+    });
+
+    await expect(command.func(page, { query: 'bike' })).rejects.toThrow(CommandExecutionError);
+  });
+
+  it('rejects bad arguments before touching the browser', async () => {
+    const command = getRegistry().get('facebook/marketplace-search');
+    const page = makePage();
+
+    await expect(command.func(page, { query: '' })).rejects.toThrow(ArgumentError);
+    await expect(command.func(page, { query: 'bike', limit: 0 })).rejects.toThrow(ArgumentError);
+    await expect(command.func(page, { query: 'bike', 'min-price': 500, 'max-price': 100 })).rejects.toThrow(ArgumentError);
+    await expect(command.func(page, { query: 'bike', days: 5 })).rejects.toThrow(ArgumentError);
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+});

--- a/docs/adapters/browser/facebook.md
+++ b/docs/adapters/browser/facebook.md
@@ -12,6 +12,7 @@
 | `opencli facebook search` | Search people, pages, posts |
 | `opencli facebook marketplace-listings` | List your Marketplace seller listings |
 | `opencli facebook marketplace-inbox` | List recent Marketplace buyer/seller conversations |
+| `opencli facebook marketplace-search` | Search Marketplace listings for sale (buyer side) with location / price / sort / recency filters |
 
 ## Usage Examples
 
@@ -31,6 +32,11 @@ opencli facebook search "OpenAI" --limit 5
 # Marketplace seller listings and inbox
 opencli facebook marketplace-listings --limit 10
 opencli facebook marketplace-inbox --limit 10
+
+# Marketplace buyer search (defaults to your saved location)
+opencli facebook marketplace-search "road bike" --limit 10
+opencli facebook marketplace-search "bike" --location chicago --min-price 100 --max-price 300 --sort newest --days 7
+opencli facebook marketplace-search "schwinn" --exact --sort price-asc -f json
 
 # JSON output
 opencli facebook profile zuck -f json
@@ -58,6 +64,36 @@ If Facebook redirects to a login/checkpoint path (for example
 the command raises `AuthRequiredError`. An empty notification list after
 a successful auth check raises `EmptyResultError` instead of a silent
 `[]`.
+
+### `marketplace-search`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `index` | int | 1-based row number |
+| `id` | string | Marketplace listing id |
+| `title` | string | Listing title |
+| `price` | number | Asking price as a plain number; `0` for "Free" |
+| `currency` | string \| null | Currency prefix as shown (`$`, `CA$`, `€`); `null` for "Free" |
+| `originalPrice` | number \| null | Previous price when the card shows "reduced from …"; otherwise `null` |
+| `location` | string \| null | `City, ST` as shown on the card; `null` for shipped-only items |
+| `badge` | string \| null | Card badge such as `Just listed`; otherwise `null` |
+| `image` | string \| null | Thumbnail URL |
+| `url` | string | Canonical `https://www.facebook.com/marketplace/item/<id>/` |
+
+Options: `--location <slug|id>` (the city segment of a Marketplace URL: a
+named slug such as `chicago` or `nyc`, which only major cities have, or the
+numeric city id such as `108659242498155`; omit to use the account's saved
+location), `--limit` (1-100; the command scrolls when more than one batch of
+24 is requested), `--min-price` / `--max-price`, `--sort`
+(`best` | `newest` | `price-asc` | `price-desc` | `distance`), `--days`
+(`1` | `7` | `30`), `--exact`.
+
+Facebook silently drops an unknown city slug and falls back to the saved
+location; the command detects that redirect and raises `ArgumentError`
+rather than returning listings for the wrong place. Rows are read from each
+card's `aria-label` (Facebook's accessibility contract:
+`"<title>, <price>[, reduced from <price>], <city>, <state>, listing <id>"`)
+with the inner spans as a fallback.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Adds `opencli facebook marketplace-search`, a buyer-side Facebook Marketplace search. #1221 added the seller-side `marketplace-listings` / `marketplace-inbox`; this is the missing read command for browsing listings for sale.

```bash
opencli facebook marketplace-search "road bike" --limit 10
opencli facebook marketplace-search "bike" --location chicago --min-price 100 --max-price 300 --sort newest --days 7
opencli facebook marketplace-search "schwinn" --exact --sort price-asc -f json
```

**Options**: `--location <slug|id>` (Marketplace city slug such as `chicago`/`nyc`, or the numeric city id from a Marketplace URL; defaults to the account's saved location), `--limit` 1-100 (scrolls when more than one batch of 24 is requested), `--min-price` / `--max-price`, `--sort` (`best` | `newest` | `price-asc` | `price-desc` | `distance`), `--days` (`1` | `7` | `30`), `--exact`.

**Columns**: `index, id, title, price, currency, originalPrice, location, badge, image, url`. `price` is a plain number (`0` for "Free"), `originalPrice` is filled when the card shows "reduced from …", `location` is `null` for shipped-only items.

**Strategy**: `UI_SELECTOR` on a visible-ui contract. Every result card is an `a[href*="/marketplace/item/"]` whose `aria-label` carries the whole row in a fixed shape: `"<title>, <price>[, reduced from <price>], <city>, <state>, listing <id>"`. The label is parsed right-to-left so commas inside titles survive; the inner `<span>`s are used only as a fallback.

**Typed errors**:
- `AuthRequiredError` on the login/checkpoint page.
- `ArgumentError` when Facebook silently drops an unknown `--location` slug and redirects to `/marketplace/category/search/` (it would otherwise return listings for the saved location without any signal). Facebook only has named slugs for major cities; smaller cities need the numeric id.
- `EmptyResultError` when no cards render, `CommandExecutionError` when cards render but none parse (diagnostics included).
- First-navigation `Navigation rejected` from the bridge is retried once, then falls back to a new tab (same pattern as `google/images.js`).

Related issue: none

## Type of Change

- [x] ✨ New feature

## Checklist

- [x] I ran the checks relevant to this PR
- [x] I updated tests or docs if needed
- [x] I included output or screenshots when useful

### Documentation (if adding/modifying an adapter)

- [ ] Added doc page under `docs/adapters/` (existing `facebook.md` updated with the command, options and column table)
- [ ] Updated `docs/adapters/index.md` table (n/a, existing site)
- [ ] Updated sidebar in `docs/.vitepress/config.mts` (n/a, existing site)
- [ ] Updated `README.md` / `README.zh-CN.md` when command discoverability changed (n/a)
- [x] Used positional args for the command's primary subject unless a named flag is clearly better
- [x] Normalized expected adapter failures to `CliError` subclasses instead of raw `Error`

## Verification

- `npx vitest run --project adapter clis/facebook/` (97 passed, 23 new)
- `npx tsc --noEmit`
- `npm run build` (manifest regenerated)
- `node dist/src/main.js validate` (0 errors)
- `npm test`
- Live read-only runs against a signed-in Chromium session: default location, `--location chicago` with price/sort/days filters, `--limit 40` (40 unique rows via scroll), `--exact --sort price-asc`, and an unknown slug (raises `ArgumentError`).

## Screenshots / Output

```
$ opencli facebook marketplace-search "road bike" --limit 3 -f yaml
- index: 1
  id: '946635585168635'
  title: 2011 Trek Lexa SLX WSD Women’s Aluminum Road Bike
  price: 550
  currency: $
  originalPrice: null
  location: Blissfield, MI
  badge: null
  image: https://scontent-ord5-2.xx.fbcdn.net/v/t39.84726-6/…
  url: https://www.facebook.com/marketplace/item/946635585168635/
- index: 2
  id: '1991608045545219'
  title: Trek Road Bike
  price: 500
  currency: $
  originalPrice: null
  location: Cedar Springs, MI
  badge: Just listed
  image: https://scontent-ord5-1.xx.fbcdn.net/v/t39.84726-6/…
  url: https://www.facebook.com/marketplace/item/1991608045545219/
- index: 3
  id: '2016665615671576'
  title: Women’s Giant Roadbike
  price: 125
  currency: $
  originalPrice: 200
  location: Grass Lake, MI
  badge: null
  image: https://scontent-ord5-2.xx.fbcdn.net/v/t39.84726-6/…
  url: https://www.facebook.com/marketplace/item/2016665615671576/
```

```
$ opencli facebook marketplace-search "bike" --location eastlansing
ok: false
error:
  code: ARGUMENT
  message: >-
    Facebook did not recognize --location "eastlansing" and fell back to your saved location. Use the city slug or
    numeric city id from a Marketplace URL (e.g. chicago, nyc, 108659242498155); only major cities have a named slug.
    Omit --location to use your saved location.
```
